### PR TITLE
Update Dockerfile

### DIFF
--- a/flexible/endpoints/src/main/appengine/Dockerfile
+++ b/flexible/endpoints/src/main/appengine/Dockerfile
@@ -1,4 +1,4 @@
 FROM gcr.io/google_appengine/jetty9
 
-ADD endpoints-1.0-SNAPSHOT.war $JETTY_BASE/webapps/root.war
+ADD flexible-endpoints-1.0-SNAPSHOT.war $JETTY_BASE/webapps/root.war
 ADD . /app


### PR DESCRIPTION
Updating the war file named endpoints-1.0-SNAPSHOT.war to flexible-endpoints-1.0-SNAPSHOT.war, otherwise the docker building process fails.