### PR TITLE
Add samples for cloud storage json api.

### DIFF
--- a/cloud-storage/json-api/pom.xml
+++ b/cloud-storage/json-api/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <parent>
+    <artifactId>doc-samples</artifactId>
+    <groupId>com.google.cloud</groupId>
+    <version>1.0.0</version>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.apis-samples</groupId>
+  <artifactId>storage-json-sample</artifactId>
+  <version>1</version>
+  <name>Sample accessing the Google Cloud Storage JSON API using OAuth 2.0.</name>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <mainClass>StorageSample</mainClass>
+        </configuration>
+      </plugin>
+    </plugins>
+    <finalName>${project.artifactId}-${project.version}</finalName>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-storage</artifactId>
+      <version>v1-rev18-1.19.0</version>
+    </dependency>
+    <!-- Test Dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.10</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/cloud-storage/json-api/src/main/java/StorageSample.java
+++ b/cloud-storage/json-api/src/main/java/StorageSample.java
@@ -1,0 +1,210 @@
+//[START all]
+/*
+ * Copyright (c) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.InputStreamContent;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.model.Bucket;
+import com.google.api.services.storage.model.ObjectAccessControl;
+import com.google.api.services.storage.model.Objects;
+import com.google.api.services.storage.model.StorageObject;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Main class for the Cloud Storage JSON API sample.
+ *
+ * Demonstrates how to make an authenticated API call using the Google Cloud Storage API client
+ * library for java, with Application Default Credentials.
+ */
+public class StorageSample {
+
+  /**
+   * Be sure to specify the name of your application. If the application name is {@code null} or
+   * blank, the application will log a warning. Suggested format is "MyCompany-ProductName/1.0".
+   */
+  private static final String APPLICATION_NAME = "[[INSERT_YOUR_APP_NAME_HERE]]";
+
+  /** Global instance of the JSON factory. */
+  private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+  private static final String TEST_FILENAME = "json-test.txt";
+
+  private static Storage storageService;
+
+  /**
+   * Returns an authenticated Storage object used to make service calls to Cloud Storage.
+   */
+  private static Storage getService() throws IOException, GeneralSecurityException {
+    if (null == storageService) {
+      GoogleCredential credential = GoogleCredential.getApplicationDefault();
+      HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+      storageService = new Storage.Builder(httpTransport, JSON_FACTORY, credential)
+          .setApplicationName(APPLICATION_NAME).build();
+    }
+    return storageService;
+  }
+
+  // [START list_bucket]
+  /**
+   * Fetch a list of the objects within the given bucket.
+   *
+   * @param bucketName the name of the bucket to list.
+   * @return a list of the contents of the specified bucket.
+   */
+  public static List<StorageObject> listBucket(String bucketName)
+      throws IOException, GeneralSecurityException {
+    Storage client = getService();
+    Storage.Objects.List listRequest = client.objects().list(bucketName);
+
+    List<StorageObject> results = new ArrayList<StorageObject>();
+    Objects objects;
+
+    // Iterate through each page of results, and add them to our results list.
+    do {
+      objects = listRequest.execute();
+      // Add the items in this page of results to the list we'll return.
+      results.addAll(objects.getItems());
+
+      // Get the next page, in the next iteration of this loop.
+      listRequest.setPageToken(objects.getNextPageToken());
+    } while (null != objects.getNextPageToken());
+
+    return results;
+  }
+  // [END list_bucket]
+
+  // [START get_bucket]
+  /**
+   * Fetches the metadata for the given bucket.
+   *
+   * @param bucketName the name of the bucket to get metadata about.
+   * @return a Bucket containing the bucket's metadata.
+   */
+  public static Bucket getBucket(String bucketName) throws IOException, GeneralSecurityException {
+    Storage client = getService();
+
+    Storage.Buckets.Get bucketRequest = client.buckets().get(bucketName);
+    // Fetch the full set of the bucket's properties (eg include the ACLs in the response)
+    bucketRequest.setProjection("full");
+    return bucketRequest.execute();
+  }
+  // [END get_bucket]
+
+  // [START upload_stream]
+  /**
+   * Uploads data to an object in a bucket.
+   *
+   * @param name the name of the destination object.
+   * @param contentType the MIME type of the data.
+   * @param stream the data - for instance, you can use a FileInputStream to upload a file.
+   * @param bucketName the name of the bucket to create the object in.
+   */
+  public static void uploadStream(
+      String name, String contentType, InputStream stream, String bucketName)
+      throws IOException, GeneralSecurityException {
+    InputStreamContent contentStream = new InputStreamContent(contentType, stream);
+    StorageObject objectMetadata = new StorageObject()
+        // Set the destination object name
+        .setName(name)
+        // Set the access control list to publicly read-only
+        .setAcl(Arrays.asList(
+            new ObjectAccessControl().setEntity("allUsers").setRole("READER")));
+
+    // Do the insert
+    Storage client = getService();
+    Storage.Objects.Insert insertRequest = client.objects().insert(
+        bucketName, objectMetadata, contentStream);
+
+    insertRequest.execute();
+  }
+  // [END upload_stream]
+
+  // [START delete_object]
+  /**
+   * Deletes an object in a bucket.
+   *
+   * @param path the path to the object to delete.
+   * @param bucketName the bucket the object is contained in.
+   */
+  public static void deleteObject(String path, String bucketName)
+      throws IOException, GeneralSecurityException {
+    Storage client = getService();
+    client.objects().delete(bucketName, path).execute();
+  }
+  // [END delete_object]
+
+  /**
+   * Exercises the class's functions - gets and lists a bucket, uploads and deletes an object.
+   *
+   * @param args the command-line arguments. The first argument should be the bucket name.
+   */
+  public static void main(String[] args) {
+    if (args.length < 1) {
+      System.out.println("Usage: StorageSample <bucket-name>");
+      System.exit(1);
+    }
+
+    String bucketName = args[0];
+
+    try {
+      // Get metadata about the specified bucket.
+      Bucket bucket = getBucket(bucketName);
+      System.out.println("name: " + bucketName);
+      System.out.println("location: " + bucket.getLocation());
+      System.out.println("timeCreated: " + bucket.getTimeCreated());
+      System.out.println("owner: " + bucket.getOwner());
+
+
+      // List the contents of the bucket.
+      List<StorageObject> bucketContents = listBucket(bucketName);
+      if (null == bucketContents) {
+        System.out.println(
+            "There were no objects in the given bucket; try adding some and re-running.");
+      }
+      for (StorageObject object : bucketContents) {
+        System.out.println(object.getName() + " (" + object.getSize() + " bytes)");
+      }
+
+
+      // Upload a stream to the bucket. This could very well be a file.
+      uploadStream(
+          TEST_FILENAME, "text/plain",
+          new ByteArrayInputStream("Test of json storage sample".getBytes()),
+          bucketName);
+
+      // Now delete the file
+      deleteObject(TEST_FILENAME, bucketName);
+
+    } catch (IOException e) {
+      System.err.println(e.getMessage());
+      System.exit(1);
+    } catch (Throwable t) {
+      t.printStackTrace();
+      System.exit(1);
+    }
+  }
+}
+//[END all]

