### PR TITLE
Checkstyle is now enforced across most modules.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ env:
 before_install:
   - openssl aes-256-cbc -K $encrypted_99d8b304f94b_key -iv $encrypted_99d8b304f94b_iv -in service-account.json.enc -out service-account.json -d
 
-script: mvn test
+script: mvn verify
 after_success:
   - mvn clean cobertura:cobertura coveralls:report

--- a/appengine/analytics/pom.xml
+++ b/appengine/analytics/pom.xml
@@ -5,7 +5,7 @@
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
   <groupId>com.example.managedvms</groupId>
-  <artifactId>analytics</artifactId>
+  <artifactId>appengine-analytics</artifactId>
   <dependencies>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -48,6 +48,20 @@
         <configuration>
           <promote>true</promote>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/appengine/appidentity/pom.xml
+++ b/appengine/appidentity/pom.xml
@@ -20,7 +20,7 @@ Copyright 2015 Google Inc. All Rights Reserved.
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
   <groupId>com.example.appengine</groupId>
-  <artifactId>appidentity</artifactId>
+  <artifactId>appengine-appidentity</artifactId>
 
   <properties>
     <appengine.target.version>1.9.30</appengine.target.version>
@@ -106,6 +106,20 @@ Copyright 2015 Google Inc. All Rights Reserved.
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
         <version>2.0.9.90.v20151210</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/appengine/appidentity/src/main/java/com/example/appengine/appidentity/IdentityServlet.java
+++ b/appengine/appidentity/src/main/java/com/example/appengine/appidentity/IdentityServlet.java
@@ -17,10 +17,8 @@
 package com.example.appengine.appidentity;
 
 import com.google.apphosting.api.ApiProxy;
-import com.google.apphosting.api.ApiProxy.Environment;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;

--- a/appengine/cloudsql/pom.xml
+++ b/appengine/cloudsql/pom.xml
@@ -5,7 +5,7 @@
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
   <groupId>com.example.managedvms</groupId>
-  <artifactId>cloudsql</artifactId>
+  <artifactId>appengine-cloudsql</artifactId>
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -50,6 +50,20 @@
         <configuration>
           <promote>true</promote>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/appengine/cloudstorage/pom.xml
+++ b/appengine/cloudstorage/pom.xml
@@ -5,7 +5,7 @@
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
   <groupId>com.example.managedvms</groupId>
-  <artifactId>cloudstorage</artifactId>
+  <artifactId>appengine-cloudstorage</artifactId>
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -48,6 +48,20 @@
         <configuration>
           <promote>true</promote>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/appengine/datastore/pom.xml
+++ b/appengine/datastore/pom.xml
@@ -5,7 +5,7 @@
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
   <groupId>com.example.managedvms</groupId>
-  <artifactId>datastore</artifactId>
+  <artifactId>appengine-datastore</artifactId>
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -48,6 +48,20 @@
         <configuration>
           <promote>true</promote>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/appengine/disk/pom.xml
+++ b/appengine/disk/pom.xml
@@ -5,7 +5,7 @@
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
   <groupId>com.example.managedvms</groupId>
-  <artifactId>disk</artifactId>
+  <artifactId>appengine-disk</artifactId>
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -40,6 +40,20 @@
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
         <version>2.0.9.90.v20151210</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/appengine/disk/src/main/java/com/example/managedvms/disk/DiskServlet.java
