### PR TITLE
datastore: Remove broken link in Concepts.java

### DIFF
--- a/datastore/src/main/java/com/google/datastore/snippets/Concepts.java
+++ b/datastore/src/main/java/com/google/datastore/snippets/Concepts.java
@@ -72,9 +72,7 @@ import java.util.Map;
 import java.util.TimeZone;
 
 /**
- * Contains Cloud Datastore snippets linked from the Concepts documentation.
- *
- * @see <a href="https://cloud.google.com/datastore/v1beta3/">Key Datastore Concepts</a>
+ * Contains Cloud Datastore snippets demonstrating concepts for documentation.
  */
 public class Concepts {
 


### PR DESCRIPTION
We should probably link to the docs where this is included in https://github.com/GoogleCloudPlatform/java-docs-samples/tree/master/datastore. We can do that using the Python team's tool to find where samples are referenced.

Fixes #325.