### PR TITLE
Update deprecated commands for `gcloud service-management`

### DIFF
--- a/appengine-java8/endpoints-v2-backend/README.md
+++ b/appengine-java8/endpoints-v2-backend/README.md
@@ -41,7 +41,7 @@ To deploy the sample API:
 
 0. Invoke the `gcloud` command to deploy the API configuration file:
 
-         gcloud service-management deploy target/openapi-docs/openapi.json
+         gcloud endpoints services deploy target/openapi-docs/openapi.json
 
 0. Deploy the API implementation code by invoking:
 
@@ -119,7 +119,7 @@ To deploy the sample API:
 
 0. Invoke the `gcloud` command to deploy the API configuration file:
 
-         gcloud service-management deploy build/endpointsOpenApiDocs/openapi.json
+         gcloud endpoints services deploy build/endpointsOpenApiDocs/openapi.json
 
 0. Deploy the API implementation code by invoking:
 

--- a/appengine-java8/endpoints-v2-backend/jenkins.sh
+++ b/appengine-java8/endpoints-v2-backend/jenkins.sh
@@ -35,7 +35,7 @@ sed -i'.bak' -e "s/YOUR_PROJECT_ID/${GOOGLE_PROJECT_ID}/g" pom.xml
 
 mvn clean endpoints-framework:openApiDocs
 
-gcloud service-management deploy target/openapi-docs/openapi.json
+gcloud endpoints services deploy target/openapi-docs/openapi.json
 
 # Test with Maven
 mvn appengine:deploy \
@@ -55,7 +55,7 @@ sed -i'.bak' -e "s/YOUR_PROJECT_ID/${GOOGLE_PROJECT_ID}/g" build.gradle
 
 gradle clean endpointsOpenApiDocs
 
-gcloud service-management deploy build/endpointsOpenApiDocs/openapi.json
+gcloud endpoints services deploy build/endpointsOpenApiDocs/openapi.json
 
 # Deploy Gradle
 gradle -Pappengine.deploy.promote=false \

--- a/appengine-java8/endpoints-v2-guice/README.md
+++ b/appengine-java8/endpoints-v2-guice/README.md
@@ -42,7 +42,7 @@ To deploy the sample API:
 
 0. Invoke the `gcloud` command to deploy the API configuration file:
 
-         gcloud service-management deploy target/openapi-docs/openapi.json
+         gcloud endpoints services deploy target/openapi-docs/openapi.json
 
 0. Deploy the API implementation code by invoking:
 
@@ -121,7 +121,7 @@ To deploy the sample API:
 
 0. Invoke the `gcloud` command to deploy the API configuration file:
 
-         gcloud service-management deploy build/endpointsOpenApiDocs/openapi.json
+         gcloud endpoints services deploy build/endpointsOpenApiDocs/openapi.json
 
 0. Deploy the API implementation code by invoking:
 

--- a/appengine/endpoints-frameworks-v2/backend/README.md
+++ b/appengine/endpoints-frameworks-v2/backend/README.md
@@ -41,7 +41,7 @@ To deploy the sample API:
 
 0. Invoke the `gcloud` command to deploy the API configuration file:
 
-         gcloud service-management deploy target/openapi-docs/openapi.json
+         gcloud endpoints services deploy target/openapi-docs/openapi.json
 
 0. Deploy the API implementation code by invoking:
 
@@ -119,7 +119,7 @@ To deploy the sample API:
 
 0. Invoke the `gcloud` command to deploy the API configuration file:
 
-         gcloud service-management deploy build/endpointsOpenApiDocs/openapi.json
+         gcloud endpoints services deploy build/endpointsOpenApiDocs/openapi.json
 
 0. Deploy the API implementation code by invoking:
 

--- a/appengine/endpoints-frameworks-v2/backend/jenkins.sh
+++ b/appengine/endpoints-frameworks-v2/backend/jenkins.sh
@@ -35,7 +35,7 @@ sed -i'.bak' -e "s/YOUR_PROJECT_ID/${GOOGLE_PROJECT_ID}/g" pom.xml
 
 mvn clean endpoints-framework:openApiDocs
 
-gcloud service-management deploy target/openapi-docs/openapi.json
+gcloud endpoints services deploy target/openapi-docs/openapi.json
 
 # Test with Maven
 mvn appengine:deploy \
@@ -55,7 +55,7 @@ sed -i'.bak' -e "s/YOUR_PROJECT_ID/${GOOGLE_PROJECT_ID}/g" build.gradle
 
 gradle clean endpointsOpenApiDocs
 
