### PR TITLE
Update dependencies for Speech sample.

### DIFF
--- a/speech/grpc/bin/speech-sample-async.sh
+++ b/speech/grpc/bin/speech-sample-async.sh
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SRC_DIR=$(cd "$(dirname "$0")/.."; pwd)
+SRC_DIR="$( cd "$( dirname "$0" )/.." && pwd )"
 java -cp "${SRC_DIR}/target/grpc-sample-1.0-jar-with-dependencies.jar" \
     com.examples.cloud.speech.AsyncRecognizeClient "$@"

--- a/speech/grpc/bin/speech-sample-streaming.sh
+++ b/speech/grpc/bin/speech-sample-streaming.sh
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SRC_DIR=$(cd "$(dirname "$0")/.."; pwd)
+SRC_DIR="$( cd "$( dirname "$0" )/.." && pwd )"
 java -cp "${SRC_DIR}/target/grpc-sample-1.0-jar-with-dependencies.jar" \
     com.examples.cloud.speech.StreamingRecognizeClient "$@"

--- a/speech/grpc/bin/speech-sample-sync.sh
+++ b/speech/grpc/bin/speech-sample-sync.sh
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SRC_DIR=$(cd "$(dirname "$0")/.."; pwd)
+SRC_DIR="$( cd "$( dirname "$0" )/.." && pwd )"
 java -cp "${SRC_DIR}/target/grpc-sample-1.0-jar-with-dependencies.jar" \
     com.examples.cloud.speech.SyncRecognizeClient "$@"

--- a/speech/grpc/pom.xml
+++ b/speech/grpc/pom.xml
@@ -124,6 +124,19 @@ limitations under the License.
       <version>1.3.1</version>
     </dependency>
     <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <version>0.4.0</version>
+      <exclusions>
+        <!-- Exclude an old version of guava that is being pulled
+        in by a transitive dependency of google-api-client -->
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava-jdk5</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>19.0</version>
@@ -131,12 +144,7 @@ limitations under the License.
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-all</artifactId>
-      <version>0.13.2</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.oauth-client</groupId>
-      <artifactId>google-oauth-client</artifactId>
-      <version>1.21.0</version>
+      <version>0.15.0</version>
     </dependency>
     <dependency>
       <!--
@@ -149,13 +157,13 @@ limitations under the License.
       -->
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>1.1.33.Fork14</version>
+      <version>1.1.33.Fork20</version>
       <classifier>${tcnative.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.28</version>
+      <version>0.29</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/speech/grpc/src/main/java/com/examples/cloud/speech/AsyncRecognizeClient.java
+++ b/speech/grpc/src/main/java/com/examples/cloud/speech/AsyncRecognizeClient.java
@@ -23,7 +23,6 @@ import com.google.cloud.speech.v1beta1.RecognitionAudio;
 import com.google.cloud.speech.v1beta1.RecognitionConfig;
 import com.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding;
 import com.google.cloud.speech.v1beta1.SpeechGrpc;
-
 import com.google.longrunning.GetOperationRequest;
 import com.google.longrunning.Operation;
 import com.google.longrunning.OperationsGrpc;
@@ -33,7 +32,6 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.auth.ClientAuthInterceptor;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;


### PR DESCRIPTION
Also, fix shell-check warnings in scripts.

Switches to the auth library recommended in the grpc documentation.
There was an old version of Guava being included from this, which I had
to exclude from the pom.

FYI @puneith 

@lesv Please take a look.