### PR TITLE
Fix checkstyle in monitoring v3 sample.

### DIFF
--- a/google-checks.xml
+++ b/google-checks.xml
@@ -2,6 +2,21 @@
 <!DOCTYPE module PUBLIC
           "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
           "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<!--
+    Copyright 2016 Google Inc. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
 
 <!--
     Checkstyle configuration that checks the Google coding conventions from:
@@ -14,9 +29,7 @@
     Most Checks are configurable, be sure to consult the documentation.
     To completely disable a check, just comment it out or delete it from the file.
     Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
-
  -->
-
 <module name = "Checker">
     <property name="charset" value="UTF-8"/>
 
@@ -25,11 +38,13 @@
     <property name="fileExtensions" value="java, properties, xml"/>
     <!-- Checks for whitespace                               -->
     <!-- See http://checkstyle.sf.net/config_whitespace.html -->
-        <module name="FileTabCharacter">
-            <property name="eachLine" value="true"/>
-        </module>
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
+    </module>
 
     <module name="TreeWalker">
+        <!-- Make @SuppressWarnings available to checkstyle http://stackoverflow.com/a/22556386/101923 -->
+        <module name="SuppressWarningsHolder" />
         <module name="UnusedImports"/>
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
@@ -179,6 +194,7 @@
         </module>
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
+            <property name="allowMissingJavadoc" value="true"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
@@ -198,4 +214,7 @@
             <property name="exceptionVariableName" value="expected"/>
         </module>
     </module>
+
+    <!-- Allow silencing rules with annotations http://stackoverflow.com/a/22556386/101923 -->
+    <module name="SuppressWarningsFilter" />
 </module>

