### PR TITLE
Fix Url & Issue #1148

### DIFF
--- a/appengine-java8/README.md
+++ b/appengine-java8/README.md
@@ -43,7 +43,7 @@ access control, billing, and services.
 This sample demonstrates how to deploy an application on Google App Engine.
 
 - [Documentation][ae-docs]
-- [Code](helloworld)
+- [Code](https://github.com/GoogleCloudPlatform/getting-started-java/tree/master/appengine-standard-java8/helloworld)
 
 ### Sending Email
 


### PR DESCRIPTION
Hello World URL was invalid, fixed URL to point to https://github.com/GoogleCloudPlatform/getting-started-java/tree/master/appengine-standard-java8/helloworld

Resolves #1148 