### PR TITLE
Readme update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,11 @@
 # java-docs-samples
 
-[![Circle-CI Build Status](https://circleci.com/gh/GoogleCloudPlatform/java-docs-samples.svg?style=shield&circle-token=117b41ead030b212fc7d519519ee9262c4f3480b)](https://circleci.com/gh/GoogleCloudPlatform/java-docs-samples)
-[![ghit.me](https://ghit.me/badge.svg?repo=GoogleCloudPlatform/java-docs-samples)](https://ghit.me/repo/GoogleCloudPlatform/java-docs-samples)
+![Kokoro Build Status](https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples.png)
 [![Coverage Status](https://codecov.io/gh/GoogleCloudPlatform/java-docs-samples/branch/master/graph/badge.svg)](https://codecov.io/gh/GoogleCloudPlatform/java-docs-samples)
-
 
 While this library is still supported, we suggest trying the newer [Cloud Client Library](https://developers.google.com/api-client-library/java/apis/vision/v1) for Google Cloud Vision, especially for new projects. For more information, please see the notice on the [API Client Library Page](https://developers.google.com/api-client-library/java/apis/vision/v1).
 
 This is a repository that contains java code snippets on [Cloud Platform Documentation](https://cloud.google.com/docs/).
-
-The repo is organized as follows:
-
-* [App Engine Standard](appengine)
-  * [TaskQueue](taskqueue) <!-- shouldn't this be in appengien ?? -->
-  * [Unit Tests](unittests)
-* [App Engine Flexible](flexible)
-* [Compute Engine](compute)
 
 Technology Samples:
 


### PR DESCRIPTION
Updates the build status badge, removes the non-functional ghit.me.

Also removes the 'This repo is organized as follows' section since it's a little outdated and doesn't mention most modules. 