### PR TITLE
KMS: Make samples consistent with all languages.

### DIFF
--- a/kms/src/main/java/com/example/CryptFile.java
+++ b/kms/src/main/java/com/example/CryptFile.java
@@ -59,64 +59,51 @@ public class CryptFile {
         .build();
   }
 
-  /**
-   * Encrypts the given bytes, using the primary version of the specified crypto key.
-   *
-   * The primary version can be updated via the <a
-   * href="https://g.co/cloud/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys/updatePrimaryVersion">updatePrimaryVersion</a>
-   * method.
-   */
-  public static byte[] encrypt(String projectId, String ringId, String keyId, byte[] plaintext)
-      throws IOException {
-    return encrypt(projectId, ringId, keyId, null, plaintext);
-  }
-
   // [START kms_encrypt]
+
   /**
-   * Encrypts the given bytes, using the specified crypto key version.
+   * Encrypts the given plaintext using the specified crypto key.
    */
   public static byte[] encrypt(
-      String projectId, String ringId, String keyId, String version, byte[] plaintext)
+      String projectId, String locationId, String keyRingId, String cryptoKeyId, byte[] plaintext)
       throws IOException {
-    String location = "global";
     // The resource name of the cryptoKey
-    String cryptoKeyName = String.format(
+    String resourceName = String.format(
         "projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s",
-        projectId, location, ringId, keyId);
-    if (null != version) {
-      cryptoKeyName += "/cryptoKeyVersions/" + version;
-    }
+        projectId, locationId, keyRingId, cryptoKeyId);
+
     // Create the Cloud KMS client.
     CloudKMS kms = createAuthorizedClient();
 
     EncryptRequest request = new EncryptRequest().encodePlaintext(plaintext);
     EncryptResponse response = kms.projects().locations().keyRings().cryptoKeys()
-            .encrypt(cryptoKeyName, request)
-            .execute();
+        .encrypt(resourceName, request)
+        .execute();
 
     return response.decodeCiphertext();
   }
   // [END kms_encrypt]
 
   // [START kms_decrypt]
+
   /**
-   * Decrypts the given encrypted bytes, using the specified crypto key.
+   * Decrypts the provided ciphertext with the specified crypto key.
    */
-  public static byte[] decrypt(String projectId, String ringId, String keyId, byte[] encrypted)
+  public static byte[] decrypt(String projectId, String locationId, String keyRingId,
+      String cryptoKeyId, byte[] ciphertext)
       throws IOException {
-    String location = "global";
     // Create the Cloud KMS client.
     CloudKMS kms = createAuthorizedClient();
 
     // The resource name of the cryptoKey
     String cryptoKeyName = String.format(
         "projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s",
-        projectId, location, ringId, keyId);
+        projectId, locationId, keyRingId, cryptoKeyId);
 
-    DecryptRequest request = new DecryptRequest().encodeCiphertext(encrypted);
+    DecryptRequest request = new DecryptRequest().encodeCiphertext(ciphertext);
     DecryptResponse response = kms.projects().locations().keyRings().cryptoKeys()
-            .decrypt(cryptoKeyName, request)
-            .execute();
+        .decrypt(cryptoKeyName, request)
+        .execute();
 
     return response.decodePlaintext();
   }

--- a/kms/src/main/java/com/example/CryptFileCommands.java
+++ b/kms/src/main/java/com/example/CryptFileCommands.java
@@ -20,10 +20,11 @@ import org.kohsuke.args4j.spi.SubCommand;
 import org.kohsuke.args4j.spi.SubCommandHandler;
 import org.kohsuke.args4j.spi.SubCommands;
 
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
 
 /**
  * Defines the different sub-commands and their parameters, for command-line invocation.
@@ -33,7 +34,7 @@ class CryptFileCommands {
    * An interface for a command-line sub-command.
    */
   interface Command {
-    public void run() throws IOException;
+    void run() throws IOException;
   }
 
   // Most of the commands take some subset of the same arguments, so specify groups of arguments
