### PR TITLE
Renovate/com.google.api client google api client 1.x

### DIFF
--- a/bigquery/rest/pom.xml
+++ b/bigquery/rest/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>1.30.5</version>
+      <version>1.30.8</version>
       <exclusions>
         <exclusion> <!-- exclude an old version of Guava -->
           <groupId>com.google.guava</groupId>

--- a/compute/cmdline/pom.xml
+++ b/compute/cmdline/pom.xml
@@ -30,8 +30,8 @@ limitations under the License.
   </parent>
 
   <properties>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
     <project.compute.version>v1-rev20200114-1.30.8</project.compute.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -72,22 +72,6 @@ limitations under the License.
             </systemProperty>
           </systemProperties>
         </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.5</version>
-        <configuration>
-          <failOnError>false</failOnError>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
     </plugins>

--- a/compute/cmdline/pom.xml
+++ b/compute/cmdline/pom.xml
@@ -40,7 +40,7 @@ limitations under the License.
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>1.30.5</version>
+      <version>1.30.8</version>
     </dependency>
     <dependency>
       <groupId>com.google.apis</groupId>

--- a/compute/cmdline/pom.xml
+++ b/compute/cmdline/pom.xml
@@ -30,8 +30,8 @@ limitations under the License.
   </parent>
 
   <properties>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+    <maven.compiler.source>8</maven.compiler.source>
     <project.compute.version>v1-rev20200114-1.30.8</project.compute.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/endpoints/getting-started/clients/pom.xml
+++ b/endpoints/getting-started/clients/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>1.30.7</version>
+      <version>1.30.8</version>
     </dependency>
     <dependency>
       <groupId>com.auth0</groupId>

--- a/endpoints/getting-started/pom.xml
+++ b/endpoints/getting-started/pom.xml
@@ -33,8 +33,8 @@
   </parent>
 
   <properties>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+    <maven.compiler.source>8</maven.compiler.source>
 
     <failOnMissingWebXml>false</failOnMissingWebXml> <!-- REQUIRED -->
   </properties>

--- a/endpoints/getting-started/pom.xml
+++ b/endpoints/getting-started/pom.xml
@@ -33,10 +33,9 @@
   </parent>
 
   <properties>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
 
-    <maven.war.plugin>2.6</maven.war.plugin>
     <failOnMissingWebXml>false</failOnMissingWebXml> <!-- REQUIRED -->
   </properties>
 
@@ -61,6 +60,11 @@
     <!-- for hot reload of the web application -->
     <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes</outputDirectory>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.2.3</version>
+      </plugin>
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>

--- a/flexible/cloudsql/pom.xml
+++ b/flexible/cloudsql/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>1.30.5</version>
+      <version>1.30.8</version>
     </dependency>
     <dependency>
       <groupId>com.google.api-client</groupId>

--- a/flexible/postgres/pom.xml
+++ b/flexible/postgres/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>1.30.5</version>
+      <version>1.30.8</version>
     </dependency>
     <dependency>
       <groupId>com.google.api-client</groupId>

--- a/healthcare/v1beta1/pom.xml
+++ b/healthcare/v1beta1/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>1.30.7</version>
+      <version>1.30.8</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>

--- a/iot/api-client/codelab/manager/pom.xml
+++ b/iot/api-client/codelab/manager/pom.xml
@@ -33,8 +33,8 @@
     <version>1.0.11</version>
   </parent>
   <properties>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
   </properties>
 
   <dependencies>

--- a/iot/api-client/codelab/manager/pom.xml
+++ b/iot/api-client/codelab/manager/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>1.30.7</version>
+      <version>1.30.8</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/iot/api-client/codelab/manager/pom.xml
+++ b/iot/api-client/codelab/manager/pom.xml
@@ -33,8 +33,8 @@
     <version>1.0.11</version>
   </parent>
   <properties>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+    <maven.compiler.source>8</maven.compiler.source>
   </properties>
 
   <dependencies>

--- a/iot/api-client/codelab/manager/src/main/java/com/example/cloud/iot/examples/MqttExampleOptions.java
+++ b/iot/api-client/codelab/manager/src/main/java/com/example/cloud/iot/examples/MqttExampleOptions.java
@@ -22,7 +22,6 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.omg.PortableInterceptor.SYSTEM_EXCEPTION;
 
 /** Command line options for the MQTT example. */
 public class MqttExampleOptions {

--- a/iot/api-client/end-to-end-example/pom.xml
+++ b/iot/api-client/end-to-end-example/pom.xml
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>1.30.7</version>
+      <version>1.30.8</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/iot/api-client/manager/pom.xml
+++ b/iot/api-client/manager/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>1.30.7</version>
+      <version>1.30.8</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/mlengine/online-prediction/pom.xml
+++ b/mlengine/online-prediction/pom.xml
@@ -66,7 +66,7 @@ limitations under the License.
     <dependency>
      <groupId>com.google.api-client</groupId>
      <artifactId>google-api-client</artifactId>
-     <version>1.30.5</version>
+     <version>1.30.8</version>
     </dependency>
     <dependency>
       <groupId>com.google.apis</groupId>

--- a/vision/face-detection/pom.xml
+++ b/vision/face-detection/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>1.30.5</version>
+      <version>1.30.8</version>
       <exclusions>
         <exclusion> <!-- exclude an old version of Guava -->
           <groupId>com.google.guava</groupId>


### PR DESCRIPTION
1. Update to Java 11
2. Get rid of Findbugs (no longer supported)
3. WAR's should use the latest war plugin.
4. Remvoe a bad / wrong import in MqttExampleOptions

PR replaces #2070 which was broken.