### PR TITLE
Exclude generated code files from code coverage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,11 @@ service-account.json
 .project
 .classpath
 .settings
+
+# Vim
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+Session.vim
+.netrwhist
+*~
+tags

--- a/java-repo-tools/pom.xml
+++ b/java-repo-tools/pom.xml
@@ -88,17 +88,29 @@ limitations under the License.
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.6</version>
+        <version>2.7</version>
         <configuration>
-          <outputDirectory>${basedir}/target</outputDirectory>
+          <!-- aggregated reports for multi-module projects -->
+          <aggregate>true</aggregate>
           <formats>
             <format>xml</format>
             <format>html</format>
           </formats>
           <format>xml</format>
+          <instrumentation>
+            <excludes>
+              <!--exclude>**/target/generated-classes/**/*</exclude-->
+              <exclude>**/*AutoValue_*</exclude>
+              <exclude>**/com/google/api/*</exclude> <!-- grpc protocol buffers -->
+              <exclude>**/com/google/rpc/*</exclude>
+              <exclude>**/com/google/type/*</exclude>
+              <exclude>**/com/google/cloud/speech/v1/*</exclude> <!-- speech API protocol buffers -->
+              <exclude>**/com/google/logging/type/*</exclude> <!-- logging API protocol buffers -->
+              <exclude>**/com/google/logging/v2/*</exclude>
+            </excludes>
+          </instrumentation>
           <maxmem>256m</maxmem>
-          <!-- aggregated reports for multi-module projects -->
-          <aggregate>true</aggregate>
+          <outputDirectory>${basedir}/target</outputDirectory>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
This was causing the Coveralls plugin to fail with "Source not found".