@@ -41,27 +42,25 @@ class CryptFileCommands {
   static class Args {
     @Option(name = "--project-id", aliases = "-p", required = true, usage = "Your GCP project ID")
     String projectId;
-    @Argument(metaVar = "ringId", required = true, index = 0, usage = "The ring id")
-    String ringId;
-    @Argument(metaVar = "keyId", required = true, index = 1, usage = "The key id")
-    String keyId;
-    @Argument(metaVar = "inFile", required = true, index = 2, usage = "The source file")
+    @Argument(metaVar = "locationId", required = true, index = 0, usage = "The key location")
+    String locationId;
+    @Argument(metaVar = "keyRingId", required = true, index = 1, usage = "The key ring id")
+    String keyRingId;
+    @Argument(metaVar = "cryptoKeyId", required = true, index = 2, usage = "The crypto key id")
+    String cryptoKeyId;
+    @Argument(metaVar = "inFile", required = true, index = 3, usage = "The source file")
     String inFile;
-    @Argument(metaVar = "outFile", required = true, index = 3, usage = "The destination file")
+    @Argument(metaVar = "outFile", required = true, index = 4, usage = "The destination file")
     String outFile;
   }
 
   public static class EncryptCommand extends Args implements Command {
     public void run() throws IOException {
       byte[] encrypted = CryptFile.encrypt(
-          projectId, ringId, keyId,
-          Files.readAllBytes(Paths.get(inFile)));
+          projectId, locationId, keyRingId, cryptoKeyId, Files.readAllBytes(Paths.get(inFile)));
 
-      FileOutputStream stream = new FileOutputStream(outFile);
-      try {
+      try (FileOutputStream stream = new FileOutputStream(outFile)) {
         stream.write(encrypted);
-      } finally {
-        stream.close();
       }
     }
   }
@@ -69,14 +68,10 @@ class CryptFileCommands {
   public static class DecryptCommand extends Args implements Command {
     public void run() throws IOException {
       byte[] decrypted = CryptFile.decrypt(
-          projectId, ringId, keyId,
-          Files.readAllBytes(Paths.get(inFile)));
+          projectId, locationId, keyRingId, cryptoKeyId, Files.readAllBytes(Paths.get(inFile)));
 
-      FileOutputStream stream = new FileOutputStream(outFile);
-      try {
+      try (FileOutputStream stream = new FileOutputStream(outFile)) {
         stream.write(decrypted);
-      } finally {
-        stream.close();
       }
     }
   }

--- a/kms/src/main/java/com/example/Quickstart.java
+++ b/kms/src/main/java/com/example/Quickstart.java
@@ -57,7 +57,7 @@ public class Quickstart {
   public static void main(String... args) throws Exception {
     String projectId = args[0];
     // The location of the Key Rings
-    String location = "global";
+    String location = args[1];
 
     // Create the Cloud KMS client.
     CloudKMS kms = createAuthorizedClient();
@@ -80,7 +80,7 @@ public class Quickstart {
         System.out.println(keyRing.getName());
       }
     } else {
-      System.out.println("No keyrings defined.");
+      System.out.println("No key rings defined.");
     }
   }
 }

--- a/kms/src/main/java/com/example/SnippetCommands.java
+++ b/kms/src/main/java/com/example/SnippetCommands.java
@@ -30,7 +30,7 @@ class SnippetCommands {
    * An interface for a command-line sub-command.
    */
   interface Command {
-    public void run() throws IOException;
+    void run() throws IOException;
   }
 
   // Most of the commands take some subset of the same arguments, so specify groups of arguments
@@ -40,79 +40,84 @@ class SnippetCommands {
     String projectId;
   }
 
-  static class KeyRingArgs extends ProjectIdArgs {
-    @Argument(metaVar = "ringId", required = true, index = 0, usage = "The ring id")
-    String ringId;
+  static class LocationIdArgs extends ProjectIdArgs {
+    @Argument(metaVar = "locationId", required = true, index = 0, usage = "The location id")
+    String locationId;
+  }
+
+  static class KeyRingArgs extends LocationIdArgs {
+    @Argument(metaVar = "keyRingId", required = true, index = 1, usage = "The key ring id")
+    String keyRingId;
   }
 
   static class KeyArgs extends KeyRingArgs {
-    @Argument(metaVar = "keyId", required = true, index = 1, usage = "The key id")
-    String keyId;
+    @Argument(metaVar = "cryptoKeyId", required = true, index = 2, usage = "The crypto key id")
+    String cryptoKeyId;
   }
 
   static class KeyVersionArgs extends KeyArgs {
-    @Argument(metaVar = "version", required = true, index = 2, usage = "The key version")
+    @Argument(metaVar = "version", required = true, index = 3, usage = "The key version")
     String version;
   }
 
 
   public static class CreateKeyRingCommand extends KeyRingArgs implements Command {
     public void run() throws IOException {
-      Snippets.createKeyRing(projectId, ringId);
+      Snippets.createKeyRing(projectId, locationId, keyRingId);
     }
   }
 
   public static class CreateCryptoKeyCommand extends KeyArgs implements Command {
     public void run() throws IOException {
-      Snippets.createCryptoKey(projectId, ringId, keyId);
+      Snippets.createCryptoKey(projectId, locationId, keyRingId, cryptoKeyId);
     }
   }
 
   public static class CreateCryptoKeyVersionCommand extends KeyArgs implements Command {
     public void run() throws IOException {
-      Snippets.createCryptoKeyVersion(projectId, ringId, keyId);
+      Snippets.createCryptoKeyVersion(projectId, locationId, keyRingId, cryptoKeyId);
     }
   }
 
-  public static class ListKeyRingsCommand extends ProjectIdArgs implements Command {
+  public static class ListKeyRingsCommand extends LocationIdArgs implements Command {
     public void run() throws IOException {
-      Snippets.listKeyRings(projectId);
+      Snippets.listKeyRings(projectId, locationId);
     }
   }
 
   public static class ListCryptoKeysCommand extends KeyRingArgs implements Command {
     public void run() throws IOException {
-      Snippets.listCryptoKeys(projectId, ringId);
+      Snippets.listCryptoKeys(projectId, locationId, keyRingId);
     }
   }
 
   public static class ListCryptoKeyVersionsCommand extends KeyArgs implements Command {
     public void run() throws IOException {
-      Snippets.listCryptoKeyVersions(projectId, ringId, keyId);
+      Snippets.listCryptoKeyVersions(projectId, locationId, keyRingId, cryptoKeyId);
     }
   }
 
   public static class DisableCryptoKeyVersionCommand extends KeyVersionArgs implements Command {
     public void run() throws IOException {
-      Snippets.disableCryptoKeyVersion(projectId, ringId, keyId, version);
+      Snippets.disableCryptoKeyVersion(projectId, locationId, keyRingId, cryptoKeyId, version);
     }
   }
 
   public static class DestroyCryptoKeyVersionCommand extends KeyVersionArgs implements Command {
     public void run() throws IOException {
-      Snippets.destroyCryptoKeyVersion(projectId, ringId, keyId, version);
+      Snippets.destroyCryptoKeyVersion(projectId, locationId, keyRingId, cryptoKeyId, version);
     }
   }
 
   public static class GetKeyRingPolicyCommand extends KeyRingArgs implements Command {
     public void run() throws IOException {
-      Snippets.getKeyRingPolicy(projectId, ringId);
+      Snippets.getKeyRingPolicy(projectId, locationId, keyRingId);
     }
   }
 
   public static class GetCryptoKeyPolicyCommand extends KeyArgs implements Command {
     public void run() throws IOException {
-      Snippets.getCryptoKeyPolicy(projectId, ringId, keyId);
+      Snippets.getCryptoKeyPolicy(projectId, locationId, keyRingId, cryptoKeyId);
     }
   }
 
@@ -128,7 +133,7 @@ class SnippetCommands {
     String role;
 
     public void run() throws IOException {
-      Snippets.addMemberToKeyRingPolicy(projectId, ringId, member, role);
+      Snippets.addMemberToKeyRingPolicy(projectId, locationId, keyRingId, member, role);
     }
   }
 
@@ -144,7 +149,7 @@ class SnippetCommands {
     String role;
 
     public void run() throws IOException {
-      Snippets.addMemberToCryptoKeyPolicy(projectId, ringId, keyId, member, role);
+      Snippets.addMemberToCryptoKeyPolicy(projectId, locationId, keyRingId, cryptoKeyId, member, role);
     }
   }
 
@@ -160,7 +165,7 @@ class SnippetCommands {
     String role;
 
     public void run() throws IOException {
-      Snippets.removeMemberFromKeyRingPolicy(projectId, ringId, member, role);
+      Snippets.removeMemberFromKeyRingPolicy(projectId, locationId, keyRingId, member, role);
     }
   }
 
@@ -176,7 +181,7 @@ class SnippetCommands {
     String role;
 
     public void run() throws IOException {
-      Snippets.removeMemberFromCryptoKeyPolicy(projectId, ringId, keyId, member, role);
+      Snippets.removeMemberFromCryptoKeyPolicy(projectId, locationId, keyRingId, cryptoKeyId, member, role);
     }
   }
 

--- a/kms/src/main/java/com/example/Snippets.java
+++ b/kms/src/main/java/com/example/Snippets.java
@@ -31,13 +31,11 @@ import com.google.api.services.cloudkms.v1.model.ListCryptoKeysResponse;
 import com.google.api.services.cloudkms.v1.model.ListKeyRingsResponse;
 import com.google.api.services.cloudkms.v1.model.Policy;
 import com.google.api.services.cloudkms.v1.model.SetIamPolicyRequest;
-
-import org.kohsuke.args4j.CmdLineException;
-import org.kohsuke.args4j.CmdLineParser;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
 
 public class Snippets {
 
@@ -68,20 +66,21 @@ public class Snippets {
   }
 
   // [START kms_create_keyring]
+
   /**
    * Creates a new key ring with the given id.
    */
-  public static KeyRing createKeyRing(String projectId, String ringId) throws IOException {
-    String location = "global";
+  public static KeyRing createKeyRing(String projectId, String locationId, String keyRingId)
+      throws IOException {
     // Create the Cloud KMS client.
     CloudKMS kms = createAuthorizedClient();
 
     // The resource name of the location associated with the KeyRing.
-    String parent = String.format("projects/%s/locations/%s", projectId, location);
+    String parent = String.format("projects/%s/locations/%s", projectId, locationId);
     // Create the KeyRing for your project.
     KeyRing keyring = kms.projects().locations().keyRings()
         .create(parent, new KeyRing())
-        .setKeyRingId(ringId)
+        .setKeyRingId(keyRingId)
         .execute();
 
     System.out.println(keyring);
@@ -90,18 +89,19 @@ public class Snippets {
   // [END kms_create_keyring]
 
   // [START kms_create_cryptokey]
+
   /**
    * Creates a new crypto key with the given id.
    */
-  public static CryptoKey createCryptoKey(String projectId, String ringId, String keyId)
+  public static CryptoKey createCryptoKey(String projectId, String locationId, String keyRingId,
+      String cryptoKeyId)
       throws IOException {
-    String location = "global";
     // Create the Cloud KMS client.
     CloudKMS kms = createAuthorizedClient();
 
     // The resource name of the location associated with the KeyRing.
     String parent = String.format(
-        "projects/%s/locations/%s/keyRings/%s", projectId, location, ringId);
+        "projects/%s/locations/%s/keyRings/%s", projectId, locationId, keyRingId);
 
     // This will allow the API access to the key for encryption and decryption.
     String purpose = "ENCRYPT_DECRYPT";
@@ -111,7 +111,7 @@ public class Snippets {
     // Create the CryptoKey for your project.
     CryptoKey createdKey = kms.projects().locations().keyRings().cryptoKeys()
         .create(parent, cryptoKey)
-        .setCryptoKeyId(keyId)
+        .setCryptoKeyId(cryptoKeyId)
         .execute();
 
     System.out.println(createdKey);
@@ -120,19 +120,20 @@ public class Snippets {
   // [END kms_create_cryptokey]
 
   // [START kms_create_cryptokey_version]
+
   /**
    * Creates a new crypto key version for the given id.
    */
   public static void createCryptoKeyVersion(
-      String projectId, String ringId, String keyId) throws IOException {
-    String location = "global";
+      String projectId, String locationId, String keyRingId, String cryptoKeyId)
+      throws IOException {
     // Create the Cloud KMS client.
     CloudKMS kms = createAuthorizedClient();
 
     // The resource name of the cryptoKey
     String cryptoKeys = String.format(
         "projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s",
-        projectId, location, ringId, keyId);
+        projectId, locationId, keyRingId, cryptoKeyId);
 
     CryptoKeyVersion version = new CryptoKeyVersion();
 
@@ -146,20 +147,20 @@ public class Snippets {
   // [END kms_create_cryptokey_version]
 
   // [START kms_disable_cryptokey_version]
+
   /**
    * Disables the given version of the crypto key.
    */
   public static CryptoKeyVersion disableCryptoKeyVersion(
-      String projectId, String ringId, String keyId, String version)
+      String projectId, String locationId, String keyRingId, String cryptoKeyId, String version)
       throws IOException {
-    String location = "global";
     // Create the Cloud KMS client.
     CloudKMS kms = createAuthorizedClient();
 
     // The resource name of the cryptoKey version
     String cryptoKeyVersion = String.format(
         "projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s/cryptoKeyVersions/%s",
-        projectId, location, ringId, keyId, version);
+        projectId, locationId, keyRingId, cryptoKeyId, version);
 
     CryptoKeyVersion newVersionState = new CryptoKeyVersion()
         .setState("DISABLED");
@@ -176,20 +177,20 @@ public class Snippets {
   // [END kms_disable_cryptokey_version]
 
   // [START kms_destroy_cryptokey_version]
+
   /**
    * Marks the given version of a crypto key to be destroyed at a scheduled future point.
    */
   public static CryptoKeyVersion destroyCryptoKeyVersion(
-      String projectId, String ringId, String keyId, String version)
+      String projectId, String locationId, String keyRingId, String cryptoKeyId, String version)
       throws IOException {
-    String location = "global";
     // Create the Cloud KMS client.
     CloudKMS kms = createAuthorizedClient();
 
     // The resource name of the cryptoKey version
     String cryptoKeyVersion = String.format(
         "projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s/cryptoKeyVersions/%s",
-        projectId, location, ringId, keyId, version);
+        projectId, locationId, keyRingId, cryptoKeyId, version);
 
     DestroyCryptoKeyVersionRequest destroyRequest = new DestroyCryptoKeyVersionRequest();
 
@@ -204,19 +205,20 @@ public class Snippets {
   // [END kms_destroy_cryptokey_version]
 
   // [START kms_get_cryptokey_policy]
+
   /**
    * Retrieves the IAM policy for the given crypto key.
    */
-  public static Policy getCryptoKeyPolicy(String projectId, String ringId, String keyId)
+  public static Policy getCryptoKeyPolicy(String projectId, String locationId, String keyRingId,
+      String cryptoKeyId)
       throws IOException {
-    String location = "global";
     // Create the Cloud KMS client.
     CloudKMS kms = createAuthorizedClient();
 
     // The resource name of the cryptoKey
     String cryptoKey = String.format(
         "projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s",
-        projectId, location, ringId, keyId);
+        projectId, locationId, keyRingId, cryptoKeyId);
 
     // Get the current IAM policy and add the new account to it.
     Policy iamPolicy = kms.projects().locations().keyRings().cryptoKeys()
@@ -229,18 +231,19 @@ public class Snippets {
   // [END kms_get_cryptokey_policy]
 
   // [START kms_get_keyring_policy]
+
   /**
    * Retrieves the IAM policy for the given crypto key.
    */
-  public static Policy getKeyRingPolicy(String projectId, String ringId) throws IOException {
-    String location = "global";
+  public static Policy getKeyRingPolicy(String projectId, String locationId, String keyRingId)
+      throws IOException {
     // Create the Cloud KMS client.
     CloudKMS kms = createAuthorizedClient();
 
     // The resource name of the keyring
     String keyring = String.format(
         "projects/%s/locations/%s/keyRings/%s",
-        projectId, location, ringId);
+        projectId, locationId, keyRingId);
 
     // Get the current IAM policy and add the new account to it.
     Policy iamPolicy = kms.projects().locations().keyRings()
@@ -253,42 +256,38 @@ public class Snippets {
   // [END kms_get_keyring_policy]
 
   // [START kms_add_member_to_cryptokey_policy]
+
   /**
    * Adds the given member to the given key, with the given role.
    *
-   * @param ringId The id of the keyring.
-   * @param keyId The id of the crypto key.
+   * @param projectId The id of the project.
+   * @param locationId The location id of the key.
+   * @param keyRingId The id of the keyring.
+   * @param cryptoKeyId The id of the crypto key.
    * @param member The member to add. Must be in the proper format, eg:
    *
-   *        allUsers
-   *        user:$userEmail
-   *        serviceAccount:$serviceAccountEmail
+   * allUsers user:$userEmail serviceAccount:$serviceAccountEmail
    *
-   *        See https://g.co/cloud/kms/docs/reference/rest/v1/Policy#binding
-   *        for more details.
+   * See https://g.co/cloud/kms/docs/reference/rest/v1/Policy#binding for more details.
+   * @param role Must be in one of the following formats: roles/[role]
+   * organizations/[organizationId]/roles/[role] projects/[projectId]/roles/[role]
    *
-   * @param role Must be in one of the following formats:
-   *        roles/[role]
-   *        organizations/[organizationId]/roles/[role]
-   *        projects/[projectId]/roles/[role]
-   *
-   *        See https://g.co/cloud/iam/docs/understanding-roles
-   *        for available values for [role].
+   * See https://g.co/cloud/iam/docs/understanding-roles for available values for [role].
    */
   public static Policy addMemberToCryptoKeyPolicy(
-      String projectId, String ringId, String keyId, String member, String role)
+      String projectId, String locationId, String keyRingId, String cryptoKeyId, String member,
+      String role)
       throws IOException {
-    String location = "global";
     // Create the Cloud KMS client.
     CloudKMS kms = createAuthorizedClient();
 
     // The resource name of the cryptoKey version
     String cryptoKey = String.format(
         "projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s",
-        projectId, location, ringId, keyId);
+        projectId, locationId, keyRingId, cryptoKeyId);
 
     // Get the current IAM policy
-    Policy iamPolicy = getCryptoKeyPolicy(projectId, ringId, keyId);
+    Policy iamPolicy = getCryptoKeyPolicy(projectId, locationId, keyRingId, cryptoKeyId);
 
     // Add the new account to it.
     Binding newBinding = new Binding()
@@ -314,41 +313,36 @@ public class Snippets {
   // [END kms_add_member_to_cryptokey_policy]
 
   // [START kms_add_member_to_keyring_policy]
+
   /**
    * Adds the given member to the given keyring, with the given role.
    *
-   * @param ringId The id of the keyring.
+   * @param projectId The id of the project.
+   * @param locationId The location id of the key.
+   * @param keyRingId The id of the keyring.
    * @param member The member to add. Must be in the proper format, eg:
    *
-   *        allUsers
-   *        user:$userEmail
-   *        serviceAccount:$serviceAccountEmail
+   * allUsers user:$userEmail serviceAccount:$serviceAccountEmail
    *
-   *        See https://g.co/cloud/kms/docs/reference/rest/v1/Policy#binding
-   *        for more details.
+   * See https://g.co/cloud/kms/docs/reference/rest/v1/Policy#binding for more details.
+   * @param role Must be in one of the following formats: roles/[role]
+   * organizations/[organizationId]/roles/[role] projects/[projectId]/roles/[role]
    *
-   * @param role Must be in one of the following formats:
-   *        roles/[role]
-   *        organizations/[organizationId]/roles/[role]
-   *        projects/[projectId]/roles/[role]
-   *
-   *        See https://g.co/cloud/iam/docs/understanding-roles
-   *        for available values for [role].
+   * See https://g.co/cloud/iam/docs/understanding-roles for available values for [role].
    */
   public static Policy addMemberToKeyRingPolicy(
-      String projectId, String ringId, String member, String role)
+      String projectId, String locationId, String keyRingId, String member, String role)
       throws IOException {
-    String location = "global";
     // Create the Cloud KMS client.
     CloudKMS kms = createAuthorizedClient();
 
     // The resource name of the keyring version
     String keyring = String.format(
         "projects/%s/locations/%s/keyRings/%s",
-        projectId, location, ringId);
+        projectId, locationId, keyRingId);
 
     // Get the current IAM policy
-    Policy iamPolicy = getKeyRingPolicy(projectId, ringId);
+    Policy iamPolicy = getKeyRingPolicy(projectId, locationId, keyRingId);
 
     // Add the new account to it.
     Binding newBinding = new Binding()
@@ -374,23 +368,24 @@ public class Snippets {
   // [END kms_add_member_to_keyring_policy]
 
   // [START kms_remove_member_from_cryptokey_policy]
+
   /**
    * Removes the given member from the given policy.
    */
   public static Policy removeMemberFromCryptoKeyPolicy(
-      String projectId, String ringId, String keyId, String member, String role)
+      String projectId, String locationId, String keyRingId, String cryptoKeyId, String member,
+      String role)
       throws IOException {
-    String location = "global";
     // Create the Cloud KMS client.
     CloudKMS kms = createAuthorizedClient();
 
     // The resource name of the cryptoKey
     String cryptoKey = String.format(
         "projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s",
-        projectId, location, ringId, keyId);
+        projectId, locationId, keyRingId, cryptoKeyId);
 
     // Get the current IAM policy and add the new account to it.
-    Policy iamPolicy = getCryptoKeyPolicy(projectId, ringId, keyId);
+    Policy iamPolicy = getCryptoKeyPolicy(projectId, locationId, keyRingId, cryptoKeyId);
 
     if (null == iamPolicy.getBindings()) {
       // Nothing to remove
@@ -417,23 +412,23 @@ public class Snippets {
   // [END kms_remove_member_from_cryptokey_policy]
 
   // [START kms_remove_member_from_keyring_policy]
+
   /**
    * Removes the given member from the given policy.
    */
   public static Policy removeMemberFromKeyRingPolicy(
-      String projectId, String ringId, String member, String role)
+      String projectId, String locationId, String keyRingId, String member, String role)
       throws IOException {
-    String location = "global";
     // Create the Cloud KMS client.
     CloudKMS kms = createAuthorizedClient();
 
     // The resource name of the cryptoKey
     String cryptoKey = String.format(
         "projects/%s/locations/%s/keyRings/%s",
-        projectId, location, ringId);
+        projectId, locationId, keyRingId);
 
     // Get the current IAM policy and add the new account to it.
-    Policy iamPolicy = getKeyRingPolicy(projectId, ringId);
+    Policy iamPolicy = getKeyRingPolicy(projectId, locationId, keyRingId);
 
     // Filter out the given member
     for (Binding b : iamPolicy.getBindings()) {
@@ -455,17 +450,16 @@ public class Snippets {
   // [END kms_remove_member_from_keyring_policy]
 
   /**
-   * Prints all the keyrings in the given project.
+   * Prints all the key rings in the given project.
    */
-  public static void listKeyRings(String projectId) throws IOException {
-    String location = "global";
+  public static void listKeyRings(String projectId, String locationId) throws IOException {
     // Create the Cloud KMS client.
     CloudKMS kms = createAuthorizedClient();
 
     // The resource name of the cryptoKey
     String keyRingPath = String.format(
         "projects/%s/locations/%s",
-        projectId, location);
+        projectId, locationId);
 
     // Make the RPC call
     ListKeyRingsResponse response = kms.projects().locations()
@@ -485,17 +479,17 @@ public class Snippets {
   }
 
   /**
-   * Prints all the keys in the given key ring.
+   * Prints all crypto keys in the given key ring.
    */
-  public static void listCryptoKeys(String projectId, String ringId) throws IOException {
-    String location = "global";
+  public static void listCryptoKeys(String projectId, String locationId, String keyRingId)
+      throws IOException {
     // Create the Cloud KMS client.
     CloudKMS kms = createAuthorizedClient();
 
     // The resource name of the cryptoKey
     String keyRingPath = String.format(
         "projects/%s/locations/%s/keyRings/%s",
-        projectId, location, ringId);
+        projectId, locationId, keyRingId);
 
     ListCryptoKeysResponse cryptoKeys = kms.projects().locations().keyRings()
         .cryptoKeys()
@@ -511,17 +505,15 @@ public class Snippets {
    * Prints all the versions for the given crypto key.
    */
   public static void listCryptoKeyVersions(
-      String projectId, String ringId, String keyId) throws IOException {
-    String location = "global";
+      String projectId, String locationId, String keyRingId, String cryptoKeyId)
+      throws IOException {
     // Create the Cloud KMS client.
     CloudKMS kms = createAuthorizedClient();
 
     // The resource name of the cryptoKey
     String cryptoKeys = String.format(
         "projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s",
-        projectId, location, ringId, keyId);
-
-    DestroyCryptoKeyVersionRequest destroyRequest = new DestroyCryptoKeyVersionRequest();
+        projectId, locationId, keyRingId, cryptoKeyId);
 
     ListCryptoKeyVersionsResponse versions = kms.projects().locations().keyRings().cryptoKeys()
         .cryptoKeyVersions()

--- a/kms/src/test/java/com/example/QuickstartIT.java
+++ b/kms/src/test/java/com/example/QuickstartIT.java
@@ -59,12 +59,13 @@ public class QuickstartIT {
     System.setOut(out);
 
     Snippets.createCryptoKeyVersion(
-        SnippetsIT.PROJECT_ID, SnippetsIT.KEY_RING_ID, SnippetsIT.CRYPTO_KEY_ID);
+        SnippetsIT.PROJECT_ID, SnippetsIT.LOCATION_ID, SnippetsIT.KEY_RING_ID,
+        SnippetsIT.CRYPTO_KEY_ID);
   }
 
   @Test
   public void listKeyRings_printsKeyRing() throws Exception {
-    Quickstart.main(SnippetsIT.PROJECT_ID);
+    Quickstart.main(SnippetsIT.PROJECT_ID, SnippetsIT.LOCATION_ID);
 
     assertThat(bout.toString()).contains(String.format("keyRings/%s", SnippetsIT.KEY_RING_ID));
   }

--- a/kms/src/test/java/com/example/SnippetsIT.java
+++ b/kms/src/test/java/com/example/SnippetsIT.java
@@ -41,6 +41,7 @@ import java.util.regex.Pattern;
 public class SnippetsIT {
 
   static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+  static final String LOCATION_ID = "global";
   static final String KEY_RING_ID = "test-snippets-key-ring";
   static final String CRYPTO_KEY_ID = "test-snippets-crypto-key";
   static final String TEST_USER = "serviceAccount:"
@@ -63,7 +64,7 @@ public class SnippetsIT {
     // Since you can't delete keyrings & cryptokeys atm, these tests assume they already exist.
     // Use the snippets functions to create them.
     try {
-      Snippets.createKeyRing(PROJECT_ID, KEY_RING_ID);
+      Snippets.createKeyRing(PROJECT_ID,LOCATION_ID, KEY_RING_ID);
 
       // Since there's no way to delete keyrings atm, have two branches - one for the first time the
       // test is run, one for after the key already exists
@@ -76,7 +77,7 @@ public class SnippetsIT {
     }
 
     try {
-      Snippets.createCryptoKey(PROJECT_ID, KEY_RING_ID, CRYPTO_KEY_ID);
+      Snippets.createCryptoKey(PROJECT_ID, LOCATION_ID, KEY_RING_ID, CRYPTO_KEY_ID);
 
       // Since there's no way to delete keyrings atm, have two branches - one for the first time the
       // test is run, one for after the key already exists
@@ -102,7 +103,7 @@ public class SnippetsIT {
 
     String stdout;
     try {
-      Snippets.listCryptoKeyVersions(PROJECT_ID, KEY_RING_ID, CRYPTO_KEY_ID);
+      Snippets.listCryptoKeyVersions(PROJECT_ID, LOCATION_ID, KEY_RING_ID, CRYPTO_KEY_ID);
       stdout = bout.toString();
     } finally {
       System.setOut(realOut);
@@ -120,7 +121,7 @@ public class SnippetsIT {
       }
 
       String version = matcher.group(1);
-      Snippets.destroyCryptoKeyVersion(PROJECT_ID, KEY_RING_ID, CRYPTO_KEY_ID, version);
+      Snippets.destroyCryptoKeyVersion(PROJECT_ID, LOCATION_ID, KEY_RING_ID, CRYPTO_KEY_ID, version);
     }
   }
 
@@ -130,7 +131,7 @@ public class SnippetsIT {
     out = new PrintStream(bout);
     System.setOut(out);
 
-    Snippets.createCryptoKeyVersion(PROJECT_ID, KEY_RING_ID, CRYPTO_KEY_ID);
+    Snippets.createCryptoKeyVersion(PROJECT_ID, LOCATION_ID, KEY_RING_ID, CRYPTO_KEY_ID);
   }
 
   @After
@@ -140,14 +141,14 @@ public class SnippetsIT {
 
   @Test
   public void listKeyRings_printsKeyRing() throws Exception {
-    Snippets.listKeyRings(PROJECT_ID);
+    Snippets.listKeyRings(PROJECT_ID, LOCATION_ID);
 
     assertThat(bout.toString()).contains(String.format("keyRings/%s", KEY_RING_ID));
   }
 
   @Test
   public void listCryptoKeys_printsCryptoKeys() throws Exception {
-    Snippets.listCryptoKeys(PROJECT_ID, KEY_RING_ID);
+    Snippets.listCryptoKeys(PROJECT_ID, LOCATION_ID, KEY_RING_ID);
 
     assertThat(bout.toString()).contains(
         String.format("keyRings/%s/cryptoKeys/%s", KEY_RING_ID, CRYPTO_KEY_ID));
@@ -155,7 +156,7 @@ public class SnippetsIT {
 
   @Test
   public void listCryptoKeyVersions_printsVersions() throws Exception {
-    Snippets.listCryptoKeyVersions(PROJECT_ID, KEY_RING_ID, CRYPTO_KEY_ID);
+    Snippets.listCryptoKeyVersions(PROJECT_ID, LOCATION_ID, KEY_RING_ID, CRYPTO_KEY_ID);
 
     assertThat(bout.toString()).containsMatch(String.format(
         "keyRings/%s/cryptoKeys/%s/cryptoKeyVersions/\\d+\",\"state\":\"ENABLED\"",
@@ -164,14 +165,14 @@ public class SnippetsIT {
 
   @Test
   public void disableCryptoKeyVersion_disables() throws Exception {
-    Snippets.listCryptoKeyVersions(PROJECT_ID, KEY_RING_ID, CRYPTO_KEY_ID);
+    Snippets.listCryptoKeyVersions(PROJECT_ID, LOCATION_ID, KEY_RING_ID, CRYPTO_KEY_ID);
 
     Matcher matcher = Pattern.compile(".*cryptoKeyVersions/(\\d+)\",\"state\":\"ENABLED\".*",
         Pattern.DOTALL | Pattern.MULTILINE).matcher(bout.toString().trim());
     assertTrue(matcher.matches());
     String version = matcher.group(1);
 
-    Snippets.disableCryptoKeyVersion(PROJECT_ID, KEY_RING_ID, CRYPTO_KEY_ID, version);
+    Snippets.disableCryptoKeyVersion(PROJECT_ID, LOCATION_ID, KEY_RING_ID, CRYPTO_KEY_ID, version);
     assertThat(bout.toString()).containsMatch(String.format(
         "keyRings/%s/cryptoKeys/%s/cryptoKeyVersions/%s\",\"state\":\"DISABLED\"",
         KEY_RING_ID, CRYPTO_KEY_ID, version));
@@ -179,7 +180,7 @@ public class SnippetsIT {
 
   @Test
   public void destroyCryptoKeyVersion_destroys() throws Exception {
-    Snippets.listCryptoKeyVersions(PROJECT_ID, KEY_RING_ID, CRYPTO_KEY_ID);
+    Snippets.listCryptoKeyVersions(PROJECT_ID, LOCATION_ID, KEY_RING_ID, CRYPTO_KEY_ID);
 
     Matcher matcher = Pattern.compile(".*cryptoKeyVersions/(\\d+)\",\"state\":\"ENABLED\".*",
         Pattern.DOTALL | Pattern.MULTILINE).matcher(bout.toString().trim());
@@ -187,7 +188,7 @@ public class SnippetsIT {
 
     String version = matcher.group(1);
 
-    Snippets.destroyCryptoKeyVersion(PROJECT_ID, KEY_RING_ID, CRYPTO_KEY_ID, version);
+    Snippets.destroyCryptoKeyVersion(PROJECT_ID, LOCATION_ID, KEY_RING_ID, CRYPTO_KEY_ID, version);
 
     assertThat(bout.toString()).containsMatch(String.format(
         "keyRings/%s/cryptoKeys/%s/cryptoKeyVersions/%s\",\"state\":\"DESTROY_SCHEDULED\"",
@@ -197,16 +198,16 @@ public class SnippetsIT {
   @Test
   public void addAndRemoveMemberToCryptoKeyPolicy_addsDisplaysAndRemoves() throws Exception {
     // Make sure the policy doesn't already have our test user
-    Snippets.getCryptoKeyPolicy(PROJECT_ID, KEY_RING_ID, CRYPTO_KEY_ID);
+    Snippets.getCryptoKeyPolicy(PROJECT_ID, LOCATION_ID, KEY_RING_ID, CRYPTO_KEY_ID);
 
     assertThat(bout.toString()).doesNotContainMatch(TEST_USER);
 
     try {
       // Add the test user, and make sure the policy has it
       Snippets.addMemberToCryptoKeyPolicy(
-          PROJECT_ID, KEY_RING_ID, CRYPTO_KEY_ID, TEST_USER, TEST_ROLE);
+          PROJECT_ID, LOCATION_ID, KEY_RING_ID, CRYPTO_KEY_ID, TEST_USER, TEST_ROLE);
 
-      Snippets.getCryptoKeyPolicy(PROJECT_ID, KEY_RING_ID, CRYPTO_KEY_ID);
+      Snippets.getCryptoKeyPolicy(PROJECT_ID, LOCATION_ID, KEY_RING_ID, CRYPTO_KEY_ID);
 
       assertThat(bout.toString()).containsMatch(TEST_USER);
 
@@ -214,13 +215,13 @@ public class SnippetsIT {
       bout.reset();
     } finally {
       Snippets.removeMemberFromCryptoKeyPolicy(
-          PROJECT_ID, KEY_RING_ID, CRYPTO_KEY_ID, TEST_USER, TEST_ROLE);
+          PROJECT_ID, LOCATION_ID, KEY_RING_ID, CRYPTO_KEY_ID, TEST_USER, TEST_ROLE);
     }
 
     assertThat(bout.toString()).doesNotContainMatch("Response:.*" + TEST_USER);
 
     bout.reset();
-    Snippets.getCryptoKeyPolicy(PROJECT_ID, KEY_RING_ID, CRYPTO_KEY_ID);
+    Snippets.getCryptoKeyPolicy(PROJECT_ID, LOCATION_ID, KEY_RING_ID, CRYPTO_KEY_ID);
 
     assertThat(bout.toString()).doesNotContainMatch(TEST_USER);
   }
@@ -228,16 +229,16 @@ public class SnippetsIT {
   @Test
   public void addAndRemoveMemberToKeyRingPolicy_addsDisplaysAndRemoves() throws Exception {
     // Make sure the policy doesn't already have our test user
-    Snippets.getKeyRingPolicy(PROJECT_ID, KEY_RING_ID);
+    Snippets.getKeyRingPolicy(PROJECT_ID, LOCATION_ID, KEY_RING_ID);
 
     assertThat(bout.toString()).doesNotContainMatch(TEST_USER);
 
     try {
       // Add the test user, and make sure the policy has it
       Snippets.addMemberToKeyRingPolicy(
-          PROJECT_ID, KEY_RING_ID, TEST_USER, TEST_ROLE);
+          PROJECT_ID, LOCATION_ID, KEY_RING_ID, TEST_USER, TEST_ROLE);
 
-      Snippets.getKeyRingPolicy(PROJECT_ID, KEY_RING_ID);
+      Snippets.getKeyRingPolicy(PROJECT_ID, LOCATION_ID, KEY_RING_ID);
 
       assertThat(bout.toString()).containsMatch(TEST_USER);
 
@@ -245,13 +246,13 @@ public class SnippetsIT {
       bout.reset();
     } finally {
       Snippets.removeMemberFromKeyRingPolicy(
-          PROJECT_ID, KEY_RING_ID, TEST_USER, TEST_ROLE);
+          PROJECT_ID, LOCATION_ID, KEY_RING_ID, TEST_USER, TEST_ROLE);
     }
 
     assertThat(bout.toString()).doesNotContainMatch("Response:.*" + TEST_USER);
 
     bout.reset();
-    Snippets.getKeyRingPolicy(PROJECT_ID, KEY_RING_ID);
+    Snippets.getKeyRingPolicy(PROJECT_ID, LOCATION_ID, KEY_RING_ID);
 
     assertThat(bout.toString()).doesNotContainMatch(TEST_USER);
   }
@@ -259,7 +260,7 @@ public class SnippetsIT {
   @Test
   public void encryptDecrypt_encryptsAndDecrypts() throws Exception {
     // Get an enabled crypto key version, since the primary version is likely disabled
-    Snippets.listCryptoKeyVersions(PROJECT_ID, KEY_RING_ID, CRYPTO_KEY_ID);
+    Snippets.listCryptoKeyVersions(PROJECT_ID, LOCATION_ID, KEY_RING_ID, CRYPTO_KEY_ID);
     Matcher matcher = Pattern.compile(".*cryptoKeyVersions/(\\d+)\",\"state\":\"ENABLED\".*",
         Pattern.DOTALL | Pattern.MULTILINE).matcher(bout.toString().trim());
     assertTrue(matcher.matches());
@@ -271,7 +272,7 @@ public class SnippetsIT {
     assertThat(new String(encrypted)).isNotEqualTo(ENCRYPT_STRING);
 
     byte[] decrypted = CryptFile.decrypt(
-        PROJECT_ID, KEY_RING_ID, CRYPTO_KEY_ID, encrypted);
+        PROJECT_ID, LOCATION_ID, KEY_RING_ID, CRYPTO_KEY_ID, encrypted);
 
     assertThat(new String(decrypted)).isEqualTo(ENCRYPT_STRING);
   }


### PR DESCRIPTION
In particular:

* Define keyRingId and cryptoKeyId consistently with the API.
* Use locationId as an argument.
* Use the language "ciphertext" and "plaintext" to refer to encrypted and unencrypted data, respectively.

I opted to keep file I/O in the Command runner to keep the API
clean, especially when being rendered on
https://cloud.google.com/kms/docs/encrypt-decrypt.

Tracking bug: http://b/64758639