### PR TITLE
Add an App Identity example.

### DIFF
--- a/appengine/appidentity/.gitignore
+++ b/appengine/appidentity/.gitignore
@@ -1,0 +1,7 @@
+# Eclipse files
+.project
+.classpath
+.settings
+
+# Target folders
+target/

--- a/appengine/appidentity/README.md
+++ b/appengine/appidentity/README.md
@@ -1,0 +1,12 @@
+# App Identity sample for Google App Engine
+This sample demonstrates how to use the App Identity APIs on Google App Engine
+
+## Setup
+1. Update the <application> tag in src/main/webapp/WEB-INF/appengine-web.xml with your project name
+1. Update the <version> tag in src/main/webapp/WEB-INF/appengine-web.xml with your version name
+
+## Running locally
+    $ mvn appengine:devserver
+
+## Deploying
+    $ mvn appengine:update

--- a/appengine/appidentity/README.md
+++ b/appengine/appidentity/README.md
@@ -2,26 +2,29 @@
 This sample demonstrates how to use the App Identity APIs on Google App Engine
 
 ## Running locally
-    $ mvn appengine:devserver
+This example uses the
+[Maven gcloud plugin](https://cloud.google.com/appengine/docs/java/managed-vms/maven).
+To run this sample locally:
+
+    $ mvn gcloud:run
 
 ## Deploying
 In the following command, replace YOUR-PROJECT-ID with your
 [Google Cloud Project ID](https://developers.google.com/console/help/new/#projectnumber)
 and YOUR-VERSION with a suitable version identifier.
 
-    $ mvn appengine:update -Dappengine.appId=YOUR-PROJECT-ID -Dappengine.version=YOUR-VERSION
+    $ mvn gcloud:deploy -Dversion=YOUR-VERSION -Dgcloud_project=YOUR-PROJECT-ID
 
 ## Setup
 To save your project settings so that you don't need to enter the
-`-Dappengine.appId=YOUR-CLOUD-PROJECT-ID` or
-`-Dappengine.version=YOUR-VERSION-NAME` parameters, you can make the following
-changes:
+`-Dgcloud_project=YOUR-CLOUD-PROJECT-ID` or `-Dversion=YOUR-VERSION-NAME`
+parameters, you can make the following changes:
 
 1. Update the <application> tag in src/main/webapp/WEB-INF/appengine-web.xml with your project name
 1. Update the <version> tag in src/main/webapp/WEB-INF/appengine-web.xml with your version name
 
 You will now be able to run
 
-    $ mvn appengine:update
+    $ mvn gcloud:deploy
 
 without the need for any additional paramters.

--- a/appengine/appidentity/README.md
+++ b/appengine/appidentity/README.md
@@ -10,18 +10,16 @@ To run this sample locally:
 
 ## Deploying
 In the following command, replace YOUR-PROJECT-ID with your
-[Google Cloud Project ID](https://developers.google.com/console/help/new/#projectnumber)
-and YOUR-VERSION with a suitable version identifier.
+[Google Cloud Project ID](https://developers.google.com/console/help/new/#projectnumber).
 
-    $ mvn gcloud:deploy -Dversion=YOUR-VERSION -Dgcloud_project=YOUR-PROJECT-ID
+    $ mvn gcloud:deploy -Dgcloud_project=YOUR-PROJECT-ID
 
 ## Setup
 To save your project settings so that you don't need to enter the
-`-Dgcloud_project=YOUR-CLOUD-PROJECT-ID` or `-Dversion=YOUR-VERSION-NAME`
-parameters, you can make the following changes:
+`-Dgcloud_project=YOUR-CLOUD-PROJECT-ID` parameters, you can:
 
-1. Update the <application> tag in src/main/webapp/WEB-INF/appengine-web.xml with your project name
-1. Update the <version> tag in src/main/webapp/WEB-INF/appengine-web.xml with your version name
+1. Update the <application> tag in src/main/webapp/WEB-INF/appengine-web.xml
+   with your project name.
 
 You will now be able to run
 

--- a/appengine/appidentity/README.md
+++ b/appengine/appidentity/README.md
@@ -1,12 +1,27 @@
 # App Identity sample for Google App Engine
 This sample demonstrates how to use the App Identity APIs on Google App Engine
 
-## Setup
-1. Update the <application> tag in src/main/webapp/WEB-INF/appengine-web.xml with your project name
-1. Update the <version> tag in src/main/webapp/WEB-INF/appengine-web.xml with your version name
-
 ## Running locally
     $ mvn appengine:devserver
 
 ## Deploying
+In the following command, replace YOUR-PROJECT-ID with your
+[Google Cloud Project ID](https://developers.google.com/console/help/new/#projectnumber)
+and YOUR-VERSION with a suitable version identifier.
+
+    $ mvn appengine:update -Dappengine.appId=YOUR-PROJECT-ID -Dappengine.version=YOUR-VERSION
+
+## Setup
+To save your project settings so that you don't need to enter the
+`-Dappengine.appId=YOUR-CLOUD-PROJECT-ID` or
+`-Dappengine.version=YOUR-VERSION-NAME` parameters, you can make the following
+changes:
+
+1. Update the <application> tag in src/main/webapp/WEB-INF/appengine-web.xml with your project name
+1. Update the <version> tag in src/main/webapp/WEB-INF/appengine-web.xml with your version name
+
+You will now be able to run
+
     $ mvn appengine:update
+
+without the need for any additional paramters.

--- a/appengine/appidentity/pom.xml
+++ b/appengine/appidentity/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2015 Google Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>war</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <groupId>com.example.appengine</groupId>
+  <artifactId>appidentity</artifactId>
+
+  <properties>
+    <appengine.target.version>1.9.30</appengine.target.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>${appengine.target.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
+      <version>2.5</version>
+      <type>jar</type>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Test Dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.10</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-testing</artifactId>
+      <version>${appengine.target.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-stubs</artifactId>
+      <version>${appengine.target.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-tools-sdk</artifactId>
+      <version>${appengine.target.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>0.27</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <!-- for hot reload of the web application -->
+    <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes</outputDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <version>3.3</version>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.google.appengine</groupId>
+        <artifactId>appengine-maven-plugin</artifactId>
+        <version>1.9.28</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/appengine/appidentity/pom.xml
+++ b/appengine/appidentity/pom.xml
@@ -95,7 +95,7 @@ Copyright 2015 Google Inc. All Rights Reserved.
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.28</version>
+        <version>${appengine.target.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/appengine/appidentity/pom.xml
+++ b/appengine/appidentity/pom.xml
@@ -94,8 +94,8 @@ Copyright 2015 Google Inc. All Rights Reserved.
       </plugin>
       <plugin>
         <groupId>com.google.appengine</groupId>
-        <artifactId>appengine-maven-plugin</artifactId>
-        <version>${appengine.target.version}</version>
+        <artifactId>gcloud-maven-plugin</artifactId>
+        <version>2.0.9.90.v20151210</version>
       </plugin>
     </plugins>
   </build>

--- a/appengine/appidentity/src/main/java/com/example/appengine/appidentity/IdentityServlet.java
+++ b/appengine/appidentity/src/main/java/com/example/appengine/appidentity/IdentityServlet.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.appengine.appidentity;
+
+import com.google.apphosting.api.ApiProxy;
+import com.google.apphosting.api.ApiProxy.Environment;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@SuppressWarnings("serial")
+public class IdentityServlet extends HttpServlet {
+
+  // [START versioned_hostnames]
+  @Override
+  public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    resp.setContentType("text/plain");
+    ApiProxy.Environment env = ApiProxy.getCurrentEnvironment();
+    resp.getWriter().print("default_version_hostname: ");
+    resp.getWriter()
+        .println(env.getAttributes().get("com.google.appengine.runtime.default_version_hostname"));
+  }
+  // [END versioned_hostnames]
+}

--- a/appengine/appidentity/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/appengine/appidentity/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
+  <application>YOUR-PROJECT-ID</application>
+  <version>YOUR-VERSION-ID</version>
+  <threadsafe>true</threadsafe>
+</appengine-web-app>

--- a/appengine/appidentity/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/appengine/appidentity/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
   <application>YOUR-PROJECT-ID</application>
-  <version>YOUR-VERSION-ID</version>
   <threadsafe>true</threadsafe>
   <vm>true</vm>
 </appengine-web-app>

--- a/appengine/appidentity/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/appengine/appidentity/src/main/webapp/WEB-INF/appengine-web.xml
@@ -3,4 +3,5 @@
   <application>YOUR-PROJECT-ID</application>
   <version>YOUR-VERSION-ID</version>
   <threadsafe>true</threadsafe>
+  <vm>true</vm>
 </appengine-web-app>

--- a/appengine/appidentity/src/main/webapp/WEB-INF/web.xml
+++ b/appengine/appidentity/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://java.sun.com/xml/ns/javaee"
+  xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+  version="2.5">
+  <servlet>
+    <servlet-name>appidentity</servlet-name>
+    <servlet-class>com.example.appengine.appidentity.IdentityServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>appidentity</servlet-name>
+    <url-pattern>/</url-pattern>
+  </servlet-mapping>
+</web-app>

--- a/appengine/appidentity/src/test/java/com/example/appengine/appidentity/IdentityServletTest.java
+++ b/appengine/appidentity/src/test/java/com/example/appengine/appidentity/IdentityServletTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.appengine.appidentity;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.appengine.tools.development.ApiProxyLocal;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.apphosting.api.ApiProxy;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Unit tests for {@link IdentityServlet}. */
+@RunWith(JUnit4.class)
+public class IdentityServletTest {
+
+  // Set up a helper so that the ApiProxy returns a valid environment for local testing.
+  private final LocalServiceTestHelper helper = new LocalServiceTestHelper();
+
+  @Mock private HttpServletRequest mockRequest;
+  @Mock private HttpServletResponse mockResponse;
+  private StringWriter responseWriter;
+  private IdentityServlet servletUnderTest;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    helper.setUp();
+
+    // Set up a fake HTTP response.
+    responseWriter = new StringWriter();
+    when(mockResponse.getWriter()).thenReturn(new PrintWriter(responseWriter));
+
+    servletUnderTest = new IdentityServlet();
+  }
+
+  @Test
+  public void doGet_defaultEnvironment_writesResponse() throws Exception {
+    servletUnderTest.doGet(mockRequest, mockResponse);
+
+    // We don't have any guarantee over what the local App Engine environment returns for
+    // "com.google.appengine.runtime.default_version_hostname".  Only assert that the response
+    // contains part of the string we have control over.
+    assertThat(responseWriter.toString())
+        .named("IdentityServlet response")
+        .contains("default_version_hostname:");
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     </prerequisites>
 
     <modules>
+        <module>appengine/appidentity</module>
         <module>taskqueue/deferred</module>
         <module>unittests</module>
         <module>bigquery</module>


### PR DESCRIPTION
This moves the first example from  https://cloud.google.com/appengine/docs/java/appidentity/ to GitHub.

I also add a simple unit test to at least make sure this code builds &
runs.  Since this sample just wraps:

    ApiProxy.getCurrentEnvironment()
        .getAttributes()
        .get("com.google.appengine.runtime.default_version_hostname"))

there isn't really much more we can test in this example.

I will move the other examples from that page over in later PRs.