### PR TITLE
Moving translate-pubsub

### DIFF
--- a/appengine-java8/translate-pubsub/README.md
+++ b/appengine-java8/translate-pubsub/README.md
@@ -1,0 +1,94 @@
+# Google Cloud API Showcase: Using Cloud Pub/Sub & Translate on App Engine Standard Java 8 Environment
+
+This sample demonstrates how to use [Google Cloud Pub/Sub][pubsub] and [Google Translate][translate]
+from [Google App Engine standard environment][ae-docs].
+
+[pubsub]: https://cloud.google.com/pubsub/docs/
+[translate]: https://cloud.google.com/translate/docs/
+[ae-docs]: https://cloud.google.com/appengine/docs/java/
+
+The home page of this application provides a form to publish messages using Google/Cloud PubSub (though publishing in
+local development is currently not supported). The application then receives these published messages over a push
+subscription endpoint, translates it from a source language into a target language, and finally stores in Google Cloud
+Datastore.
+
+The home page also provides a view of the most recently translated messages persisted in storage.
+
+## Clone the sample app
+
+Copy the sample apps to your local machine, and cd to the translate-pubsub directory:
+
+```
+git clone https://github.com/GoogleCloudPlatform/java-docs-samples
+cd java-docs-samples/appengine-java8/translate-pubsub
+```
+
+## Setup
+
+- Make sure [`gcloud`](https://cloud.google.com/sdk/docs/) is installed and initialized:
+```
+   gcloud init
+```
+- If this is the first time you are creating an App Engine project
+```
+   gcloud app create
+```
+- For local development, [set up](https://cloud.google.com/docs/authentication/getting-started) authentication
+- Enable [Pub/Sub](https://console.cloud.google.com/launcher/details/google/pubsub.googleapis.com) and 
+  [Translate](https://console.cloud.google.com/launcher/details/google/translate.googleapis.com) APIs
+
+- Choose a topic name and verification token.
+
+  - Set the following environment variables. The verification token is used to ensure that the end point only handles
+    requests that are sent matching the verification token. You can use `uuidgen` on MacOS X, Windows, and Linux to
+    generate a unique verification token. There are also online tools to generate UUIDs, such as 
+    [uuidgenerator.net][uuid].
+
+```
+export PUBSUB_TOPIC=<your-topic-name>
+export PUBSUB_VERIFICATION_TOKEN=<your-verification-token>
+```
+
+[uuid]: https://www.uuidgenerator.net/
+
+- Create a topic
+```
+gcloud pubsub topics create $PUBSUB_TOPIC
+```
+
+- Create a push subscription, to send messages to a Google Cloud Project URL such as
+  https://<your-project-id>.appspot.com/push.
+
+```
+gcloud pubsub subscriptions create <your-subscription-name> \
+  --topic $PUBSUB_TOPIC \
+  --push-endpoint \
+  https://<your-project-id>.appspot.com/pubsub/push?token=$PUBSUB_VERIFICATION_TOKEN \
+  --ack-deadline 30
+```
+
+## Run locally
+Run using shown Maven command. You can then direct your browser to `http://localhost:8080/` to see translated messages
+created in the following step.
+
+```
+mvn appengine:run
+```
+
+## Send fake subscription push messages
+
+```
+   curl -H "Content-Type: application/json" -i --data @sample_message.json \
+   "localhost:8080/pubsub/push?token=$PUBSUB_VERIFICATION_TOKEN"
+```
+
+## Deploy
+
+Update the environment variables `PUBSUB_TOPIC` and `PUBSUB_VERIFICATION_TOKEN` in
+[`appengine-web.xml`](src/main/webapp/WEB-INF/appengine-web.xml), then:
+
+```
+   mvn appengine:deploy
+```
+
+Direct your browser to `https://<your-project-id>.appspot.com`.

--- a/appengine-java8/translate-pubsub/pom.xml
+++ b/appengine-java8/translate-pubsub/pom.xml
@@ -1,0 +1,89 @@
+<!--
+  Copyright 2018 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- [START project] -->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>war</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <groupId>com.example.appengine</groupId>
+  <artifactId>appengine-translate-pubsub</artifactId>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.0.8</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+      <type>jar</type>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- [START dependencies] -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-pubsub</artifactId>
+      <version>0.32.0-beta</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-datastore</artifactId>
+      <version>1.12.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-translate</artifactId>
+      <version>1.14.0</version>
+    </dependency>
+    <!-- [END dependencies] -->
+  </dependencies>
+  <build>
+    <!-- for hot reload of the web application -->
+    <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes</outputDirectory>
+    <plugins>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>appengine-maven-plugin</artifactId>
+        <version>1.3.1</version>
+        <configuration>
+          <deploy.promote>true</deploy.promote>
+          <deploy.stopPreviousVersion>true</deploy.stopPreviousVersion>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.1.0</version>
+      </plugin>
+
+    </plugins>
+  </build>
+</project>
+<!-- [END project] -->

--- a/appengine-java8/translate-pubsub/sample_message.json
+++ b/appengine-java8/translate-pubsub/sample_message.json
@@ -1,0 +1,1 @@
+{"message":{"data":"eyJkYXRhIjoidHJhbnNsYXRlIiwic291cmNlTGFuZyI6ImVuIiwidGFyZ2V0TGFuZyI6ImVuIn0=","attributes":{"sourceLang":"en","targetLang":"es"},"messageId":"181789827785060","publishTime":"2018-01-06T00:41:01.839Z"}}

--- a/appengine-java8/translate-pubsub/src/main/java/com/example/appengine/translatepubsub/Message.java
+++ b/appengine-java8/translate-pubsub/src/main/java/com/example/appengine/translatepubsub/Message.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine.translatepubsub;
+
+import com.google.protobuf.ByteString;
+
+/**
+ * A message captures information from the Pubsub message received over the push endpoint and is
+ * persisted in storage.
+ */
+public class Message {
+  private String messageId;
+  private String publishTime;
+  private String data;
+  private String sourceLang = "en";
+  private String targetLang = "en";
+
+  public Message(String messageId) {
+    this.messageId = messageId;
+  }
+
+  public String getMessageId() {
+    return messageId;
+  }
+
+  public void setMessageId(String messageId) {
+    this.messageId = messageId;
+  }
+
+  public String getPublishTime() {
+    return publishTime;
+  }
+
+  public void setPublishTime(String publishTime) {
+    this.publishTime = publishTime;
+  }
+
+  public String getData() {
+    return data;
+  }
+
+  public void setData(String data) {
+    this.data = data;
+  }
+
+  public String getSourceLang() {
+    return sourceLang;
+  }
+
+  public void setSourceLang(String sourceLang) {
+    this.sourceLang = sourceLang;
+  }
+
+  public String getTargetLang() {
+    return targetLang;
+  }
+
+  public void setTargetLang(String targetLang) {
+    this.targetLang = targetLang;
+  }
+
+  public String getTranslated() {
+    return Translate.translateText(
+        ByteString.copyFrom(data.getBytes()).toStringUtf8(), sourceLang, targetLang);
+  }
+}

--- a/appengine-java8/translate-pubsub/src/main/java/com/example/appengine/translatepubsub/MessageRepository.java
+++ b/appengine-java8/translate-pubsub/src/main/java/com/example/appengine/translatepubsub/MessageRepository.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine.translatepubsub;
+
+import java.util.List;
+
+public interface MessageRepository {
+
+  /**
+   * Save message to persistent storage.
+   */
+  void save(Message message);
+
+  /**
+   * Retrieve most recent stored messages.
+   *
+   * @param limit number of messages
+   * @return list of messages
+   */
+  List<Message> retrieve(int limit);
+}

--- a/appengine-java8/translate-pubsub/src/main/java/com/example/appengine/translatepubsub/MessageRepositoryImpl.java
+++ b/appengine-java8/translate-pubsub/src/main/java/com/example/appengine/translatepubsub/MessageRepositoryImpl.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine.translatepubsub;
+
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreOptions;
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.Key;
+import com.google.cloud.datastore.KeyFactory;
+import com.google.cloud.datastore.Query;
+import com.google.cloud.datastore.QueryResults;
+import com.google.cloud.datastore.StructuredQuery;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Storage for Message objects using Cloud Datastore.
+ */
+public class MessageRepositoryImpl implements MessageRepository {
+
+  private static MessageRepositoryImpl instance;
+
+  private String messagesKind = "messages";
+  private KeyFactory keyFactory = getDatastoreInstance().newKeyFactory().setKind(messagesKind);
+
+  private MessageRepositoryImpl() {
+  }
+
+  // retrieve a singleton instance
+  public static synchronized MessageRepositoryImpl getInstance() {
+    if (instance == null) {
+      instance = new MessageRepositoryImpl();
+    }
+    return instance;
+  }
+
+  @Override
+  public void save(Message message) {
+    // Save message to "messages"
+    Datastore datastore = getDatastoreInstance();
+    Key key = datastore.allocateId(keyFactory.newKey());
+
+    Entity.Builder messageEntityBuilder = Entity.newBuilder(key)
+        .set("messageId", message.getMessageId());
+
+    String translated = message.getTranslated();
+    if (translated != null) {
+      messageEntityBuilder = messageEntityBuilder.set("data", translated);
+    }
+
+    if (message.getPublishTime() != null) {
+      messageEntityBuilder = messageEntityBuilder.set("publishTime", message.getPublishTime());
+    }
+
+    if (message.getSourceLang() != null) {
+      messageEntityBuilder = messageEntityBuilder.set("sourceLang", message.getSourceLang());
+    }
+
+    if (message.getTargetLang() != null) {
+      messageEntityBuilder = messageEntityBuilder.set("targetLang", message.getTargetLang());
+    }
+    datastore.put(messageEntityBuilder.build());
+  }
+
+  @Override
+  public List<Message> retrieve(int limit) {
+    // Get Message saved in Datastore
+    Datastore datastore = getDatastoreInstance();
+    Query<Entity> query =
+        Query.newEntityQueryBuilder()
+            .setKind(messagesKind)
+            .setLimit(limit)
+            .addOrderBy(StructuredQuery.OrderBy.desc("publishTime"))
+            .build();
+    QueryResults<Entity> results = datastore.run(query);
+
+    List<Message> messages = new ArrayList<>();
+    while (results.hasNext()) {
+      Entity entity = results.next();
+      Message message = new Message(entity.getString("messageId"));
+      String data = entity.getString("data");
+      if (data != null) {
+        message.setData(data);
+      }
+      String publishTime = entity.getString("publishTime");
+      if (publishTime != null) {
+        message.setPublishTime(publishTime);
+      }
+      if (entity.contains("sourceLang")) {
+        String sourceLang = entity.getString("sourceLang");
+        if (sourceLang != null) {
+          message.setSourceLang(sourceLang);
+        }
+      }
+      if (entity.contains("targetLang")) {
+        String targetLang = entity.getString("targetLang");
+        if (targetLang != null) {
+          message.setTargetLang(targetLang);
+        }
+      }
+      messages.add(message);
+    }
+    return messages;
+  }
+
+  private Datastore getDatastoreInstance() {
+    DatastoreOptions instance = DatastoreOptions.getDefaultInstance();
+    return instance.getService();
+  }
+}

--- a/appengine-java8/translate-pubsub/src/main/java/com/example/appengine/translatepubsub/PubSubHome.java
+++ b/appengine-java8/translate-pubsub/src/main/java/com/example/appengine/translatepubsub/PubSubHome.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine.translatepubsub;
+
+import java.util.List;
+
+public class PubSubHome {
+
+  private static MessageRepository messageRepository = MessageRepositoryImpl.getInstance();
+  private static int MAX_MESSAGES = 10;
+
+  private PubSubHome() {
+  }
+
+  /**
+   * Retrieve received messages in html.
+   *
+   * @return html representation of messages (one per row)
+   */
+  public static String getReceivedMessages() {
+    List<Message> messageList = messageRepository.retrieve(MAX_MESSAGES);
+    return convertToHtmlTable(messageList);
+  }
+
+  private static String convertToHtmlTable(List<Message> messages) {
+    StringBuilder sb = new StringBuilder();
+    for (Message message : messages) {
+      sb.append("<tr>");
+      addColumn(sb, message.getMessageId());
+      addColumn(sb, message.getData());
+      addColumn(sb, message.getPublishTime());
+      addColumn(sb, message.getSourceLang());
+      addColumn(sb, message.getTargetLang());
+      sb.append("</tr>");
+    }
+    return sb.toString();
+  }
+
+  private static void addColumn(StringBuilder sb, String content) {
+    sb.append("<td>").append(content).append("</td>");
+  }
+}

--- a/appengine-java8/translate-pubsub/src/main/java/com/example/appengine/translatepubsub/PubSubPublish.java
+++ b/appengine-java8/translate-pubsub/src/main/java/com/example/appengine/translatepubsub/PubSubPublish.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine.translatepubsub;
+
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.gson.Gson;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.TopicName;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet(name = "Publish with PubSub", value = "/pubsub/publish")
+public class PubSubPublish extends HttpServlet {
+  private Gson gson = new Gson();
+  private Publisher publisher;
+
+  public PubSubPublish() {
+  }
+
+  PubSubPublish(Publisher publisher) {
+    this.publisher = publisher;
+  }
+
+  @Override
+  public void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    Publisher publisher = this.publisher;
+    // construct a pubsub message from the payload
+    final String payload = req.getParameter("payload");
+    Message message = new Message(null);
+    message.setData(payload);
+    PubsubMessage pubsubMessage =
+        PubsubMessage.newBuilder().setData(ByteString.copyFromUtf8(payload))
+            .putAttributes("sourceLang", req.getParameter("sourceLang"))
+            .putAttributes("targetLang", req.getParameter("targetLang"))
+            .build();
+    String topicId = System.getenv("PUBSUB_TOPIC");
+    // create a publisher on the topic
+    if (publisher == null) {
+      this.publisher = publisher = Publisher.newBuilder(
+          TopicName.of(ServiceOptions.getDefaultProjectId(), topicId))
+          .build();
+    }
+
+    publisher.publish(pubsubMessage);
+    // redirect to home page
+    resp.sendRedirect("/");
+  }
+}

--- a/appengine-java8/translate-pubsub/src/main/java/com/example/appengine/translatepubsub/PubSubPush.java
+++ b/appengine-java8/translate-pubsub/src/main/java/com/example/appengine/translatepubsub/PubSubPush.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine.translatepubsub;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.stream.Collectors;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet(value = "/pubsub/push")
+public class PubSubPush extends HttpServlet {
+  private final JsonParser jsonParser = new JsonParser();
+  private final Gson gson = new Gson();
+  private MessageRepository messageRepository;
+
+  PubSubPush(MessageRepository messageRepository) {
+    this.messageRepository = messageRepository;
+  }
+
+  public PubSubPush() {
+    this.messageRepository = MessageRepositoryImpl.getInstance();
+  }
+
+  @Override
+  public void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    String pubsubVerificationToken = System.getenv("PUBSUB_VERIFICATION_TOKEN");
+    // Do not process message if request token does not match pubsubVerificationToken
+    if (req.getParameter("token").compareTo(pubsubVerificationToken) != 0) {
+      resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      return;
+    }
+    // parse message object from "message" field in the request body json
+    // decode message data from base64
+    Message message = getMessage(req);
+    try {
+      messageRepository.save(message);
+      // 200, 201, 204, 102 status codes are interpreted as success by the Pub/Sub system.
+      // Returning 102 indicates that the server has accepted the complete request, but has not yet
+      // completed it.
+      resp.setStatus(102);
+    } catch (Exception e) {
+      resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  private Message getMessage(HttpServletRequest request) throws IOException {
+    String requestBody = request.getReader().lines().collect(Collectors.joining("\n"));
+    JsonObject jsonRoot = jsonParser.parse(requestBody).getAsJsonObject();
+    JsonObject messageOb = jsonRoot.get("message").getAsJsonObject();
+    Message message = gson.fromJson(jsonRoot.get("message").toString(), Message.class);
+    JsonObject attributes = messageOb.get("attributes").getAsJsonObject();
+    message.setSourceLang(attributes.get("sourceLang").getAsString());
+    message.setTargetLang(attributes.get("targetLang").getAsString());
+
+    // decode data from base64 and translate
+    String decoded = decode(message.getData());
+    message.setData(
+        Translate.translateText(decoded, message.getSourceLang(), message.getTargetLang()));
+    return message;
+  }
+
+  private String decode(String data) {
+    return new String(Base64.getDecoder().decode(data));
+  }
+}

--- a/appengine-java8/translate-pubsub/src/main/java/com/example/appengine/translatepubsub/Translate.java
+++ b/appengine-java8/translate-pubsub/src/main/java/com/example/appengine/translatepubsub/Translate.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine.translatepubsub;
+
+import com.google.cloud.translate.Translate.TranslateOption;
+import com.google.cloud.translate.TranslateOptions;
+import com.google.cloud.translate.Translation;
+import com.google.common.base.Strings;
+
+public class Translate {
+  /**
+   * Translate the source text from source to target language.
+   *
+   * @param sourceText source text to be translated
+   * @param sourceLang source language of the text
+   * @param targetLang target language of translated text
+   * @return source text translated into target language.
+   */
+  public static String translateText(
+      String sourceText,
+      String sourceLang,
+      String targetLang) {
+    if (Strings.isNullOrEmpty(sourceLang)
+        || Strings.isNullOrEmpty(targetLang)
+        || sourceLang.equals(targetLang)) {
+      return sourceText;
+    }
+    com.google.cloud.translate.Translate translate = createTranslateService();
+    TranslateOption srcLang = TranslateOption.sourceLanguage(sourceLang);
+    TranslateOption tgtLang = TranslateOption.targetLanguage(targetLang);
+
+    Translation translation = translate.translate(sourceText, srcLang, tgtLang);
+    return translation.getTranslatedText();
+  }
+
+  /**
+   * Create Google Translate API Service.
+   *
+   * @return Google Translate Service
+   */
+  public static com.google.cloud.translate.Translate createTranslateService() {
+    return TranslateOptions.newBuilder().build().getService();
+  }
+}

--- a/appengine-java8/translate-pubsub/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/appengine-java8/translate-pubsub/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,0 +1,9 @@
+<appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
+  <threadsafe>true</threadsafe>
+  <runtime>java8</runtime>
+
+  <env-variables>
+    <env-var name="PUBSUB_TOPIC" value="your-topic" />
+    <env-var name="PUBSUB_VERIFICATION_TOKEN" value="your-verification-token" />
+  </env-variables>
+</appengine-web-app>

--- a/appengine-java8/translate-pubsub/src/main/webapp/index.jsp
+++ b/appengine-java8/translate-pubsub/src/main/webapp/index.jsp
@@ -1,0 +1,35 @@
+<%@ page import="com.example.appengine.translatepubsub.PubSubHome" %>
+
+<html>
+  <head>
+    <meta http-equiv="refresh" content="10">
+  </head>
+  <title>An example of using PubSub on App Engine Standard</title>
+  <body>
+    <h3>Publish a message</h3>
+    <h4><a href="https://cloud.google.com/translate/docs/languages">See more language codes</a></h4>
+    <form action="pubsub/publish" method="POST">
+      <label for="payload">Message:</label>
+      <input id="payload" type="input" name="payload" />
+      <br/>
+      <label for="sourceLang">Source Language Code:</label>
+      <input id="sourceLang" type="text" name="sourceLang" value="en"/>
+      <br/>
+      <label for="targetLang">Target Language Code:</label>
+      <input id="targetLang" type="text" name="targetLang" value="en"/>
+      <br/>
+      <input id="submit"  type="submit" value="Send" />
+    </form>
+    <h3> Last received messages </h3>
+    <table border="1" cellpadding="10">
+      <tr>
+      <th>Id</th>
+      <th>Data</th>
+      <th>PublishTime</th>
+      <th>SourceLang</th>
+      <th>TargetLang</th>
+      </tr>
+      <%= PubSubHome.getReceivedMessages() %>
+    </table>
+  </body>
+</html>


### PR DESCRIPTION
Moving translate-pubsub sample from [GoogleCloudPlatform/getting-started-java](https://github.com/GoogleCloudPlatform/getting-started-java) to [GoogleCloudPlatform/java-docs-samples](https://github.com/GoogleCloudPlatform/java-docs-samples).

Only changes from that project's version are updates to the pom.xml & README.md where appropriate, and fixing a typo in index.jsp (importing translate_pubsub.PubSubHome instead of translatepubsub.PubSubHome).