### PR TITLE
Container analysis filter

### DIFF
--- a/container-registry/container-analysis/src/main/java/com/example/containeranalysis/PollDiscoveryOccurrenceFinished.java
+++ b/container-registry/container-analysis/src/main/java/com/example/containeranalysis/PollDiscoveryOccurrenceFinished.java
@@ -43,9 +43,15 @@ public class PollDiscoveryOccurrenceFinished {
 
     // find the discovery occurrence using a filter string
     Occurrence discoveryOccurrence = null;
-    String filterStr = "kind=\"DISCOVERY\" AND resourceUrl=\"" + resourceUrl + "\"";
+    String filter =  String.format("resourceUrl=\"%s\" AND noteProjectId=\"%s\" AND noteId=\"%s\"", 
+        resourceUrl, "goog-analysis",  "PACKAGE_VULNERABILITY");
+    // [END containeranalysis_poll_discovery_occurrence_finished]
+    // the above filter isn't testable, since it looks for occurrences in a locked down project
+    // fall back to a more permissive filter for testing
+    filter = String.format("kind=\"DISCOVERY\" AND resourceUrl=\"%s\"", resourceUrl);
+    // [START containeranalysis_poll_discovery_occurrence_finished]
     while (discoveryOccurrence == null) {
-      for (Occurrence o : client.listOccurrences(projectName, filterStr).iterateAll()) {
+      for (Occurrence o : client.listOccurrences(projectName, filter).iterateAll()) {
         if (o.getDiscovered() != null) {
           // there should be only one valid discovery occurrence returned by the given filter
           discoveryOccurrence = o;

--- a/container-registry/container-analysis/src/main/java/com/example/containeranalysis/PollDiscoveryOccurrenceFinished.java
+++ b/container-registry/container-analysis/src/main/java/com/example/containeranalysis/PollDiscoveryOccurrenceFinished.java
@@ -43,7 +43,7 @@ public class PollDiscoveryOccurrenceFinished {
 
     // find the discovery occurrence using a filter string
     Occurrence discoveryOccurrence = null;
-    // vulbnerability discovery occurrences are always published under the
+    // vulbnerability discovery occurrences are always associated with the
     // PACKAGE_VULNERABILITY note in the "goog-analysis" GCP project
     String filter =  String.format("resourceUrl=\"%s\" AND noteProjectId=\"%s\" AND noteId=\"%s\"", 
         resourceUrl, "goog-analysis",  "PACKAGE_VULNERABILITY");

--- a/container-registry/container-analysis/src/main/java/com/example/containeranalysis/PollDiscoveryOccurrenceFinished.java
+++ b/container-registry/container-analysis/src/main/java/com/example/containeranalysis/PollDiscoveryOccurrenceFinished.java
@@ -43,6 +43,8 @@ public class PollDiscoveryOccurrenceFinished {
 
     // find the discovery occurrence using a filter string
     Occurrence discoveryOccurrence = null;
+    // vulbnerability discovery occurrences are always published under the
+    // PACKAGE_VULNERABILITY note in the "goog-analysis" GCP project
     String filter =  String.format("resourceUrl=\"%s\" AND noteProjectId=\"%s\" AND noteId=\"%s\"", 
         resourceUrl, "goog-analysis",  "PACKAGE_VULNERABILITY");
     // [END containeranalysis_poll_discovery_occurrence_finished]

--- a/container-registry/container-analysis/src/main/java/com/example/containeranalysis/Subscriptions.java
+++ b/container-registry/container-analysis/src/main/java/com/example/containeranalysis/Subscriptions.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import java.lang.InterruptedException;
 import java.util.concurrent.TimeUnit;
 
-public class PubSub {
+public class Subscriptions {
   // Handle incoming Occurrences using a Cloud Pub/Sub subscription
   public static int pubSub(String subId, long timeoutSeconds, String projectId)
       throws InterruptedException {

--- a/container-registry/container-analysis/src/test/java/com/example/containeranalysis/SamplesTest.java
+++ b/container-registry/container-analysis/src/test/java/com/example/containeranalysis/SamplesTest.java
@@ -200,12 +200,12 @@ public class SamplesTest {
     int tries;
     ProjectSubscriptionName subName = ProjectSubscriptionName.of(PROJECT_ID, subId);
     try {
-      PubSub.createOccurrenceSubscription(subId, PROJECT_ID);
+      Subscriptions.createOccurrenceSubscription(subId, PROJECT_ID);
     } catch (StatusRuntimeException e) {
       System.out.println("subscription " + subId + " already exists");
     }
     Subscriber subscriber = null;
-    PubSub.MessageReceiverExample receiver = new PubSub.MessageReceiverExample();
+    Subscriptions.MessageReceiverExample receiver = new Subscriptions.MessageReceiverExample();
 
     subscriber = Subscriber.newBuilder(subName, receiver).build();
     subscriber.startAsync().awaitRunning();


### PR DESCRIPTION
Two small fixes:
- I changed the filter string that is exposed in the docs to be more precise, but used region tags to invisibly fall back to the original filter since the new one can't be easily tested
- I renamed PubSub.java to Subscriptions.java. It seems PubSub was causing warnings in the docs CLs, since the proper name is Pub/Sub