### PR TITLE
vision: relax another case comparison in vision (labels).

### DIFF
--- a/vision/label/src/test/java/com/google/cloud/vision/samples/label/LabelAppIT.java
+++ b/vision/label/src/test/java/com/google/cloud/vision/samples/label/LabelAppIT.java
@@ -49,7 +49,7 @@ public class LabelAppIT {
 
     ImmutableSet.Builder<String> builder = ImmutableSet.builder();
     for (EntityAnnotation label : labels) {
-      builder.add(label.getDescription());
+      builder.add(label.getDescription().toLowerCase());
     }
     ImmutableSet<String> descriptions = builder.build();
 


### PR DESCRIPTION
Missed this as I was focused on the detect samples, and missed this
additional failure in labeling.