### PR TITLE
Cloud Spanner: Specify the name for packaging the JAR

### DIFF
--- a/spanner/cloud-client/pom.xml
+++ b/spanner/cloud-client/pom.xml
@@ -18,7 +18,6 @@ limitations under the License.
   <groupId>com.example.spanner</groupId>
   <artifactId>spanner-google-cloud-samples</artifactId>
   <packaging>jar</packaging>
-  <version>${revision}</version>
 
   <!--
     The parent pom defines common style checks and testing strategies for our samples.
@@ -31,7 +30,6 @@ limitations under the License.
   </parent>
 
   <properties>
-    <revision>${project.parent.version}</revision>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -142,6 +140,7 @@ limitations under the License.
     </dependency>
   </dependencies>
   <build>
+    <finalName>spanner-google-cloud-samples</finalName>
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>

--- a/spanner/cloud-client/pom.xml
+++ b/spanner/cloud-client/pom.xml
@@ -18,6 +18,7 @@ limitations under the License.
   <groupId>com.example.spanner</groupId>
   <artifactId>spanner-google-cloud-samples</artifactId>
   <packaging>jar</packaging>
+  <version>${revision}</version>
 
   <!--
     The parent pom defines common style checks and testing strategies for our samples.
@@ -30,6 +31,7 @@ limitations under the License.
   </parent>
 
   <properties>
+    <revision>${project.parent.version}</revision>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Right now, the Cloud Spanner docs go stale whenever we upgrade the parent to a new version. The docs are stale right now, in fact; they say `1.0.10`, but the current version is `1.0.11` ([example](https://cloud.google.com/spanner/docs/getting-started/java/)).

With this change, we can update the docs to tell customers to run something like `mvn package -Drevision=0.1.0-SNAPSHOT`, and then use `0.1.0-SNAPSHOT` throughout the examples.