### PR TITLE
enforce java 7 on Endpoints sample

### DIFF
--- a/appengine/endpoints-frameworks-v2/backend/pom.xml
+++ b/appengine/endpoints-frameworks-v2/backend/pom.xml
@@ -154,6 +154,15 @@
                     </jvmFlags -->
                 </configuration>
             </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <version>3.6.0</version>
+              <configuration>
+                <source>1.7</source>
+                <target>1.7</target>
+              </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/appengine/endpoints-frameworks-v2/backend/pom.xml
+++ b/appengine/endpoints-frameworks-v2/backend/pom.xml
@@ -35,6 +35,8 @@
         <endpoints.management.version>1.0.0-beta.11</endpoints.management.version>
 
         <endpoints.project.id>YOUR_PROJECT_ID</endpoints.project.id>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
     </properties>
 
     <dependencies>
@@ -153,15 +155,6 @@
                       <jvmFlag>-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n</jvmFlag>
                     </jvmFlags -->
                 </configuration>
-            </plugin>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <version>3.6.0</version>
-              <configuration>
-                <source>1.7</source>
-                <target>1.7</target>
-              </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Currently, mvn appengine:update fails because it compiles Java 8
bytecode. This forces the app code to Java 7.