### PR TITLE
Add sample for App Engine  Datastore setDistinct projection queries.

### DIFF
--- a/appengine/datastore/src/test/java/com/example/appengine/GuestbookStrongTest.java
+++ b/appengine/datastore/src/test/java/com/example/appengine/GuestbookStrongTest.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.example.time.testing.FakeClock;
 
-import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.appengine.tools.development.testing.LocalUserServiceTestConfig;
@@ -53,7 +52,6 @@ public class GuestbookStrongTest {
       .setEnvEmail("test@example.com")
       .setEnvAuthDomain("gmail.com");
 
-  private DatastoreService datastore;
   private FakeClock clock;
   private GuestbookStrong guestbookUnderTest;
 

--- a/appengine/datastore/src/test/java/com/example/appengine/GuestbookTest.java
+++ b/appengine/datastore/src/test/java/com/example/appengine/GuestbookTest.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.example.time.testing.FakeClock;
 
-import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.dev.HighRepJobPolicy;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
@@ -68,7 +67,6 @@ public class GuestbookTest {
       .setEnvEmail("test@example.com")
       .setEnvAuthDomain("gmail.com");
 
-  private DatastoreService datastore;
   private FakeClock clock;
   private Guestbook guestbookUnderTest;
 

--- a/appengine/datastore/src/test/java/com/example/appengine/ProjectionTest.java
+++ b/appengine/datastore/src/test/java/com/example/appengine/ProjectionTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.PropertyProjection;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.List;
+
+/**
+ * Unit tests to demonstrate App Engine Datastore projection queries.
+ */
+@RunWith(JUnit4.class)
+public class ProjectionTest {
+
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+          // Set no eventual consistency, that way queries return all results.
+          // https://cloud.google.com/appengine/docs/java/tools/localunittesting#Java_Writing_High_Replication_Datastore_tests
+          new LocalDatastoreServiceTestConfig()
+              .setDefaultHighRepJobPolicyUnappliedJobPercentage(0));
+
+  private DatastoreService datastore;
+
+  @Before
+  public void setUp() throws Exception {
+    helper.setUp();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+
+  @Test
+  public void projectionQuery_grouping_filtersDuplicates() {
+    putTestData("some duplicate", 0L);
+    putTestData("some duplicate", 0L);
+    putTestData("too big", 1L);
+
+    Query q = new Query("TestKind");
+    q.addProjection(new PropertyProjection("A", String.class));
+    q.addProjection(new PropertyProjection("B", Long.class));
+    q.setDistinct(true);
+    q.setFilter(Query.FilterOperator.LESS_THAN.of("B", 1L));
+    q.addSort("B", Query.SortDirection.DESCENDING);
+    q.addSort("A");
+
+    List<Entity> entities =
+        datastore.prepare(q).asList(FetchOptions.Builder.withLimit(5));
+    assertThat(entities).hasSize(1);
+    // [START_EXCLUDE silent]
+    Entity entity = entities.get(0);
+    assertThat((String) entity.getProperty("A")).named("entity.A").isEqualTo("some duplicate");
+    assertThat((long) entity.getProperty("B")).named("entity.B").isEqualTo(0L);
+    // [END_EXCLUDE]
+  }
+
+  private void putTestData(String a, long b) {
+    Entity entity = new Entity("TestKind");
+    entity.setProperty("A", a);
+    entity.setProperty("B", b);
+    datastore.put(entity);
+  }
+}

--- a/java-repo-tools/google-checks.xml
+++ b/java-repo-tools/google-checks.xml
@@ -121,13 +121,13 @@
              value="Member name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="ParameterName">
-            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
             <message key="name.invalidPattern"
              value="Parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="LocalVariableName">
             <property name="tokens" value="VARIABLE_DEF"/>
-            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
             <property name="allowOneCharVarInForLoop" value="true"/>
             <message key="name.invalidPattern"
              value="Local variable name ''{0}'' must match pattern ''{1}''."/>


### PR DESCRIPTION
Also update checkstyle to allow 1-letter variable names, since it
doesn't make sense to give long names to something like "arbitrary
column A that doesn't actually mean anything".