### PR TITLE
Add back missing break statement

### DIFF
--- a/speech/cloud-client/src/main/java/com/example/speech/Recognize.java
+++ b/speech/cloud-client/src/main/java/com/example/speech/Recognize.java
@@ -699,6 +699,7 @@ public class Recognize {
           System.out.println("Stop speaking.");
           targetDataLine.stop();
           targetDataLine.close();
+          break;
         }
         request =
             StreamingRecognizeRequest.newBuilder()


### PR DESCRIPTION
Looks like this line accidentally got removed awhile back. Putting it back in so the program properly terminates.