### PR TITLE
DLP dependency update, fix tests (still requires right service account credentials)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
   && set +x && source secrets.env && set -x
   || true
 # Cross project - GOOGLE_APPLICATION_CREDENTIALS uses cloud-docs-tests, but BQ uses G_C_P (argh!)
-- export GOOGLE_CLOUD_PROJECT=java-docs-samples-tests
+- export GOOGLE_CLOUD_PROJECT=java-docs-samples-testing
 # Skip the install step, since Maven will download the dependencies we need
 # when the test build runs.
 # http://stackoverflow.com/q/31945809/101923

--- a/dlp/pom.xml
+++ b/dlp/pom.xml
@@ -37,29 +37,12 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-  <!-- Temporary workaround for known issue : https://github.com/GoogleCloudPlatform/google-cloud-java/issues/2192 -->
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.google.auth</groupId>
-        <artifactId>google-auth-library-credentials</artifactId>
-        <version>${google.auth.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.auth</groupId>
-        <artifactId>google-auth-library-oauth2-http</artifactId>
-        <version>${google.auth.version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-  <!--- End of workaround -->
-
   <dependencies>
     <!-- [START dlp_maven] -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-dlp</artifactId>
-      <version>0.20.3-alpha</version>
+      <version>0.21.0-alpha</version>
     </dependency>
     <!-- [END dlp_maven] -->
     <dependency>

--- a/dlp/src/main/java/com/example/dlp/Inspect.java
+++ b/dlp/src/main/java/com/example/dlp/Inspect.java
@@ -15,9 +15,10 @@
 
 package com.example.dlp;
 
-import com.google.api.gax.grpc.OperationFuture;
+import com.google.api.gax.rpc.OperationFuture;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.dlp.v2beta1.DlpServiceClient;
+import com.google.longrunning.Operation;
 import com.google.privacy.dlp.v2beta1.CloudStorageOptions;
 import com.google.privacy.dlp.v2beta1.CloudStorageOptions.FileSet;
 import com.google.privacy.dlp.v2beta1.ContentItem;
@@ -226,7 +227,7 @@ public class Inspect {
       OutputStorageConfig outputConfig = OutputStorageConfig.getDefaultInstance();
 
       // asynchronously submit an inspect operation
-      OperationFuture<InspectOperationResult, InspectOperationMetadata> responseFuture =
+      OperationFuture<InspectOperationResult, InspectOperationMetadata, Operation> responseFuture =
           dlpServiceClient.createInspectOperationAsync(inspectConfig, storageConfig, outputConfig);
 
       // ...
@@ -291,7 +292,7 @@ public class Inspect {
       OutputStorageConfig outputConfig = OutputStorageConfig.getDefaultInstance();
 
       // asynchronously submit an inspect operation
-      OperationFuture<InspectOperationResult, InspectOperationMetadata> responseFuture =
+      OperationFuture<InspectOperationResult, InspectOperationMetadata, Operation> responseFuture =
           dlpServiceClient.createInspectOperationAsync(inspectConfig, storageConfig, outputConfig);
 
       // ...


### PR DESCRIPTION
Note :the service account credentials used for tests need to have access to Datastore, Storage.