### PR TITLE
Update App Engine SDK version.

### DIFF
--- a/appengine/helloworld/pom.xml
+++ b/appengine/helloworld/pom.xml
@@ -21,6 +21,7 @@ Copyright 2015 Google Inc. All Rights Reserved.
   <version>1.0-SNAPSHOT</version>
   <groupId>com.example.appengine</groupId>
   <artifactId>appengine-helloworld</artifactId>
+  <!-- Parent POM defines ${appengine.sdk.version} (updates frequently). -->
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>doc-samples</artifactId>
@@ -52,7 +53,7 @@ Copyright 2015 Google Inc. All Rights Reserved.
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.31</version>
+        <version>${appengine.sdk.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <appengine.sdk.version>1.9.19</appengine.sdk.version>
+        <appengine.sdk.version>1.9.32</appengine.sdk.version>
         <appengine.app.version>1</appengine.app.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.http.version>1.19.0</project.http.version>

--- a/storage/xml-api/serviceaccount-appengine-sample/pom.xml
+++ b/storage/xml-api/serviceaccount-appengine-sample/pom.xml
@@ -2,6 +2,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <!-- Parent POM defines ${appengine.sdk.version} (updates frequently). -->
   <parent>
     <artifactId>doc-samples</artifactId>
     <groupId>com.google.cloud</groupId>
@@ -16,8 +17,7 @@
   <packaging>war</packaging>
 
   <properties>
-    <google-api-client.version>1.18.0-rc</google-api-client.version>
-    <project.appengine.version>1.8.3</project.appengine.version>
+    <google-api-client.version>1.21.0</google-api-client.version>
     <webappDirectory>${project.build.directory}/${project.build.finalName}
     </webappDirectory>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -76,7 +76,7 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>${project.appengine.version}</version>
+        <version>${appengine.sdk.version}</version>
         <configuration>
           <port>8888</port>
         </configuration>
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
-      <version>${project.appengine.version}</version>
+      <version>${appengine.sdk.version}</version>
     </dependency>
 
     <dependency>

--- a/taskqueue/deferred/pom.xml
+++ b/taskqueue/deferred/pom.xml
@@ -5,6 +5,7 @@
     <packaging>war</packaging>
     <version>1.0-SNAPSHOT</version>
 
+    <!-- Parent POM defines ${appengine.sdk.version} (updates frequently). -->
     <parent>
         <artifactId>doc-samples</artifactId>
         <groupId>com.google.cloud</groupId>
@@ -14,12 +15,6 @@
 
     <groupId>com.google.cloud.taskqueue.samples</groupId>
     <artifactId>taskqueue-defer-sample</artifactId>
-
-    <properties>
-        <appengine.version>1.9.19</appengine.version>
-        <appengine.app.version>1</appengine.app.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
 
     <dependencies>
         <!-- Compile/runtime dependencies -->
@@ -103,7 +98,7 @@
             <plugin>
                 <groupId>com.google.appengine</groupId>
                 <artifactId>appengine-maven-plugin</artifactId>
-                <version>1.9.19</version>
+                <version>${appengine.sdk.version}</version>
                 <configuration>
                     <enableJarClasses>false</enableJarClasses>
                     <!-- Comment in the below snippet to bind to all IPs instead of just localhost -->

--- a/unittests/pom.xml
+++ b/unittests/pom.xml
@@ -5,6 +5,7 @@
     <packaging>war</packaging>
     <version>1.0-SNAPSHOT</version>
 
+    <!-- Parent POM defines ${appengine.sdk.version} (updates frequently). -->
     <parent>
         <artifactId>doc-samples</artifactId>
         <groupId>com.google.cloud</groupId>
@@ -15,18 +16,12 @@
     <groupId>com.google.appengine.samples</groupId>
     <artifactId>unittests-appengine-local-testing-samples</artifactId>
 
-    <properties>
-        <appengine.app.version>1</appengine.app.version>
-        <appengine.target.version>1.8.4</appengine.target.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <dependencies>
         <!-- Compile/runtime dependencies -->
         <dependency>
             <groupId>com.google.appengine</groupId>
             <artifactId>appengine-api-1.0-sdk</artifactId>
-            <version>${appengine.target.version}</version>
+            <version>${appengine.sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -48,19 +43,19 @@
         <dependency>
             <groupId>com.google.appengine</groupId>
             <artifactId>appengine-testing</artifactId>
-            <version>${appengine.target.version}</version>
+            <version>${appengine.sdk.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.appengine</groupId>
             <artifactId>appengine-api-stubs</artifactId>
-            <version>${appengine.target.version}</version>
+            <version>${appengine.sdk.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.appengine</groupId>
             <artifactId>appengine-tools-sdk</artifactId>
-            <version>${appengine.target.version}</version>
+            <version>${appengine.sdk.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -97,7 +92,7 @@
             <plugin>
                 <groupId>com.google.appengine</groupId>
                 <artifactId>appengine-maven-plugin</artifactId>
-                <version>${appengine.target.version}</version>
+                <version>${appengine.sdk.version}</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
We don't have many samples that use the appengine-maven-plugin anymore, but those that do now should all inherit from the root pom.xml.

CC @ludoch @shun-fan 