### PR TITLE
Use latest (beta) versions of cloud client libraries.

### DIFF
--- a/bigquery/cloud-client/pom.xml
+++ b/bigquery/cloud-client/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquery</artifactId>
-      <version>0.7.0</version>
+      <version>0.8.0-beta</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/datastore/cloud-client/pom.xml
+++ b/datastore/cloud-client/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-datastore</artifactId>
-      <version>0.7.0</version>
+      <version>0.8.0-beta</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/datastore/pom.xml
+++ b/datastore/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-datastore</artifactId>
-      <version>0.7.0</version>
+      <version>0.8.0-beta</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/datastore/src/test/java/com/google/datastore/snippets/ConceptsTest.java
+++ b/datastore/src/test/java/com/google/datastore/snippets/ConceptsTest.java
@@ -51,6 +51,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 
+import org.joda.time.Duration;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -72,6 +73,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Contains Cloud Datastore snippets demonstrating concepts for documentation.
@@ -133,8 +135,8 @@ public class ConceptsTest {
    * @throws InterruptedException if there are errors stopping the local Datastore
    */
   @AfterClass
-  public static void afterClass() throws IOException, InterruptedException {
-    HELPER.stop();
+  public static void afterClass() throws IOException, InterruptedException, TimeoutException {
+    HELPER.stop(Duration.standardMinutes(1));
   }
 
   private void assertValidKey(Key taskKey) {

--- a/flexible/cloudstorage/pom.xml
+++ b/flexible/cloudstorage/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>0.7.0</version>
+      <version>0.8.0-beta</version>
     </dependency>
     <!-- [END dependencies] -->
   </dependencies>

--- a/flexible/datastore/pom.xml
+++ b/flexible/datastore/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-datastore</artifactId>
-      <version>0.7.0</version>
+      <version>0.8.0-beta</version>
     </dependency>
     <!-- [END dependencies] -->
   </dependencies>

--- a/language/cloud-client/pom.xml
+++ b/language/cloud-client/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-language</artifactId>
-      <version>0.7.0</version>
+      <version>0.8.0</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/logging/cloud-client/pom.xml
+++ b/logging/cloud-client/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-logging</artifactId>
-      <version>0.7.0</version>
+      <version>0.8.0-beta</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
         <module>flexible/static-files</module>
         <module>flexible/twilio</module>
         <module>language/analysis</module>
+        <module>language/cloud-client</module>
         <module>logging</module>
         <module>logging/cloud-client</module>
         <module>monitoring/v2</module>

--- a/storage/cloud-client/pom.xml
+++ b/storage/cloud-client/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>0.7.0</version>
+      <version>0.8.0-beta</version>
     </dependency>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
Note this wasn't automatically done because dpebot currently skips beta
releases. We can look at how to add an exception for the
com.google.cloud libraries if they are going to stay beta a while.