-gcloud service-management deploy build/endpointsOpenApiDocs/openapi.json
+gcloud endpoints services deploy build/endpointsOpenApiDocs/openapi.json
 
 # Deploy Gradle
 gradle -Pappengine.deploy.promote=false \

--- a/appengine/endpoints-frameworks-v2/guice-example/README.md
+++ b/appengine/endpoints-frameworks-v2/guice-example/README.md
@@ -42,7 +42,7 @@ To deploy the sample API:
 
 0. Invoke the `gcloud` command to deploy the API configuration file:
 
-         gcloud service-management deploy target/openapi-docs/openapi.json
+         gcloud endpoints services deploy target/openapi-docs/openapi.json
 
 0. Deploy the API implementation code by invoking:
 
@@ -121,7 +121,7 @@ To deploy the sample API:
 
 0. Invoke the `gcloud` command to deploy the API configuration file:
 
-         gcloud service-management deploy build/endpointsOpenApiDocs/openapi.json
+         gcloud endpoints services deploy build/endpointsOpenApiDocs/openapi.json
 
 0. Deploy the API implementation code by invoking:
 

--- a/appengine/endpoints-frameworks-v2/guice-example/jenkins.sh
+++ b/appengine/endpoints-frameworks-v2/guice-example/jenkins.sh
@@ -35,7 +35,7 @@ sed -i'.bak' -e "s/YOUR_PROJECT_ID/${GOOGLE_PROJECT_ID}/g" pom.xml
 
 mvn clean endpoints-framework:openApiDocs
 
-gcloud service-management deploy target/openapi-docs/openapi.json
+gcloud endpoints services deploy target/openapi-docs/openapi.json
 
 # Test with Maven
 mvn appengine:deploy \
@@ -55,7 +55,7 @@ sed -i'.bak' -e "s/YOUR_PROJECT_ID/${GOOGLE_PROJECT_ID}/g" build.gradle
 
 gradle clean endpointsOpenApiDocs
 
-gcloud service-management deploy build/endpointsOpenApiDocs/openapi.json
+gcloud endpoints services deploy build/endpointsOpenApiDocs/openapi.json
 
 # Deploy Gradle
 gradle -Pappengine.deploy.promote=false \

--- a/endpoints/getting-started-grpc/README.md
+++ b/endpoints/getting-started-grpc/README.md
@@ -37,14 +37,14 @@ and [SDK](https://cloud.google.com/sdk/) configured.
 1. Deploy your service config to Service Management:
 
     ```bash
-    gcloud service-management deploy out.pb api_config.yaml
+    gcloud endpoints services deploy out.pb api_config.yaml
     # The Config ID should be printed out, looks like: 2017-02-01r0, remember this
 
     # set your project to make commands easier
     GCLOUD_PROJECT=<Your Project ID>
 
     # Print out your Config ID again, in case you missed it
-    gcloud service-management configs list --service hellogrpc.endpoints.${GCLOUD_PROJECT}.cloud.goog
+    gcloud endpoints configs list --service hellogrpc.endpoints.${GCLOUD_PROJECT}.cloud.goog
     ```
 
 1. Also get an API key from the Console's API Manager for use in the client later. (https://console.cloud.google.com/apis/credentials)

--- a/endpoints/getting-started/src/main/appengine/app.yaml
+++ b/endpoints/getting-started/src/main/appengine/app.yaml
@@ -22,6 +22,6 @@ handlers:
 
 endpoints_api_service:
   # The following values are to be replaced by information from the output of
-  # 'gcloud service-management deploy openapi.yaml' command.
+  # 'gcloud endpoints services deploy openapi.yaml' command.
   name: ENDPOINTS-SERVICE-NAME
   config_id: ENDPOINTS-CONFIG-ID

--- a/endpoints/multiple-versions/src/main/appengine/app.yaml
+++ b/endpoints/multiple-versions/src/main/appengine/app.yaml
@@ -22,6 +22,6 @@ handlers:
 
 endpoints_api_service:
   # The following values are to be replaced by information from the output of
-  # 'gcloud service-management deploy openapi-v1.yaml openapi-v2.yaml' command.
+  # 'gcloud endpoints services deploy openapi-v1.yaml openapi-v2.yaml' command.
   name: ENDPOINTS-SERVICE-NAME
   config_id: ENDPOINTS-CONFIG-ID


### PR DESCRIPTION
@inklesspen

 - `gcloud service-management deploy` becomes `gcloud endpoints deploy`
 - `gcloud service-management configs` becomes `gcloud endpoints configs`