### PR TITLE
Fix Vision tests.

### DIFF
--- a/vision/label/src/test/java/com/google/cloud/vision/samples/label/LabelAppIT.java
+++ b/vision/label/src/test/java/com/google/cloud/vision/samples/label/LabelAppIT.java
@@ -63,9 +63,7 @@ public class LabelAppIT {
       appUnderTest.labelImage(Paths.get("data/bad.txt"), MAX_LABELS);
       fail("Expected IOException");
     } catch (IOException expected) {
-      assertThat(expected.getMessage().toLowerCase())
-          .named("IOException message")
-          .contains("malformed request");
+      assertThat(expected.getMessage()).isNotEmpty();
     }
   }
 }


### PR DESCRIPTION
They were brittle, since they were looking for a specific error message,
which changed in the service.

@jerjou @lesv PTAL.