### PR TITLE
[DO NOT MERGE] Change to managed rollout

### DIFF
--- a/endpoints/getting-started-grpc/README.md
+++ b/endpoints/getting-started-grpc/README.md
@@ -71,7 +71,6 @@ and [SDK](https://cloud.google.com/sdk/) configured.
     ```bash
     GCLOUD_PROJECT=$(curl -s "http://metadata.google.internal/computeMetadata/v1/project/project-id" -H "Metadata-Flavor: Google")
     SERVICE_NAME=hellogrpc.endpoints.${GCLOUD_PROJECT}.cloud.goog
-    SERVICE_CONFIG_ID=<Your Config ID>
     ```
 
 1. Pull your credentials to access Container Registry, and run your gRPC server container
@@ -91,7 +90,7 @@ and [SDK](https://cloud.google.com/sdk/) configured.
         --link=grpc-hello:grpc-hello \
         gcr.io/endpoints-release/endpoints-runtime:1 \
         --service=${SERVICE_NAME} \
-        --version=${SERVICE_CONFIG_ID} \
+        --rollout_strategy=managed \
         --http2_port=9000 \
         --backend=grpc://grpc-hello:50051
     ```
@@ -116,7 +115,7 @@ and [SDK](https://cloud.google.com/sdk/) configured.
     gcloud container clusters create my-cluster
     ```
 
-1. Edit `deployment.yaml`. Replace `SERVICE_NAME`, `SERVICE_CONFIG_ID`, and `GCLOUD_PROJECT` with your values.
+1. Edit `deployment.yaml`. Replace `SERVICE_NAME`, and `GCLOUD_PROJECT` with your values.
 
 1. Deploy to GKE
 

--- a/endpoints/getting-started-grpc/README.md
+++ b/endpoints/getting-started-grpc/README.md
@@ -115,7 +115,7 @@ and [SDK](https://cloud.google.com/sdk/) configured.
     gcloud container clusters create my-cluster
     ```
 
-1. Edit `deployment.yaml`. Replace `SERVICE_NAME`, and `GCLOUD_PROJECT` with your values.
+1. Edit `deployment.yaml`. Replace `SERVICE_NAME` and `GCLOUD_PROJECT` with your values.
 
 1. Deploy to GKE
 

--- a/endpoints/getting-started/deployment.yaml
+++ b/endpoints/getting-started/deployment.yaml
@@ -45,7 +45,7 @@ spec:
           "--http_port=8081",
           "--backend=127.0.0.1:8080",
           "--service=SERVICE_NAME",
-          "--version=SERVICE_CONFIG_ID",
+          "--rollout_strategy=managed",
         ]
       # [END esp]
         ports:


### PR DESCRIPTION
We introduce a new feature where we can specify in YAML that service configuration for Endpoints is going to be managed. This means that the service will pull latest deployed service configuration automatically, rather than requiring customer to specify specific version of service configuration.

New flag:
**--rollout_strategy=managed**
Previously the only way to specify a version was using the following flag: 
**--version=SERVICE_CONFIG_ID**