### PR TITLE
Update Appengine example for updated Postgres JDBC SocketFactory.

### DIFF
--- a/appengine-java8/cloudsql-postgres/pom.xml
+++ b/appengine-java8/cloudsql-postgres/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>com.google.cloud.sql</groupId>
       <artifactId>postgres-socket-factory</artifactId>
-      <version>1.0.10</version>
+      <version>1.0.11</version>
     </dependency>
     <!-- [END dependencies] -->
   </dependencies>

--- a/appengine-java8/cloudsql-postgres/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/appengine-java8/cloudsql-postgres/src/main/webapp/WEB-INF/appengine-web.xml
@@ -17,7 +17,7 @@
   <runtime>java8</runtime>
 
   <system-properties>
-    <property name="cloudsql" value="jdbc:postgresql://google/${database}?useSSL=false&amp;socketFactoryArg=${INSTANCE_CONNECTION_NAME}&amp;socketFactory=com.google.cloud.sql.postgres.SocketFactory&amp;user=${user}&amp;password=${password}" />
+    <property name="cloudsql" value="jdbc:postgresql://google/${database}?cloudSqlInstance=${INSTANCE_CONNECTION_NAME}&amp;socketFactory=com.google.cloud.sql.postgres.SocketFactory&amp;user=${user}&amp;password=${password}" />
   </system-properties>
 </appengine-web-app>
 <!-- [END config] -->


### PR DESCRIPTION
The JDBC SocketFactory is deprecating 'socketFactoryArg' in favor of 'cloudSqlInstance'. This updates the Postgres example with that change. 