### PR TITLE
Saner Jetty native WebSocket usage

### DIFF
--- a/appengine-java8/websocket-jetty/src/main/java/com/example/flexible/websocket/jettynative/EchoServlet.java
+++ b/appengine-java8/websocket-jetty/src/main/java/com/example/flexible/websocket/jettynative/EchoServlet.java
@@ -17,17 +17,27 @@
 package com.example.flexible.websocket.jettynative;
 
 import javax.servlet.annotation.WebServlet;
+
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
+import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
 import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
 import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
 
 /*
- * Server-side WebSocket registered as /echo servlet.
+ * Server-side WebSocket upgraded on /echo servlet.
  */
 @SuppressWarnings("serial")
 @WebServlet(name = "Echo WebSocket Servlet", urlPatterns = { "/echo" })
-public class EchoServlet extends WebSocketServlet {
+public class EchoServlet extends WebSocketServlet implements WebSocketCreator {
   @Override
   public void configure(WebSocketServletFactory factory) {
-    factory.register(ServerSocket.class);
+    factory.setCreator(this);
+  }
+
+  @Override
+  public Object createWebSocket(ServletUpgradeRequest servletUpgradeRequest,
+      ServletUpgradeResponse servletUpgradeResponse) {
+    return new ServerSocket();
   }
 }

--- a/appengine-java8/websocket-jetty/src/main/java/com/example/flexible/websocket/jettynative/ServerSocket.java
+++ b/appengine-java8/websocket-jetty/src/main/java/com/example/flexible/websocket/jettynative/ServerSocket.java
@@ -20,40 +20,44 @@ import java.io.IOException;
 import java.util.logging.Logger;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.WebSocketAdapter;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 
 /*
  * Server-side WebSocket : echoes received message back to client.
  */
-public class ServerSocket extends WebSocketAdapter {
+@WebSocket(maxTextMessageSize = 64 * 1024)
+public class ServerSocket {
   private Logger logger = Logger.getLogger(SendServlet.class.getName());
+  private Session session;
 
-  @Override
+  @OnWebSocketConnect
   public void onWebSocketConnect(Session session) {
-    super.onWebSocketConnect(session);
+    this.session = session;
     logger.fine("Socket Connected: " + session);
   }
 
-  @Override
+  @OnWebSocketMessage
   public void onWebSocketText(String message) {
-    super.onWebSocketText(message);
     logger.fine("Received message: " + message);
     try {
       // echo message back to client
-      getRemote().sendString(message);
+      this.session.getRemote().sendString(message);
     } catch (IOException e) {
       logger.severe("Error echoing message: " + e.getMessage());
     }
   }
 
-  @Override
+  @OnWebSocketClose
   public void onWebSocketClose(int statusCode, String reason) {
-    super.onWebSocketClose(statusCode, reason);
     logger.fine("Socket Closed: [" + statusCode + "] " + reason);
   }
 
-  @Override
+  @OnWebSocketError
   public void onWebSocketError(Throwable cause) {
-    super.onWebSocketError(cause);
     logger.severe("Websocket error : " + cause.getMessage());
   }
 }


### PR DESCRIPTION
+ Eliminate reliance on SimpleContainerScope (it is deprecated
  and has already been removed in Jetty 10).
+ Use HttpClient properly instead of SimpleContainerScope.
+ SslContextFactory belongs to HttpClient.
+ WebSocketClient uses HttpClient (recommended if you need/want SSL).
+ Use WebSocket Endpoint Annotations, not Adapter (this is also Jetty 10 compatible).
+ Use WebSocketCreator, not raw registered classes (this is also Jetty 10 compatible).

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>