### PR TITLE
Limit Travis to master branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ env:
 before_install:
   - openssl aes-256-cbc -K $encrypted_37a4f399de75_key -iv $encrypted_37a4f399de75_iv -in service-account.json.enc -out service-account.json -d
 
-script: mvn verify -DskipTests=false
+script: mvn --batch-mode clean verify -DskipTests=false | egrep -v "(^\[INFO\] Download|^\[INFO\].*skipping)"
 after_success:
   - mvn clean cobertura:cobertura coveralls:report
+branches:
+  only:
+  - master


### PR DESCRIPTION
This will keep Travis from building twice for pull requests. (Currently
it builds once for the branch push and again for the pull request.)