### PR TITLE
Add  DLP replace with info type transformation examples, and update DLP README

### DIFF
--- a/dlp/README.md
+++ b/dlp/README.md
@@ -44,43 +44,46 @@ Note: image scanning is not currently supported on Google Cloud Storage.
 For more information, refer to the [API documentation](https://cloud.google.com/dlp/docs). 
 Optional flags are explained in [this resource](https://cloud.google.com/dlp/docs/reference/rest/v2beta1/content/inspect#InspectConfig).
 ```
-Commands:
-  -s <string>                   Inspect a string using the Data Loss Prevention API.
-  -f <filepath>                 Inspects a local text, PNG, or JPEG file using the Data Loss Prevention API.
-  -gcs -bucketName <bucketName> -fileName <fileName>  Inspects a text file stored on Google Cloud Storage using the Data Loss
-                                          Prevention API.
-  -ds -projectId [projectId] -namespace [namespace] - kind <kind> Inspect a Datastore instance using the Data Loss Prevention API.
-
-Options:
-  --help               Show help 
-  -minLikelihood       [string] [choices: "LIKELIHOOD_UNSPECIFIED", "VERY_UNLIKELY", "UNLIKELY", "POSSIBLE", "LIKELY", "VERY_LIKELY"]
-                       [default: "LIKELIHOOD_UNSPECIFIED"]
-                       specifies the minimum reporting likelihood threshold.
-  -f, --maxFindings    [number] [default: 0]
-                       maximum number of results to retrieve
-  -q, --includeQuote   [boolean] [default: true] include matching string in results
-  -t, --infoTypes      set of infoTypes to search for [eg. PHONE_NUMBER US_PASSPORT]
-  -customDictionaries  set of comma-separated dictionary words to search for as customInfoTypes
-  -customRegexes       set of regex patterns to search for as customInfoTypes
+usage: com.example.dlp.Inspect
+ -bq,--Google BigQuery         inspect BigQuery table
+ -bucketName <arg>
+ -customDictionaries <arg>
+ -customRegexes <arg>
+ -datasetId <arg>
+ -ds,--Google Datastore        inspect Datastore kind
+ -f,--file path <arg>          inspect input file path
+ -fileName <arg>
+ -gcs,--Google Cloud Storage   inspect GCS file
+ -includeQuote <arg>
+ -infoTypes <arg>
+ -kind <arg>
+ -maxFindings <arg>
+ -minLikelihood <arg>
+ -namespace <arg>
+ -projectId <arg>
+ -s,--string <arg>             inspect string
+ -subscriptionId <arg>
+ -tableId <arg>
+ -topicId <arg>
 ```
 ### Examples
  - Inspect a string:
    ```
-   java -cp dlp/target/dlp-samples-1.0-jar-with-dependencies.jar com.example.dlp.Inspect -s "My phone number is (123) 456-7890 and my email address is me@somedomain.com" --infoTypes PHONE_NUMBER EMAIL_ADDRESS
+   java -cp dlp/target/dlp-samples-1.0-jar-with-dependencies.jar com.example.dlp.Inspect -s "My phone number is (123) 456-7890 and my email address is me@somedomain.com" -infoTypes PHONE_NUMBER EMAIL_ADDRESS
    java -cp dlp/target/dlp-samples-1.0-jar-with-dependencies.jar com.example.dlp.Inspect -s "My phone number is (123) 456-7890 and my email address is me@somedomain.com" -customDictionaries me@somedomain.com -customRegexes "\(\d{3}\) \d{3}-\d{4}"
    ```
  - Inspect a local file (text / image):
    ```
-     java -cp dlp/target/dlp-samples-1.0-jar-with-dependencies.jar com.example.dlp.Inspect -f src/test/resources/test.txt --infoTypes PHONE_NUMBER EMAIL_ADDRESS
-     java -cp dlp/target/dlp-samples-1.0-jar-with-dependencies.jar com.example.dlp.Inspect -f src/test/resources/test.png --infoTypes PHONE_NUMBER EMAIL_ADDRESS
+     java -cp dlp/target/dlp-samples-1.0-jar-with-dependencies.jar com.example.dlp.Inspect -f src/test/resources/test.txt -infoTypes PHONE_NUMBER EMAIL_ADDRESS
+     java -cp dlp/target/dlp-samples-1.0-jar-with-dependencies.jar com.example.dlp.Inspect -f src/test/resources/test.png -infoTypes PHONE_NUMBER EMAIL_ADDRESS
    ```
 - Inspect a file on Google Cloud Storage:
   ```
-    java -cp dlp/target/dlp-samples-1.0-jar-with-dependencies.jar com.example.dlp.Inspect -gcs -bucketName my-bucket -fileName my-file.txt --infoTypes PHONE_NUMBER EMAIL_ADDRESS
+    java -cp dlp/target/dlp-samples-1.0-jar-with-dependencies.jar com.example.dlp.Inspect -gcs -bucketName my-bucket -fileName my-file.txt -infoTypes PHONE_NUMBER EMAIL_ADDRESS
   ```
 - Inspect a Google Cloud Datastore kind:
   ```
-    java -cp dlp/target/dlp-samples-1.0-jar-with-dependencies.jar com.example.dlp.Inspect -ds -kind my-kind --infoTypes PHONE_NUMBER EMAIL_ADDRESS
+    java -cp dlp/target/dlp-samples-1.0-jar-with-dependencies.jar com.example.dlp.Inspect -ds -kind my-kind -infoTypes PHONE_NUMBER EMAIL_ADDRESS
   ```
 
 ## Automatic redaction of sensitive data from images

--- a/dlp/src/test/java/com/example/dlp/DeIdentificationIT.java
+++ b/dlp/src/test/java/com/example/dlp/DeIdentificationIT.java
@@ -58,6 +58,18 @@ public class DeIdentificationIT {
   }
 
   @Test
+  public void testDeidReplaceWithInfoType() throws Exception {
+    String text = "\"My SSN is 372819127\"";
+    DeIdentification.main(
+        new String[] {
+          "-it", text,
+          "-infoTypes", "US_SOCIAL_SECURITY_NUMBER"
+        });
+    String output = bout.toString();
+    assertThat(output, containsString("My SSN is [US_SOCIAL_SECURITY_NUMBER]"));
+  }
+
+  @Test
   public void testDeidStringMasksCharacters() throws Exception {
     String text = "\"My SSN is 372819127\"";
     DeIdentification.main(


### PR DESCRIPTION
The DLP team is in the process of expanding code samples to include features that we have launched since the initial samples were written.

This pull request adds code samples for transformations that replace pieces of sensitive info with their info types. It also updates the README to bring the CLI usage info and flags up to date.