### PR TITLE
remove "secure: always"

### DIFF
--- a/flexible/helloworld/src/main/appengine/app.yaml
+++ b/flexible/helloworld/src/main/appengine/app.yaml
@@ -18,5 +18,4 @@ env: flex
 handlers:
 - url: /.*
   script: this field is required, but ignored
-  secure: always
 # [END appyaml]


### PR DESCRIPTION
the "secure" directive it does nothing in Flexible and it's presence can imply support for this feature.