### PR TITLE
vision: Got empty response when requests are gzipped.

### DIFF
--- a/vision/label/src/main/java/com/google/cloud/vision/samples/label/LabelApp.java
+++ b/vision/label/src/main/java/com/google/cloud/vision/samples/label/LabelApp.java
@@ -129,7 +129,7 @@ public class LabelApp {
         vision.images()
             .annotate(new BatchAnnotateImagesRequest().setRequests(ImmutableList.of(request)));
     // Due to a bug: requests to Vision API containing large images fail when GZipped.
-    // annotate.setDisableGZipContent(true);
+    annotate.setDisableGZipContent(true);
     // [END construct_request]
 
     // [START parse_response]

--- a/vision/landmark-detection/src/main/java/com/google/cloud/vision/samples/landmarkdetection/DetectLandmark.java
+++ b/vision/landmark-detection/src/main/java/com/google/cloud/vision/samples/landmarkdetection/DetectLandmark.java
@@ -115,6 +115,8 @@ public class DetectLandmark {
     Vision.Images.Annotate annotate =
         vision.images()
             .annotate(new BatchAnnotateImagesRequest().setRequests(ImmutableList.of(request)));
+    // Due to a bug: requests to Vision API containing large images fail when GZipped.
+    annotate.setDisableGZipContent(true);
 
     BatchAnnotateImagesResponse batchResponse = annotate.execute();
     assert batchResponse.getResponses().size() == 1;


### PR DESCRIPTION
This adds a workaround to the remaining samples for an issue where
requests over a certain size will "succeed" but return an empty response
from the vision API when gzipped.

The workaround is to disable gzip compression. Most images should be in
compressed formats anyway, so it's not like we are saving much bandwidth
with it.