### PR TITLE
Update list logs region tag.

### DIFF
--- a/logging/cloud-client/src/main/java/com/example/logging/ListLogs.java
+++ b/logging/cloud-client/src/main/java/com/example/logging/ListLogs.java
@@ -29,7 +29,7 @@ public class ListLogs {
 
   /** Expects an existing Stackdriver log name as an argument. */
   public static void main(String... args) throws Exception {
-    // [START listlogs]
+    // [START logging_list_log_entries]
     // Instantiates a client
     LoggingOptions options = LoggingOptions.getDefaultInstance();
 
@@ -50,6 +50,6 @@ public class ListLogs {
       } while (entries != null);
 
     }
-    // [END listlogs]
+    // [END logging_list_log_entries]
   }
 }


### PR DESCRIPTION
Updating so that https://cloud.google.com/logging/docs/api/tasks/creating-logs#logging-list-entries-java can point to this sample in java-docs-samples instead of google-cloud-java.

Searched CS to confirm no reference to "listlogs" region tag anywhere.