### PR TITLE
Disable Container Analysis 

### DIFF
--- a/container-registry/container-analysis/src/main/java/com/example/containeranalysis/Samples.java
+++ b/container-registry/container-analysis/src/main/java/com/example/containeranalysis/Samples.java
@@ -161,7 +161,7 @@ public class Samples {
 
   // [START get_occurrence]
   /**
-   * Retrieves an occurrence based on it's name
+   * Retrieves an occurrence based on its name
    *
    * @param occurrenceName the name of the occurrence to delete
    *                       format: "projects/{projectId}/occurrences/{occurrence_id}"
@@ -177,7 +177,7 @@ public class Samples {
 
   // [START get_note]
   /**
-   * Retrieves a note based on it's noteId and projectId
+   * Retrieves a note based on its noteId and projectId
    *
    * @param noteId the note's unique identifier
    * @param projectId the project's unique identifier
@@ -280,22 +280,22 @@ public class Samples {
   // [START pubsub]
   /**
    * Handle incoming occurrences using a pubsub subscription
-   * @param subscriptionId the user-specified identifier for the pubsub subscription
+   * @param subId the user-specified identifier for the pubsub subscription
    * @param timeout the amount of time to listen for pubsub messages (in seconds)
    * @param projectId the project's unique identifier
    * @return number of occurrence pubsub messages received
    * @throws Exception on errors with the subscription client
    */
-  public static int pubSub(String subscriptionId, int timeout, String projectId) throws Exception {
+  public static int pubSub(String subId, int timeout, String projectId) throws Exception {
     Subscriber subscriber = null;
     MessageReceiverExample receiver = new MessageReceiverExample();
 
     try {
       // subscribe to the requested pubsub channel
-      ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of(projectId, subscriptionId);
-      subscriber = Subscriber.newBuilder(subscriptionName, receiver).build();
+      ProjectSubscriptionName subName = ProjectSubscriptionName.of(projectId, subId);
+      subscriber = Subscriber.newBuilder(subName, receiver).build();
       subscriber.startAsync().awaitRunning();
-      // listen to messages for 'listenTimeout' seconds
+      // listen to messages for 'timeout' seconds
       for (int i = 0; i < timeout; i++) {
         sleep(1000);
       }
@@ -330,18 +330,18 @@ public class Samples {
 
   /**
    * Creates and returns a pubsub subscription object listening to the occurrence topic
-   * @param subscriptionId the identifier you want to associate with the subscription
+   * @param subId the identifier you want to associate with the subscription
    * @param projectId the project's unique identifier
    * @throws Exception on errors with the subscription client
    */
-  public static Subscription createOccurrenceSubscription(String subscriptionId, String projectId)
+  public static Subscription createOccurrenceSubscription(String subId, String projectId)
       throws Exception {
     String topicId = "resource-notes-occurrences-v1alpha1";
     try (SubscriptionAdminClient client = SubscriptionAdminClient.create()) {
       PushConfig config = PushConfig.getDefaultInstance();
       ProjectTopicName topicName = ProjectTopicName.of(projectId, topicId);
-      ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of(projectId, subscriptionId);
-      Subscription sub = client.createSubscription(subscriptionName, topicName, config, 0);
+      ProjectSubscriptionName subName = ProjectSubscriptionName.of(projectId, subId);
+      Subscription sub = client.createSubscription(subName, topicName, config, 0);
       return sub;
     }
   }

--- a/container-registry/container-analysis/src/test/java/com/example/containeranalysis/SamplesTests.java
+++ b/container-registry/container-analysis/src/test/java/com/example/containeranalysis/SamplesTests.java
@@ -166,6 +166,7 @@ public class SamplesTests {
     do {
       newCount = Samples.getOccurrencesForImage(imageUrl, PROJECT_ID);
       sleep(SLEEP_TIME);
+      tries += 1;
     } while (newCount != 1 && tries < TRY_LIMIT);
     assertEquals(1, newCount);
     assertEquals(0, origCount);
@@ -183,6 +184,7 @@ public class SamplesTests {
     do {
       newCount = Samples.getOccurrencesForNote(noteId, PROJECT_ID);
       sleep(SLEEP_TIME);
+      tries += 1;
     } while (newCount != 1 && tries < TRY_LIMIT);
     assertEquals(0, origCount);
     assertEquals(1, newCount);
@@ -195,14 +197,14 @@ public class SamplesTests {
   public void testPubSub() throws Exception {
     int newCount;
     int tries;
-    String subscriptionId = "drydockOccurrences";
-    ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of(PROJECT_ID, subscriptionId);
+    String subId = "drydockOccurrences";
+    ProjectSubscriptionName subName = ProjectSubscriptionName.of(PROJECT_ID, subId);
 
-    Samples.createOccurrenceSubscription(subscriptionId, PROJECT_ID);
+    Samples.createOccurrenceSubscription(subId, PROJECT_ID);
     Subscriber subscriber = null;
     Samples.MessageReceiverExample receiver = new Samples.MessageReceiverExample();
     try {
-      subscriber = Subscriber.newBuilder(subscriptionName, receiver).build();
+      subscriber = Subscriber.newBuilder(subName, receiver).build();
       subscriber.startAsync().awaitRunning();
       // sleep so any messages in the queue can go through and be counted before we start the test
       sleep(SLEEP_TIME);
@@ -231,7 +233,7 @@ public class SamplesTests {
       }
       //delete subscription now that we're done with it
       try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
-        subscriptionAdminClient.deleteSubscription(subscriptionName);
+        subscriptionAdminClient.deleteSubscription(subName);
       }
     }
 

--- a/container-registry/container-analysis/src/test/java/com/example/containeranalysis/SamplesTests.java
+++ b/container-registry/container-analysis/src/test/java/com/example/containeranalysis/SamplesTests.java
@@ -29,6 +29,7 @@ import com.google.pubsub.v1.ProjectSubscriptionName;
 import java.util.Date;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -40,6 +41,7 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
+@Ignore
 public class SamplesTests {
 
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");


### PR DESCRIPTION
The Container Analysis tests are currently failing, due to conflicts with dependencies after an update from the DPE bot (b/78643399). After discussing how to resolve the issue, we decided the best option is to temporarily disable the tests until the official release of the client libraries into the maven repo. 

This PR **removes the container analysis project from the pom file to disable the automated tests**. It also adds in some miscellaneous minor fixes for the container analysis samples (primarily typos and variable changes)