### PR TITLE
Remove unused dependency region tags and update used region tags

### DIFF
--- a/bigquery/cloud-client/pom.xml
+++ b/bigquery/cloud-client/pom.xml
@@ -36,13 +36,13 @@
   </properties>
 
   <dependencies>
-    <!-- [START dependencies] -->
+    <!-- [START bigquery_java_dependencies] -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquery</artifactId>
       <version>1.38.0</version>
     </dependency>
-    <!-- [END dependencies] -->
+    <!-- [END bigquery_java_dependencies] -->
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>

--- a/bigquery/datatransfer/cloud-client/pom.xml
+++ b/bigquery/datatransfer/cloud-client/pom.xml
@@ -36,13 +36,12 @@
   </properties>
 
   <dependencies>
-    <!-- [START dependencies] -->
+    <!-- dependencies -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquerydatatransfer</artifactId>
       <version>0.56.0-beta</version>
     </dependency>
-    <!-- [END dependencies] -->
 
     <!-- Test dependencies -->
     <dependency>

--- a/bigquery/datatransfer/cloud-client/pom.xml
+++ b/bigquery/datatransfer/cloud-client/pom.xml
@@ -36,12 +36,13 @@
   </properties>
 
   <dependencies>
-    <!-- dependencies -->
+    <!-- [START bigquerydatatransfer_java_dependencies] -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquerydatatransfer</artifactId>
       <version>0.56.0-beta</version>
     </dependency>
+    <!-- [END bigquerydatatransfer_java_dependencies] -->
 
     <!-- Test dependencies -->
     <dependency>

--- a/language/analysis/pom.xml
+++ b/language/analysis/pom.xml
@@ -35,7 +35,7 @@ limitations under the License.
   </properties>
 
   <dependencies>
-    <!-- [START dependencies] -->
+    <!-- dependencies -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-language</artifactId>
@@ -46,7 +46,6 @@ limitations under the License.
       <artifactId>guava</artifactId>
       <version>20.0</version>
     </dependency>
-    <!-- [END dependencies] -->
 
     <!-- Test Dependencies -->
     <dependency>

--- a/language/analysis/pom.xml
+++ b/language/analysis/pom.xml
@@ -35,12 +35,13 @@ limitations under the License.
   </properties>
 
   <dependencies>
-    <!-- dependencies -->
+    <!-- [START language_java_dependencies] -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-language</artifactId>
       <version>1.38.0</version>
     </dependency>
+    <!-- [END language_java_dependencies] -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/language/automl/pom.xml
+++ b/language/automl/pom.xml
@@ -36,7 +36,7 @@
   </properties>
 
   <dependencies>
-    <!-- [START dependencies] -->
+    <!-- dependencies -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-automl</artifactId>
@@ -47,7 +47,6 @@
       <artifactId>argparse4j</artifactId>
       <version>0.8.1</version>
     </dependency>
-    <!-- [END dependencies] -->
 
     <!-- Test dependencies -->
     <dependency>

--- a/language/automl/pom.xml
+++ b/language/automl/pom.xml
@@ -36,12 +36,13 @@
   </properties>
 
   <dependencies>
-    <!-- dependencies -->
+    <!-- [START automl_language_java_dependencies] -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-automl</artifactId>
       <version>0.55.1-beta</version>
     </dependency>
+    <!-- [END automl_language_java_dependencies] -->
     <dependency>
       <groupId>net.sourceforge.argparse4j</groupId>
       <artifactId>argparse4j</artifactId>

--- a/pubsub/cloud-client/pom.xml
+++ b/pubsub/cloud-client/pom.xml
@@ -35,13 +35,13 @@
   </properties>
 
   <dependencies>
-    <!-- [START dependencies] -->
+    <!-- [START pubsub_java_dependencies] -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsub</artifactId>
       <version>1.38.0</version>
     </dependency>
-    <!-- [END dependencies] -->
+    <!-- [END pubsub_java_dependencies] -->
 
     <!-- Test dependencies -->
     <dependency>

