### PR TITLE
Heathcare API: fix resource path and console output for HL7v2MessageList

### DIFF
--- a/healthcare/v1beta1/src/main/java/snippets/healthcare/hl7v2/messages/HL7v2MessageList.java
+++ b/healthcare/v1beta1/src/main/java/snippets/healthcare/hl7v2/messages/HL7v2MessageList.java
@@ -33,7 +33,7 @@ import java.util.Collections;
 import java.util.List;
 
 public class HL7v2MessageList {
-  private static final String HL7v2_NAME = "projects/%s/locations/%s/datasets/%s/hl7C2Store/%s";
+  private static final String HL7v2_NAME = "projects/%s/locations/%s/datasets/%s/hl7V2Stores/%s";
   private static final JsonFactory JSON_FACTORY = new JacksonFactory();
   private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
 
@@ -71,7 +71,7 @@ public class HL7v2MessageList {
     } while (pageToken != null);
 
     // Print results.
-    System.out.printf("Retrieved %s HL7v2 stores: \n", messages.size());
+    System.out.printf("Retrieved %s HL7v2 messages: \n", messages.size());
     for (String data : messages) {
       System.out.println("\t" + data);
     }


### PR DESCRIPTION
The tests didn't catch this because the tests use their own resource path, not the path used in HL7v2MessageList.java.