--- a/cloud-storage/json-api/src/test/java/StorageSampleTest.java
+++ b/cloud-storage/json-api/src/test/java/StorageSampleTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START all]
+
+import static org.junit.Assert.*;
+
+import com.google.api.services.storage.model.Bucket;
+import com.google.api.services.storage.model.StorageObject;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import java.io.ByteArrayInputStream;
+
+public class StorageSampleTest {
+  private static final String BUCKET = "cloud-samples-tests";
+  private static final String TEST_OBJECT = "storage-sample-test-upload.txt";
+
+  @Test
+  public void testListBucket() throws Exception {
+    List<StorageObject> listing = StorageSample.listBucket(BUCKET);
+    assertTrue(listing.size() > 0);
+  }
+
+  @Test
+  public void testGetBucket() throws Exception {
+    Bucket bucket = StorageSample.getBucket(BUCKET);
+    assertEquals(bucket.getName(), BUCKET);
+    assertEquals(bucket.getLocation(), "US-CENTRAL1");
+  }
+
+  @Test
+  public void testUploadDelete() throws Exception {
+    StorageSample.uploadStream(
+        TEST_OBJECT, "text/plain",
+        new ByteArrayInputStream(("This object is uploaded and deleted as part of the "
+            + "StorageSampleTest integration test.").getBytes()),
+        BUCKET);
+
+    try {
+      // Verify that the object was created
+      List<StorageObject> listing = StorageSample.listBucket(BUCKET);
+      boolean found = false;
+      for (StorageObject so : listing) {
+        if (TEST_OBJECT.equals(so.getName())) {
+          found = true;
+          break;
+        }
+      }
+      assertTrue("Should have uploaded successfully", found);
+
+    } finally {
+      StorageSample.deleteObject(TEST_OBJECT, BUCKET);
+
+      // Verify that the object no longer exists
+      List<StorageObject> listing = StorageSample.listBucket(BUCKET);
+      boolean found = false;
+      for (StorageObject so : listing) {
+        if (TEST_OBJECT.equals(so.getName())) {
+          found = true;
+          break;
+        }
+      }
+      assertFalse("Object (" + TEST_OBJECT + ") should have been deleted", found);
+    }
+  }
+}
+// [END all]


### PR DESCRIPTION
Move in the sample from [its own repo](https://github.com/GoogleCloudPlatform/cloud-storage-docs-json-api-examples/tree/master/java-example), modify to use Application Default Credentials, and add samples for uploading and deleting objects