### PR TITLE
Update renovate to use new "rebaseWhen" flag.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,6 @@
   "labels": [
     "automerge"
   ],
-  "rebaseStalePrs": false,
+  "rebaseWhen": "never",
   "masterIssue": true
 }


### PR DESCRIPTION
"rebaseStalePrs" has been deprecated:

https://docs.renovatebot.com/configuration-options/#rebasewhen