--- a/texttospeech/beta/pom.xml
+++ b/texttospeech/beta/pom.xml
@@ -31,7 +31,7 @@
   </properties>
 
   <dependencies>
-    <!-- [START dependencies] -->
+    <!-- dependencies -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-texttospeech</artifactId>
@@ -42,7 +42,6 @@
       <artifactId>argparse4j</artifactId>
       <version>0.8.1</version>
     </dependency>
-    <!-- [END dependencies] -->
 
     <!-- Test dependencies -->
     <dependency>

--- a/texttospeech/beta/pom.xml
+++ b/texttospeech/beta/pom.xml
@@ -31,7 +31,7 @@
   </properties>
 
   <dependencies>
-    <!-- dependencies -->
+    <!-- [START tts_java_dependencies_beta] -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-texttospeech</artifactId>
@@ -42,6 +42,7 @@
       <artifactId>argparse4j</artifactId>
       <version>0.8.1</version>
     </dependency>
+    <!-- [END tts_java_dependencies_beta] -->
 
     <!-- Test dependencies -->
     <dependency>

--- a/texttospeech/cloud-client/pom.xml
+++ b/texttospeech/cloud-client/pom.xml
@@ -31,7 +31,7 @@
     </properties>
 
     <dependencies>
-        <!-- [START dependencies] -->
+        <!-- [START tts_java_dependencies] -->
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-texttospeech</artifactId>
@@ -42,7 +42,7 @@
             <artifactId>argparse4j</artifactId>
             <version>0.8.1</version>
         </dependency>
-        <!-- [END dependencies] -->
+        <!-- [END tts_java_dependencies] -->
 
         <!-- Test dependencies -->
         <dependency>

--- a/translate/automl/pom.xml
+++ b/translate/automl/pom.xml
@@ -36,7 +36,7 @@
   </properties>
 
   <dependencies>
-    <!-- [START dependencies] -->
+    <!-- dependencies -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-automl</artifactId>
@@ -47,7 +47,6 @@
       <artifactId>argparse4j</artifactId>
       <version>0.8.1</version>
     </dependency>
-    <!-- [END dependencies] -->
 
     <!-- Test dependencies -->
     <dependency>

--- a/translate/automl/pom.xml
+++ b/translate/automl/pom.xml
@@ -36,7 +36,7 @@
   </properties>
 
   <dependencies>
-    <!-- dependencies -->
+    <!-- [START automl_translate_java_dependencies] -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-automl</artifactId>
@@ -47,6 +47,7 @@
       <artifactId>argparse4j</artifactId>
       <version>0.8.1</version>
     </dependency>
+    <!-- [END automl_translate_java_dependencies] -->
 
     <!-- Test dependencies -->
     <dependency>

--- a/translate/cloud-client/pom.xml
+++ b/translate/cloud-client/pom.xml
@@ -36,13 +36,13 @@
   </properties>
 
   <dependencies>
-    <!-- [START dependencies] -->
+    <!-- [START translate_java_dependencies] -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-translate</artifactId>
       <version>1.38.0</version>
     </dependency>
-    <!-- [END dependencies] -->
+    <!-- [END translate_java_dependencies] -->
 
     <!-- Test dependencies -->
     <dependency>

--- a/vision/automl/pom.xml
+++ b/vision/automl/pom.xml
@@ -36,7 +36,7 @@
   </properties>
 
   <dependencies>
-    <!-- [START dependencies] -->
+    <!-- dependencies -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-automl</artifactId>
@@ -47,7 +47,6 @@
       <artifactId>argparse4j</artifactId>
       <version>0.8.1</version>
     </dependency>
-    <!-- [END dependencies] -->
 
     <!-- Test dependencies -->
     <dependency>

--- a/vision/automl/pom.xml
+++ b/vision/automl/pom.xml
@@ -36,7 +36,7 @@
   </properties>
 
   <dependencies>
