### PR TITLE
Adds snippet for restoring a crypto key version

### DIFF
--- a/kms/README.md
+++ b/kms/README.md
@@ -27,4 +27,4 @@ and can see the available snippet commands with:
 For example:
 
     java -cp target/kms-samples-1.0.0-jar-with-dependencies.jar \
-        com.example.Snippets createKeyRing -p <your-project-id> <location> myFirstKeyRing
+        com.example.Snippets createKeyRing -p [your-project-id] [your-location] myFirstKeyRing

--- a/kms/README.md
+++ b/kms/README.md
@@ -3,7 +3,7 @@
 Google [Cloud Key Management Service](https://cloud.google.com/kms/) is a
 cloud-hosted key management service that lets you manage encryption for your
 cloud services the same way you do on-premise. You can generate, use, rotate and
-destroy AES256 encryption keys. These sample Java applications demonstrate
+destroy AES-256 encryption keys. These sample Java applications demonstrate
 how to access the KMS API using the Google Java API Client Libraries.
 
 ## Quickstart
@@ -17,7 +17,7 @@ Build your project with:
 You can run the quickstart with:
 
     java -cp target/kms-samples-1.0.0-jar-with-dependencies.jar \
-        com.example.Quickstart [your-project-id]
+        com.example.Quickstart [your-project-id] [your-location]
 
 and can see the available snippet commands with:
 
@@ -27,4 +27,4 @@ and can see the available snippet commands with:
 For example:
 
     java -cp target/kms-samples-1.0.0-jar-with-dependencies.jar \
-        com.example.Snippets createKeyRing -p <your-project-id> myFirstKeyRing
+        com.example.Snippets createKeyRing -p <your-project-id> <location> myFirstKeyRing

--- a/kms/src/main/java/com/example/SnippetCommands.java
+++ b/kms/src/main/java/com/example/SnippetCommands.java
@@ -109,6 +109,12 @@ class SnippetCommands {
     }
   }
 
