### PR TITLE
Use key name in Datastore snippet.

### DIFF
--- a/appengine/datastore/src/test/java/com/example/appengine/EntitiesTest.java
+++ b/appengine/datastore/src/test/java/com/example/appengine/EntitiesTest.java
@@ -72,7 +72,7 @@ public class EntitiesTest {
     // [START kind_example]
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
-    Entity employee = new Entity("Employee");
+    Entity employee = new Entity("Employee", "asalieri");
     employee.setProperty("firstName", "Antonio");
     employee.setProperty("lastName", "Salieri");
     employee.setProperty("hireDate", new Date());


### PR DESCRIPTION
Writers are using this snippet in a slightly different way, so it needs to include the key name instead of using the auto ID.