### PR TITLE
Update README

### DIFF
--- a/speech/cloud-client/README.md
+++ b/speech/cloud-client/README.md
@@ -73,7 +73,7 @@ mvn exec:java -DRecognize -Dexec.args="model-selection gs://cloud-samples-tests/
 
 Perform streaming speech transcription on an audio file
 ```
-mvn exec:java -DRecognize -Dexec.args="streamrecognize ./resources/Google_Gnome.wav"
+mvn exec:java -DRecognize -Dexec.args="streamrecognize ./resources/audio.raw"
 ```
 
 ## Auto Punctuation


### PR DESCRIPTION
Streaming throwing an Audio Content too long error, investigating the issue, updating to shorter file in the meantime. 

Related issue: https://github.com/GoogleCloudPlatform/java-docs-samples/issues/1117