### PR TITLE
Add updated region tags for error_reporting_setup_java[_appengine_flex].

### DIFF
--- a/errorreporting/src/main/java/com/example/errorreporting/QuickStart.java
+++ b/errorreporting/src/main/java/com/example/errorreporting/QuickStart.java
@@ -18,6 +18,7 @@ package com.example.errorreporting;
 
 // [START errorreporting_quickstart]
 // [START error_reporting_quickstart]
+// [START error_reporting_setup_java]
 
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.errorreporting.v1beta1.ReportErrorsServiceClient;
@@ -65,5 +66,6 @@ public class QuickStart {
     }
   }
 }
+// [END error_reporting_setup_java]
 // [END error_reporting_quickstart]
 // [END errorreporting_quickstart]

--- a/flexible/errorreporting/src/main/java/com/example/flexible/errorreporting/ErrorReportingExample.java
+++ b/flexible/errorreporting/src/main/java/com/example/flexible/errorreporting/ErrorReportingExample.java
@@ -23,6 +23,7 @@ import com.google.devtools.clouderrorreporting.v1beta1.ProjectName;
 import com.google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent;
 
 import com.google.devtools.clouderrorreporting.v1beta1.SourceLocation;
+
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -33,6 +34,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 // [START flex_error_reporting]
+// [START error_reporting_setup_java_appengine_flex]
 @WebServlet(name = "Error reporting", value = "/error")
 public class ErrorReportingExample extends HttpServlet {
 
@@ -77,4 +79,5 @@ public class ErrorReportingExample extends HttpServlet {
     }
   }
 }
+// [END error_reporting_setup_java_appengine_flex]
 // [END flex_error_reporting]


### PR DESCRIPTION
As with `error_reporting_quickstart`, I can remove the old tag `flex_error_reporting` once the docs change is pushed.