### PR TITLE
automl: fix old beta snippet tests

### DIFF
--- a/vision/automl/src/main/java/com/google/cloud/vision/samples/automl/ClassificationDeployModel.java
+++ b/vision/automl/src/main/java/com/google/cloud/vision/samples/automl/ClassificationDeployModel.java
@@ -30,7 +30,8 @@ import java.util.concurrent.ExecutionException;
 class ClassificationDeployModel {
 
   // Deploy a model
-  static void classificationDeployModel(String projectId, String modelId) {
+  static void classificationDeployModel(String projectId, String modelId)
+          throws IOException, ExecutionException, InterruptedException {
     // String projectId = "YOUR_PROJECT_ID";
     // String modelId = "YOUR_MODEL_ID";
 
@@ -54,8 +55,6 @@ class ClassificationDeployModel {
 
       // Display the deployment details of model.
       System.out.println("Model deployment finished");
-    } catch (IOException | InterruptedException | ExecutionException e) {
-      e.printStackTrace();
     }
   }
 }

--- a/vision/automl/src/main/java/com/google/cloud/vision/samples/automl/ClassificationDeployModelNodeCount.java
+++ b/vision/automl/src/main/java/com/google/cloud/vision/samples/automl/ClassificationDeployModelNodeCount.java
@@ -31,7 +31,8 @@ import java.util.concurrent.ExecutionException;
 class ClassificationDeployModelNodeCount {
 
   // Deploy a model with a specified node count
-  static void classificationDeployModelNodeCount(String projectId, String modelId) {
+  static void classificationDeployModelNodeCount(String projectId, String modelId)
+          throws IOException, ExecutionException, InterruptedException {
     // String projectId = "YOUR_PROJECT_ID";
     // String modelId = "YOUR_MODEL_ID";
 
@@ -54,8 +55,6 @@ class ClassificationDeployModelNodeCount {
       OperationFuture<Empty, OperationMetadata> future = client.deployModelAsync(request);
       future.get();
       System.out.println("Model deployment on 2 nodes finished");
-    } catch (IOException | InterruptedException | ExecutionException e) {
-      e.printStackTrace();
     }
   }
 }

--- a/vision/automl/src/main/java/com/google/cloud/vision/samples/automl/ClassificationUndeployModel.java
+++ b/vision/automl/src/main/java/com/google/cloud/vision/samples/automl/ClassificationUndeployModel.java
@@ -30,7 +30,8 @@ import java.util.concurrent.ExecutionException;
 class ClassificationUndeployModel {
 
   // Deploy a model
-  static void classificationUndeployModel(String projectId, String modelId) {
+  static void classificationUndeployModel(String projectId, String modelId)
+          throws IOException, ExecutionException, InterruptedException {
     // String projectId = "YOUR_PROJECT_ID";
     // String modelId = "YOUR_MODEL_ID";
 
@@ -54,8 +55,6 @@ class ClassificationUndeployModel {
 
       // Display the deployment details of model.
       System.out.println("Model undeploy finished");
-    } catch (IOException | InterruptedException | ExecutionException e) {
-      e.printStackTrace();
     }
   }
 }

--- a/vision/automl/src/main/java/com/google/cloud/vision/samples/automl/ObjectDetectionDeployModelNodeCount.java
+++ b/vision/automl/src/main/java/com/google/cloud/vision/samples/automl/ObjectDetectionDeployModelNodeCount.java
@@ -30,7 +30,8 @@ import java.util.concurrent.ExecutionException;
 
 class ObjectDetectionDeployModelNodeCount {
 
-  static void objectDetectionDeployModelNodeCount(String projectId, String modelId) {
+  static void objectDetectionDeployModelNodeCount(String projectId, String modelId)
+          throws IOException, ExecutionException, InterruptedException {
     // String projectId = "YOUR_PROJECT_ID";
     // String modelId = "YOUR_MODEL_ID";
     
@@ -53,8 +54,6 @@ class ObjectDetectionDeployModelNodeCount {
       OperationFuture<Empty, OperationMetadata> future = client.deployModelAsync(request);
       future.get();
       System.out.println("Model deployment on 2 nodes finished");
-    } catch (IOException | InterruptedException | ExecutionException e) {
-      e.printStackTrace();
     }
   }
 }

--- a/vision/automl/src/test/java/com/google/cloud/vision/samples/automl/ClassificationDeployModelIT.java
+++ b/vision/automl/src/test/java/com/google/cloud/vision/samples/automl/ClassificationDeployModelIT.java
@@ -19,7 +19,9 @@ package com.google.cloud.vision.samples.automl;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
+import java.util.concurrent.ExecutionException;
 
 import org.junit.After;
 import org.junit.Before;
@@ -27,7 +29,7 @@ import org.junit.Test;
 
 public class ClassificationDeployModelIT {
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
-  private static final String MODEL_ID = "ICN3125115511348658176";
+  private static final String MODEL_ID = "ICN0000000000000000000";
   private ByteArrayOutputStream bout;
   private PrintStream out;
 
@@ -45,27 +47,44 @@ public class ClassificationDeployModelIT {
 
   @Test
   public void testClassificationDeployModelApi() {
-    ClassificationDeployModel.classificationDeployModel(PROJECT_ID, MODEL_ID);
+    // As model deployment can take a long time, instead try to deploy a
+    // nonexistent model and confirm that the model was not found, but other
+    // elements of the request were valid.
+    try {
+      ClassificationDeployModel.classificationDeployModel(PROJECT_ID, MODEL_ID);
+      String got = bout.toString();
+      assertThat(got).contains("The model does not exist");
+    } catch (IOException | ExecutionException | InterruptedException e) {
+      assertThat(e.getMessage()).contains("The model does not exist");
+    }
+  }
 
-    String got = bout.toString();
-    assertThat(got).contains("Model deployment finished");
+  @Test
+  public void testClassificationUndeployModelApi() {
+    // As model deployment can take a long time, instead try to deploy a
+    // nonexistent model and confirm that the model was not found, but other
+    // elements of the request were valid.
+    try {
+      ClassificationUndeployModel.classificationUndeployModel(PROJECT_ID, MODEL_ID);
+      String got = bout.toString();
+      assertThat(got).contains("The model does not exist");
+    } catch (IOException | ExecutionException | InterruptedException e) {
+      assertThat(e.getMessage()).contains("The model does not exist");
+    }
 
-    ClassificationUndeployModel.classificationUndeployModel(PROJECT_ID, MODEL_ID);
-
-    got = bout.toString();
-    assertThat(got).contains("Model undeploy finished");
   }
 
   @Test
   public void testClassificationDeployModelNodeCountApi() {
-    ClassificationDeployModelNodeCount.classificationDeployModelNodeCount(PROJECT_ID, MODEL_ID);
-
-    String got = bout.toString();
-    assertThat(got).contains("Model deployment on 2 nodes finished");
-
-    ClassificationUndeployModel.classificationUndeployModel(PROJECT_ID, MODEL_ID);
-
-    got = bout.toString();
-    assertThat(got).contains("Model undeploy finished");
+    // As model deployment can take a long time, instead try to deploy a
+    // nonexistent model and confirm that the model was not found, but other
+    // elements of the request were valid.
+    try {
+      ClassificationDeployModelNodeCount.classificationDeployModelNodeCount(PROJECT_ID, MODEL_ID);
+      String got = bout.toString();
+      assertThat(got).contains("The model does not exist");
+    } catch (IOException | ExecutionException | InterruptedException e) {
+      assertThat(e.getMessage()).contains("The model does not exist");
+    }
   }
 }

--- a/vision/automl/src/test/java/com/google/cloud/vision/samples/automl/ObjectDetectionDeployModelNodeCountIT.java
+++ b/vision/automl/src/test/java/com/google/cloud/vision/samples/automl/ObjectDetectionDeployModelNodeCountIT.java
@@ -40,7 +40,7 @@ import org.junit.runners.JUnit4;
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class ObjectDetectionDeployModelNodeCountIT {
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
-  private static final String MODEL_ID = "IOD1854128448151224320";
+  private static final String MODEL_ID = "0000000000000000000000";
   private ByteArrayOutputStream bout;
   private PrintStream out;
 
@@ -52,22 +52,21 @@ public class ObjectDetectionDeployModelNodeCountIT {
   }
 
   @After
-  public void tearDown() throws IOException, InterruptedException, ExecutionException {
+  public void tearDown() {
     System.setOut(null);
-
-    try (AutoMlClient client = AutoMlClient.create()) {
-      OperationFuture<Empty, OperationMetadata> future = client.undeployModelAsync(
-              ModelName.of(PROJECT_ID, "us-central1", MODEL_ID).toString());
-
-      future.get();
-    }
   }
 
   @Test
   public void testObjectDetectionDeployModelNodeCountApi() {
-    ObjectDetectionDeployModelNodeCount.objectDetectionDeployModelNodeCount(PROJECT_ID, MODEL_ID);
-
-    String got = bout.toString();
-    assertThat(got).contains("Model deployment on 2 nodes finished");
+    // As model deployment can take a long time, instead try to deploy a
+    // nonexistent model and confirm that the model was not found, but other
+    // elements of the request were valid.
+    try {
+      ObjectDetectionDeployModelNodeCount.objectDetectionDeployModelNodeCount(PROJECT_ID, MODEL_ID);
+      String got = bout.toString();
+      assertThat(got).contains("The model does not exist");
+    } catch (IOException | ExecutionException | InterruptedException e) {
+      assertThat(e.getMessage()).contains("The model does not exist");
+    }
   }
 }


### PR DESCRIPTION
Fix: https://github.com/GoogleCloudPlatform/java-docs-samples/issues/1992

Use fake model Ids and just catch the error. 
Can't yet remove the snippets as a large number of localization docs rely on these. 