### PR TITLE
PubSub: move topic/subscription success statement to inside try block

### DIFF
--- a/pubsub/cloud-client/src/main/java/com/example/pubsub/CreatePullSubscriptionExample.java
+++ b/pubsub/cloud-client/src/main/java/com/example/pubsub/CreatePullSubscriptionExample.java
@@ -55,15 +55,15 @@ public class CreatePullSubscriptionExample {
       Subscription subscription =
           subscriptionAdminClient.createSubscription(
               subscriptionName, topicName, PushConfig.getDefaultInstance(), 0);
+      System.out.printf(
+          "Subscription %s:%s created.\n",
+          subscriptionName.getProject(), subscriptionName.getSubscription());
     } catch (ApiException e) {
       // example : code = ALREADY_EXISTS(409) implies subscription already exists
       System.out.print(e.getStatusCode().getCode());
       System.out.print(e.isRetryable());
     }
 
-    System.out.printf(
-        "Subscription %s:%s created.\n",
-        subscriptionName.getProject(), subscriptionName.getSubscription());
   }
 }
 // [END pubsub_quickstart_create_subscription]

--- a/pubsub/cloud-client/src/main/java/com/example/pubsub/CreateTopicExample.java
+++ b/pubsub/cloud-client/src/main/java/com/example/pubsub/CreateTopicExample.java
@@ -44,13 +44,12 @@ public class CreateTopicExample {
     ProjectTopicName topic = ProjectTopicName.of(projectId, topicId);
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.createTopic(topic);
+      System.out.printf("Topic %s:%s created.\n", topic.getProject(), topic.getTopic());
     } catch (ApiException e) {
       // example : code = ALREADY_EXISTS(409) implies topic already exists
       System.out.print(e.getStatusCode().getCode());
       System.out.print(e.isRetryable());
     }
-
-    System.out.printf("Topic %s:%s created.\n", topic.getProject(), topic.getTopic());
   }
 }
 // [END pubsub_quickstart_create_topic]


### PR DESCRIPTION
"Subscription/topic created" messages were being printed even during failure cases. Move inside try block to fix

Fixes minor issue reported by #1419 