### PR TITLE
Checkstyle fixes in Cloud Storage JSON API tests.

### DIFF
--- a/storage/json-api/pom.xml
+++ b/storage/json-api/pom.xml
@@ -12,6 +12,12 @@
   <artifactId>storage-json-sample</artifactId>
   <version>1</version>
   <name>Sample accessing the Google Cloud Storage JSON API using OAuth 2.0.</name>
+
+  <properties>
+      <maven.compiler.target>1.8</maven.compiler.target>
+      <maven.compiler.source>1.8</maven.compiler.source>
+  </properties>
+
   <build>
     <plugins>
       <plugin>
@@ -43,6 +49,12 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.10</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>0.28</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Getting ready to use shared java-repo-tools configuration.

I also convert the assertions to use [truth](http://google.github.io/truth/).

Since I find it more readable to get a list of object names first
instead of manually looping through, I also update the sample to use
Java 8 lambdas to extract these object names. The sample is used here:
https://cloud.google.com/storage/docs/json_api/v1/json-api-java-samples
which does not indicate the required Java version.

Depends on https://github.com/GoogleCloudPlatform/java-docs-samples/pull/107