### PR TITLE
The `.isEqualTo()` method is deprecated for doubles.

### DIFF
--- a/language/analysis/src/test/java/com/google/cloud/language/samples/AnalyzeIT.java
+++ b/language/analysis/src/test/java/com/google/cloud/language/samples/AnalyzeIT.java
@@ -65,7 +65,7 @@ public class AnalyzeIT {
     
     // Assert
     assertThat((double)sentiment.getMagnitude()).isGreaterThan(0.0);
-    assertThat((double)sentiment.getPolarity()).isEqualTo(1.0);
+    assertThat((double)sentiment.getPolarity()).isGreaterThan(0.0);
   }
 
   @Test public void analyzeSentiment_returnNegative() throws Exception {
@@ -76,7 +76,7 @@ public class AnalyzeIT {
 
     // Assert
     assertThat((double)sentiment.getMagnitude()).isGreaterThan(0.0);
-    assertThat((double)sentiment.getPolarity()).isEqualTo(-1.0);
+    assertThat((double)sentiment.getPolarity()).isLessThan(0.0);
   }
 
   @Test public void analyzeSyntax_partOfSpeech() throws Exception {


### PR DESCRIPTION
Comparing to 1.0 should have been accurate since it is accurately represented in base-2 floating point, but I think the method is deprecated to discourage depending on a fragile thing due to rounding issues.