### PR TITLE
Fixed missing cloud_region in MQTT example

### DIFF
--- a/iot/api-client/manager/README.md
+++ b/iot/api-client/manager/README.md
@@ -357,6 +357,7 @@ Run mqtt example:
 
     mvn exec:exec -Dmqtt \
                   -Dproject_id=blue-jet-123 \
+                  -Dcloud_region=asia-east1 \
                   -Dregistry_id=my-registry \
                   -Ddevice_id=my-test-device \
                   -Dalgorithm=RS256 \


### PR DESCRIPTION
The readme mentions that the project ID `blue-jet-123` is in `asia-east1` but then it forgets to pass the `cloud_region` parameter which results in a `Not authorized to connect (5)` exception since the default region is `us-central1`.