### PR TITLE
Add App Engine Hello World to devserver tests.

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -26,6 +26,7 @@ mvn --batch-mode clean verify -DskipTests=$SKIP_TESTS | egrep -v "(^\[INFO\] Dow
 
 # Run tests using App Engine local devserver.
 devserver_tests=(
+    appengine/helloworld
     appengine/datastore/geo
     appengine/datastore/indexes
     appengine/datastore/indexes-exploding


### PR DESCRIPTION
This is the first step in e2e testing the user journey for the [App
Engine quickstart][ae-quickstart].

This will verify that the App Engine Maven plugin works in this sample.

[ae-quickstart]: https://cloud.google.com/appengine/docs/java/quickstart