### PR TITLE
fix: bigquery/bigquerystorage needs a java property set

### DIFF
--- a/bigquery/bigquerystorage/pom.xml
+++ b/bigquery/bigquerystorage/pom.xml
@@ -33,6 +33,9 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <!-- the arrow-vector library currently necessitates setting the netty property --!>
+      <!-- For more info: https://github.com/apache/arrow/tree/master/java#java-properties --!>
+    <argLine>-Dio.netty.tryReflectionSetAccessible=true</argLine>
   </properties>
 
   <dependencies>

--- a/bigquery/bigquerystorage/pom.xml
+++ b/bigquery/bigquerystorage/pom.xml
@@ -33,8 +33,8 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <!-- the arrow-vector library currently necessitates setting the netty property --!>
-      <!-- For more info: https://github.com/apache/arrow/tree/master/java#java-properties --!>
+      <!-- the arrow-vector library currently necessitates setting the netty property -->
+      <!-- For more info: https://github.com/apache/arrow/tree/master/java#java-properties -->
     <argLine>-Dio.netty.tryReflectionSetAccessible=true</argLine>
   </properties>
 


### PR DESCRIPTION
The arrow (de)serialization library requires a netty java property
to be set per guidance in
https://github.com/apache/arrow/tree/master/java#java-properties

Fixes: #2162