### PR TITLE
Allow Travis to continue build if decryption fails. [DO NOT MERGE]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,16 @@
 language: java
 jdk:
   - oraclejdk8
-env:
-  - GOOGLE_APPLICATION_CREDENTIALS=$TRAVIS_BUILD_DIR/service-account.json GCLOUD_PROJECT=cloud-samples-tests
 before_install:
   - openssl aes-256-cbc -K $encrypted_37a4f399de75_key -iv $encrypted_37a4f399de75_iv -in service-account.json.enc -out service-account.json -d
-
-script: mvn --batch-mode clean verify -DskipTests=false | egrep -v "(^\[INFO\] Download|^\[INFO\].*skipping)"
+        && export GOOGLE_APPLICATION_CREDENTIALS=$TRAVIS_BUILD_DIR/service-account.json GCLOUD_PROJECT=cloud-samples-tests
+        || true
+# Skip the install step, since Maven will download the dependencies we need
+# when the test build runs.
+# http://stackoverflow.com/q/31945809/101923
+# https://docs.travis-ci.com/user/customizing-the-build/#Skipping-the-Installation-Step
+install: true
+script: ./travis.sh
 after_success:
   - mvn clean cobertura:cobertura coveralls:report
 branches:

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+# Set pipefail so that `egrep` does not eat the exit code.
+set -o pipefail
+
+SKIP_TESTS=false
+if [ -z "$GOOGLE_APPLICATION_CREDENTIALS"]; then
+  SKIP_TESTS=true
+fi
+mvn --batch-mode clean verify -DskipTests=$SKIP_TESTS | egrep -v "(^\[INFO\] Download|^\[INFO\].*skipping)"
+


### PR DESCRIPTION
Decryption of the service key can fail if Travis is building from a fork instead of a branch.

Note: I'm doing this from a fork to see how far Travis gets with this change. It won't complete all the tests, as some make calls to services that require the service account credentials, but hopefully it at least gets past the build phase.