### PR TITLE
Updates for the Developer Portal

### DIFF
--- a/endpoints/getting-started/openapi.yaml
+++ b/endpoints/getting-started/openapi.yaml
@@ -25,7 +25,9 @@ consumes:
 produces:
   - "application/json"
 schemes:
-  - "https"
+# Uncomment the next line if you configure SSL for this API.
+# - "https"
+  - "http"  
 paths:
   "/echo":
     post:
@@ -78,6 +80,7 @@ paths:
           google_id_token: []
 definitions:
   echoMessage:
+    type: "object"
     properties:
       message:
         type: "string"


### PR DESCRIPTION
Updates so the sample API can be used easily in the Developer Portal. 
-- In schemes, it has to be "http" so that you can test the echo API in the Developer Portal. 
-- In the echoMessage definition, adding type: "object" provides a better user experience in the Developer Portal.