### PR TITLE
Update Firestore Quickstart to use exec:exec

### DIFF
--- a/firestore/README.md
+++ b/firestore/README.md
@@ -35,7 +35,7 @@ Build your project:
  demonstrates adding and querying documents in a collection in Firestore.
 You can run the quickstart with:
 
-    mvn exec:java -Dexec.mainClass=com.example.firestore.Quickstart -Dexec.args="your-firestore-project-id"
+    mvn exec:exec -Dfirestore.project.id="your-firestore-project-id"
 
 Note: the default project-id will be used if no argument is provided.
 

--- a/firestore/pom.xml
+++ b/firestore/pom.xml
@@ -37,6 +37,9 @@
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
+    <!-- Define a default empty value property which can be overridden on the command line if
+         necessary by passing `-Dfirestore.project.id="some-id"` when running maven exec -->
+    <firestore.project.id/>
   </properties>
 
   <dependencies>
@@ -57,4 +60,30 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.6.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <executable>java</executable>
+          <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>com.example.firestore.Quickstart</argument>
+            <argument>${firestore.project.id}</argument>
+          </arguments>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
When exec-maven-plugin runs the `exec:java` goal, it executes the java
program in the maven process (there currently isn't an option to fork
instead of running it in process). As a side effect of this, shutdown
hooks are not run when the program has completed running. In the case
of our Quickstart that means the daemon thread for grpc and gax do not
shutdown when the program has completed running, resulting in maven
listing all the threads that are still running and showing a stacktrace.

This change uses `exec:exec` and manually builds the java command to be
run, thereby forcing the program to be ran in a forked process and able
to use the normal shutdown process.

Attached are a logs showing the following
* Errors printed by maven when using `exec:java`
* A thread dump of the maven process when using `exec:java`
* A log without errors after changing to `exec:exec`

[exec_java.log](https://github.com/GoogleCloudPlatform/java-docs-samples/files/3427694/exec_java.log)
[exec_java_thread_dump.log](https://github.com/GoogleCloudPlatform/java-docs-samples/files/3427693/exec_java_thread_dump.log)
[exec_exec.log](https://github.com/GoogleCloudPlatform/java-docs-samples/files/3427692/exec_exec.log)


