### PR TITLE
Add link to the Android sample.

### DIFF
--- a/vision/README.md
+++ b/vision/README.md
@@ -2,6 +2,8 @@
 
 This directory contains [Cloud Vision API](https://cloud.google.com/vision/) Java samples.
 
+For Android samples, check out the [mobile samples](https://cloud.google.com/vision/docs/samples#mobile_platform_examples) for the Cloud Vision API. ([Source code for Android sample](https://github.com/GoogleCloudPlatform/cloud-vision/tree/master/android))
+
 ## Prerequisites
 
 ### Download Maven


### PR DESCRIPTION
We got a question https://github.com/GoogleCloudPlatform/java-docs-samples/issues/469 about using this sample code in an Android application. We should mention the Android samples whereever we have them. (I think this will become even more important when we add Google Cloud client library samples since I don't think Android is supported for those libraries)