### PR TITLE
Fix auth sample to explicitly set the projectId

### DIFF
--- a/auth/src/main/java/com/google/cloud/auth/samples/AuthExample.java
+++ b/auth/src/main/java/com/google/cloud/auth/samples/AuthExample.java
@@ -96,24 +96,25 @@ public class AuthExample {
       authImplicit();
       return;
     }
-    String suite = args[0];
-    if ("explicit".equals(suite)) {
-      if (args.length >= 3) {
-        authExplicit(args[1], args[2]);
-      } else {
-        throw new IllegalArgumentException(
-          "Project ID and path to credential file required with 'explicit'.");
-      }
-      return;
+
+    switch (args[0]) {
+      case "explicit":
+        if (args.length >= 3) {
+          authExplicit(args[1], args[2]);
+        } else {
+          throw new IllegalArgumentException(
+            "Project ID and path to credential file required with 'explicit'.");
+        }
+        break;
+      case "compute":
+        authCompute();
+        break;
+      case "appengine":
+        authAppEngineStandard();
+        break;
+      default:
+        authImplicit();
+        break;
     }
-    if ("compute".equals(suite)) {
-      authCompute();
-      return;
-    }
-    if ("appengine".equals(suite)) {
-      authAppEngineStandard();
-      return;
-    }
-    authImplicit();
   }
 }

--- a/auth/src/main/java/com/google/cloud/auth/samples/AuthExample.java
+++ b/auth/src/main/java/com/google/cloud/auth/samples/AuthExample.java
@@ -47,12 +47,13 @@ public class AuthExample {
   // [END auth_cloud_implicit]
 
   // [START auth_cloud_explicit]
-  static void authExplicit(String jsonPath) throws IOException {
+  static void authExplicit(String projectId, String jsonPath) throws IOException {
     // You can specify a credential file by providing a path to GoogleCredentials.
     // Otherwise credentials are read from the GOOGLE_APPLICATION_CREDENTIALS environment variable.
     GoogleCredentials credentials = GoogleCredentials.fromStream(new FileInputStream(jsonPath))
           .createScoped(Lists.newArrayList("https://www.googleapis.com/auth/cloud-platform"));
-    Storage storage = StorageOptions.newBuilder().setCredentials(credentials).build().getService();
+    Storage storage = StorageOptions.newBuilder().setCredentials(credentials)
+          .setProjectId(projectId).build().getService();
 
     System.out.println("Buckets:");
     Page<Bucket> buckets = storage.list();
@@ -95,19 +96,21 @@ public class AuthExample {
       authImplicit();
       return;
     }
-    if ("explicit".equals(args[0])) {
-      if (args.length >= 2) {
-        authExplicit(args[1]);
+    String suite = args[0];
+    if ("explicit".equals(suite)) {
+      if (args.length >= 3) {
+        authExplicit(args[1], args[2]);
       } else {
-        throw new IllegalArgumentException("Path to credential file required with 'explicit'.");
+        throw new IllegalArgumentException(
+          "Project ID and path to credential file required with 'explicit'.");
       }
       return;
     }
-    if ("compute".equals(args[0])) {
+    if ("compute".equals(suite)) {
       authCompute();
       return;
     }
-    if ("appengine".equals(args[0])) {
+    if ("appengine".equals(suite)) {
       authAppEngineStandard();
       return;
     }

--- a/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
+++ b/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
@@ -35,6 +35,7 @@ public class AuthExampleIT {
   private ByteArrayOutputStream bout;
   private PrintStream out;
   private String credentials;
+  private String projectId;
 
   @Before
   public void setUp() {
@@ -42,7 +43,9 @@ public class AuthExampleIT {
     out = new PrintStream(bout);
     System.setOut(out);
     credentials = System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
-    assertNotNull(credentials);
+    assertNotNull(credentials, "Please set the GOOGLE_APPLICATION_CREDENTIALS env var.");
+    projectId = System.getenv("GOOGLE_PROJECT_ID");
+    assertNotNull(projectId, "Please set the GOOGLE_PROJECT_ID env var.");
   }
 
   @Test
@@ -54,7 +57,7 @@ public class AuthExampleIT {
 
   @Test
   public void testAuthExplicitNoPath() throws IOException {
-    AuthExample.main(new String[] {"explicit", credentials});
+    AuthExample.main(new String[] {"explicit", projectId, credentials});
     String output = bout.toString();
     assertTrue(output.contains("Buckets:"));
   }


### PR DESCRIPTION
When explicitly setting credentials for a service, we should also advise the user to explicitly set their project id. `ServiceOptions` will not look for the project id in the service account json if provided (See https://github.com/GoogleCloudPlatform/google-cloud-java/issues/3386). Instead, it will still use ADC's rules for finding the projectId with may or may not be what the user intends.

Context: internal b/110528397