### PR TITLE
firestore: add snipped for IN & ARRAY_CONTAINS_ANY

### DIFF
--- a/firestore/src/main/java/com/example/firestore/snippets/QueryDataSnippets.java
+++ b/firestore/src/main/java/com/example/firestore/snippets/QueryDataSnippets.java
@@ -441,4 +441,37 @@ class QueryDataSnippets {
     //CHECKSTYLE ON: RightCurlyAlone
     //CHECKSTYLE ON: Indentation
   }
+
+  public Query arrayContainsAnyQueries() {
+    // [START fs_query_filter_array_contains_any]
+    CollectionReference citiesRef = db.collection("cities");
+
+    Query query = citiesRef
+        .whereArrayContainsAny("regions", Arrays.asList("west_coast", "east_coast"));
+    // [END fs_query_filter_array_contains_any]
+    return query;
+  }
+
+  public Query inQueryWithoutArray() {
+    // [START fs_query_filter_in]
+    CollectionReference citiesRef = db.collection("cities");
+
+    Query query = citiesRef.whereIn("country", Arrays.asList("USA", "Japan"));
+    // [END fs_query_filter_in]
+    return query;
+  }
+
+  public Query inQueryWithArray() {
+    // [START fs_query_filter_in_with_array]
+    CollectionReference citiesRef = db.collection("cities");
+
+    Query query = citiesRef
+        .whereIn("regions", Arrays.asList(
+            Arrays.asList("west_coast"),
+            Arrays.asList("east_coast")
+        ));
+    // [END fs_query_filter_in_with_array]
+    return query;
+  }
+
 }

--- a/firestore/src/test/java/com/example/firestore/snippets/QueryDataSnippetsIT.java
+++ b/firestore/src/test/java/com/example/firestore/snippets/QueryDataSnippetsIT.java
@@ -16,6 +16,7 @@
 
 package com.example.firestore.snippets;
 
+import static com.google.common.collect.Sets.newHashSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -213,6 +214,30 @@ public class QueryDataSnippetsIT extends BaseIntegrationTest {
     List<String> secondPage = getResults(pages.get(1));
     assertEquals(Arrays.asList("DC", "SF", "LA", "TOK", "BJ"), firstPage);
     assertEquals(new ArrayList<String>(), secondPage);
+  }
+
+  @Test
+  public void testQueryFilterArrayContainsAny() throws Exception {
+    Query query = queryDataSnippets.arrayContainsAnyQueries();
+    Set<String> expected = newHashSet("SF", "LA", "DC");
+    Set<String> actual = getResultsAsSet(query);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testQueryFilterInQueryWithoutArray() throws Exception {
+    Query query = queryDataSnippets.inQueryWithoutArray();
+    Set<String> expected = newHashSet("SF", "LA", "DC", "TOK");
+    Set<String> actual = getResultsAsSet(query);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testQueryFilterInQueryWithArray() throws Exception {
+    Query query = queryDataSnippets.inQueryWithArray();
+    Set<String> expected = newHashSet("DC");
+    Set<String> actual = getResultsAsSet(query);
+    assertEquals(expected, actual);
   }
 
   private Set<String> getResultsAsSet(Query query) throws Exception {


### PR DESCRIPTION
New samples:
* `fs_query_filter_in`
* `fs_query_filter_in_with_array`
* `fs_query_filter_array_contains_any`

Bump google-cloud-firestore to v1.29.0

Fixes b/141194359