### PR TITLE
Update Speech sample to gRPC v1.0.

### DIFF
--- a/speech/grpc/pom.xml
+++ b/speech/grpc/pom.xml
@@ -49,7 +49,8 @@ limitations under the License.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <codehaus-versions-maven-plugin-version>2.2</codehaus-versions-maven-plugin-version>
-    <maven-compiler-plugin-version>3.1</maven-compiler-plugin-version>
+    <grpc-protobuf-version>1.0.0</grpc-protobuf-version>
+    <maven-compiler-plugin-version>3.5.1</maven-compiler-plugin-version>
     <xolstice-protobuf-maven-plugin-version>0.5.0</xolstice-protobuf-maven-plugin-version>
   </properties>
 
@@ -128,6 +129,11 @@ limitations under the License.
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-credentials</artifactId>
+      <version>0.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
       <version>0.4.0</version>
       <exclusions>
@@ -145,29 +151,44 @@ limitations under the License.
       <version>19.0</version>
     </dependency>
     <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-all</artifactId>
-      <version>0.15.0</version>
-    </dependency>
-    <dependency>
-      <!--
-        It is recommended to use OpenSSL: Statically Linked Netty
-        for transport security.  These steps do not use the TLS that
-        comes with JDK (Jetty APLN/NPN), which is not
-        recommended. See
-        https://github.com/grpc/grpc-java/blob/master/SECURITY.md
-        for details.
-      -->
-      <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>1.1.33.Fork20</version>
-      <classifier>${tcnative.classifier}</classifier>
-    </dependency>
-    <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <version>0.29</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-auth</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-protobuf</artifactId>
+      <version>${grpc-protobuf-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <!--
+-        It is recommended to use OpenSSL: Statically Linked Netty
+-        for transport security.  These steps do not use the TLS that
+-        comes with JDK (Jetty APLN/NPN), which is not
+-        recommended. See
+-        https://github.com/grpc/grpc-java/blob/master/SECURITY.md
+-        for details.
+-      -->
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>1.1.33.Fork21</version>
+      <classifier>${tcnative.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>
@@ -216,10 +237,10 @@ limitations under the License.
             transitively depending on the protobuf-java version that
             grpc depends on.
           -->
-          <protocArtifact>com.google.protobuf:protoc:3.0.0-beta-2:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:3.0.0:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
           <protoSourceRoot>${basedir}/src/main/java/third_party</protoSourceRoot>
-          <pluginArtifact>io.grpc:protoc-gen-grpc-java:0.13.2:exe:${os.detected.classifier}</pluginArtifact>
+          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc-protobuf-version}:exe:${os.detected.classifier}</pluginArtifact>
         </configuration>
         <executions>
           <execution>

--- a/speech/grpc/src/main/java/com/examples/cloud/speech/AsyncRecognizeClient.java
+++ b/speech/grpc/src/main/java/com/examples/cloud/speech/AsyncRecognizeClient.java
@@ -35,7 +35,7 @@ import io.grpc.netty.NettyChannelBuilder;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.OptionBuilder;
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
@@ -166,29 +166,33 @@ public class AsyncRecognizeClient {
 
     Options options = new Options();
     options.addOption(
-        OptionBuilder.withLongOpt("uri")
-            .withDescription("path to audio uri")
+        Option.builder()
+            .longOpt("uri")
+            .desc("path to audio uri")
             .hasArg()
-            .withArgName("FILE_PATH")
-            .create());
+            .argName("FILE_PATH")
+            .build());
     options.addOption(
-        OptionBuilder.withLongOpt("host")
-            .withDescription("endpoint for api, e.g. speech.googleapis.com")
+        Option.builder()
+            .longOpt("host")
+            .desc("endpoint for api, e.g. speech.googleapis.com")
             .hasArg()
-            .withArgName("ENDPOINT")
-            .create());
+            .argName("ENDPOINT")
+            .build());
     options.addOption(
-        OptionBuilder.withLongOpt("port")
-            .withDescription("SSL port, usually 443")
+        Option.builder()
+            .longOpt("port")
+            .desc("SSL port, usually 443")
             .hasArg()
-            .withArgName("PORT")
-            .create());
+            .argName("PORT")
+            .build());
     options.addOption(
-        OptionBuilder.withLongOpt("sampling")
-            .withDescription("Sampling Rate, i.e. 16000")
+        Option.builder()
+            .longOpt("sampling")
+            .desc("Sampling Rate, i.e. 16000")
             .hasArg()
-            .withArgName("RATE")
-            .create());
+            .argName("RATE")
+            .build());
 
     try {
       CommandLine line = parser.parse(options, args);

--- a/speech/grpc/src/main/java/com/examples/cloud/speech/StreamingRecognizeClient.java
+++ b/speech/grpc/src/main/java/com/examples/cloud/speech/StreamingRecognizeClient.java
@@ -33,7 +33,7 @@ import io.grpc.stub.StreamObserver;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.OptionBuilder;
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.log4j.ConsoleAppender;
@@ -180,29 +180,33 @@ public class StreamingRecognizeClient {
 
     Options options = new Options();
     options.addOption(
-        OptionBuilder.withLongOpt("file")
-            .withDescription("path to audio file")
+        Option.builder()
+            .longOpt("file")
+            .desc("path to audio file")
             .hasArg()
-            .withArgName("FILE_PATH")
-            .create());
+            .argName("FILE_PATH")
+            .build());
     options.addOption(
-        OptionBuilder.withLongOpt("host")
-            .withDescription("endpoint for api, e.g. speech.googleapis.com")
+        Option.builder()
+            .longOpt("host")
+            .desc("endpoint for api, e.g. speech.googleapis.com")
             .hasArg()
-            .withArgName("ENDPOINT")
-            .create());
+            .argName("ENDPOINT")
+            .build());
     options.addOption(
-        OptionBuilder.withLongOpt("port")
-            .withDescription("SSL port, usually 443")
+        Option.builder()
+            .longOpt("port")
+            .desc("SSL port, usually 443")
             .hasArg()
-            .withArgName("PORT")
-            .create());
+            .argName("PORT")
+            .build());
     options.addOption(
-        OptionBuilder.withLongOpt("sampling")
-            .withDescription("Sampling Rate, i.e. 16000")
+        Option.builder()
+            .longOpt("sampling")
+            .desc("Sampling Rate, i.e. 16000")
             .hasArg()
-            .withArgName("RATE")
-            .create());
+            .argName("RATE")
+            .build());
 
     try {
       CommandLine line = parser.parse(options, args);

--- a/speech/grpc/src/main/java/com/examples/cloud/speech/SyncRecognizeClient.java
+++ b/speech/grpc/src/main/java/com/examples/cloud/speech/SyncRecognizeClient.java
@@ -30,7 +30,7 @@ import io.grpc.StatusRuntimeException;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.OptionBuilder;
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
@@ -117,29 +117,33 @@ public class SyncRecognizeClient {
 
     Options options = new Options();
     options.addOption(
-        OptionBuilder.withLongOpt("uri")
-            .withDescription("path to audio uri")
+        Option.builder()
+            .longOpt("uri")
+            .desc("path to audio uri")
             .hasArg()
-            .withArgName("FILE_PATH")
-            .create());
+            .argName("FILE_PATH")
+            .build());
     options.addOption(
-        OptionBuilder.withLongOpt("host")
-            .withDescription("endpoint for api, e.g. speech.googleapis.com")
+        Option.builder()
+            .longOpt("host")
+            .desc("endpoint for api, e.g. speech.googleapis.com")
             .hasArg()
-            .withArgName("ENDPOINT")
-            .create());
+            .argName("ENDPOINT")
+            .build());
     options.addOption(
-        OptionBuilder.withLongOpt("port")
-            .withDescription("SSL port, usually 443")
+        Option.builder()
+            .longOpt("port")
+            .desc("SSL port, usually 443")
             .hasArg()
-            .withArgName("PORT")
-            .create());
+            .argName("PORT")
+            .build());
     options.addOption(
-        OptionBuilder.withLongOpt("sampling")
-            .withDescription("Sampling Rate, i.e. 16000")
+        Option.builder()
+            .longOpt("sampling")
+            .desc("Sampling Rate, i.e. 16000")
             .hasArg()
-            .withArgName("RATE")
-            .create());
+            .argName("RATE")
+            .build());
 
     try {
       CommandLine line = parser.parse(options, args);


### PR DESCRIPTION
Also, remove references to `OptionBuilder` since it was deprecated in
favor of `Option.builder()`. (Ideally I'd update this to use properties
like our other samples, but I think that might require some docs
updates, too.)

@lesv @puneith PTAL