+  public static class RestoreCryptoKeyVersionCommand extends KeyVersionArgs implements Command {
+    public void run() throws IOException {
+      Snippets.restoreCryptoKeyVersion(projectId, locationId, keyRingId, cryptoKeyId, version);
+    }
+  }
+
   public static class SetPrimaryVersionCommand extends KeyVersionArgs implements Command {
 
     public void run() throws IOException {
@@ -206,6 +212,7 @@ class SnippetCommands {
       @SubCommand(name = "listCryptoKeyVersions", impl = ListCryptoKeyVersionsCommand.class),
       @SubCommand(name = "disableCryptoKeyVersion", impl = DisableCryptoKeyVersionCommand.class),
       @SubCommand(name = "destroyCryptoKeyVersion", impl = DestroyCryptoKeyVersionCommand.class),
+      @SubCommand(name = "restoreCryptoKeyVersion", impl = RestoreCryptoKeyVersionCommand.class),
       @SubCommand(name = "getKeyRingPolicy", impl = GetKeyRingPolicyCommand.class),
       @SubCommand(name = "getCryptoKeyPolicy", impl = GetCryptoKeyPolicyCommand.class),
       @SubCommand(name = "setPrimaryVersion", impl = SetPrimaryVersionCommand.class),

--- a/kms/src/main/java/com/example/Snippets.java
+++ b/kms/src/main/java/com/example/Snippets.java
@@ -26,6 +26,7 @@ import com.google.api.services.cloudkms.v1.model.Binding;
 import com.google.api.services.cloudkms.v1.model.CryptoKey;
 import com.google.api.services.cloudkms.v1.model.CryptoKeyVersion;
 import com.google.api.services.cloudkms.v1.model.DestroyCryptoKeyVersionRequest;
+import com.google.api.services.cloudkms.v1.model.RestoreCryptoKeyVersionRequest;
 import com.google.api.services.cloudkms.v1.model.KeyRing;
 import com.google.api.services.cloudkms.v1.model.ListCryptoKeyVersionsResponse;
 import com.google.api.services.cloudkms.v1.model.ListCryptoKeysResponse;
@@ -203,6 +204,34 @@ public class Snippets {
 
     System.out.println(destroyed);
     return destroyed;
+  }
+  // [END kms_destroy_cryptokey_version]
+
+  // [START kms_restore_cryptokey_version]
+
+  /**
+   * Restores the given version of a crypto key that is currently scheduled for destruction.
+   */
+  public static CryptoKeyVersion restoreCryptoKeyVersion(
+      String projectId, String locationId, String keyRingId, String cryptoKeyId, String version)
+      throws IOException {
+    // Create the Cloud KMS client.
+    CloudKMS kms = createAuthorizedClient();
+
+    // The resource name of the cryptoKey version
+    String cryptoKeyVersion = String.format(
+        "projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s/cryptoKeyVersions/%s",
+        projectId, locationId, keyRingId, cryptoKeyId, version);
+
+    RestoreCryptoKeyVersionRequest restoreRequest = new RestoreCryptoKeyVersionRequest();
+
+    CryptoKeyVersion restored = kms.projects().locations().keyRings().cryptoKeys()
+        .cryptoKeyVersions()
+        .restore(cryptoKeyVersion, restoreRequest)
+        .execute();
+
+    System.out.println(restored);
+    return restored;
   }
   // [END kms_destroy_cryptokey_version]
 

--- a/kms/src/main/java/com/example/Snippets.java
+++ b/kms/src/main/java/com/example/Snippets.java
@@ -233,7 +233,7 @@ public class Snippets {
     System.out.println(restored);
     return restored;
   }
-  // [END kms_destroy_cryptokey_version]
+  // [END kms_restore_cryptokey_version]
 
   // [START kms_get_cryptokey_policy]
 

--- a/kms/src/test/java/com/example/SnippetsIT.java
+++ b/kms/src/test/java/com/example/SnippetsIT.java
@@ -209,12 +209,21 @@ public class SnippetsIT {
   public void restoreCryptoKeyVersion_restores() throws Exception {
     Snippets.createCryptoKeyVersion(PROJECT_ID, LOCATION_ID, KEY_RING_ID, CRYPTO_KEY_ID);
 
-    Matcher matcher = Pattern.compile(".*cryptoKeyVersions/(\\d+)\",\"state\":\"DESTROY_SCHEDULED\".*",
+    Matcher matcher = Pattern.compile(".*cryptoKeyVersions/(\\d+)\",\"state\":\"ENABLED\".*",
         Pattern.DOTALL | Pattern.MULTILINE).matcher(bout.toString().trim());
     assertTrue(matcher.matches());
 
     String version = matcher.group(1);
 
+    // Only key versions schedule for destruction are restorable, so schedule this key
+    // version for destruction.
+    Snippets.destroyCryptoKeyVersion(PROJECT_ID, LOCATION_ID, KEY_RING_ID, CRYPTO_KEY_ID, version);
+
+    assertThat(bout.toString()).containsMatch(String.format(
+        "keyRings/%s/cryptoKeys/%s/cryptoKeyVersions/%s\",\"state\":\"DESTROY_SCHEDULED\"",
+        KEY_RING_ID, CRYPTO_KEY_ID, version));
+
+    // Now restore the key version.
     Snippets.restoreCryptoKeyVersion(PROJECT_ID, LOCATION_ID, KEY_RING_ID, CRYPTO_KEY_ID, version);
 
     assertThat(bout.toString()).containsMatch(String.format(

--- a/kms/src/test/java/com/example/SnippetsIT.java
+++ b/kms/src/test/java/com/example/SnippetsIT.java
@@ -204,6 +204,24 @@ public class SnippetsIT {
         KEY_RING_ID, CRYPTO_KEY_ID, version));
   }
 
+
+  @Test
+  public void restoreCryptoKeyVersion_restores() throws Exception {
+    Snippets.createCryptoKeyVersion(PROJECT_ID, LOCATION_ID, KEY_RING_ID, CRYPTO_KEY_ID);
+
+    Matcher matcher = Pattern.compile(".*cryptoKeyVersions/(\\d+)\",\"state\":\"DESTROY_SCHEDULED\".*",
+        Pattern.DOTALL | Pattern.MULTILINE).matcher(bout.toString().trim());
+    assertTrue(matcher.matches());
+
+    String version = matcher.group(1);
+
+    Snippets.restoreCryptoKeyVersion(PROJECT_ID, LOCATION_ID, KEY_RING_ID, CRYPTO_KEY_ID, version);
+
+    assertThat(bout.toString()).containsMatch(String.format(
+        "keyRings/%s/cryptoKeys/%s/cryptoKeyVersions/%s\",\"state\":\"DISABLED\"",
+        KEY_RING_ID, CRYPTO_KEY_ID, version));
+  }
+
   @Test
   public void setPrimaryVersion_createKeyAndSetPrimaryVersion() throws Exception {
     // We can't test that setPrimaryVersion actually took effect via a list call because of


### PR DESCRIPTION
New snippet to use at https://cloud.google.com/kms/docs/destroy-restore.