### PR TITLE
Remove extra dependency from Spring Vision Sample

### DIFF
--- a/vision/spring-framework/pom.xml
+++ b/vision/spring-framework/pom.xml
@@ -56,11 +56,6 @@ limitations under the License.
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-gcp-starter-vision</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-gcp-starter-storage</artifactId>
-		</dependency>
 		<!-- [END spring_vision_dependency_fragment] -->
 
 		<dependency>


### PR DESCRIPTION
Removes an unnecessary dependency from the Spring Framework Vision sample.

This is helpful to making the documentation code fragment more accurate.