### PR TITLE
OpenCensus: Update EXPORT interval

### DIFF
--- a/opencensus/src/main/java/com/example/opencensus/Quickstart.java
+++ b/opencensus/src/main/java/com/example/opencensus/Quickstart.java
@@ -36,7 +36,7 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 public class Quickstart {
-  private static final int EXPORT_INTERVAL = 60;
+  private static final int EXPORT_INTERVAL = 70;
   private static final MeasureLong LATENCY_MS = MeasureLong.create(
       "task_latency",
       "The task latency in milliseconds",


### PR DESCRIPTION
OpenCensus Stackdriver exporter exports every 60s by default, we need make sure main thread is running for longer than that.