### PR TITLE
fix compile by inheriting version of compiler plugin from parent

### DIFF
--- a/kms/pom.xml
+++ b/kms/pom.xml
@@ -53,7 +53,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
@kurtisvg fixes #1765 