-    <!-- dependencies -->
+    <!-- [START automl_vision_java_dependencies] -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-automl</artifactId>
@@ -47,6 +47,7 @@
       <artifactId>argparse4j</artifactId>
       <version>0.8.1</version>
     </dependency>
+    <!-- [START automl_vision_java_dependencies] -->
 
     <!-- Test dependencies -->
     <dependency>

--- a/vision/beta/cloud-client/pom.xml
+++ b/vision/beta/cloud-client/pom.xml
@@ -36,7 +36,7 @@
   </properties>
 
   <dependencies>
-    <!-- [START dependencies] -->
+    <!-- dependencies -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-vision</artifactId>
@@ -47,7 +47,6 @@
       <artifactId>google-cloud-storage</artifactId>
       <version>1.38.0</version>
     </dependency>
-    <!-- [END dependencies] -->
 
     <!-- Test dependencies -->
     <dependency>

--- a/vision/beta/cloud-client/pom.xml
+++ b/vision/beta/cloud-client/pom.xml
@@ -36,7 +36,7 @@
   </properties>
 
   <dependencies>
-    <!-- dependencies -->
+    <!-- [START vision_java_dependencies_beta] -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-vision</artifactId>
@@ -47,6 +47,7 @@
       <artifactId>google-cloud-storage</artifactId>
       <version>1.38.0</version>
     </dependency>
+    <!-- [END vision_java_dependencies_beta] -->
 
     <!-- Test dependencies -->
     <dependency>

--- a/vision/cloud-client/pom.xml
+++ b/vision/cloud-client/pom.xml
@@ -36,7 +36,7 @@
   </properties>
 
   <dependencies>
-    <!-- [START dependencies] -->
+    <!-- [START vision_java_dependencies] -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-vision</artifactId>
@@ -47,7 +47,7 @@
       <artifactId>google-cloud-storage</artifactId>
       <version>1.38.0</version>
     </dependency>
-    <!-- [END dependencies] -->
+    <!-- [END vision_java_dependencies] -->
 
     <!-- Test dependencies -->
     <dependency>

--- a/vision/face-detection/pom.xml
+++ b/vision/face-detection/pom.xml
@@ -37,7 +37,7 @@
   </properties>
 
   <dependencies>
-    <!-- [START dependencies] -->
+    <!-- dependencies -->
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-vision</artifactId>
@@ -54,7 +54,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- [END dependencies] -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/vision/product-search/cloud-client/pom.xml
+++ b/vision/product-search/cloud-client/pom.xml
@@ -36,7 +36,7 @@
   </properties>
 
   <dependencies>
-    <!-- [START dependencies] -->
+    <!-- dependencies -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-vision</artifactId>
@@ -57,7 +57,6 @@
       <artifactId>commons-csv</artifactId>
       <version>1.5</version>
     </dependency>
-    <!-- [END dependencies] -->
 
     <!-- Test dependencies -->
     <dependency>

--- a/vision/product-search/cloud-client/pom.xml
+++ b/vision/product-search/cloud-client/pom.xml
@@ -36,7 +36,7 @@
   </properties>
 
   <dependencies>
-    <!-- dependencies -->
+    <!-- [START vision_product_search_java_dependencies] -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-vision</artifactId>
@@ -57,6 +57,7 @@
       <artifactId>commons-csv</artifactId>
       <version>1.5</version>
     </dependency>
+    <!-- [END vision_product_search_java_dependencies] -->
 
     <!-- Test dependencies -->
     <dependency>


### PR DESCRIPTION
The goal with sample region tags is to have a globally unique tag for each sample. The "dependencies" tag is used throughout the java-docs-samples repo, which goes against best practices. This PR accomplishes the following:
+ For region tags that are not used on cloud.google.com, remove the region tag
+ For region tags that are used on cloud.google.com, add a prefix of product_java_ (ex. bigquery_java_dependencies)

Note that this PR does not include all products, only ones that I am responsible for adding to the sample tracker. Others will be performing this update for the remaining products.