### PR TITLE
Checkstyle fixes in Cloud Storage JSON API tests.

### DIFF
--- a/storage/json-api/pom.xml
+++ b/storage/json-api/pom.xml
@@ -15,6 +15,15 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.5.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.1</version>
@@ -43,6 +52,12 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.10</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>0.28</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Getting ready to use shared java-repo-tools configuration.

I also convert the assertions to use [truth](http://google.github.io/truth/).

Since I find it more readable to get a list of object names first
instead of manually looping through, I also update the sample to use
Java 8 lambdas to extract these object names. The sample is used here:
https://cloud.google.com/storage/docs/json_api/v1/json-api-java-samples
which does not indicate the required Java version.

Depends on https://github.com/GoogleCloudPlatform/java-docs-samples/pull/107