### PR TITLE
Datastore Samples: Change comment format for XML license header.

### DIFF
--- a/appengine/datastore/indexes-exploding/src/main/webapp/WEB-INF/datastore-indexes.xml
+++ b/appengine/datastore/indexes-exploding/src/main/webapp/WEB-INF/datastore-indexes.xml
@@ -1,21 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- [START_EXCLUDE silent] -->
-<!--
-  Copyright 2016 Google Inc. All Rights Reserved.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
--->
-<!-- [END_EXCLUDE] -->
+<!-- Copyright 2016 Google Inc. All Rights Reserved.                        -->
+<!--                                                                        -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License");        -->
+<!-- you may not use this file except in compliance with the License.       -->
+<!-- You may obtain a copy of the License at                                -->
+<!--                                                                        -->
+<!--       http://www.apache.org/licenses/LICENSE-2.0                       -->
+<!--                                                                        -->
+<!-- Unless required by applicable law or agreed to in writing, software    -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS,      -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or        -->
+<!-- implied. See the License for the specific language governing           -->
+<!-- permissions and limitations under the License.                         -->
 <datastore-indexes autoGenerate="false">
   <datastore-index kind="Widget">
     <property name="x" direction="asc" />

--- a/appengine/datastore/indexes/src/main/webapp/WEB-INF/datastore-indexes.xml
+++ b/appengine/datastore/indexes/src/main/webapp/WEB-INF/datastore-indexes.xml
@@ -1,23 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- [START_EXCLUDE silent] -->
-<!--
-  Copyright 2016 Google Inc. All Rights Reserved.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
--->
-<!-- [END_EXCLUDE] -->
-<!-- The autoGenerate attribute can be true or false. We set it to false to
-     allow verification that the index is correct in local tests. -->
+<!-- Copyright 2016 Google Inc. All Rights Reserved.                        -->
+<!--                                                                        -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License");        -->
+<!-- you may not use this file except in compliance with the License.       -->
+<!-- You may obtain a copy of the License at                                -->
+<!--                                                                        -->
+<!--       http://www.apache.org/licenses/LICENSE-2.0                       -->
+<!--                                                                        -->
+<!-- Unless required by applicable law or agreed to in writing, software    -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS,      -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or        -->
+<!-- implied. See the License for the specific language governing           -->
+<!-- permissions and limitations under the License.                         -->
+<!--                                                                        -->
+<!-- The autoGenerate attribute can be true or false. We set it to false to -->
+<!-- allow verification that the index is correct in local tests.           -->
 <datastore-indexes autoGenerate="false">
   <datastore-index kind="Widget" ancestor="false" source="manual">
     <property name="x" direction="asc"/>


### PR DESCRIPTION
Makes it easier to filter with regex, since we can't put a region tag before
the  definition.