### PR TITLE
Use getters for DatastoreOptions and the Datastore service

### DIFF
--- a/datastore/cloud-client/src/main/java/com/example/datastore/QuickstartSample.java
+++ b/datastore/cloud-client/src/main/java/com/example/datastore/QuickstartSample.java
@@ -26,7 +26,7 @@ import com.google.cloud.datastore.Key;
 public class QuickstartSample {
   public static void main(String... args) throws Exception {
     // Instantiates a client
-    Datastore datastore = DatastoreOptions.defaultInstance().service();
+    Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
 
     // The kind for the new entity
     String kind = "Task";


### PR DESCRIPTION
`defaultInstance()` and `service()` seem to be deprecated in favor of `getDefaultInstance()` and `getService()`