### PR TITLE
App Engine standard env uses Java Servlets 2.5.

### DIFF
--- a/appengine/analytics/pom.xml
+++ b/appengine/analytics/pom.xml
@@ -39,8 +39,8 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <artifactId>servlet-api</artifactId>
+      <version>2.5</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>

--- a/appengine/mailgun/pom.xml
+++ b/appengine/mailgun/pom.xml
@@ -28,8 +28,8 @@
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <artifactId>servlet-api</artifactId>
+      <version>2.5</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>

--- a/appengine/mailjet/pom.xml
+++ b/appengine/mailjet/pom.xml
@@ -35,8 +35,8 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <artifactId>servlet-api</artifactId>
+      <version>2.5</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>

--- a/appengine/memcache/pom.xml
+++ b/appengine/memcache/pom.xml
@@ -30,8 +30,8 @@ Copyright 2015 Google Inc. All Rights Reserved.
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <artifactId>servlet-api</artifactId>
+      <version>2.5</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>

--- a/appengine/remote/remote-server/pom.xml
+++ b/appengine/remote/remote-server/pom.xml
@@ -39,8 +39,8 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <artifactId>servlet-api</artifactId>
+      <version>2.5</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>

--- a/appengine/sendgrid/pom.xml
+++ b/appengine/sendgrid/pom.xml
@@ -30,8 +30,8 @@ Copyright 2015 Google Inc. All Rights Reserved.
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <artifactId>servlet-api</artifactId>
+      <version>2.5</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>

--- a/appengine/sendgrid/src/main/java/com/example/appengine/sendgrid/SendEmailServlet.java
+++ b/appengine/sendgrid/src/main/java/com/example/appengine/sendgrid/SendEmailServlet.java
@@ -22,14 +22,12 @@ import com.sendgrid.SendGridException;
 import java.io.IOException;
 
 import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 // [START example]
 @SuppressWarnings("serial")
-@WebServlet(name = "sendemail", value = "/send/email")
 public class SendEmailServlet extends HttpServlet {
 
   @Override

--- a/appengine/twilio/pom.xml
+++ b/appengine/twilio/pom.xml
@@ -37,8 +37,8 @@ Copyright 2015 Google Inc. All Rights Reserved.
     <!-- [END dependencies] -->
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <artifactId>servlet-api</artifactId>
+      <version>2.5</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>

--- a/appengine/twilio/src/main/java/com/example/appengine/twilio/SendSmsServlet.java
+++ b/appengine/twilio/src/main/java/com/example/appengine/twilio/SendSmsServlet.java
@@ -29,14 +29,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 // [START example]
 @SuppressWarnings("serial")
-@WebServlet(name = "sendsms", value = "/sms/send")
 public class SendSmsServlet extends HttpServlet {
 
   @Override


### PR DESCRIPTION
According to:
https://cloud.google.com/appengine/docs/java/runtime#Java_Introduction

"App Engine uses the Java Servlet 2.5 standard for web applications."

This updates these samples to use version 2.5. Annotations are not
supported. I see that the SendGrid servlet already has a web.xml
defined, so the annotation were redundant, anyway (and not functional).