### PR TITLE
Removing Endpoints v1 workflow from java8 samples

### DIFF
--- a/appengine-java8/endpoints-v2-migration/README.md
+++ b/appengine-java8/endpoints-v2-migration/README.md
@@ -7,11 +7,6 @@ This sample provides an example of a [migration][7] from the prior version of
 the new App Engine Maven and Gradle plugins for deploying your Google App Engine
 Standard applications.
 
-This sample contains comments of how to use the prior Endpoints Frameworks as
-well. For clarity, the prior Endpoints Frameworks and the new Endpoints
-Frameworks are denoted as Endpoints Frameworks v1.0 and Endpoints Frameworks
-v2.0, respectively.
-
 Google Cloud Endpoints Frameworks v2.0 provides new functionality which may
 require payment and uses an OpenAPI specification. The OpenAPI development
 process is explained [here][8] and a quickstart is provided [here][9].
@@ -67,19 +62,6 @@ process is explained [here][8] and a quickstart is provided [here][9].
       found in [Greetings.java](src/main/java/com/example/helloendpoints/Greetings.java).
 
     - You can read more about different user authentication supported [here][12].
-
-
-1. [Optional]: Use Cloud Endpoints Frameworks v2.0 Maven and Gradle
-   client library generation plugins with Cloud Endpoints Frameworks v1.0.
-
-    - Uncomment `Endpoints Frameworks v1.0` sections and comment
-        `Endpoints Frameworks v2.0` sections in the following files.
-
-      ```
-        pom.xml
-        build.gradle
-        src/main/webapp/WEB-INF/web.xml
-      ```
 
 ## Build and Deployment
 

--- a/appengine-java8/endpoints-v2-migration/build.gradle
+++ b/appengine-java8/endpoints-v2-migration/build.gradle
@@ -49,15 +49,9 @@ dependencies {
   compile 'jstl:jstl:1.2'
   compile group: 'javax.inject', name: 'javax.inject', version: '1'
 
-  // Uncomment to use Endpoints Frameworks v1.0 and comment the v2.0 section
-  // compile group: 'com.google.appengine', name: 'appengine-endpoints', version: '+'
-  // End of Endpoints Frameworks v1.0
-
-  // Endpoints Frameworks v2.0
   // [START endpoints-tools]
   compile group: 'com.google.endpoints', name: 'endpoints-framework-tools', version: '+'
   // [END endpoints-tools]
-  // End of Endpoints Frameworks v2.0
 }
 
 appengine {  // App Engine tasks configuration
@@ -71,12 +65,12 @@ appengine {  // App Engine tasks configuration
   }
 }
 
-/* [START endpoints-server]
+// [START endpoints-server]
 endpointsServer {
   // Endpoints Framework Plugin server-side configuration
   hostname = 'YOUR-PROJECT-ID.appspot.com'
 }
-[END endpoints-server] */
+// [END endpoints-server]
 
 group   = 'com.example.helloendpoints' // Generated output GroupId
 version = '1'                          // Version in generated output

--- a/appengine-java8/endpoints-v2-migration/pom.xml
+++ b/appengine-java8/endpoints-v2-migration/pom.xml
@@ -37,18 +37,6 @@ limitations under the License.
 
   <dependencies>
     <!-- Compile/runtime dependencies -->
-    <!-- Uncomment to use Endpoints Frameworks v1.0 and comment the v2.0 section-->
-    <!--
-    [START appengine-endpoints]
-    <dependency>
-          <groupId>com.google.appengine</groupId>
-          <artifactId>appengine-endpoints</artifactId>
-          <version>1.9.48</version>
-    </dependency>
-    [END appengine-endpoints]
-    -->
-    <!-- End of Endpoints Frameworks v1.0 -->
-    <!-- Endpoints Frameworks v2.0 -->
     <!-- [START endpoints-frameworks] -->
     <dependency>
       <groupId>com.google.endpoints</groupId>
@@ -56,7 +44,6 @@ limitations under the License.
       <version>2.0.7</version>
     </dependency>
     <!-- [END endpoints-frameworks] -->
-    <!-- End of Endpoints Frameworks v2.0 -->
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
@@ -97,6 +84,7 @@ limitations under the License.
           <version>1.0.0-beta4</version>
           <configuration>
               <!-- plugin configuration -->
+              <hostname>YOUR-PROJECT-ID.appspot.com</hostname>
           </configuration>
         </plugin>
         <!-- [END endpoints-frameworks-plugin] -->

--- a/appengine-java8/endpoints-v2-migration/src/main/webapp/WEB-INF/web.xml
+++ b/appengine-java8/endpoints-v2-migration/src/main/webapp/WEB-INF/web.xml
@@ -19,30 +19,6 @@ limitations under the License.
          xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
          http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
          version="3.1">
-    <!-- Uncomment to use Endpoints Frameworks v1.0 and comment the v2.0 section -->
-    <!--
-    [START appengine-endpoints]
-    <servlet>
-        <servlet-name>SystemServiceServlet</servlet-name>
-        <servlet-class>com.google.api.server.spi.SystemServiceServlet</servlet-class>
-        <init-param>
-            <param-name>services</param-name>
-            <param-value>com.example.helloendpoints.Greetings</param-value>
-        </init-param>
-        <init-param>
-            <param-name>restricted</param-name>
-            <param-value>false</param-value>
-        </init-param>
-    </servlet>
-    <servlet-mapping>
-        <servlet-name>SystemServiceServlet</servlet-name>
-        <url-pattern>/_ah/spi/*</url-pattern>
-    </servlet-mapping>
-    [END appengine-endpoints]
-    -->
-    <!-- End of Endpoints Frameworks v1.0 -->
-
-    <!-- Endpoints Frameworks v2.0 -->
     <!-- [START endpoints-frameworks] -->
     <servlet>
         <servlet-name>EndpointsServlet</servlet-name>
@@ -61,7 +37,6 @@ limitations under the License.
         <url-pattern>/_ah/api/*</url-pattern>
     </servlet-mapping>
     <!-- [END endpoints-frameworks] -->
-    <!-- End of Endpoints Frameworks v2.0 -->
 
     <welcome-file-list>
         <welcome-file>index.html</welcome-file>


### PR DESCRIPTION
This PR removes the Endpoints Frameworks v1 flow from Java 8 version of Endpoints Frameworks v2 migration sample. 