### PR TITLE
deps: update to Beam 2.18

### DIFF
--- a/dataflow/spanner-io/pom.xml
+++ b/dataflow/spanner-io/pom.xml
@@ -38,7 +38,7 @@
     <java.version>1.8</java.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <apache_beam.version>2.17.0</apache_beam.version>
+    <apache_beam.version>2.18.0</apache_beam.version>
   </properties>
 
   <build>
@@ -78,6 +78,11 @@
         <exclusion>
           <groupId>com.google.api.grpc</groupId>
           <artifactId>grpc-google-common-protos</artifactId>
+        </exclusion>
+        <!-- The BigTable client brings in an OpenCensus version that conflicts with Spanner. -->
+        <exclusion>
+          <groupId>com.google.cloud.bigtable</groupId>
+          <artifactId>bigtable-client-core</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/dataflow/spanner-io/src/test/java/com/example/dataflow/SpannerGroupWriteIT.java
+++ b/dataflow/spanner-io/src/test/java/com/example/dataflow/SpannerGroupWriteIT.java
@@ -39,6 +39,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
@@ -49,6 +51,7 @@ import org.junit.Test;
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class SpannerGroupWriteIT {
 
+  private final Random random = new Random();
   private String instanceId;
   private String databaseId;
 
@@ -59,7 +62,7 @@ public class SpannerGroupWriteIT {
   @Before
   public void setUp() throws Exception {
     instanceId = System.getProperty("spanner.test.instance");
-    databaseId = "df-spanner-groupwrite-it";
+    databaseId = "df-spanner-gwrite-it-" + random.nextInt(1000000000);
 
     spannerOptions = SpannerOptions.getDefaultInstance();
     spanner = spannerOptions.getService();

--- a/dataflow/spanner-io/src/test/java/com/example/dataflow/SpannerReadIT.java
+++ b/dataflow/spanner-io/src/test/java/com/example/dataflow/SpannerReadIT.java
@@ -34,6 +34,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -44,6 +46,7 @@ import org.junit.Test;
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class SpannerReadIT {
 
+  private final Random random = new Random();
   private String instanceId;
   private String databaseId;
 
@@ -53,7 +56,7 @@ public class SpannerReadIT {
   @Before
   public void setUp() throws InterruptedException, ExecutionException {
     instanceId = System.getProperty("spanner.test.instance");
-    databaseId = "df-spanner-read-it";
+    databaseId = "df-spanner-read-it-" + random.nextInt(1000000000);
 
     spannerOptions = SpannerOptions.getDefaultInstance();
     spanner = spannerOptions.getService();

--- a/dataflow/spanner-io/src/test/java/com/example/dataflow/SpannerWriteIT.java
+++ b/dataflow/spanner-io/src/test/java/com/example/dataflow/SpannerWriteIT.java
@@ -34,6 +34,8 @@ import com.google.spanner.admin.database.v1.CreateDatabaseMetadata;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Random;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.After;
@@ -43,6 +45,7 @@ import org.junit.Test;
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class SpannerWriteIT {
 
+  private final Random random = new Random();
   private String instanceId;
   private String databaseId;
 
@@ -55,7 +58,7 @@ public class SpannerWriteIT {
   public void setUp() throws Exception {
 
     instanceId = System.getProperty("spanner.test.instance");
-    databaseId = "df-spanner-write-it";
+    databaseId = "df-spanner-write-it-" + random.nextInt(1000000000);
 
     spannerOptions = SpannerOptions.getDefaultInstance();
     spanner = spannerOptions.getService();


### PR DESCRIPTION
Updates the Spanner example to Beam 2.18. This requires the BigTable client to be excluded, as it brings in a version of OpenCensus that is incompatible with Spanner. See also https://issues.apache.org/jira/browse/BEAM-9304.

Fixes #2025 