### PR TITLE
Update KnowledgeBaseId and update rouge SA roles

### DIFF
--- a/dialogflow/cloud-client/src/test/java/com/example/dialogflow/KnowledgeBaseManagementIT.java
+++ b/dialogflow/cloud-client/src/test/java/com/example/dialogflow/KnowledgeBaseManagementIT.java
@@ -49,8 +49,8 @@ import org.junit.runners.JUnit4;
 public class KnowledgeBaseManagementIT {
 
   private static String PROJECT_ID = System.getenv().get("GOOGLE_CLOUD_PROJECT");
-  private static String TEST_KNOWLEDGE_BASE_ID = "MTUwMTg2NzM1MjY0OTAwMDU1MDQ";
-  private static String TEST_DOCUMENT_ID = "MTE4MTI3OTY2ODcwNTc5NDQ1NzY";
+  private static String TEST_KNOWLEDGE_BASE_ID = "MTA4MzE0ODY5NTczMTQzNzU2ODA";
+  private static String TEST_DOCUMENT_ID = "MTUwNjk0ODg1NTU4NzkzMDExMg";
   private static String SESSION_ID = "fake_session_for_testing";
   private static String LANGUAGE_CODE = "en-US";
   private static String KNOWLEDGE_BASE_NAME = "fake_knowledge_base_name";


### PR DESCRIPTION
This is mostly just an FYI to all of you, but I've changed the rouge SA role to Project Viewer, in case someone complains. This should be the final time I have to do this fix (I hope).

Otherwise, if Dialogflow is failing again, it is likely that the Test Knowledge Base was deleted and needs to be re-created and these IDs have to be updated each time. 