### PR TITLE
BigQuery query samples: command line parameters.

### DIFF
--- a/bigquery/README.md
+++ b/bigquery/README.md
@@ -1,6 +1,11 @@
 # Getting Started with BigQuery and the Google Java API Client library
 
-Google's BigQuery Service features a REST-based API that allows developers to create applications to run ad-hoc queries on massive datasets. These sample Java applications demonstrate how to access the BigQuery API using the Google Java API Client Libraries. For more information, read the [Getting Started with BigQuery and the Google Java API Client library][1] codelab.
+Google's BigQuery Service features a REST-based API that allows developers to create applications to run ad-hoc queries
+on massive datasets. These sample Java applications demonstrate how to access the BigQuery API using the Google Java API
+Client Libraries.
+
+For more information, read the [Getting Started with BigQuery and the Google Java API Client
+library][1] codelab.
 
 ## Quickstart
 
@@ -8,7 +13,7 @@ Install [Maven](http://maven.apache.org/).
 
 Build your project with:
 
-	mvn package -DskipTests
+	mvn clean package -DskipTests
 
 You can then run a given `ClassName` via:
 

--- a/bigquery/src/test/java/com/google/cloud/bigquery/samples/test/AsyncQuerySampleTest.java
+++ b/bigquery/src/test/java/com/google/cloud/bigquery/samples/test/AsyncQuerySampleTest.java
@@ -38,17 +38,41 @@ public class AsyncQuerySampleTest {
   @Test
   public void testInteractive() throws IOException, InterruptedException {
     Iterator<GetQueryResultsResponse> pages =
-        AsyncQuerySample.run(Constants.PROJECT_ID, Constants.QUERY, false, 5000);
+        AsyncQuerySample.run(
+            Constants.PROJECT_ID,
+            "SELECT corpus FROM `publicdata.samples.shakespeare` GROUP BY corpus;",
+            false /* useBatchMode */,
+            5000,
+            false /* useLegacySql */);
     while (pages.hasNext()) {
       assertThat(pages.next().getRows()).isNotEmpty();
     }
   }
 
   @Test
-  @Ignore // Batches can take up to 3 hours to run, probably shouldn't use this
+  public void testInteractiveLegacySql() throws IOException, InterruptedException {
+    Iterator<GetQueryResultsResponse> pages =
+        AsyncQuerySample.run(
+            Constants.PROJECT_ID,
+            Constants.QUERY,
+            false /* useBatchMode */,
+            5000,
+            true /* useLegacySql */);
+    while (pages.hasNext()) {
+      assertThat(pages.next().getRows()).isNotEmpty();
+    }
+  }
+
+  @Test
+  @Ignore // Batches can take up to 3 hours to run, don't run during the system tests.
   public void testBatch() throws IOException, InterruptedException {
     Iterator<GetQueryResultsResponse> pages =
-        AsyncQuerySample.run(Constants.PROJECT_ID, Constants.QUERY, true, 5000);
+        AsyncQuerySample.run(
+            Constants.PROJECT_ID,
+            Constants.QUERY,
+            true /* useBatchMode */,
+            5000,
+            true /* useLegacySql */);
     while (pages.hasNext()) {
       assertThat(pages.next().getRows()).isNotEmpty();
     }

--- a/bigquery/src/test/java/com/google/cloud/bigquery/samples/test/SyncQuerySampleTest.java
+++ b/bigquery/src/test/java/com/google/cloud/bigquery/samples/test/SyncQuerySampleTest.java
@@ -37,7 +37,20 @@ public class SyncQuerySampleTest {
   @Test
   public void testSyncQuery() throws IOException {
     Iterator<GetQueryResultsResponse> pages =
-        SyncQuerySample.run(Constants.PROJECT_ID, Constants.QUERY, 10000);
+        SyncQuerySample.run(
+            Constants.PROJECT_ID,
+            "SELECT corpus FROM `publicdata.samples.shakespeare` GROUP BY corpus;",
+            10000,
+            false /* useLegacySql */);
+    while (pages.hasNext()) {
+      assertThat(pages.next().getRows()).isNotEmpty();
+    }
+  }
+
+  @Test
+  public void testSyncQueryLegacySql() throws IOException {
+    Iterator<GetQueryResultsResponse> pages =
+        SyncQuerySample.run(Constants.PROJECT_ID, Constants.QUERY, 10000, true /* useLegacySql */);
     while (pages.hasNext()) {
       assertThat(pages.next().getRows()).isNotEmpty();
     }


### PR DESCRIPTION
Switches all parameters to be supplied by properties rather than standard in.

Adds a flag to switch between legacy and standard SQL syntax.

@lesv PTAL.