+++ b/appengine/disk/src/main/java/com/example/managedvms/disk/DiskServlet.java
@@ -46,7 +46,7 @@ public class DiskServlet extends HttpServlet {
     StringBuffer sb = new StringBuffer();
     List<String> strings = Files.readAllLines(tmpFile, StandardCharsets.US_ASCII);
     for (String s : strings) {
-      sb.append(s+"\n");
+      sb.append(s + "\n");
     }
     PrintWriter out = resp.getWriter();
     resp.setContentType("text/plain");

--- a/appengine/extending-runtime/pom.xml
+++ b/appengine/extending-runtime/pom.xml
@@ -5,7 +5,7 @@
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
   <groupId>com.example.managedvms</groupId>
-  <artifactId>extendingruntime</artifactId>
+  <artifactId>appengine-extendingruntime</artifactId>
   <properties>
     <writeable.directory></writeable.directory>
     <gcloud.sdk.directory></gcloud.sdk.directory>
@@ -57,6 +57,20 @@
             jetty.port={port}
           </custom_entrypoint>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/appengine/helloworld-mvm/pom.xml
+++ b/appengine/helloworld-mvm/pom.xml
@@ -5,7 +5,7 @@
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
   <groupId>com.example.managedvms</groupId>
-  <artifactId>helloworld</artifactId>
+  <artifactId>appengine-helloworld-mvm</artifactId>
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -40,6 +40,20 @@
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
         <version>2.0.9.90.v20151210</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/appengine/helloworld/pom.xml
+++ b/appengine/helloworld/pom.xml
@@ -20,7 +20,7 @@ Copyright 2015 Google Inc. All Rights Reserved.
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
   <groupId>com.example.appengine</groupId>
-  <artifactId>helloworld</artifactId>
+  <artifactId>appengine-helloworld</artifactId>
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -47,6 +47,20 @@ Copyright 2015 Google Inc. All Rights Reserved.
         <groupId>com.google.appengine</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
         <version>1.9.31</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/appengine/mailgun/pom.xml
+++ b/appengine/mailgun/pom.xml
@@ -5,7 +5,7 @@
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
   <groupId>com.example.managedvms</groupId>
-  <artifactId>mailgun</artifactId>
+  <artifactId>appengine-mailgun</artifactId>
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -57,6 +57,20 @@
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
         <version>2.0.9.90.v20151210</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/appengine/memcache/pom.xml
+++ b/appengine/memcache/pom.xml
@@ -5,7 +5,7 @@
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
   <groupId>com.example.managedvms</groupId>
-  <artifactId>memcache</artifactId>
+  <artifactId>appengine-memcache</artifactId>
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -45,6 +45,20 @@
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
         <version>2.0.9.90.v20151210</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/appengine/sendgrid/pom.xml
+++ b/appengine/sendgrid/pom.xml
@@ -5,7 +5,7 @@
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
   <groupId>com.example.managedvms</groupId>
-  <artifactId>sendgrid</artifactId>
+  <artifactId>appengine-sendgrid</artifactId>
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -48,6 +48,24 @@
         <artifactId>gcloud-maven-plugin</artifactId>
         <version>2.0.9.90.v20151210</version>
       </plugin>
+      <!--
+           The sendgrid sample currently (2016-01-22) fails the Google Style
+           checks. We can uncomment this block when it is fixed.
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
+      </plugin>
+      -->
     </plugins>
   </build>
 </project>

--- a/appengine/static-files/pom.xml
+++ b/appengine/static-files/pom.xml
@@ -5,7 +5,7 @@
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
   <groupId>com.example.managedvms</groupId>
-  <artifactId>staticfiles</artifactId>
+  <artifactId>appengine-staticfiles</artifactId>
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -40,6 +40,20 @@
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
         <version>2.0.9.90.v20151210</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/appengine/twilio/pom.xml
+++ b/appengine/twilio/pom.xml
@@ -5,7 +5,7 @@
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
   <groupId>com.example.managedvms</groupId>
-  <artifactId>twilio</artifactId>
+  <artifactId>appengine-twilio</artifactId>
   <dependencies>
     <!-- [START dependencies] -->
     <dependency>
@@ -49,6 +49,24 @@
         <artifactId>gcloud-maven-plugin</artifactId>
         <version>2.0.9.90.v20151210</version>
       </plugin>
+      <!--
+           The twilio sample currently (2016-01-22) fails the Google Style
+           checks. We can uncomment this block when it is fixed.
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
+      </plugin>
+      -->
     </plugins>
   </build>
 </project>

--- a/appengine/twilio/src/main/java/com/example/managedvms/twilio/ReceiveSmsServlet.java
+++ b/appengine/twilio/src/main/java/com/example/managedvms/twilio/ReceiveSmsServlet.java
@@ -43,7 +43,7 @@ public class ReceiveSmsServlet extends HttpServlet {
     TwiMLResponse twiml = new TwiMLResponse();
     Message sms = new Message(message);
     try {
-        twiml.append(sms);
+      twiml.append(sms);
     } catch (TwiMLException e) {
       throw new ServletException("Twilio error", e);
     }

--- a/appengine/twilio/src/main/java/com/example/managedvms/twilio/SendSmsServlet.java
+++ b/appengine/twilio/src/main/java/com/example/managedvms/twilio/SendSmsServlet.java
@@ -16,14 +16,13 @@
 
 package com.example.managedvms.twilio;
 
-import org.apache.http.NameValuePair;
-import org.apache.http.message.BasicNameValuePair;
-
 import com.twilio.sdk.TwilioRestClient;
 import com.twilio.sdk.TwilioRestException;
 import com.twilio.sdk.resource.factory.MessageFactory;
 import com.twilio.sdk.resource.instance.Account;
 import com.twilio.sdk.resource.instance.Message;
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicNameValuePair;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/appengine/websockets/pom.xml
+++ b/appengine/websockets/pom.xml
@@ -5,7 +5,7 @@
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
   <groupId>com.example.managedvms</groupId>
-  <artifactId>websockets</artifactId>
+  <artifactId>appengine-websockets</artifactId>
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -70,6 +70,20 @@
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
         <version>2.0.9.90.v20151210</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/appengine/websockets/src/main/java/com/example/managedvms/websockets/WebsocketServlet.java
+++ b/appengine/websockets/src/main/java/com/example/managedvms/websockets/WebsocketServlet.java
@@ -57,6 +57,9 @@ public class WebsocketServlet extends HttpServlet {
     req.getRequestDispatcher("/index.jsp").forward(req, resp);
   }
 
+  /**
+   * Returns the static IP address of the compute node this servlet is running on.
+   */
   public static String getExternalIp() {
     try {
       URL url = new URL(METADATA_NETWORK_INTERFACE_URL);

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -81,6 +81,20 @@
           <target>5</target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -55,6 +55,20 @@
           <target>5</target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/managedvms/sparkjava/pom.xml
+++ b/managedvms/sparkjava/pom.xml
@@ -61,7 +61,7 @@
           <archive>
             <manifest>
               <mainClass>com.google.appengine.sparkdemo.Main</mainClass>
-            </manifest>           
+            </manifest>
           </archive>
         </configuration>
       </plugin>
@@ -84,6 +84,24 @@
         <configuration>
         </configuration>
       </plugin>
+      <!--
+           The SparkJava demo currently (2016-01-22) fails the Google Style
+           checks. We can uncomment this block when it is fixed.
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
+      </plugin>
+      -->
     </plugins>
   </build>
 </project>

--- a/monitoring/pom.xml
+++ b/monitoring/pom.xml
@@ -63,6 +63,20 @@
           <target>5</target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,16 +23,31 @@
     </prerequisites>
 
     <modules>
+        <module>appengine/analytics</module>
         <module>appengine/appidentity</module>
-        <module>taskqueue/deferred</module>
-        <module>unittests</module>
+        <module>appengine/cloudsql</module>
+        <module>appengine/cloudstorage</module>
+        <module>appengine/datastore</module>
+        <module>appengine/disk</module>
+        <module>appengine/extending-runtime</module>
+        <module>appengine/helloworld</module>
+        <module>appengine/helloworld-mvm</module>
+        <module>appengine/mailgun</module>
+        <module>appengine/memcache</module>
+        <module>appengine/sendgrid</module>
+        <module>appengine/static-files</module>
+        <module>appengine/twilio</module>
+        <module>appengine/websockets</module>
         <module>bigquery</module>
-        <module>storage/xml-api/cmdline-sample</module>
-        <module>storage/xml-api/serviceaccount-appengine-sample</module>
-        <module>storage/storage-transfer</module>
-        <module>monitoring</module>
         <module>logging</module>
         <module>managedvms/sparkjava</module>
+        <module>monitoring</module>
+        <module>storage/json-api</module>
+        <module>storage/storage-transfer</module>
+        <module>storage/xml-api/cmdline-sample</module>
+        <module>storage/xml-api/serviceaccount-appengine-sample</module>
+        <module>taskqueue/deferred</module>
+        <module>unittests</module>
     </modules>
 
     <build>
@@ -40,26 +55,15 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.15</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>com.puppycrawl.tools</groupId>
-                            <artifactId>checkstyle</artifactId>
-                            <version>6.8.1</version>
-                        </dependency>
-                    </dependencies>
-                    <configuration>
-                        <configLocation>google-checks.xml</configLocation>
-                        <consoleOutput>true</consoleOutput>
-                        <failOnViolation>true</failOnViolation>
-                        <failsOnError>true</failsOnError>
-                    </configuration>
+                <version>2.17</version>
+                <configuration>
+                    <configLocation>google-checks.xml</configLocation>
+                    <consoleOutput>true</consoleOutput>
+                    <failOnViolation>true</failOnViolation>
+                    <failsOnError>true</failsOnError>
+                </configuration>
                 <executions>
-                <execution>
-                    <goals>
-                    <goal>check</goal>
-                    </goals>
-                    </execution>
+                    <execution><goals><goal>check</goal></goals></execution>
                 </executions>
              </plugin>
              <plugin>

--- a/storage/json-api/pom.xml
+++ b/storage/json-api/pom.xml
@@ -29,6 +29,20 @@
           <mainClass>StorageSample</mainClass>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
+      </plugin>
     </plugins>
     <finalName>${project.artifactId}-${project.version}</finalName>
   </build>

--- a/storage/json-api/src/main/java/StorageSample.java
+++ b/storage/json-api/src/main/java/StorageSample.java
@@ -27,7 +27,6 @@ import com.google.api.services.storage.model.Objects;
 import com.google.api.services.storage.model.StorageObject;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.GeneralSecurityException;

--- a/storage/storage-transfer/pom.xml
+++ b/storage/storage-transfer/pom.xml
@@ -70,6 +70,20 @@
           <target>1.7</target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/storage/xml-api/cmdline-sample/pom.xml
+++ b/storage/xml-api/cmdline-sample/pom.xml
@@ -17,6 +17,20 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../../../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.1</version>

--- a/storage/xml-api/serviceaccount-appengine-sample/pom.xml
+++ b/storage/xml-api/serviceaccount-appengine-sample/pom.xml
@@ -92,6 +92,20 @@
           <goals>gae:deploy</goals>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>../../../google-checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution><goals><goal>check</goal></goals></execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/taskqueue/deferred/pom.xml
+++ b/taskqueue/deferred/pom.xml
@@ -116,6 +116,20 @@
                     </jvmFlags -->
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>2.17</version>
+                <configuration>
+                    <configLocation>../../google-checks.xml</configLocation>
+                    <consoleOutput>true</consoleOutput>
+                    <failOnViolation>true</failOnViolation>
+                    <failsOnError>true</failsOnError>
+                </configuration>
+                <executions>
+                    <execution><goals><goal>check</goal></goals></execution>
+                </executions>
+             </plugin>
         </plugins>
     </build>
 

--- a/unittests/pom.xml
+++ b/unittests/pom.xml
@@ -100,6 +100,20 @@
                 <artifactId>appengine-maven-plugin</artifactId>
                 <version>${appengine.target.version}</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>2.17</version>
+                <configuration>
+                    <configLocation>../google-checks.xml</configLocation>
+                    <consoleOutput>true</consoleOutput>
+                    <failOnViolation>true</failOnViolation>
+                    <failsOnError>true</failsOnError>
+                </configuration>
+                <executions>
+                    <execution><goals><goal>check</goal></goals></execution>
+                </executions>
+             </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Also, many modules were not being built by Travis, since they were not included in the root pom.xml. By changing the Travis config to use `mvn verify` instead of `mvn test`, we ensure that the checkstyle plugin will run, since [by default](https://maven.apache.org/plugins/maven-checkstyle-plugin/check-mojo.html) it is bound to the verify [phase](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#Lifecycle_Reference).