### PR TITLE
Fix error deploying hello world.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <appengine.version>1.9.19</appengine.version>
+        <appengine.sdk.version>1.9.19</appengine.sdk.version>
         <appengine.app.version>1</appengine.app.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.http.version>1.19.0</project.http.version>
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>com.google.appengine</groupId>
             <artifactId>appengine-api-1.0-sdk</artifactId>
-            <version>${appengine.version}</version>
+            <version>${appengine.sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -138,13 +138,13 @@
         <dependency>
             <groupId>com.google.appengine</groupId>
             <artifactId>appengine-testing</artifactId>
-            <version>${appengine.version}</version>
+            <version>${appengine.sdk.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.appengine</groupId>
             <artifactId>appengine-api-stubs</artifactId>
-            <version>${appengine.version}</version>
+            <version>${appengine.sdk.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
The `appengine.version` overrides the version tag for the instance
rather than the SDK version. Changing to `appengine.sdk.version` fixes
the errors we encounter when deploying.