### PR TITLE
 Used CMD instead of ENTRYPOINT to set default runtime args

### DIFF
--- a/managed_vms/sparkjava/src/main/appengine/Dockerfile
+++ b/managed_vms/sparkjava/src/main/appengine/Dockerfile
@@ -1,4 +1,4 @@
 FROM gcr.io/google_appengine/openjdk8
 VOLUME /tmp
 ADD managed-vms-spark-1.0-jar-with-dependencies.jar app.jar
-ENTRYPOINT [ "java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+CMD [ "java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]


### PR DESCRIPTION
Using the ENTRYPOINT directive here would override the settings from the base docker image, breaking the configuration of the cloud debugger. Instead, CMD is the proper directive to use here to specify runtime arguments.