### PR TITLE
Add appengine-api-1.0-sdk dep to users sample.

### DIFF
--- a/appengine/taskqueue-push/pom.xml
+++ b/appengine/taskqueue-push/pom.xml
@@ -28,11 +28,6 @@ Copyright 2016 Google Inc. All Rights Reserved.
     <relativePath>../..</relativePath>
   </parent>
   <dependencies>
-   <dependency>
-    <groupId>com.google.appengine</groupId>
-    <artifactId>appengine-maven-plugin</artifactId>
-    <version>${appengine.sdk.version}</version>
-   </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>servlet-api</artifactId>

--- a/appengine/users/pom.xml
+++ b/appengine/users/pom.xml
@@ -29,12 +29,12 @@ Copyright 2015 Google Inc. All Rights Reserved.
     <relativePath>../..</relativePath>
   </parent>
   <dependencies>
-   <dependency>
-    <groupId>com.google.appengine</groupId>
-    <artifactId>appengine-maven-plugin</artifactId>
-    <version>${appengine.sdk.version}</version>
-   </dependency>
-   <dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>${appengine.sdk.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>19.0</version>


### PR DESCRIPTION
dpebot found another one when I tried to re-run the dependency updater this morning.

The users sample and the taskqueue-push sample were depending on the
appengine-maven-plugin, which used to depend transitively on the
appengine-api-1.0-sdk package, but it does not in the latest version.

These samples should not have been using the plugin as a dependency,
anyway.

@lesv PTAL