### PR TITLE
Update CloudSQL Samples

### DIFF
--- a/appengine-java8/cloudsql-postgres/README.md
+++ b/appengine-java8/cloudsql-postgres/README.md
@@ -32,7 +32,7 @@ Engine standard Java 8
 ## Running locally
 
 ```bash
-$ mvn clean appengine:run -DINSTANCE_CONNECTION_NAME=instanceConnectionName -Duser=root -Dpassword=myPassowrd -Ddatabase=myDatabase
+$ mvn clean appengine:run -DINSTANCE_CONNECTION_NAME=instanceConnectionName -Duser=root -Dpassword=myPassword -Ddatabase=myDatabase
 ```
 
 ## Deploying

--- a/appengine-java8/cloudsql-postgres/pom.xml
+++ b/appengine-java8/cloudsql-postgres/pom.xml
@@ -30,22 +30,23 @@
     <version>1.0.9</version>
   </parent>
 
-<!-- [START properties] -->
+  <!-- [START properties] -->
   <properties>
-<!-- INSTANCE_CONNECTION_NAME from Cloud Console > SQL > Instance Details > Properties
-     or gcloud sql instances describe <instance>
--->
-    <INSTANCE_CONNECTION_NAME>Project:Region:Instance</INSTANCE_CONNECTION_NAME>
+    <!--
+    INSTANCE_CONNECTION_NAME from Cloud Console > SQL > Instance Details > Properties
+    or gcloud sql instances describe <instance>
+    -->
+    <INSTANCE_CONNECTION_NAME>project:region:instance</INSTANCE_CONNECTION_NAME>
     <user>root</user>
     <password>myPassword</password>
-    <database>sqldemo</database>
+    <database>myDatabase</database>
 
-<!-- [START_EXCLUDE] -->
+    <!-- [START_EXCLUDE] -->
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-<!-- [END_EXCLUDE] -->
+    <!-- [END_EXCLUDE] -->
   </properties>
-<!-- [END properties] -->
+  <!-- [END properties] -->
 
   <dependencies>
     <dependency>
@@ -78,7 +79,7 @@
     <dependency>
       <groupId>com.google.cloud.sql</groupId>
       <artifactId>postgres-socket-factory</artifactId>
-      <version>1.0.5</version>
+      <version>1.0.8</version>
     </dependency>
     <!-- [END dependencies] -->
   </dependencies>

