### PR TITLE
Updated to java version 8

### DIFF
--- a/bigquery/cloud-client/pom.xml
+++ b/bigquery/cloud-client/pom.xml
@@ -30,8 +30,8 @@
   </parent>
 
   <properties>
-    <maven.compiler.target>1.7</maven.compiler.target>
-    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 


### PR DESCRIPTION
Oracle no longer posts updated of Java 7. Updated to Java 8. See: https://java.com/en/download/faq/java_7.xml 