### PR TITLE
[Endpoints] Fix local development for Guice sample.

### DIFF
--- a/appengine-java8/endpoints-v2-guice/README.md
+++ b/appengine-java8/endpoints-v2-guice/README.md
@@ -34,7 +34,7 @@ To build the project:
 
 To generate the required configuration file `openapi.json`:
 
-    mvn endpoints-framework:openApiDoc
+    mvn endpoints-framework:openApiDocs
 
 ### Deploying the sample API to App Engine
 

--- a/appengine-java8/endpoints-v2-guice/build.gradle
+++ b/appengine-java8/endpoints-v2-guice/build.gradle
@@ -44,16 +44,20 @@ apply plugin: 'com.google.cloud.tools.appengine'
 
 dependencies {
     compile 'com.google.endpoints:endpoints-framework:2.0.8'
+    // [START guice_dependency]
     compile 'com.google.endpoints:endpoints-framework-guice:'
+    // [END guice_dependency]
     compile 'com.google.endpoints:endpoints-management-control-appengine:1.0.5'
     compile 'com.google.endpoints:endpoints-framework-auth:1.0.5'
 }
 
+// [START endpoints_plugin_configuration]
 endpointsServer {
   // Endpoints Framework Plugin server-side configuration
   hostname = "${projectId}.appspot.com"
   serviceClasses = ['com.example.echo.Echo']
 }
+// [END endpoints_plugin_configuration]
 
 appengine {  // App Engine tasks configuration
   deploy {   // deploy configuration

--- a/appengine-java8/endpoints-v2-guice/pom.xml
+++ b/appengine-java8/endpoints-v2-guice/pom.xml
@@ -47,11 +47,13 @@
             <artifactId>endpoints-framework</artifactId>
             <version>${endpoints.framework.version}</version>
         </dependency>
+        <!-- [START guice_dependency] -->
         <dependency>
             <groupId>com.google.endpoints</groupId>
             <artifactId>endpoints-framework-guice</artifactId>
             <version>2.0.9</version>
         </dependency>
+        <!-- [END guice_dependency] -->
         <dependency>
             <groupId>com.google.endpoints</groupId>
             <artifactId>endpoints-management-control-appengine-all</artifactId>
@@ -102,6 +104,7 @@
                     <!-- deploy configuration -->
                 </configuration>
             </plugin>
+            <!-- [START endpoints_plugin] -->
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>endpoints-framework-maven-plugin</artifactId>
@@ -113,14 +116,8 @@
                       <serviceClass>com.example.echo.Echo</serviceClass>
                     </serviceClasses>
                 </configuration>
-                <dependencies>
-                  <dependency>
-                      <groupId>com.google.endpoints</groupId>
-                      <artifactId>endpoints-management-control-appengine-all</artifactId>
-                      <version>1.0.5</version>
-                  </dependency>
-                </dependencies>
             </plugin>
+            <!-- [START endpoints_plugin] -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>

--- a/appengine-java8/endpoints-v2-guice/src/main/java/com/example/echo/EchoGuiceListener.java
+++ b/appengine-java8/endpoints-v2-guice/src/main/java/com/example/echo/EchoGuiceListener.java
@@ -16,7 +16,6 @@
 
 package com.example.echo;
 
-//import com.google.api.server.spi.guice.GuiceServletContextListener;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.servlet.GuiceServletContextListener;

--- a/appengine-java8/endpoints-v2-guice/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/appengine-java8/endpoints-v2-guice/src/main/webapp/WEB-INF/appengine-web.xml
@@ -18,10 +18,6 @@
     <runtime>java8</runtime>
     <threadsafe>true</threadsafe>
 
-    <basic-scaling>
-        <max-instances>2</max-instances>
-    </basic-scaling>
-
     <system-properties>
         <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
     </system-properties>

--- a/appengine-java8/endpoints-v2-guice/src/main/webapp/WEB-INF/web.xml
+++ b/appengine-java8/endpoints-v2-guice/src/main/webapp/WEB-INF/web.xml
@@ -36,8 +36,4 @@
         <listener-class>com.example.echo.EchoGuiceListener</listener-class>
     </listener>
 
-    <welcome-file-list>
-        <welcome-file>index.html</welcome-file>
-    </welcome-file-list>
-
 </web-app>

--- a/appengine-java8/endpoints-v2-guice/src/main/webapp/WEB-INF/web.xml
+++ b/appengine-java8/endpoints-v2-guice/src/main/webapp/WEB-INF/web.xml
@@ -17,6 +17,7 @@
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"  version="2.5">
     <!-- Wrap the backend with Endpoints Frameworks v2. -->
     <!-- Route API method requests to the backend using Guice. -->
+    <!-- [START guice_configuration] -->
     <filter>
         <filter-name>guiceFilter</filter-name>
         <filter-class>com.google.inject.servlet.GuiceFilter</filter-class>
@@ -35,5 +36,6 @@
     <listener>
         <listener-class>com.example.echo.EchoGuiceListener</listener-class>
     </listener>
+    <!-- [END guice_configuration] -->
 
 </web-app>

--- a/appengine/endpoints-frameworks-v2/guice-example/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/appengine/endpoints-frameworks-v2/guice-example/src/main/webapp/WEB-INF/appengine-web.xml
@@ -17,10 +17,6 @@
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
     <threadsafe>true</threadsafe>
 
-    <basic-scaling>
-        <max-instances>2</max-instances>
-    </basic-scaling>
-
     <system-properties>
         <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
     </system-properties>

--- a/appengine/endpoints-frameworks-v2/guice-example/src/main/webapp/WEB-INF/web.xml
+++ b/appengine/endpoints-frameworks-v2/guice-example/src/main/webapp/WEB-INF/web.xml
@@ -36,8 +36,4 @@
         <listener-class>com.example.echo.EchoGuiceListener</listener-class>
     </listener>
 
-    <welcome-file-list>
-        <welcome-file>index.html</welcome-file>
-    </welcome-file-list>
-
 </web-app>


### PR DESCRIPTION
There exists a bug with the DevAppServer and Guice + Basic Scaling that causes the main serving port 8080 to 404 when accessing the sample API endpoint, but works from an instance port when this isn't the correct way to access the API endpoint.

Reported here: b/68948960