### PR TITLE
Add templates for READMEs.

### DIFF
--- a/.github/templates/README.md
+++ b/.github/templates/README.md
@@ -1,0 +1,23 @@
+# Markdown Templates for Google Cloud Platform Samples for Java
+
+The `.mdpp` files in this directory are templates used in READMEs relating to
+Google Cloud samples for Java.
+
+## Before you begin
+
+Install [MarkdownPP](https://github.com/jreese/markdown-pp), a preprocessor for
+Markdown files. (Requires Python and PIP)
+
+    pip install MarkdownPP
+
+## Rendering the templates
+
+    for readme in **/README.mdpp; do
+      (
+        cd $(dirname "$readme")
+        markdown-pp README.mdpp -o README.md
+      )
+    done
+
+Java is a registered trademark of Oracle Corporation and/or its affiliates.
+

--- a/.github/templates/appengine-flexible-before-you-begin.mdpp
+++ b/.github/templates/appengine-flexible-before-you-begin.mdpp
@@ -1,0 +1,14 @@
+## Before you begin
+
+1.  Follow the [quickstart for Java in the App Engine flexible
+    environment](https://cloud.google.com/appengine/docs/flexible/java/quickstart) to 
+    set up your environment to deploy the sample applications App Engine.
+    1.  Download and install the [Google Cloud SDK](https://cloud.google.com/sdk/docs/).
+    1.  [Install and configure Apache Maven](http://maven.apache.org/index.html).
+    1.  [Create a new Google Cloud Platform project, or use an existing
+        one](https://console.cloud.google.com/project).
+    1.  [Enable billing for your
+        project](https://support.google.com/cloud/answer/6293499#enable-billing).
+    1. Initialize the Cloud SDK.
+
+           gcloud init

--- a/.github/templates/appengine-flexible-deploy.mdpp
+++ b/.github/templates/appengine-flexible-deploy.mdpp
@@ -1,0 +1,21 @@
+## Deploying to App Engine
+
+To run the application locally, use the Maven Jetty plugin.
+
+    mvn clean jetty:run-exploded
+
+View the app at [localhost:8080](http://localhost:8080).
+
+To deploy the app to App Engine, run
+
+    mvn clean appengine:deploy
+
+After the deploy finishes (can take up to 10 minutes), you can view your application at
+`https://YOUR_PROJECT.appspot.com`, where `YOUR_PROJECT` is your Google Cloud project ID. You can
+see the new version deployed on the [App Engine section of the Google Cloud
+Console](https://console.cloud.google.com/appengine/versions).
+
+For a more detailed walkthrough, see the [getting started
+guide for Java in the App Engine flexible
+environment](https://cloud.google.com/java/getting-started/hello-world).
+

--- a/.github/templates/getting-sample-code.mdpp
+++ b/.github/templates/getting-sample-code.mdpp
@@ -1,0 +1,7 @@
+## Getting the sample code
+
+Get the latest sample code from GitHub using Git or download the repository as a ZIP file.
+([Download](https://github.com/GoogleCloudPlatform/java-docs-samples/archive/master.zip))
+
+    git clone https://github.com/GoogleCloudPlatform/java-docs-samples.git
+

--- a/flexible/README.md
+++ b/flexible/README.md
@@ -9,44 +9,50 @@ scaffolding for other frameworks and use cases.
 
 [aeflex-docs]: https://cloud.google.com/appengine/docs/flexible/
 
-## Run Locally
-1. Install the [Google Cloud SDK](https://cloud.google.com/sdk/), including the [gcloud tool](https://cloud.google.com/sdk/gcloud/), and [gcloud app component](https://cloud.google.com/sdk/gcloud-app).
-1. Setup the gcloud tool.
+## Getting the sample code
 
-   ```
-   gcloud init
-   ```
+Get the latest sample code from GitHub using Git or download the repository as a ZIP file.
+([Download](https://github.com/GoogleCloudPlatform/java-docs-samples/archive/master.zip))
 
-1. Clone this repo.
+    git clone https://github.com/GoogleCloudPlatform/java-docs-samples.git
 
-   ```
-   git clone https://github.com/GoogleCloudPlatform/java-docs-samples.git
-   ```
 
-1. Run this project locally from the command line.
+## Before you begin
 
-   ```
-   mvn clean jetty:run
-   ```
+1.  Follow the [quickstart for Java in the App Engine flexible
+    environment](https://cloud.google.com/appengine/docs/flexible/java/quickstart) to 
+    set up your environment to deploy the sample applications App Engine.
+    1.  Download and install the [Google Cloud SDK](https://cloud.google.com/sdk/docs/).
+    1.  [Install and configure Apache Maven](http://maven.apache.org/index.html).
+    1.  [Create a new Google Cloud Platform project, or use an existing
+        one](https://console.cloud.google.com/project).
+    1.  [Enable billing for your
+        project](https://support.google.com/cloud/answer/6293499#enable-billing).
+    1. Initialize the Cloud SDK.
 
-1. Visit the application at [http://localhost:8080](http://localhost:8080).
+           gcloud init
 
-## Deploying
+## Deploying to App Engine
 
-1. Use the [Cloud Developer Console](https://console.developer.google.com)  to create a project/app id. (App id and project id are identical)
-1. Setup the gcloud tool.
+To run the application locally, use the Maven Jetty plugin.
 
-   ```
-   gcloud init
-   ```
-1. Use the [Admin Console](https://appengine.google.com) to view data, queues, and other App Engine specific administration tasks.
-1. Use gcloud to deploy your app.
+    mvn clean jetty:run
 
-   ```
-   mvn clean gcloud:deploy
-   ```
+View the app at [localhost:8080](http://localhost:8080).
 
-1. Congratulations!  Your application is now live at your-app-id.appspot.com
+To deploy the app to App Engine, run
+
+    mvn clean appengine:deploy
+
+After the deploy finishes (can take up to 10 minutes), you can view your application at
+`https://YOUR_PROJECT.appspot.com`, where `YOUR_PROJECT` is your Google Cloud project ID. You can
+see the new version deployed on the [App Engine section of the Google Cloud
+Console](https://console.cloud.google.com/appengine/versions).
+
+For a more detailed walkthrough, see the [getting started
+guide for Java in the App Engine flexible
+environment](https://cloud.google.com/java/getting-started/hello-world).
+
 
 ## Contributing changes
 

--- a/flexible/README.mdpp
+++ b/flexible/README.mdpp
@@ -1,0 +1,24 @@
+# Google App Engine Flexible Environment Java Samples
+
+This is a repository that contains Java code samples for [Google App Engine
+flexible environment][aeflex-docs].
+
+See our other [Google Cloud Platform GitHub
+repos](https://github.com/GoogleCloudPlatform) for sample applications and
+scaffolding for other frameworks and use cases.
+
+[aeflex-docs]: https://cloud.google.com/appengine/docs/flexible/
+
+!INCLUDE "../.github/templates/getting-sample-code.mdpp"
+
+!INCLUDE "../.github/templates/appengine-flexible-before-you-begin.mdpp"
+
+!INCLUDE "../.github/templates/appengine-flexible-deploy.mdpp"
+
+## Contributing changes
+
+* See [CONTRIBUTING.md](CONTRIBUTING.md)
+
+## Licensing
+
+* See [LICENSE](LICENSE)


### PR DESCRIPTION
This uses https://github.com/jreese/markdown-pp to include markdown from
other files.  The templates in this repository can also be used in other
repositories with the `!INCLUDEURL` directive.

@lesv PTAL