### PR TITLE
Update gcloud-java version to 0.1.5 and clean up cloudstorage sample

### DIFF
--- a/datastore/pom.xml
+++ b/datastore/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>com.google.gcloud</groupId>
       <artifactId>gcloud-java-datastore</artifactId>
-      <version>0.1.4</version>
+      <version>0.1.5</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/managed_vms/cloudstorage/README.md
+++ b/managed_vms/cloudstorage/README.md
@@ -1,14 +1,25 @@
-# Cloud Storage sample for Google Maanged VMs
-This sample demonstrates how to use [Cloud Storage](https://cloud.google.com/storage/) on Google Managed VMs
+# Cloud Storage sample for Google Managed VMs
+This sample demonstrates how to use [Cloud Storage](https://cloud.google.com/storage/) on Google Managed VMs.
+
 ## Setup
 Before you can run or deploy the sample, you will need to do the following:
+
 1. Enable the Cloud Storage API in the [Google Developers Console](https://console.developers.google.com/project/_/apiui/apiview/storage/overview).
-1. Create a Cloud Storage Bucket. You can do this with the [Google Cloud SDK](https://cloud.google.com/sdk) with the following command:
-    $ gsutil mb gs://[your-bucket-name]
-1. Set the default ACL on your bucket to public read in order to serve files directly from Cloud Storage. You can do this with the [Google Cloud SDK](https://cloud.google.com/sdk) with the following command:
-    $ gsutil defacl set public-read gs://[your-bucket-name]
-1. Update the bucket name in ``src/main/appengine/app.yaml``.
+2. Create a Cloud Storage Bucket. You can do this with the [Google Cloud SDK](https://cloud.google.com/sdk) using the following command:
+
+  ```
+  $ gsutil mb gs://[your-bucket-name]
+  ```
+3. Set the default ACL on your bucket to public read in order to serve files directly from Cloud Storage. You can do this with the [Google Cloud SDK](https://cloud.google.com/sdk) using the following command:
+
+  ```
+  $ gsutil defacl set public-read gs://[your-bucket-name]
+  ```
+4. Update the bucket name in `src/main/appengine/app.yaml`. This makes the bucket name an environment variable in deployment. You still need to set the environment variable when running locally, as shown below.
+
 ## Running locally
+    $ export BUCKET_NAME=[your-bucket-name]
     $ mvn clean jetty:run
+
 ## Deploying
     $ mvn clean gcloud:deploy

--- a/managed_vms/cloudstorage/src/main/java/com/example/managedvms/cloudstorage/UploadServlet.java
+++ b/managed_vms/cloudstorage/src/main/java/com/example/managedvms/cloudstorage/UploadServlet.java
@@ -17,6 +17,7 @@
 package com.example.managedvms.cloudstorage;
 
 import com.google.gcloud.storage.Acl;
+import com.google.gcloud.storage.Blob;
 import com.google.gcloud.storage.BlobInfo;
 import com.google.gcloud.storage.Storage;
 import com.google.gcloud.storage.StorageOptions;
@@ -57,14 +58,13 @@ public class UploadServlet extends HttpServlet {
     List<Acl> acls = new ArrayList<>();
     acls.add(Acl.of(Acl.User.ofAllUsers(), Acl.Role.READER));
     // the inputstream is closed by default, so we don't need to close it here
-    BlobInfo blobInfo =
+    Blob blob =
         storage.create(
             BlobInfo.builder(BUCKET_NAME, fileName).acl(acls).build(),
             filePart.getInputStream());
-    blobInfo = storage.get(BUCKET_NAME, fileName);
 
     // return the public download link
-    resp.getWriter().print(blobInfo.mediaLink());
+    resp.getWriter().print(blob.mediaLink());
   }
 }
 // [END example]

--- a/managed_vms/sparkjava/pom.xml
+++ b/managed_vms/sparkjava/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>com.google.gcloud</groupId>
       <artifactId>gcloud-java</artifactId>
-      <version>0.1.4</version>
+      <version>0.1.5</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Updates the gcloud-java version in the remaining two gcloud-java samples.  Also cleans up the managed_vms/cloudstorage sample and docs.

I tested the cloudstorage sample manually both locally and in deployment.