### PR TITLE
 Fix broken Java URL in README (#978)

### DIFF
--- a/storage/xml-api/cmdline-sample/README.md
+++ b/storage/xml-api/cmdline-sample/README.md
@@ -26,7 +26,7 @@ Command-line Instructions
 -------------------------
 
 * **Prerequisites:**
-    * Install the latest version of [Java](http://java.com) and [Maven](http://maven.apache.org/download.html).
+    * Install the latest version of [Java](https://java.com) and [Maven](https://maven.apache.org/download.html).
     * Set the environment variable: `export GOOGLE_APPLICATION_CREDENTIALS=your-key-filename.json`
     * You may need to set your `JAVA_HOME`.
 

--- a/storage/xml-api/cmdline-sample/README.md
+++ b/storage/xml-api/cmdline-sample/README.md
@@ -26,7 +26,7 @@ Command-line Instructions
 -------------------------
 
 * **Prerequisites:**
-    * Install the latest version of [Java](http//java.com) and [Maven](http://maven.apache.org/download.html).
+    * Install the latest version of [Java](http://java.com) and [Maven](http://maven.apache.org/download.html).
     * Set the environment variable: `export GOOGLE_APPLICATION_CREDENTIALS=your-key-filename.json`
     * You may need to set your `JAVA_HOME`.
 

--- a/storage/xml-api/serviceaccount-appengine-sample/README.md
+++ b/storage/xml-api/serviceaccount-appengine-sample/README.md
@@ -15,7 +15,7 @@ for getting your App Engine Service Account Name and adding it to your project t
 Checkout Instructions
 ---------------------
 
-**Prerequisites:** install the latest version of [Java](http//java.com) and [Maven](http://maven.apache.org/download.html). You may need to set your `JAVA_HOME`.
+**Prerequisites:** install the latest version of [Java](http://java.com) and [Maven](http://maven.apache.org/download.html). You may need to set your `JAVA_HOME`.
 
 You must also be able to work with a GitHub repository (see e.g.,
 https://help.github.com/articles/set-up-git).

--- a/storage/xml-api/serviceaccount-appengine-sample/README.md
+++ b/storage/xml-api/serviceaccount-appengine-sample/README.md
@@ -15,7 +15,7 @@ for getting your App Engine Service Account Name and adding it to your project t
 Checkout Instructions
 ---------------------
 
-**Prerequisites:** install the latest version of [Java](http://java.com) and [Maven](http://maven.apache.org/download.html). You may need to set your `JAVA_HOME`.
+**Prerequisites:** install the latest version of [Java](https://java.com) and [Maven](https://maven.apache.org/download.html). You may need to set your `JAVA_HOME`.
 
 You must also be able to work with a GitHub repository (see e.g.,
 https://help.github.com/articles/set-up-git).


### PR DESCRIPTION
This is a patch for fixing the invalid URLs of following two README files.
* storage/xml-api/cmdline-sample/README.md
* storage/xml-api/serviceaccount-appengine-sample/README.md

Also changed the URLs to _https_ as per the review comment of @lesv 

