### PR TITLE
Add config for auto-assigning issues and PRs to folks. 

### DIFF
--- a/.kvgbot.yml
+++ b/.kvgbot.yml
@@ -1,0 +1,11 @@
+assign_issues:
+  - averikitsch
+  - dzlier-gcp
+  - gguuss
+  - kurtisvg
+  - lesv
+  - nnegrey
+assign_prs:
+  - dzlier-gcp
+  - kurtisvg
+  - lesv


### PR DESCRIPTION
Little bot that assigns issues or PRs to folks when opened if they don't already have an assignee. 

May still be a little rough around the edges. 