### PR TITLE
Change Hello World compiler to Java 7.

### DIFF
--- a/managed_vms/helloworld/pom.xml
+++ b/managed_vms/helloworld/pom.xml
@@ -49,8 +49,8 @@
         <version>3.3</version>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
This sample is linked to from https://cloud.google.com/java/ as "App Engine flexible environment for Java 7" https://cloud.google.com/appengine/docs/flexible/java/hello-world. We should make sure it really is compatible with Java 7 by making sure we use that compiler instead of Java 8.