### PR TITLE
make it work again

### DIFF
--- a/spanner/cloud-client/pom.xml
+++ b/spanner/cloud-client/pom.xml
@@ -60,17 +60,13 @@ limitations under the License.
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>2.0.0.Beta6</version>
-      <scope>runtime</scope>
-    </dependency>
+
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>20.0</version>
     </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>junit</groupId>
@@ -84,7 +80,9 @@ limitations under the License.
       <version>0.32</version>
       <scope>test</scope>
     </dependency>
+
   </dependencies>
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
1. netty-tcnative-boringssl-static got upgraded by DPEBot to 2.0.0Beta6
which broke everything.  But it shouldn’t have been in the POM to begin
with.  The library includes all this.  Argh!