### PR TITLE
Remove extraneous comment about BigQuery timestamps.

### DIFF
--- a/bigquery/cloud-client/src/main/java/com/example/bigquery/QueryParametersSample.java
+++ b/bigquery/cloud-client/src/main/java/com/example/bigquery/QueryParametersSample.java
@@ -231,8 +231,6 @@ public class QueryParametersSample {
     BigQuery bigquery =
         new BigQueryOptions.DefaultBigqueryFactory().create(BigQueryOptions.getDefaultInstance());
 
-    // Timestamps are expected to be in the format YYYY-MM-DD HH:MM:SS.DDDDDD time_zone
-    // See: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#timestamp-type
     DateTime timestamp = new DateTime(2016, 12, 7, 8, 0, 0, DateTimeZone.UTC);
 
     String queryString = "SELECT TIMESTAMP_ADD(@ts_value, INTERVAL 1 HOUR);";


### PR DESCRIPTION
That comment (about the format for timestamps) was copied from a raw API sample. It doesn't apply to the Java client library.