### PR TITLE
Pub/Sub: add note for high volume push requests

### DIFF
--- a/appengine-java8/pubsub/src/main/java/com/example/appengine/pubsub/PubSubAuthenticatedPush.java
+++ b/appengine-java8/pubsub/src/main/java/com/example/appengine/pubsub/PubSubAuthenticatedPush.java
@@ -71,6 +71,11 @@ public class PubSubAuthenticatedPush extends HttpServlet {
 
     try {
       // Verify and decode the JWT.
+      // Note: For high volume push requests, it would save some network overhead
+      // if you verify the tokens offline by decoding them using Google's Public
+      // Cert; caching already seen tokens works best when a large volume of
+      // messsages have prompted a singple push server to handle them, in which
+      // case they would all share the same token for a limited time window.
       GoogleIdToken idToken = verifier.verify(authorization);
       messageRepository.saveToken(authorization);
       messageRepository.saveClaim(idToken.getPayload().toPrettyString());


### PR DESCRIPTION
Adding a note to tell our users about best practices when the volume of push requests is high. 