### PR TITLE
Stop hardcoding Netty dependency so example works on Android

### DIFF
--- a/speech/grpc/src/main/java/com/examples/cloud/speech/AsyncRecognizeClient.java
+++ b/speech/grpc/src/main/java/com/examples/cloud/speech/AsyncRecognizeClient.java
@@ -88,7 +88,7 @@ public class AsyncRecognizeClient {
     GoogleCredentials creds = GoogleCredentials.getApplicationDefault();
     creds = creds.createScoped(OAUTH2_SCOPES);
     ManagedChannel channel =
-        NettyChannelBuilder.forAddress(host, port)
+        ManagedChannelBuilder.forAddress(host, port)
             .negotiationType(NegotiationType.TLS)
             .intercept(new ClientAuthInterceptor(creds, Executors.newSingleThreadExecutor()))
             .build();

--- a/speech/grpc/src/main/java/com/examples/cloud/speech/AsyncRecognizeClient.java
+++ b/speech/grpc/src/main/java/com/examples/cloud/speech/AsyncRecognizeClient.java
@@ -29,6 +29,7 @@ import com.google.longrunning.Operation;
 import com.google.longrunning.OperationsGrpc;
 
 import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
 import io.grpc.auth.ClientAuthInterceptor;
 import io.grpc.netty.NegotiationType;


### PR DESCRIPTION
Using ManagedChannelBuilder allows GRPC to auto-detect the best transport for the runtime environment on which this code will run.