### PR TITLE
Restrict the export url to admins and cron jobs

### DIFF
--- a/appengine-java8/datastore-schedule-export/src/main/webapp/WEB-INF/web.xml
+++ b/appengine-java8/datastore-schedule-export/src/main/webapp/WEB-INF/web.xml
@@ -6,4 +6,13 @@
   <welcome-file-list>
     <welcome-file>index.jsp</welcome-file>
   </welcome-file-list>
+  <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>export</web-resource-name>
+            <url-pattern>/cloud-datastore-export</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>admin</role-name>
+        </auth-constraint>
+    </security-constraint>
 </web-app>


### PR DESCRIPTION
Restrict the export URL according to https://cloud.google.com/appengine/docs/standard/java/config/webxml#security-auth