### PR TITLE
Remove dependency on AutoValue.

### DIFF
--- a/vision/text/pom.xml
+++ b/vision/text/pom.xml
@@ -51,12 +51,6 @@
       <version>20.0</version>
     </dependency>
     <dependency>
-      <groupId>com.google.auto.value</groupId>
-      <artifactId>auto-value</artifactId>
-      <version>1.3</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.opennlp</groupId>
       <artifactId>opennlp-tools</artifactId>
       <version>1.6.0</version>

--- a/vision/text/src/main/java/com/google/cloud/vision/samples/text/ImageText.java
+++ b/vision/text/src/main/java/com/google/cloud/vision/samples/text/ImageText.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package com.google.cloud.vision.samples.text;
 
 import com.google.api.services.vision.v1.model.EntityAnnotation;
 import com.google.api.services.vision.v1.model.Status;
-import com.google.auto.value.AutoValue;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -28,28 +27,58 @@ import javax.annotation.Nullable;
 /**
  * A data object for mapping text to file paths.
  */
-@AutoValue
-abstract class ImageText {
+public class ImageText {
+  private Path pth;
+  private List<EntityAnnotation> ts;
+  private Status err;
 
   public static Builder builder() {
-    return new AutoValue_ImageText.Builder();
+    return new Builder();
   }
 
-  public abstract Path path();
+  private ImageText() {}
 
-  public abstract List<EntityAnnotation> textAnnotations();
+  public Path path() {
+    return this.pth;
+  }
+
+  public List<EntityAnnotation> textAnnotations() {
+    return this.ts;
+  }
 
   @Nullable
-  public abstract Status error();
+  public Status error() {
+    return this.err;
+  }
 
-  @AutoValue.Builder
-  public abstract static class Builder {
-    public abstract Builder path(Path path);
+  public static class Builder {
+    private Path pth;
+    private List<EntityAnnotation> ts;
+    private Status err;
 
-    public abstract Builder textAnnotations(List<EntityAnnotation> ts);
+    Builder() {}
 
-    public abstract Builder error(@Nullable Status err);
+    public Builder path(Path path) {
+      this.pth = path;
+      return this;
+    }
 
-    public abstract ImageText build();
+    public Builder textAnnotations(List<EntityAnnotation> ts) {
+      this.ts = ts;
+      return this;
+    }
+
+    public Builder error(@Nullable Status err) {
+      this.err = err;
+      return this;
+    }
+
+    public ImageText build() {
+      ImageText out = new ImageText();
+      out.pth = this.pth;
+      out.ts = this.ts;
+      out.err = this.err;
+      return out;
+    }
   }
 }

--- a/vision/text/src/main/java/com/google/cloud/vision/samples/text/Index.java
+++ b/vision/text/src/main/java/com/google/cloud/vision/samples/text/Index.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/vision/text/src/main/java/com/google/cloud/vision/samples/text/TextApp.java
+++ b/vision/text/src/main/java/com/google/cloud/vision/samples/text/TextApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/vision/text/src/main/java/com/google/cloud/vision/samples/text/Word.java
+++ b/vision/text/src/main/java/com/google/cloud/vision/samples/text/Word.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,30 +16,65 @@
 
 package com.google.cloud.vision.samples.text;
 
-import com.google.auto.value.AutoValue;
-
 import java.nio.file.Path;
 
 /**
  * A data object for mapping words to file paths.
  */
-@AutoValue
-abstract class Word {
+public class Word {
+  private Path pth;
+  private String wrd;
 
   public static Builder builder() {
-    return new AutoValue_Word.Builder();
+    return new Builder();
   }
 
-  public abstract Path path();
+  public Path path() {
+    return this.pth;
+  }
 
-  public abstract String word();
+  public String word() {
+    return this.wrd;
+  }
 
-  @AutoValue.Builder
-  public abstract static class Builder {
-    public abstract Builder path(Path path);
+  @Override
+  public boolean equals(Object other) {
+    if (other == null) {
+      return false;
+    }
+    if (!(other instanceof Word)) {
+      return false;
+    }
+    Word otherWord = (Word) other;
+    return this.path().equals(otherWord.path()) && this.word().equals(otherWord.word());
+  }
 
-    public abstract Builder word(String word);
+  @Override
+  public int hashCode() {
+    return this.word().hashCode() ^ this.path().hashCode();
+  }
 
-    public abstract Word build();
+  public static class Builder {
+    private Path pth;
+    private String wrd;
+
+    Builder() {}
+
+    public Builder path(Path path) {
+      this.pth = path;
+      return this;
+    }
+
+    public Builder word(String word) {
+      this.wrd = word;
+      return this;
+    }
+
+    public Word build() {
+      Word out = new Word();
+      out.pth = this.pth;
+      out.wrd = this.wrd;
+      return out;
+    }
   }
 }


### PR DESCRIPTION
AutoValue saves us from having to write boilerplate, but it only works
with Maven or Gradle. Those users using Eclipse and IntelliJ to compile
have been having difficulty.

Fixes https://github.com/GoogleCloudPlatform/java-docs-samples/issues/252

@lesv PTAL