### PR TITLE
Delete unused Datastore region tags / samples.

### DIFF
--- a/datastore/pom.xml
+++ b/datastore/pom.xml
@@ -57,10 +57,6 @@
   </dependencies>
   <build>
     <plugins>
-<!-- // [START datastore_maven]-->
-
-<!-- // [END datastore_maven]-->
-<!-- // [START datastore_exec] -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
@@ -69,7 +65,6 @@
           <mainClass>com.google.datastore.snippets.TaskList</mainClass>
         </configuration>
       </plugin>
-<!-- // [END datastore_exec] -->
     </plugins>
   </build>
 </project>

--- a/datastore/src/main/java/com/google/datastore/snippets/TaskList.java
+++ b/datastore/src/main/java/com/google/datastore/snippets/TaskList.java
@@ -114,7 +114,6 @@ public class TaskList {
   }
   // [END datastore_delete_entity]
 
-  // [START datastore_format_results]
   /**
    * Converts a list of task entities to a list of formatted task strings.
    *
@@ -135,7 +134,6 @@ public class TaskList {
     }
     return strings;
   }
-  // [END datastore_format_results]
 
   /**
    * Handles a single command.

--- a/datastore/src/test/java/com/google/datastore/snippets/ConceptsTest.java
+++ b/datastore/src/test/java/com/google/datastore/snippets/ConceptsTest.java
@@ -541,31 +541,6 @@ public class ConceptsTest {
   }
 
   @Test
-  public void testRunKeysOnlyQuery() {
-    setUpQueryTests();
-    Query<Key> query = Query.newKeyQueryBuilder().setKind("Task").build();
-    // [START datastore_run_keys_only_query]
-    QueryResults<Key> taskKeys = datastore.run(query);
-    // [END datastore_run_keys_only_query]
-    assertNotNull(taskKeys.next());
-    assertFalse(taskKeys.hasNext());
-  }
-
-  @Test
-  public void testDistinctQuery() {
-    setUpQueryTests();
-    // [START datastore_distinct_query]
-    Query<ProjectionEntity> query = Query.newProjectionEntityQueryBuilder()
-        .setKind("Task")
-        .setProjection("category", "priority")
-        .setDistinctOn("category", "priority")
-        .setOrderBy(OrderBy.asc("category"), OrderBy.asc("priority"))
-        .build();
-    // [END datastore_distinct_query]
-    assertValidQuery(query);
-  }
-
-  @Test
   public void testDistinctOnQuery() {
     setUpQueryTests();
     // [START datastore_distinct_on_query]
@@ -997,55 +972,5 @@ public class ConceptsTest {
     Map<String, ImmutableSet<String>> expected =
         ImmutableMap.of("Task", ImmutableSet.of("priority", "tag"));
     assertEquals(expected, propertiesByKind);
-  }
-
-  @Test
-  public void testGqlRunQuery() {
-    setUpQueryTests();
-    // [START datastore_gql_run_query]
-    Query<Entity> query = Query.newGqlQueryBuilder(
-        ResultType.ENTITY, "select * from Task order by created asc").build();
-    // [END datastore_gql_run_query]
-    assertValidQuery(query);
-  }
-
-  @Test
-  public void testGqlNamedBindingQuery() {
-    setUpQueryTests();
-    // [START datastore_gql_named_binding_query]
-    Query<Entity> query =
-        Query.newGqlQueryBuilder(
-            ResultType.ENTITY,
-            "select * from Task where completed = @completed and priority = @priority")
-        .setBinding("completed", false)
-        .setBinding("priority", 4)
-        .build();
-    // [END datastore_gql_named_binding_query]
-    assertValidQuery(query);
-  }
-
-  @Test
-  public void testGqlPositionalBindingQuery() {
-    setUpQueryTests();
-    // [START datastore_gql_positional_binding_query]
-    Query<Entity> query = Query.newGqlQueryBuilder(
-          ResultType.ENTITY, "select * from Task where completed = @1 and priority = @2")
-        .addBinding(false)
-        .addBinding(4)
-        .build();
-    // [END datastore_gql_positional_binding_query]
-    assertValidQuery(query);
-  }
-
-  @Test
-  public void testGqlLiteralQuery() {
-    setUpQueryTests();
-    // [START datastore_gql_literal_query]
-    Query<Entity> query = Query.newGqlQueryBuilder(
-            ResultType.ENTITY, "select * from Task where completed = false and priority = 4")
-        .setAllowLiteral(true)
-        .build();
-    // [END datastore_gql_literal_query]
-    assertValidQuery(query);
   }
 }


### PR DESCRIPTION
These samples/region tags aren't used on cloud.google.com, so I'm deleting them.

Related:

- GoogleCloudPlatform/python-docs-samples#1531
- googleapis/nodejs-datastore#110
- GoogleCloudPlatform/php-docs-samples#631
- GoogleCloudPlatform/dotnet-docs-samples#569
- GoogleCloudPlatform/ruby-docs-samples#292
- GoogleCloudPlatform/golang-samples#516