### PR TITLE
Fixing jwt uri

### DIFF
--- a/appengine-java8/endpoints-v2-backend/src/main/java/com/example/echo/Echo.java
+++ b/appengine-java8/endpoints-v2-backend/src/main/java/com/example/echo/Echo.java
@@ -47,7 +47,7 @@ import com.google.api.server.spi.response.UnauthorizedException;
             name = "firebase",
             issuer = "https://securetoken.google.com/YOUR-PROJECT-ID",
             jwksUri =
-                "https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system"
+                "https://www.googleapis.com/service_accounts/v1/metadata/x509/securetoken@system"
                     + ".gserviceaccount.com"
         )
     }


### PR DESCRIPTION
This is an old sample that used deprecated **robot** instead of **service_accounts** as part of the URI