### PR TITLE
Remove extra end region tag.

### DIFF
--- a/flexible/pubsub/src/main/java/com/example/flexible/pubsub/PubSubPublish.java
+++ b/flexible/pubsub/src/main/java/com/example/flexible/pubsub/PubSubPublish.java
@@ -51,7 +51,6 @@ public class PubSubPublish extends HttpServlet {
       publisher.publish(pubsubMessage);
       // redirect to home page
       resp.sendRedirect("/");
-      // [END publish]
     } catch (Exception e) {
       resp.sendError(HttpStatus.SC_INTERNAL_SERVER_ERROR, e.getMessage());
     }


### PR DESCRIPTION
The removed region tag caused the sample to end too early. It should have the full function definition, but especially the end of the try block.