### PR TITLE
Fix an issue in openapi.yaml.

### DIFF
--- a/endpoints/getting-started/openapi.yaml
+++ b/endpoints/getting-started/openapi.yaml
@@ -65,7 +65,7 @@ paths:
             $ref: "#/definitions/authInfoResponse"
       security:
         - api_key: []
-        - google_jwt: []
+          google_jwt: []
   "/auth/info/googleidtoken":
     get:
       description: "Returns the requests' authentication information."
@@ -79,7 +79,7 @@ paths:
             $ref: "#/definitions/authInfoResponse"
       security:
         - api_key: []
-        - google_id_token: []
+          google_id_token: []
 definitions:
   echoMessage:
     properties:


### PR DESCRIPTION
In our sample, both api_key and the auth issuer are required, the config
should use "AND" semantics.