### PR TITLE
Iap sample v2

### DIFF
--- a/iap/README.md
+++ b/iap/README.md
@@ -32,6 +32,9 @@ It will be used to test both the authorization of an incoming request to an IAP 
 ```
 
 ## References
-- [JWT library for Java](https://github.com/jwtk/jjwt)
+- [JWT library for Java (jjwt)](https://github.com/jwtk/jjwt)
 - [Cloud IAP docs](https://cloud.google.com/iap/docs/)
 - [Service account credentials](https://cloud.google.com/docs/authentication#getting_credentials_for_server-centric_flow)
+
+## Known issues
+- [Auth0 JWT library](https://github.com/auth0/java-jwt) has intermittent IAP token verification issues on OpenJDK.

--- a/iap/README.md
+++ b/iap/README.md
@@ -1,5 +1,8 @@
 # Cloud Identity-Aware Proxy Java Samples
-Cloud Identity-Aware Proxy (Cloud IAP) lets you manage access to applications running in Compute Engine, App Engine standard environment, and Container Engine. Cloud IAP establishes a central authorization layer for applications accessed by HTTPS, enabling you to adopt an application-level access control model instead of relying on network-level firewalls. When you enable Cloud IAP, you must also use signed headers or the App Engine standard environment Users API to secure your app.
+Cloud Identity-Aware Proxy (Cloud IAP) lets you manage access to applications running in Compute Engine, App Engine standard environment, and Container Engine.
+Cloud IAP establishes a central authorization layer for applications accessed by HTTPS,
+enabling you to adopt an application-level access control model instead of relying on network-level firewalls.
+ When you enable Cloud IAP, you must also use signed headers or the App Engine standard environment Users API to secure your app.
 
 ## Setup
 - A Google Cloud project with billing enabled
@@ -29,6 +32,6 @@ It will be used to test both the authorization of an incoming request to an IAP 
 ```
 
 ## References
-[JWT library for Java](https://github.com/auth0/java-jwt)
+[JWT library for Java](https://github.com/jwtk/jjwt)
 [Cloud IAP docs](https://cloud.google.com/iap/docs/)
 [Service account credentials](https://cloud.google.com/docs/authentication#getting_credentials_for_server-centric_flow)

--- a/iap/README.md
+++ b/iap/README.md
@@ -32,6 +32,6 @@ It will be used to test both the authorization of an incoming request to an IAP 
 ```
 
 ## References
-[JWT library for Java](https://github.com/jwtk/jjwt)
-[Cloud IAP docs](https://cloud.google.com/iap/docs/)
-[Service account credentials](https://cloud.google.com/docs/authentication#getting_credentials_for_server-centric_flow)
+- [JWT library for Java](https://github.com/jwtk/jjwt)
+- [Cloud IAP docs](https://cloud.google.com/iap/docs/)
+- [Service account credentials](https://cloud.google.com/docs/authentication#getting_credentials_for_server-centric_flow)

--- a/iap/pom.xml
+++ b/iap/pom.xml
@@ -52,9 +52,9 @@
       <version>0.6.0</version>
     </dependency>
     <dependency>
-      <groupId>com.auth0</groupId>
-      <artifactId>java-jwt</artifactId>
-      <version>3.2.0</version>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt</artifactId>
+      <version>0.7.0</version>
     </dependency>
     <!-- [END dependencies] -->
 

--- a/iap/src/test/java/com/example/iap/BuildAndVerifyIapRequestIT.java
+++ b/iap/src/test/java/com/example/iap/BuildAndVerifyIapRequestIT.java
@@ -1,32 +1,29 @@
 /**
  * Copyright 2017 Google Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.example.iap;
 
 import static com.example.iap.BuildIapRequest.buildIAPRequest;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import com.auth0.jwt.interfaces.DecodedJWT;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
+import io.jsonwebtoken.Jwt;
 import org.apache.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
@@ -70,7 +67,7 @@ public class BuildAndVerifyIapRequestIT {
     assertNotNull(split);
     assertEquals(split.length, 2);
     assertEquals(split[0].trim(), "x-goog-authenticated-user-jwt");
-    DecodedJWT decodedJWT = verifyIapRequestHeader.verifyJWTToken(split[1].trim(), iapProtectedUrl);
+    Jwt decodedJWT = verifyIapRequestHeader.verifyJWTToken(split[1].trim(), iapProtectedUrl);
     assertNotNull(decodedJWT);
   }
 }


### PR DESCRIPTION
Using jjwt instead of auth0 jwt library. Auth0 jwt library has intermittent token verification failures for IAP on OpenJDK.