--- a/appengine-java8/cloudsql-postgres/src/main/java/com/example/appengine/postgresql/PostgreSqlServlet.java
+++ b/appengine-java8/cloudsql-postgres/src/main/java/com/example/appengine/postgresql/PostgreSqlServlet.java
@@ -37,7 +37,7 @@ import javax.servlet.http.HttpServletResponse;
 @SuppressWarnings("serial")
 // With @WebServlet annotation the webapp/WEB-INF/web.xml is no longer required.
 @WebServlet(name = "PostgreSQL",
-    description = "PostgreSQL: Write low order IP address to PostgreSQL",
+    description = "PostgreSQL: Write timestamps of visitors to PostgreSQL",
     urlPatterns = "/postgresql")
 public class PostgreSqlServlet extends HttpServlet {
 

--- a/appengine-java8/cloudsql-postgres/src/main/java/com/example/appengine/postgresql/PostgreSqlServlet.java
+++ b/appengine-java8/cloudsql-postgres/src/main/java/com/example/appengine/postgresql/PostgreSqlServlet.java
@@ -37,7 +37,7 @@ import javax.servlet.http.HttpServletResponse;
 @SuppressWarnings("serial")
 // With @WebServlet annotation the webapp/WEB-INF/web.xml is no longer required.
 @WebServlet(name = "PostgreSQL",
-    description = "PostgreSQL: Write timestamps of visitors to PostgreSQL",
+    description = "PostgreSQL: Write low order IP address to PostgreSQL",
     urlPatterns = "/postgresql")
 public class PostgreSqlServlet extends HttpServlet {
 
@@ -84,7 +84,7 @@ public class PostgreSqlServlet extends HttpServlet {
 
   @Override
   public void init() throws ServletException {
-    String url = System.getProperty("postgresql");
+    String url = System.getProperty("cloudsql");
     log("connecting to: " + url);
     try {
       conn = DriverManager.getConnection(url);

--- a/appengine-java8/cloudsql-postgres/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/appengine-java8/cloudsql-postgres/src/main/webapp/WEB-INF/appengine-web.xml
@@ -17,7 +17,7 @@
   <runtime>java8</runtime>
 
   <system-properties>
-    <property name="postgresql" value="jdbc:postgresql://google/${database}?useSSL=false&amp;socketFactoryArg=${INSTANCE_CONNECTION_NAME}&amp;socketFactory=com.google.cloud.sql.postgres.SocketFactory&amp;user=${user}&amp;password=${password}" />
+    <property name="cloudsql" value="jdbc:postgresql://google/${database}?useSSL=false&amp;socketFactoryArg=${INSTANCE_CONNECTION_NAME}&amp;socketFactory=com.google.cloud.sql.postgres.SocketFactory&amp;user=${user}&amp;password=${password}" />
   </system-properties>
 </appengine-web-app>
 <!-- [END config] -->

--- a/appengine-java8/cloudsql/README.md
+++ b/appengine-java8/cloudsql/README.md
@@ -34,7 +34,7 @@ Engine standard Java 8
 ## Running locally
 
 ```bash
-$ mvn clean appengine:run -DINSTANCE_CONNECTION_NAME=instanceConnectionName -Duser=root -Dpassword=myPassowrd -Ddatabase=myDatabase
+$ mvn clean appengine:run -DINSTANCE_CONNECTION_NAME=instanceConnectionName -Duser=root -Dpassword=myPassword -Ddatabase=myDatabase
 ```
 
 ## Deploying

--- a/appengine-java8/cloudsql/pom.xml
+++ b/appengine-java8/cloudsql/pom.xml
@@ -30,22 +30,25 @@
     <version>1.0.9</version>
   </parent>
 
-<!-- [START properties] -->
+  <!-- [START properties] -->
   <properties>
-<!-- INSTANCE_CONNECTION_NAME from Cloud Console > SQL > Instance Details > Properties
-     or gcloud sql instances describe <instance>
-     project:region:instance for Cloud SQL 2nd Generation or
-     project:instance        for Cloud SQL 1st Generation
--->
-    <INSTANCE_CONNECTION_NAME></INSTANCE_CONNECTION_NAME>
+    <!--
+      INSTANCE_CONNECTION_NAME from Cloud Console > SQL > Instance Details > Properties
+      or gcloud sql instances describe <instance>
+      project:region:instance for Cloud SQL 2nd Generation or
+      project:instance        for Cloud SQL 1st Generation
+    -->
+    <INSTANCE_CONNECTION_NAME>project:region:instance</INSTANCE_CONNECTION_NAME>
     <user>root</user>
     <password>myPassword</password>
-    <database>sqldemo</database>
+    <database>myDatabase</database>
 
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <!-- [START_EXCLUDE] -->
+      <maven.compiler.target>1.8</maven.compiler.target>
+      <maven.compiler.source>1.8</maven.compiler.source>
+    <!-- [END_EXCLUDE] -->
   </properties>
-<!-- [END properties] -->
+  <!-- [END properties] -->
 
   <dependencies>
     <dependency>
@@ -69,17 +72,15 @@
     </dependency>
 
     <!-- [START dependencies] -->
-    <!-- Driver injected at runtime by the use of <use-google-connector-j> in appengine-web.xml -->
     <dependency> <!-- Only used locally -->
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.42</version>  <!-- v5.x.x is for production, v6.x.x EAP X DevAPI -->
+      <version>5.1.42</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.sql</groupId>
-      <!-- If using MySQL 6.x driver, use mysql-socket-factory-connector-j-6 instead -->
       <artifactId>mysql-socket-factory</artifactId>
-      <version>1.0.5</version>
+      <version>1.0.8</version>
     </dependency>
     <!-- [END dependencies] -->
   </dependencies>

--- a/appengine-java8/cloudsql/src/main/java/com/example/appengine/cloudsql/CloudSqlServlet.java
+++ b/appengine-java8/cloudsql/src/main/java/com/example/appengine/cloudsql/CloudSqlServlet.java
@@ -91,22 +91,12 @@ public class CloudSqlServlet extends HttpServlet {
 
   @Override
   public void init() throws ServletException {
+    String url = System.getProperty("cloudsql");
+    log("connecting to: " + url);
     try {
-      ApiProxy.Environment env = ApiProxy.getCurrentEnvironment();
-      Map<String,Object> attr = env.getAttributes();
-      String hostname = (String) attr.get("com.google.appengine.runtime.default_version_hostname");
-
-      String url = hostname.contains("localhost:")
-          ? System.getProperty("cloudsql-local") : System.getProperty("cloudsql");
-      log("connecting to: " + url);
-      try {
-        conn = DriverManager.getConnection(url);
-      } catch (SQLException e) {
-        throw new ServletException("Unable to connect to Cloud SQL", e);
-      }
-
-    } finally {
-      // Nothing really to do here.
+      conn = DriverManager.getConnection(url);
+    } catch (SQLException e) {
+      throw new ServletException("Unable to connect to Cloud SQL", e);
     }
   }
 }

--- a/appengine-java8/cloudsql/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/appengine-java8/cloudsql/src/main/webapp/WEB-INF/appengine-web.xml
@@ -15,13 +15,11 @@
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
   <threadsafe>true</threadsafe>
   <runtime>java8</runtime>
-  <use-google-connector-j>true</use-google-connector-j>
 
   <service>cloudsql</service>
 
   <system-properties>
-    <property name="cloudsql" value="jdbc:google:mysql://${INSTANCE_CONNECTION_NAME}/${database}?user=${user}&amp;password=${password}" />
-    <property name="cloudsql-local" value="jdbc:mysql://google/${database}?useSSL=false&amp;cloudSqlInstance=${INSTANCE_CONNECTION_NAME}&amp;socketFactory=com.google.cloud.sql.mysql.SocketFactory&amp;user=${user}&amp;password=${password}" />
+    <property name="cloudsql" value="jdbc:mysql://google/${database}?useSSL=false&amp;cloudSqlInstance=${INSTANCE_CONNECTION_NAME}&amp;socketFactory=com.google.cloud.sql.mysql.SocketFactory&amp;user=${user}&amp;password=${password}" />
   </system-properties>
 </appengine-web-app>
 <!-- [END config] -->


### PR DESCRIPTION
Updates for the AppEngine Standard samples to use a single jdbc url, remove references to v6 connector, and other minor text fixes. 

FYI - @piaxc 