### PR TITLE
Update gcloud Maven plugin.

### DIFF
--- a/appengine/appidentity/pom.xml
+++ b/appengine/appidentity/pom.xml
@@ -96,7 +96,7 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.90.v20151210</version>
+        <version>2.0.9.101.v20160316</version>
       </plugin>
     </plugins>
   </build>

--- a/managed_vms/analytics/pom.xml
+++ b/managed_vms/analytics/pom.xml
@@ -35,7 +35,7 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.95.v20160203</version>
+        <version>2.0.9.101.v20160316</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/managed_vms/async-rest/pom.xml
+++ b/managed_vms/async-rest/pom.xml
@@ -53,7 +53,7 @@
        <plugin>
          <groupId>com.google.appengine</groupId>
          <artifactId>gcloud-maven-plugin</artifactId>
-         <version>2.0.9.95.v20160203</version>
+         <version>2.0.9.101.v20160316</version>
          <configuration>
            <verbosity>debug</verbosity>
            <log_level>debug</log_level>

--- a/managed_vms/cloudstorage/pom.xml
+++ b/managed_vms/cloudstorage/pom.xml
@@ -37,7 +37,7 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.95.v20160203</version>
+        <version>2.0.9.101.v20160316</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/managed_vms/datastore/pom.xml
+++ b/managed_vms/datastore/pom.xml
@@ -37,7 +37,7 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.95.v20160203</version>
+        <version>2.0.9.101.v20160316</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/managed_vms/disk/pom.xml
+++ b/managed_vms/disk/pom.xml
@@ -30,7 +30,7 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.95.v20160203</version>
+        <version>2.0.9.101.v20160316</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/managed_vms/extending-runtime/pom.xml
+++ b/managed_vms/extending-runtime/pom.xml
@@ -30,7 +30,7 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.95.v20160203</version>
+        <version>2.0.9.101.v20160316</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/managed_vms/helloworld/pom.xml
+++ b/managed_vms/helloworld/pom.xml
@@ -34,7 +34,7 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.95.v20160203</version>
+        <version>2.0.9.101.v20160316</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/managed_vms/mailgun/pom.xml
+++ b/managed_vms/mailgun/pom.xml
@@ -47,7 +47,7 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.95.v20160203</version>
+        <version>2.0.9.101.v20160316</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/managed_vms/memcache/pom.xml
+++ b/managed_vms/memcache/pom.xml
@@ -37,7 +37,7 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.95.v20160203</version>
+        <version>2.0.9.101.v20160316</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/managed_vms/sendgrid/pom.xml
+++ b/managed_vms/sendgrid/pom.xml
@@ -37,7 +37,7 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.95.v20160203</version>
+        <version>2.0.9.101.v20160316</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/managed_vms/sparkjava/pom.xml
+++ b/managed_vms/sparkjava/pom.xml
@@ -95,7 +95,7 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.92.v20160118</version>
+        <version>2.0.9.101.v20160316</version>
         <configuration>
         </configuration>
       </plugin>

--- a/managed_vms/static-files/pom.xml
+++ b/managed_vms/static-files/pom.xml
@@ -30,7 +30,7 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.95.v20160203</version>
+        <version>2.0.9.101.v20160316</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/managed_vms/twilio/pom.xml
+++ b/managed_vms/twilio/pom.xml
@@ -37,7 +37,7 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.95.v20160203</version>
+        <version>2.0.9.101.v20160316</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/java-docs-samples/issues/126.

I used this script, slightly modified from one Shun sent out to work on my Linux workstation instead of Mac.

```
#!/bin/bash
# Copyright 2016 Google Inc.
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
# http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

# This script changes gcloud maven update for a list of pom.xml files.
# Usage:
#     update-gcloud-plugin.sh [new-version-number] [path/to/pom.xml] [another/pom.xml] ...
echo 'new version is:'$1
# search directory for pom
echo "${@:2}"
for path in "${@:2}"
do
  # Path must end in pom.xml.
  # http://stackoverflow.com/a/2172367/101923
  if [[ ! ( $path == */pom.xml ) ]] ; then
    >&2 echo "$path is not a pom.xml file."
    exit
  fi
  echo "Processing: $path"
  # find line number of groupId
  lineOfArtifactId=`grep -n '<artifactId>gcloud-maven-plugin</artifactId>' $path | cut -f1 -d:`
  echo $lineOfArtifactId
  lineOfVersion=$(($lineOfArtifactId+1))
  echo $lineOfVersion

  # sed
  sed -i "$lineOfVersion"'s:<version>.*</version>:<version>'"$1"'</version>:' $path
done
```

I used ZSH to get all the pom.xml files in subdirectories with`~/bin/update-gcloud.sh "2.0.9.101.v20160316" **/*/pom.xml`