### PR TITLE
Move plugin version definitions to properties.

### DIFF
--- a/appengine/analytics/pom.xml
+++ b/appengine/analytics/pom.xml
@@ -27,6 +27,12 @@
     <relativePath>../..</relativePath>
   </parent>
   <!-- Parent POM defines ${appengine.sdk.version} (updates frequently). -->
+
+  <properties>
+    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.google.appengine</groupId>
@@ -54,15 +60,6 @@
         <groupId>com.google.appengine</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
         <version>${appengine.sdk.version}</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>3.3</version>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/appengine/appidentity/pom.xml
+++ b/appengine/appidentity/pom.xml
@@ -27,6 +27,10 @@
     <relativePath>../..</relativePath>
   </parent>
 
+  <properties>
+    <gcloud-maven-plugin-version>2.0.9.101.v20160316</gcloud-maven-plugin-version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.google.appengine</groupId>
@@ -96,7 +100,7 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.101.v20160316</version>
+        <version>${gcloud-maven-plugin-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/compute/error-reporting/pom.xml
+++ b/compute/error-reporting/pom.xml
@@ -1,17 +1,17 @@
 <!--
-Copyright 2016 Google Inc. All Rights Reserved.
+  Copyright 2016 Google Inc. All Rights Reserved.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
        http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 -->
 <project>
   <modelVersion>4.0.0</modelVersion>
@@ -19,6 +19,22 @@ Copyright 2016 Google Inc. All Rights Reserved.
   <version>1.0-SNAPSHOT</version>
   <groupId>com.example.compute</groupId>
   <artifactId>compute-error-reporting</artifactId>
+
+  <!-- TODO: Use common parent after fixing checkstyle errors.
+       https://github.com/GoogleCloudPlatform/java-docs-samples/issues/298
+  <parent>
+    <artifactId>doc-samples</artifactId>
+    <groupId>com.google.cloud</groupId>
+    <version>1.0.0</version>
+    <relativePath>../..</relativePath>
+  </parent>
+  -->
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven-assembly-plugin-version>2.6</maven-assembly-plugin-version>
+  </properties>
 
   <dependencies>
     <!-- [START dependencies] -->
@@ -33,6 +49,7 @@ Copyright 2016 Google Inc. All Rights Reserved.
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
+        <version>${maven-assembly-plugin-version}</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -50,15 +67,6 @@ Copyright 2016 Google Inc. All Rights Reserved.
           <descriptorRefs>
             <descriptorRef>jar-with-dependencies</descriptorRef>
           </descriptorRefs>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>3.3</version>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/compute/sendgrid/pom.xml
+++ b/compute/sendgrid/pom.xml
@@ -1,17 +1,17 @@
 <!--
-Copyright 2016 Google Inc. All Rights Reserved.
+  Copyright 2016 Google Inc. All Rights Reserved.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
        http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 -->
 <project>
   <modelVersion>4.0.0</modelVersion>
@@ -19,6 +19,22 @@ Copyright 2016 Google Inc. All Rights Reserved.
   <version>1.0-SNAPSHOT</version>
   <groupId>com.example.compute</groupId>
   <artifactId>compute-sendgrid</artifactId>
+
+  <!-- TODO: Use common parent after fixing checkstyle errors.
+       https://github.com/GoogleCloudPlatform/java-docs-samples/issues/298
+  <parent>
+    <artifactId>doc-samples</artifactId>
+    <groupId>com.google.cloud</groupId>
+    <version>1.0.0</version>
+    <relativePath>../..</relativePath>
+  </parent>
+  -->
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven-assembly-plugin-version>2.6</maven-assembly-plugin-version>
+  </properties>
 
   <dependencies>
     <!-- [START dependencies] -->
@@ -33,6 +49,7 @@ Copyright 2016 Google Inc. All Rights Reserved.
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
+        <version>${maven-assembly-plugin-version}</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -50,15 +67,6 @@ Copyright 2016 Google Inc. All Rights Reserved.
           <descriptorRefs>
             <descriptorRef>jar-with-dependencies</descriptorRef>
           </descriptorRefs>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>3.3</version>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/java-repo-tools/pom.xml
+++ b/java-repo-tools/pom.xml
@@ -24,6 +24,16 @@ limitations under the License.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <codehaus-versions-maven-plugin-version>2.2</codehaus-versions-maven-plugin-version>
+    <jacoco-maven-plugin-version>0.7.6.201602180812</jacoco-maven-plugin-version>
+    <maven-clean-plugin-version>3.0.0</maven-clean-plugin-version>
+    <maven-checkstyle-plugin-version>2.17</maven-checkstyle-plugin-version>
+    <maven-deploy-plugin-version>2.8.2</maven-deploy-plugin-version>
+    <maven-failsafe-plugin-version>2.19.1</maven-failsafe-plugin-version>
+    <maven-install-plugin-version>2.5.2</maven-install-plugin-version>
+    <maven-resources-plugin-version>2.7</maven-resources-plugin-version>
+    <maven-site-plugin-version>3.5.1</maven-site-plugin-version>
+    <maven-surefire-plugin-version>2.19.1</maven-surefire-plugin-version>
   </properties>
 
   <prerequisites>
@@ -40,7 +50,7 @@ limitations under the License.
         <!-- Unit tests -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
+        <version>${maven-surefire-plugin-version}</version>
         <configuration>
           <trimStackTrace>false</trimStackTrace>
         </configuration>
@@ -49,7 +59,7 @@ limitations under the License.
         <!-- Integration / system tests -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.19.1</version>
+        <version>${maven-failsafe-plugin-version}</version>
         <executions>
           <execution>
             <goals>
@@ -62,7 +72,7 @@ limitations under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.17</version>
+        <version>${maven-checkstyle-plugin-version}</version>
         <configuration>
           <configLocation>google-checks.xml</configLocation>
           <consoleOutput>true</consoleOutput>
@@ -78,12 +88,12 @@ limitations under the License.
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.2</version>
+        <version>${codehaus-versions-maven-plugin-version}</version>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.6.201602180812</version>
+        <version>${jacoco-maven-plugin-version}</version>
         <executions>
           <execution>
             <goals>

--- a/managed_vms/analytics/pom.xml
+++ b/managed_vms/analytics/pom.xml
@@ -1,6 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<!--
+  Copyright 2016 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project>
   <modelVersion>4.0.0</modelVersion>
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
@@ -13,6 +26,14 @@
     <version>1.0.0</version>
     <relativePath>../..</relativePath>
   </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven-war-plugin-version>2.6</maven-war-plugin-version>
+    <gcloud-maven-plugin-version>2.0.9.106.v20160420</gcloud-maven-plugin-version>
+    <jetty-maven-plugin-version>9.3.7.v20160115</jetty-maven-plugin-version>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -35,29 +56,20 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.106.v20160420</version>
+        <version>${gcloud-maven-plugin-version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.6</version>
+        <version>${maven-war-plugin-version}</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>3.3</version>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.3.7.v20160115</version>
+        <version>${jetty-maven-plugin-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/managed_vms/cloudsql/pom.xml
+++ b/managed_vms/cloudsql/pom.xml
@@ -1,18 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright 2016 Google Inc. All Rights Reserved.
+  Copyright 2016 Google Inc. All Rights Reserved.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
        http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 -->
 <project>
   <modelVersion>4.0.0</modelVersion>
@@ -27,6 +26,14 @@ Copyright 2016 Google Inc. All Rights Reserved.
     <version>1.0.0</version>
     <relativePath>../..</relativePath>
   </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven-war-plugin-version>2.6</maven-war-plugin-version>
+    <gcloud-maven-plugin-version>2.0.9.106.v20160420</gcloud-maven-plugin-version>
+    <jetty-maven-plugin-version>9.3.7.v20160115</jetty-maven-plugin-version>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -51,29 +58,20 @@ Copyright 2016 Google Inc. All Rights Reserved.
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>${maven.plugin.version}</version>
+        <version>${gcloud-maven-plugin-version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.6</version>
+        <version>${maven-war-plugin-version}</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.3.7.v20160115</version>
+        <version>${jetty-maven-plugin-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/managed_vms/cloudstorage/pom.xml
+++ b/managed_vms/cloudstorage/pom.xml
@@ -1,6 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<!--
+  Copyright 2016 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project>
   <modelVersion>4.0.0</modelVersion>
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
@@ -13,6 +26,14 @@
     <version>1.0.0</version>
     <relativePath>../..</relativePath>
   </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven-war-plugin-version>2.6</maven-war-plugin-version>
+    <gcloud-maven-plugin-version>2.0.9.106.v20160420</gcloud-maven-plugin-version>
+    <jetty-maven-plugin-version>9.3.7.v20160115</jetty-maven-plugin-version>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -37,29 +58,20 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.106.v20160420</version>
+        <version>${gcloud-maven-plugin-version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.6</version>
+        <version>${maven-war-plugin-version}</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.3.7.v20160115</version>
+        <version>${jetty-maven-plugin-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/managed_vms/cron/pom.xml
+++ b/managed_vms/cron/pom.xml
@@ -1,7 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<!--
+  Copyright 2016 Google Inc. All Rights Reserved.
 
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project>
   <modelVersion>4.0.0</modelVersion>
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
@@ -14,6 +26,14 @@
     <version>1.0.0</version>
     <relativePath>../..</relativePath>
   </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven-war-plugin-version>2.6</maven-war-plugin-version>
+    <gcloud-maven-plugin-version>2.0.9.106.v20160420</gcloud-maven-plugin-version>
+    <jetty-maven-plugin-version>9.3.7.v20160115</jetty-maven-plugin-version>
+  </properties>
 
   <!-- [START dependencies] -->
   <dependencies>
@@ -34,29 +54,20 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.106.v20160420</version>
+        <version>${gcloud-maven-plugin-version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.6</version>
+        <version>${maven-war-plugin-version}</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>3.3</version>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.3.7.v20160115</version>
+        <version>${jetty-maven-plugin-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/managed_vms/datastore/pom.xml
+++ b/managed_vms/datastore/pom.xml
@@ -1,6 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<!--
+  Copyright 2016 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project>
   <modelVersion>4.0.0</modelVersion>
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
@@ -13,6 +26,14 @@
     <version>1.0.0</version>
     <relativePath>../..</relativePath>
   </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven-war-plugin-version>2.6</maven-war-plugin-version>
+    <gcloud-maven-plugin-version>2.0.9.106.v20160420</gcloud-maven-plugin-version>
+    <jetty-maven-plugin-version>9.3.7.v20160115</jetty-maven-plugin-version>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -37,29 +58,20 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.106.v20160420</version>
+        <version>${gcloud-maven-plugin-version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.6</version>
+        <version>${maven-war-plugin-version}</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.3.7.v20160115</version>
+        <version>${jetty-maven-plugin-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/managed_vms/disk/pom.xml
+++ b/managed_vms/disk/pom.xml
@@ -1,6 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<!--
+  Copyright 2016 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project>
   <modelVersion>4.0.0</modelVersion>
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
@@ -13,6 +26,14 @@
     <version>1.0.0</version>
     <relativePath>../..</relativePath>
   </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven-war-plugin-version>2.6</maven-war-plugin-version>
+    <gcloud-maven-plugin-version>2.0.9.106.v20160420</gcloud-maven-plugin-version>
+    <jetty-maven-plugin-version>9.3.7.v20160115</jetty-maven-plugin-version>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -30,29 +51,20 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.106.v20160420</version>
+        <version>${gcloud-maven-plugin-version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.6</version>
+        <version>${maven-war-plugin-version}</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>3.3</version>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.3.7.v20160115</version>
+        <version>${jetty-maven-plugin-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/managed_vms/extending-runtime/pom.xml
+++ b/managed_vms/extending-runtime/pom.xml
@@ -1,6 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<!--
+  Copyright 2016 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project>
   <modelVersion>4.0.0</modelVersion>
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
@@ -13,6 +26,14 @@
     <version>1.0.0</version>
     <relativePath>../..</relativePath>
   </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven-war-plugin-version>2.6</maven-war-plugin-version>
+    <gcloud-maven-plugin-version>2.0.9.106.v20160420</gcloud-maven-plugin-version>
+    <jetty-maven-plugin-version>9.3.7.v20160115</jetty-maven-plugin-version>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -30,29 +51,20 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.106.v20160420</version>
+        <version>${gcloud-maven-plugin-version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.6</version>
+        <version>${maven-war-plugin-version}</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>3.3</version>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.3.7.v20160115</version>
+        <version>${jetty-maven-plugin-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/managed_vms/helloworld/pom.xml
+++ b/managed_vms/helloworld/pom.xml
@@ -1,7 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<!--
+  Copyright 2016 Google Inc. All Rights Reserved.
 
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project>
   <modelVersion>4.0.0</modelVersion>
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
@@ -14,6 +26,14 @@
     <version>1.0.0</version>
     <relativePath>../..</relativePath>
   </parent>
+
+  <properties>
+    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven-war-plugin-version>2.6</maven-war-plugin-version>
+    <gcloud-maven-plugin-version>2.0.9.106.v20160420</gcloud-maven-plugin-version>
+    <jetty-maven-plugin-version>9.3.7.v20160115</jetty-maven-plugin-version>
+  </properties>
 
   <!-- [START dependencies] -->
   <dependencies>
@@ -34,29 +54,20 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.106.v20160420</version>
+        <version>${gcloud-maven-plugin-version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.6</version>
+        <version>${maven-war-plugin-version}</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>3.3</version>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.3.7.v20160115</version>
+        <version>${jetty-maven-plugin-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/managed_vms/mailgun/pom.xml
+++ b/managed_vms/mailgun/pom.xml
@@ -1,6 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<!--
+  Copyright 2016 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project>
   <modelVersion>4.0.0</modelVersion>
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
@@ -13,6 +26,14 @@
     <version>1.0.0</version>
     <relativePath>../..</relativePath>
   </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven-war-plugin-version>2.6</maven-war-plugin-version>
+    <gcloud-maven-plugin-version>2.0.9.106.v20160420</gcloud-maven-plugin-version>
+    <jetty-maven-plugin-version>9.3.7.v20160115</jetty-maven-plugin-version>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -47,29 +68,20 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.106.v20160420</version>
+        <version>${gcloud-maven-plugin-version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.6</version>
+        <version>${maven-war-plugin-version}</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>3.3</version>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.3.7.v20160115</version>
+        <version>${jetty-maven-plugin-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/managed_vms/mailjet/pom.xml
+++ b/managed_vms/mailjet/pom.xml
@@ -1,17 +1,17 @@
 <!--
- Copyright 2015 Google Inc. All Rights Reserved.
+  Copyright 2016 Google Inc. All Rights Reserved.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
        http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 -->
 <project>
   <modelVersion>4.0.0</modelVersion>
@@ -19,12 +19,21 @@
   <version>1.0-SNAPSHOT</version>
   <groupId>com.example.managedvms</groupId>
   <artifactId>managed-vms-mailjet</artifactId>
+
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>doc-samples</artifactId>
     <version>1.0.0</version>
     <relativePath>../..</relativePath>
   </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven-war-plugin-version>2.6</maven-war-plugin-version>
+    <gcloud-maven-plugin-version>2.0.9.106.v20160420</gcloud-maven-plugin-version>
+    <jetty-maven-plugin-version>9.3.7.v20160115</jetty-maven-plugin-version>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -49,29 +58,20 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.106.v20160420</version>
+        <version>${gcloud-maven-plugin-version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.6</version>
+        <version>${maven-war-plugin-version}</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>3.3</version>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.3.7.v20160115</version>
+        <version>${jetty-maven-plugin-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/managed_vms/memcache/pom.xml
+++ b/managed_vms/memcache/pom.xml
@@ -1,6 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<!--
+  Copyright 2016 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project>
   <modelVersion>4.0.0</modelVersion>
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
@@ -13,6 +26,14 @@
     <version>1.0.0</version>
     <relativePath>../..</relativePath>
   </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven-war-plugin-version>2.6</maven-war-plugin-version>
+    <gcloud-maven-plugin-version>2.0.9.106.v20160420</gcloud-maven-plugin-version>
+    <jetty-maven-plugin-version>9.3.7.v20160115</jetty-maven-plugin-version>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -37,29 +58,20 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.106.v20160420</version>
+        <version>${gcloud-maven-plugin-version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.6</version>
+        <version>${maven-war-plugin-version}</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.3.7.v20160115</version>
+        <version>${jetty-maven-plugin-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/managed_vms/sendgrid/pom.xml
+++ b/managed_vms/sendgrid/pom.xml
@@ -1,6 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<!--
+  Copyright 2016 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project>
   <modelVersion>4.0.0</modelVersion>
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
@@ -13,6 +26,14 @@
     <version>1.0.0</version>
     <relativePath>../..</relativePath>
   </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven-war-plugin-version>2.6</maven-war-plugin-version>
+    <gcloud-maven-plugin-version>2.0.9.106.v20160420</gcloud-maven-plugin-version>
+    <jetty-maven-plugin-version>9.3.7.v20160115</jetty-maven-plugin-version>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -37,29 +58,20 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.106.v20160420</version>
+        <version>${gcloud-maven-plugin-version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.6</version>
+        <version>${maven-war-plugin-version}</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>3.3</version>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.3.7.v20160115</version>
+        <version>${jetty-maven-plugin-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/managed_vms/static-files/pom.xml
+++ b/managed_vms/static-files/pom.xml
@@ -1,6 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<!--
+  Copyright 2016 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project>
   <modelVersion>4.0.0</modelVersion>
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
@@ -13,6 +26,14 @@
     <version>1.0.0</version>
     <relativePath>../..</relativePath>
   </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven-war-plugin-version>2.6</maven-war-plugin-version>
+    <gcloud-maven-plugin-version>2.0.9.106.v20160420</gcloud-maven-plugin-version>
+    <jetty-maven-plugin-version>9.3.7.v20160115</jetty-maven-plugin-version>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -30,29 +51,20 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.106.v20160420</version>
+        <version>${gcloud-maven-plugin-version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.6</version>
+        <version>${maven-war-plugin-version}</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>3.3</version>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.3.7.v20160115</version>
+        <version>${jetty-maven-plugin-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/managed_vms/twilio/pom.xml
+++ b/managed_vms/twilio/pom.xml
@@ -1,6 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<!--
+  Copyright 2016 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project>
   <modelVersion>4.0.0</modelVersion>
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>
@@ -13,6 +26,15 @@
     <version>1.0.0</version>
     <relativePath>../..</relativePath>
   </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <gcloud-maven-plugin-version>2.0.9.106.v20160420</gcloud-maven-plugin-version>
+    <jetty-maven-plugin-version>9.3.7.v20160115</jetty-maven-plugin-version>
+    <maven-war-plugin-version>2.6</maven-war-plugin-version>
+    <maven-surefire-plugin-version>2.19.1</maven-surefire-plugin-version>
+  </properties>
 
   <dependencies>
     <!-- [START dependencies] -->
@@ -37,29 +59,20 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.106.v20160420</version>
+        <version>${gcloud-maven-plugin-version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.6</version>
+        <version>${maven-war-plugin-version}</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>3.3</version>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.3.7.v20160115</version>
+        <version>${jetty-maven-plugin-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/monitoring/v3/pom.xml
+++ b/monitoring/v3/pom.xml
@@ -1,6 +1,19 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<!--
+  Copyright 2016 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.google.cloud.monotoring.samples</groupId>
     <artifactId>cloud-monitoring-v3-samples</artifactId>
@@ -15,6 +28,8 @@
     </parent>
 
     <properties>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
         <project.http.version>1.19.0</project.http.version>
         <project.oauth.version>1.19.0</project.oauth.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -87,17 +102,9 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.3.2</version>
-                    <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.4.2</version>
+                    <version>${maven-surefire-plugin-version}</version>
                     <configuration>
                         <skipTests>${skipTests}</skipTests>
                     </configuration>

--- a/speech/grpc/pom.xml
+++ b/speech/grpc/pom.xml
@@ -48,6 +48,9 @@ limitations under the License.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <codehaus-versions-maven-plugin-version>2.2</codehaus-versions-maven-plugin-version>
+    <maven-compiler-plugin-version>3.1</maven-compiler-plugin-version>
+    <xolstice-protobuf-maven-plugin-version>0.5.0</xolstice-protobuf-maven-plugin-version>
   </properties>
 
   <profiles>
@@ -205,7 +208,7 @@ limitations under the License.
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
-        <version>0.5.0</version>
+        <version>${xolstice-protobuf-maven-plugin-version}</version>
         <configuration>
           <!--
             The version of protoc must match protobuf-java. If you
@@ -230,7 +233,7 @@ limitations under the License.
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.1</version>
+        <version>${codehaus-versions-maven-plugin-version}</version>
         <executions>
           <execution>
             <phase>compile</phase>
@@ -242,7 +245,7 @@ limitations under the License.
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>${maven-compiler-plugin-version}</version>
         <configuration>
           <source>${jdk.version}</source>
           <target>${jdk.version}</target>

--- a/storage/xml-api/cmdline-sample/pom.xml
+++ b/storage/xml-api/cmdline-sample/pom.xml
@@ -1,5 +1,24 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2016 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.apis-samples</groupId>
+  <artifactId>storage-xml-cmdline-sample</artifactId>
+  <version>1</version>
+
   <parent>
     <artifactId>doc-samples</artifactId>
     <groupId>com.google.cloud</groupId>
@@ -7,17 +26,19 @@
     <relativePath>../../..</relativePath>
   </parent>
 
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>com.google.apis-samples</groupId>
-  <artifactId>storage-xml-cmdline-sample</artifactId>
-  <version>1</version>
-  <name>Example for the Google Cloud Storage XML API using Application Default Credentials.</name>
+  <properties>
+    <project.http.version>1.20.0</project.http.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <codehaus-exec-maven-plugin>1.1</codehaus-exec-maven-plugin>
+    <maven-compiler-plugin-version>3.2</maven-compiler-plugin-version>
+  </properties>
+
   <build>
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>1.1</version>
+        <version>${codehaus-exec-maven-plugin}</version>
         <executions>
           <execution>
             <goals>
@@ -32,7 +53,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
+        <version>${maven-compiler-plugin-version}</version>
         <configuration>
           <source>7</source>
           <target>7</target>
@@ -71,8 +92,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <properties>
-    <project.http.version>1.20.0</project.http.version>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
 </project>

--- a/storage/xml-api/serviceaccount-appengine-sample/pom.xml
+++ b/storage/xml-api/serviceaccount-appengine-sample/pom.xml
@@ -31,8 +31,8 @@
   <packaging>war</packaging>
 
   <properties>
-    <maven.compiler.target>1.6</maven.compiler.target>
-    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
     <google-api-client.version>1.21.0</google-api-client.version>
     <webappDirectory>${project.build.directory}/${project.build.finalName}
     </webappDirectory>

--- a/storage/xml-api/serviceaccount-appengine-sample/pom.xml
+++ b/storage/xml-api/serviceaccount-appengine-sample/pom.xml
@@ -1,5 +1,19 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<!--
+  Copyright 2016 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project>
   <modelVersion>4.0.0</modelVersion>
 
   <!-- Parent POM defines ${appengine.sdk.version} (updates frequently). -->
@@ -17,10 +31,15 @@
   <packaging>war</packaging>
 
   <properties>
+    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.6</maven.compiler.source>
     <google-api-client.version>1.21.0</google-api-client.version>
     <webappDirectory>${project.build.directory}/${project.build.finalName}
     </webappDirectory>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <codehaus-exec-maven-plugin-version>1.1</codehaus-exec-maven-plugin-version>
+    <codehaus-findbugs-maven-plugin-version>2.3.2</codehaus-findbugs-maven-plugin-version>
+    <maven-war-plugin-version>2.1.1</maven-war-plugin-version>
   </properties>
 
   <build>
@@ -29,18 +48,9 @@
 
     <plugins>
       <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
-        <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.1.1</version>
+        <version>${maven-war-plugin-version}</version>
         <executions>
           <execution>
             <phase>compile</phase>
@@ -56,7 +66,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>${codehaus-findbugs-maven-plugin-version}</version>
         <configuration>
           <failOnError>false</failOnError>
         </configuration>

--- a/taskqueue/deferred/pom.xml
+++ b/taskqueue/deferred/pom.xml
@@ -1,9 +1,24 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<!--
+  Copyright 2016 Google Inc. All Rights Reserved.
 
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project>
     <modelVersion>4.0.0</modelVersion>
     <packaging>war</packaging>
     <version>1.0-SNAPSHOT</version>
+    <groupId>com.google.cloud.taskqueue.samples</groupId>
+    <artifactId>taskqueue-defer-sample</artifactId>
 
     <!-- Parent POM defines ${appengine.sdk.version} (updates frequently). -->
     <parent>
@@ -13,8 +28,12 @@
         <relativePath>../..</relativePath>
     </parent>
 
-    <groupId>com.google.cloud.taskqueue.samples</groupId>
-    <artifactId>taskqueue-defer-sample</artifactId>
+    <properties>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <codehaus-versions-maven-plugin-version>2.1</codehaus-versions-maven-plugin-version>
+        <maven-war-plugin-version>2.4</maven-war-plugin-version>
+    </properties>
 
     <dependencies>
         <!-- Compile/runtime dependencies -->
@@ -57,7 +76,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.1</version>
+                <version>${codehaus-versions-maven-plugin-version}</version>
                 <executions>
                     <execution>
                         <phase>compile</phase>
@@ -68,20 +87,11 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <version>3.1</version>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.4</version>
+                <version>${maven-war-plugin-version}</version>
                 <configuration>
                     <archiveClasses>true</archiveClasses>
                     <webResources>

--- a/unittests/pom.xml
+++ b/unittests/pom.xml
@@ -16,6 +16,14 @@
     <groupId>com.google.appengine.samples</groupId>
     <artifactId>unittests-appengine-local-testing-samples</artifactId>
 
+    <properties>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven-war-plugin-version>2.6</maven-war-plugin-version>
+        <maven-compiler-plugin-version>2.5.1</maven-compiler-plugin-version>
+    </properties>
+
     <dependencies>
         <!-- Compile/runtime dependencies -->
         <dependency>
@@ -64,18 +72,8 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <version>2.5.1</version>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.3</version>
+                <version>${maven-war-plugin-version}</version>
                 <configuration>
                     <archiveClasses>true</archiveClasses>
                     <webResources>

--- a/vision/face-detection/pom.xml
+++ b/vision/face-detection/pom.xml
@@ -30,8 +30,8 @@
   </parent>
 
   <properties>
-    <maven.compiler.target>1.7</maven.compiler.target>
-    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
 
   <dependencies>

--- a/vision/face-detection/pom.xml
+++ b/vision/face-detection/pom.xml
@@ -29,6 +29,11 @@
     <relativePath>../..</relativePath>
   </parent>
 
+  <properties>
+    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+  </properties>
+
   <dependencies>
     <!-- [START dependencies] -->
     <dependency>
@@ -71,15 +76,6 @@
   </dependencies>
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>3.3</version>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/vision/label/pom.xml
+++ b/vision/label/pom.xml
@@ -30,8 +30,8 @@
   </parent>
 
   <properties>
-    <maven.compiler.target>1.7</maven.compiler.target>
-    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
 
   <dependencies>

--- a/vision/label/pom.xml
+++ b/vision/label/pom.xml
@@ -29,6 +29,11 @@
     <relativePath>../..</relativePath>
   </parent>
 
+  <properties>
+    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.google.apis</groupId>

--- a/vision/landmark-detection/pom.xml
+++ b/vision/landmark-detection/pom.xml
@@ -30,8 +30,8 @@
   </parent>
 
   <properties>
-    <maven.compiler.target>1.7</maven.compiler.target>
-    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
 
   <dependencies>

--- a/vision/landmark-detection/pom.xml
+++ b/vision/landmark-detection/pom.xml
@@ -29,6 +29,11 @@
     <relativePath>../..</relativePath>
   </parent>
 
+  <properties>
+    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.google.apis</groupId>
@@ -69,15 +74,6 @@
   </dependencies>
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>3.3</version>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/vision/text/pom.xml
+++ b/vision/text/pom.xml
@@ -29,6 +29,11 @@
     <relativePath>../..</relativePath>
   </parent>
 
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.google.apis</groupId>
@@ -85,15 +90,6 @@
   </dependencies>
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>3.3</version>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
This a workaround for a missing feature in the codehaus versions maven
plugin where is cannot update plugins directly, but it can detect when
there are new plugins and update the related properties. https://github.com/mojohaus/versions-maven-plugin/issues/8#issuecomment-225593578

I don't actually update anything (or I tried not to, anyway). I'll get dpebot to do that.

@lesv