### PR TITLE
BigQuery: Add explicit service account key auth sample.

### DIFF
--- a/bigquery/cloud-client/.gitignore
+++ b/bigquery/cloud-client/.gitignore
@@ -1,0 +1,1 @@
+service_account.json

--- a/bigquery/cloud-client/src/main/java/com/example/bigquery/AuthSnippets.java
+++ b/bigquery/cloud-client/src/main/java/com/example/bigquery/AuthSnippets.java
@@ -1,0 +1,95 @@
+/*
+  Copyright 2017, Google, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package com.example.bigquery;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.Dataset;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+/**
+ * Examples for authenticating to Google BigQuery.
+ *
+ * <p>See: https://cloud.google.com/bigquery/authentication
+ */
+public class AuthSnippets {
+
+  // [START default_credentials]
+  public static void implicit() {
+    // Instantiate a client. If you don't specify credentials when constructing a client, the
+    // client library will look for credentials in the environment, such as the
+    // GOOGLE_APPLICATION_CREDENTIALS environment variable.
+    BigQuery bigquery = BigQueryOptions.getDefaultInstance().getService();
+
+    // Use the client.
+    System.out.println("Datasets:");
+    for (Dataset dataset : bigquery.listDatasets().iterateAll()) {
+      System.out.printf("%s%n", dataset.getDatasetId().getDataset());
+    }
+  }
+  // [END default_credentials]
+
+  // [START explicit_service_account]
+  public static void explicit() throws IOException {
+    // Load credentials from JSON key file. If you can't set the GOOGLE_APPLICATION_CREDENTIALS
+    // environment variable, you can explicitly load the credentials file to construct the
+    // credentials.
+    GoogleCredentials credentials;
+    File credentialsPath = new File("service_account.json");  // TODO: update to your key path.
+    try (FileInputStream serviceAccountStream = new FileInputStream(credentialsPath)) {
+      credentials = ServiceAccountCredentials.fromStream(serviceAccountStream);
+    }
+
+    // Instantiate a client.
+    BigQuery bigquery =
+        BigQueryOptions.newBuilder().setCredentials(credentials).build().getService();
+
+    // Use the client.
+    System.out.println("Datasets:");
+    for (Dataset dataset : bigquery.listDatasets().iterateAll()) {
+      System.out.printf("%s%n", dataset.getDatasetId().getDataset());
+    }
+  }
+  // [END explicit_service_account]
+
+  public static void main(String... args) throws IOException {
+    boolean validArgs = args.length == 1;
+    String sample = "explicit";
+    if (validArgs) {
+      sample = args[0];
+      if (!sample.equals("explicit") && !sample.equals("implicit")) {
+        validArgs = false;
+      }
+    }
+
+    if (!validArgs) {
+      System.err.println("Expected auth type argument: implict|explict");
+      System.exit(1);
+    }
+
+    if (sample.equals("implicit")) {
+      implicit();
+    } else {
+      explicit();
+    }
+  }
+}

--- a/bigquery/cloud-client/src/test/java/com/example/bigquery/AuthSnippetsIT.java
+++ b/bigquery/cloud-client/src/test/java/com/example/bigquery/AuthSnippetsIT.java
@@ -1,0 +1,55 @@
+/*
+  Copyright 2017, Google, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package com.example.bigquery;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+/** Tests for auth samples. */
+@RunWith(JUnit4.class)
+@SuppressWarnings("checkstyle:abbreviationaswordinname")
+public class AuthSnippetsIT {
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    System.setOut(null);
+  }
+
+  @Test
+  public void testAuthSnippetsImplicit() throws Exception {
+    AuthSnippets.main(new String[]{"implicit"});
+    String got = bout.toString();
+    assertThat(got).contains("Datasets:");
+  }
+}


### PR DESCRIPTION
For inclusion in the BigQuery authentication docs: https://cloud.google.com/bigquery/authentication

I followed the Python example here: https://cloud.google.com/docs/authentication/production#auth-cloud-explicit-python