### PR TITLE
Use long-flags everywhere, for readability.

### DIFF
--- a/endpoints/getting-started-grpc/README.md
+++ b/endpoints/getting-started-grpc/README.md
@@ -78,20 +78,22 @@ and [SDK](https://cloud.google.com/sdk/) configured.
 
     ```bash
     /usr/share/google/dockercfg_update.sh
-    docker run -d --name=grpc-hello gcr.io/${GCLOUD_PROJECT}/java-grpc-hello:1.0
+    docker run --detach --name=grpc-hello gcr.io/${GCLOUD_PROJECT}/java-grpc-hello:1.0
     ```
 
 1. Run the Endpoints proxy
 
     ```bash
-    docker run --detach --name=esp \
-        -p 80:9000 \
+    docker run \
+        --detach \
+        --name=esp \
+        --publish 80:9000 \
         --link=grpc-hello:grpc-hello \
         gcr.io/endpoints-release/endpoints-runtime:1 \
-        -s ${SERVICE_NAME} \
-        -v ${SERVICE_CONFIG_ID} \
-        -P 9000 \
-        -a grpc://grpc-hello:50051
+        --service=${SERVICE_NAME} \
+        --version=${SERVICE_CONFIG_ID} \
+        --http2_port=9000 \
+        --backend=grpc://grpc-hello:50051
     ```
 
 1. Back on your local machine, get the external IP of your GCE instance.

--- a/endpoints/getting-started-grpc/deployment.yaml
+++ b/endpoints/getting-started-grpc/deployment.yaml
@@ -41,10 +41,10 @@ spec:
       - name: esp
         image: gcr.io/endpoints-release/endpoints-runtime:1
         args: [
-          "-P", "9000",
-          "-a", "grpc://127.0.0.1:50051",
-          "-s", "SERVICE_NAME",
-          "-v", "SERVICE_CONFIG_ID",
+          "--http2_port=9000",
+          "--backend=grpc://127.0.0.1:50051",
+          "--service=SERVICE_NAME",
+          "--version=SERVICE_CONFIG_ID",
         ]
         ports:
           - containerPort: 9000

--- a/endpoints/getting-started/deployment.yaml
+++ b/endpoints/getting-started/deployment.yaml
@@ -42,10 +42,10 @@ spec:
       - name: esp
         image: gcr.io/endpoints-release/endpoints-runtime:1
         args: [
-          "--http_port", "8081",
-          "--backend", "127.0.0.1:8080",
-          "--service", "SERVICE_NAME",
-          "--version", "SERVICE_CONFIG_ID",
+          "--http_port=8081",
+          "--backend=127.0.0.1:8080",
+          "--service=SERVICE_NAME",
+          "--version=SERVICE_CONFIG_ID",
         ]
       # [END esp]
         ports:

--- a/endpoints/multiple-versions/container-engine.yaml
+++ b/endpoints/multiple-versions/container-engine.yaml
@@ -42,10 +42,10 @@ spec:
       - name: esp
         image: gcr.io/endpoints-release/endpoints-runtime:1
         args: [
-          "-p", "8081",
-          "-a", "127.0.0.1:8080",
-          "-s", "SERVICE_NAME",
-          "-v", "SERVICE_CONFIG_ID",
+          "--http_port=8081",
+          "--backend=127.0.0.1:8080",
+          "--service=SERVICE_NAME",
+          "--version=SERVICE_CONFIG_ID",
         ]
       # [END esp]
         ports:


### PR DESCRIPTION
Prevents common mistake between -p and -P.

@navinger @p-buse 