--- a/monitoring/v3/README.md
+++ b/monitoring/v3/README.md
@@ -15,8 +15,9 @@ Go to the [Google Developers Console](https://console.developer.google.com).
 
     * Go too API Manager -> Credentials
     * Click ['New Credentials', and create a Service Account](https://console.developers.google.com/project/_/apiui/credential/serviceaccount)
-     Download the JSON for this service account, and set the `GOOGLE_APPLICATION_CREDENTIALS`
-     environment variable to point to the file containing the JSON credentials.
+     Download the JSON for this service account, and set the
+     `GOOGLE_APPLICATION_CREDENTIALS` environment variable to point to the file
+     containing the JSON credentials.
 
     ```
     export GOOGLE_APPLICATION_CREDENTIALS=~/Downloads/<project-id>-0123456789abcdef.json
@@ -26,23 +27,25 @@ Go to the [Google Developers Console](https://console.developer.google.com).
 
 To run locally:
     * `mvn clean install`
-    * `./run_monitoring_example.sh <YOUR-PROJECT-ID>
+    * `./list_resources_example.sh <YOUR-PROJECT-ID>
     * `./run_custom_metrics.sh <YOUR-PROJECT-ID>
 
 ## Run Tests
 
-The tests emulate what the scripts accomplish, so there isn't a reason why they need to be run if the examples work. 
-However, if you'd like to run them, change TEST_PROJECT_ID in ListResourcesTest to the appropriate project ID
-that matches the Service Account pointed to by GOOGLE_APPLICATION_CREDENTIALS, then run:
+The tests emulate what the scripts accomplish, so there isn't a reason why they
+need to be run if the examples work.  However, if you'd like to run them, change
+`TEST_PROJECT_ID` in [`ListResourcesTest`](src/test/java/ListResourcesTest.java)
+to the appropriate project ID that matches the Service Account pointed to by
+`GOOGLE_APPLICATION_CREDENTIALS`, then run:
 
     mvn test -DskipTests=false
 
 ## Contributing changes
 
-See CONTRIBUTING.md
+See [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
 ## Licensing
 
-* See [LICENSE](LICENSE)
+See [LICENSE](../../LICENSE).
 
 

--- a/monitoring/v3/pom.xml
+++ b/monitoring/v3/pom.xml
@@ -14,7 +14,6 @@
         <relativePath>../..</relativePath>
     </parent>
 
-
     <properties>
         <project.http.version>1.19.0</project.http.version>
         <project.oauth.version>1.19.0</project.oauth.version>
@@ -44,23 +43,6 @@
             <version>${project.oauth.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.3.1</version>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-            <version>4.12</version>
-        </dependency>
-        <dependency>
-            <groupId>com.jcabi</groupId>
-            <artifactId>jcabi-matchers</artifactId>
-            <scope>test</scope>
-            <version>1.3</version>
-        </dependency>
-        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>2.9</version>
@@ -70,11 +52,35 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.4</version>
         </dependency>
-        <!-- To be replaced by a Maven dependency on public release -->
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-monitoring</artifactId>
             <version>v3-rev1-1.21.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jcabi</groupId>
+            <artifactId>jcabi-matchers</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.truth</groupId>
+            <artifactId>truth</artifactId>
+            <version>0.28</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/monitoring/v3/src/test/java/CreateCustomMetricTest.java
+++ b/monitoring/v3/src/test/java/CreateCustomMetricTest.java
@@ -1,12 +1,12 @@
-/**
+/*
  * Copyright (c) 2015 Google Inc.
- * <p/>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * <p/>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -14,10 +14,14 @@
  * the License.
  */
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.api.services.monitoring.v3.Monitoring;
 import com.google.api.services.monitoring.v3.model.Point;
+import com.google.common.collect.ImmutableList;
+
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.Assert;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -49,8 +53,6 @@ public class CreateCustomMetricTest {
 
   /**
    * Creates the monitoring service client.
-   *
-   * @throws Exception
    */
   @Before
   public void setUp() throws Exception {
@@ -62,8 +64,6 @@ public class CreateCustomMetricTest {
 
   /**
    * Tests that the value written for a custom metric can be read back correctly.
-   *
-   * @throws Exception
    */
   @Test
   public void testValueRead() throws Exception {
@@ -75,17 +75,14 @@ public class CreateCustomMetricTest {
     underTest.writeCustomMetricTimeseriesValue();
     // give time for write to register
     Thread.sleep(2000);
-    List<Point> response = underTest.readTimeseriesValue()
-        .getTimeSeries().get(0).getPoints();
+    List<Point> response =
+        underTest.readTimeseriesValue().getTimeSeries().get(0).getPoints();
 
-    boolean found = false;
+    ImmutableList.Builder<Long> timeSeries = ImmutableList.builder();
     for (Point p : response) {
-      System.out.println("found a response " + p.getValue().getInt64Value());
-      if (p.getValue().getInt64Value() == 0) {
-        found = true;
-      }
+      timeSeries.add(p.getValue().getInt64Value());
     }
-    Assert.assertTrue(found);
+    assertThat(timeSeries.build()).contains(0L);
   }
 
 }

--- a/monitoring/v3/src/test/java/ListResourcesTest.java
+++ b/monitoring/v3/src/test/java/ListResourcesTest.java
@@ -1,12 +1,12 @@
-/**
+/*
  * Copyright (c) 2015 Google Inc.
- * <p/>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * <p/>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -14,9 +14,10 @@
  * the License.
  */
 
+import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.services.monitoring.v3.Monitoring;
-import junit.framework.Assert;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,7 +35,7 @@ public class ListResourcesTest {
   /**
    * The project ID of the project created for the integration tests.
    */
-  public static final String TEST_PROJECT_ID = "cloud-monitoring-dev";
+  public static final String TEST_PROJECT_ID = "cloud-samples-tests";
 
   /**
    * Google Cloud Monitoring client to integration test.
@@ -63,7 +64,9 @@ public class ListResourcesTest {
   public void testListMonitoredResourceDescriptors() throws Exception {
     this.underTest.listMonitoredResourceDescriptors();
     String result = new String(os.toByteArray());
-    Assert.assertTrue(result.contains("An application running in Google App Engine"));
+    assertThat(result)
+        .named("output text stream")
+        .contains("An application running in Google App Engine");
   }
 
   /**
@@ -74,7 +77,9 @@ public class ListResourcesTest {
   public void testListMetrics() throws Exception {
     this.underTest.listMetricDescriptors();
     String result = new String(os.toByteArray());
-    Assert.assertTrue(result.contains("Delta CPU usage time. Units are second"));
+    assertThat(result)
+        .named("output text stream")
+        .contains("Delta CPU usage time. Units are second");
   }
 
   /**
@@ -85,7 +90,8 @@ public class ListResourcesTest {
   public void testListTimeseries() throws Exception {
     this.underTest.listTimeseries();
     String result = new String(os.toByteArray());
-    Assert.assertTrue(result.contains("listTimeseries response"));
+    assertThat(result)
+        .named("output text stream")
+        .contains("listTimeseries response");
   }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,8 @@
                     <consoleOutput>true</consoleOutput>
                     <failOnViolation>true</failOnViolation>
                     <failsOnError>true</failsOnError>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    <suppressionsLocation>suppressions.xml</suppressionsLocation>
                 </configuration>
                 <executions>
                     <execution><goals><goal>check</goal></goals></execution>

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+<!--
+Copyright 2016 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<suppressions>
+  <!-- For our tests we do not demand API documentation. -->
+  <suppress files="[/\\]src[/\\]test[/\\]java[/\\].*\.java" checks="Javadoc.*"/>
+
+  <!-- Suppress checks for generated code. -->
+  <suppress files="[/\\]target[/\\]" checks=".+"/>
+  <suppress files=".*AutoValue_.*\.java$" checks=".+"/>
+</suppressions>


### PR DESCRIPTION
In this case rolling back (the git submodule which started applying checkstyle to test classes) was the correct fix for the build breakage, but I've also fixed the checkstyle issues.

CC @lesv