### PR TITLE
bump API management version to 1.0.1

### DIFF
--- a/appengine/endpoints-frameworks-v2/backend/pom.xml
+++ b/appengine/endpoints-frameworks-v2/backend/pom.xml
@@ -32,7 +32,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <endpoints.framework.version>2.0.0</endpoints.framework.version>
-        <endpoints.management.version>1.0.0</endpoints.management.version>
+        <endpoints.management.version>1.0.1</endpoints.management.version>
 
         <endpoints.project.id>YOUR_PROJECT_ID</endpoints.project.id>
         <maven.compiler.target>1.7</maven.compiler.target>


### PR DESCRIPTION
* fix for character encoding issue
* fix local development server startup

Please don't merge this until January 25, 1.0.1 is currently being pushed to Maven right now.