### PR TITLE
revert endpoints-framework-all dependency

### DIFF
--- a/appengine/endpoints-frameworks-v2/backend/pom.xml
+++ b/appengine/endpoints-frameworks-v2/backend/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>com.google.endpoints</groupId>
-            <artifactId>endpoints-framework-all</artifactId>
+            <artifactId>endpoints-framework</artifactId>
             <version>${endpoints.framework.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
This clashes with the GetSwaggerDoc task, since the tool doesn't depend
on the -all dependency, so we revert it for now.