### PR TITLE
Fix flaky DLP inspect tests

### DIFF
--- a/dlp/src/main/java/dlp/snippets/InspectBigQueryTable.java
+++ b/dlp/src/main/java/dlp/snippets/InspectBigQueryTable.java
@@ -18,11 +18,11 @@ package dlp.snippets;
 
 // [START dlp_inspect_bigquery]
 
+import com.google.api.core.SettableApiFuture;
 import com.google.cloud.dlp.v2.DlpServiceClient;
 import com.google.cloud.pubsub.v1.AckReplyConsumer;
 import com.google.cloud.pubsub.v1.MessageReceiver;
 import com.google.cloud.pubsub.v1.Subscriber;
-import com.google.common.util.concurrent.SettableFuture;
 import com.google.privacy.dlp.v2.Action;
 import com.google.privacy.dlp.v2.BigQueryOptions;
 import com.google.privacy.dlp.v2.BigQueryTable;
@@ -54,10 +54,9 @@ public class InspectBigQueryTable {
     String projectId = "your-project-id";
     String bigQueryDatasetId = "your-bigquery-dataset-id";
     String bigQueryTableId = "your-bigquery-table-id";
-    String pubSubTopicId = "your-pubsub-topic-id";
-    String pubSubSubscriptionId = "your-pubsub-subscription-id";
-    inspectBigQueryTable(
-        projectId, bigQueryDatasetId, bigQueryTableId, pubSubTopicId, pubSubSubscriptionId);
+    String topicId = "your-pubsub-topic-id";
+    String subscriptionId = "your-pubsub-subscription-id";
+    inspectBigQueryTable(projectId, bigQueryDatasetId, bigQueryTableId, topicId, subscriptionId);
   }
 
   // Inspects a BigQuery Table
@@ -65,8 +64,8 @@ public class InspectBigQueryTable {
       String projectId,
       String bigQueryDatasetId,
       String bigQueryTableId,
-      String pubSubTopicId,
-      String pubSubSubscriptionName)
+      String topicId,
+      String subscriptionId)
       throws ExecutionException, InterruptedException, IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
@@ -98,7 +97,7 @@ public class InspectBigQueryTable {
           InspectConfig.newBuilder().addAllInfoTypes(infoTypes).setIncludeQuote(true).build();
 
       // Specify the action that is triggered when the job completes.
-      String pubSubTopic = String.format("projects/%s/topics/%s", projectId, pubSubTopicId);
+      String pubSubTopic = String.format("projects/%s/topics/%s", projectId, topicId);
       Action.PublishToPubSub publishToPubSub =
           Action.PublishToPubSub.newBuilder().setTopic(pubSubTopic).build();
       Action action = Action.newBuilder().setPubSub(publishToPubSub).build();
@@ -119,36 +118,32 @@ public class InspectBigQueryTable {
               .build();
 
       // Use the client to send the request.
-      final DlpJob job = dlp.createDlpJob(createDlpJobRequest);
-      System.out.println("Job created: " + job.getName());
+      final DlpJob dlpJob = dlp.createDlpJob(createDlpJobRequest);
+      System.out.println("Job created: " + dlpJob.getName());
 
-      // Set up a Pub/Sub subscriber to listen for the job completion status
-      SettableFuture<Void> jobDone = SettableFuture.create();
+      // Set up a Pub/Sub subscriber to listen on the job completion status
+      final SettableApiFuture<Boolean> done = SettableApiFuture.create();
+
       ProjectSubscriptionName subscriptionName =
-          ProjectSubscriptionName.of(projectId, pubSubSubscriptionName);
-      MessageReceiver handleMessage =
+          ProjectSubscriptionName.of(projectId, subscriptionId);
+
+      MessageReceiver messageHandler =
           (PubsubMessage pubsubMessage, AckReplyConsumer ackReplyConsumer) -> {
-            String messageAttribute = pubsubMessage.getAttributesMap().get("DlpJobName");
-            if (job.getName().equals(messageAttribute)) {
-              jobDone.set(null);
-              ackReplyConsumer.ack();
-            } else {
-              ackReplyConsumer.nack();
-            }
+            handleMessage(dlpJob, done, pubsubMessage, ackReplyConsumer);
           };
-      Subscriber subscriber = Subscriber.newBuilder(subscriptionName, handleMessage).build();
-      subscriber.startAsync(); // Let the subscriber listen to messages
+      Subscriber subscriber = Subscriber.newBuilder(subscriptionName, messageHandler).build();
+      subscriber.startAsync();
 
       // Wait for the original job to complete
       try {
-        jobDone.get(10, TimeUnit.MINUTES);
+        done.get(15, TimeUnit.MINUTES);
       } catch (TimeoutException e) {
-        System.out.println("Job was not completed after 10 minutes.");
+        System.out.println("Job was not completed after 15 minutes.");
         return;
       }
 
       // Get the latest state of the job from the service
-      GetDlpJobRequest request = GetDlpJobRequest.newBuilder().setName(job.getName()).build();
+      GetDlpJobRequest request = GetDlpJobRequest.newBuilder().setName(dlpJob.getName()).build();
       DlpJob completedJob = dlp.getDlpJob(request);
 
       // Parse the response and process results.
@@ -159,6 +154,20 @@ public class InspectBigQueryTable {
         System.out.print("\tInfo type: " + infoTypeStat.getInfoType().getName());
         System.out.println("\tCount: " + infoTypeStat.getCount());
       }
+    }
+  }
+  // handleMessage injects the job and settableFuture into the message reciever interface
+  private static void handleMessage(
+      DlpJob job,
+      SettableApiFuture<Boolean> done,
+      PubsubMessage pubsubMessage,
+      AckReplyConsumer ackReplyConsumer) {
+    String messageAttribute = pubsubMessage.getAttributesMap().get("DlpJobName");
+    if (job.getName().equals(messageAttribute)) {
+      done.set(true);
+      ackReplyConsumer.ack();
+    } else {
+      ackReplyConsumer.nack();
     }
   }
 }

--- a/dlp/src/main/java/dlp/snippets/InspectBigQueryTable.java
+++ b/dlp/src/main/java/dlp/snippets/InspectBigQueryTable.java
@@ -156,6 +156,7 @@ public class InspectBigQueryTable {
       }
     }
   }
+  
   // handleMessage injects the job and settableFuture into the message reciever interface
   private static void handleMessage(
       DlpJob job,

--- a/dlp/src/main/java/dlp/snippets/InspectDatastoreEntity.java
+++ b/dlp/src/main/java/dlp/snippets/InspectDatastoreEntity.java
@@ -157,6 +157,7 @@ public class InspectDatastoreEntity {
       }
     }
   }
+
   // handleMessage injects the job and settableFuture into the message reciever interface
   private static void handleMessage(
       DlpJob job,

--- a/dlp/src/main/java/dlp/snippets/InspectDatastoreEntity.java
+++ b/dlp/src/main/java/dlp/snippets/InspectDatastoreEntity.java
@@ -18,11 +18,11 @@ package dlp.snippets;
 
 // [START dlp_inspect_datastore]
 
+import com.google.api.core.SettableApiFuture;
 import com.google.cloud.dlp.v2.DlpServiceClient;
 import com.google.cloud.pubsub.v1.AckReplyConsumer;
 import com.google.cloud.pubsub.v1.MessageReceiver;
 import com.google.cloud.pubsub.v1.Subscriber;
-import com.google.common.util.concurrent.SettableFuture;
 import com.google.privacy.dlp.v2.Action;
 import com.google.privacy.dlp.v2.CreateDlpJobRequest;
 import com.google.privacy.dlp.v2.DatastoreOptions;
@@ -55,10 +55,9 @@ public class InspectDatastoreEntity {
     String projectId = "your-project-id";
     String datastoreNamespace = "your-datastore-namespace";
     String datastoreKind = "your-datastore-kind";
-    String pubSubTopicId = "your-pubsub-topic-id";
-    String pubSubSubscriptionId = "your-pubsub-subscription-id";
-    insepctDatastoreEntity(
-        projectId, datastoreNamespace, datastoreKind, pubSubTopicId, pubSubSubscriptionId);
+    String topicId = "your-pubsub-topic-id";
+    String subscriptionId = "your-pubsub-subscription-id";
+    insepctDatastoreEntity(projectId, datastoreNamespace, datastoreKind, topicId, subscriptionId);
   }
 
   // Inspects a Datastore Entity.
@@ -66,8 +65,8 @@ public class InspectDatastoreEntity {
       String projectId,
       String datastoreNamespce,
       String datastoreKind,
-      String pubSubTopicId,
-      String pubSubSubscriptionName)
+      String topicId,
+      String subscriptionId)
       throws ExecutionException, InterruptedException, IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
@@ -99,7 +98,7 @@ public class InspectDatastoreEntity {
           InspectConfig.newBuilder().addAllInfoTypes(infoTypes).setIncludeQuote(true).build();
 
       // Specify the action that is triggered when the job completes.
-      String pubSubTopic = String.format("projects/%s/topics/%s", projectId, pubSubTopicId);
+      String pubSubTopic = String.format("projects/%s/topics/%s", projectId, topicId);
       Action.PublishToPubSub publishToPubSub =
           Action.PublishToPubSub.newBuilder().setTopic(pubSubTopic).build();
       Action action = Action.newBuilder().setPubSub(publishToPubSub).build();
@@ -120,37 +119,32 @@ public class InspectDatastoreEntity {
               .build();
 
       // Use the client to send the request.
-      final DlpJob job = dlp.createDlpJob(createDlpJobRequest);
-      System.out.println("Job created: " + job.getName());
+      final DlpJob dlpJob = dlp.createDlpJob(createDlpJobRequest);
+      System.out.println("Job created: " + dlpJob.getName());
 
-      // Set up a Pub/Sub subscriber to listen for the job completion status
-      SettableFuture<Void> jobDone = SettableFuture.create();
+      // Set up a Pub/Sub subscriber to listen on the job completion status
+      final SettableApiFuture<Boolean> done = SettableApiFuture.create();
+
       ProjectSubscriptionName subscriptionName =
-          ProjectSubscriptionName.of(projectId, pubSubSubscriptionName);
-      MessageReceiver handleMessage =
+          ProjectSubscriptionName.of(projectId, subscriptionId);
+
+      MessageReceiver messageHandler =
           (PubsubMessage pubsubMessage, AckReplyConsumer ackReplyConsumer) -> {
-            String messageAttribute = pubsubMessage.getAttributesMap().get("DlpJobName");
-            if (job.getName().equals(messageAttribute)) {
-              jobDone.set(null);
-              ackReplyConsumer.ack();
-            } else {
-              ackReplyConsumer.nack();
-              ;
-            }
+            handleMessage(dlpJob, done, pubsubMessage, ackReplyConsumer);
           };
-      Subscriber subscriber = Subscriber.newBuilder(subscriptionName, handleMessage).build();
-      subscriber.startAsync(); // Let the subscriber listen to messages
+      Subscriber subscriber = Subscriber.newBuilder(subscriptionName, messageHandler).build();
+      subscriber.startAsync();
 
       // Wait for the original job to complete
       try {
-        jobDone.get(10, TimeUnit.MINUTES);
+        done.get(15, TimeUnit.MINUTES);
       } catch (TimeoutException e) {
-        System.out.println("Job was not completed after 10 minutes.");
+        System.out.println("Job was not completed after 15 minutes.");
         return;
       }
 
       // Get the latest state of the job from the service
-      GetDlpJobRequest request = GetDlpJobRequest.newBuilder().setName(job.getName()).build();
+      GetDlpJobRequest request = GetDlpJobRequest.newBuilder().setName(dlpJob.getName()).build();
       DlpJob completedJob = dlp.getDlpJob(request);
 
       // Parse the response and process results.
@@ -161,6 +155,20 @@ public class InspectDatastoreEntity {
         System.out.print("\tInfo type: " + infoTypeStat.getInfoType().getName());
         System.out.println("\tCount: " + infoTypeStat.getCount());
       }
+    }
+  }
+  // handleMessage injects the job and settableFuture into the message reciever interface
+  private static void handleMessage(
+      DlpJob job,
+      SettableApiFuture<Boolean> done,
+      PubsubMessage pubsubMessage,
+      AckReplyConsumer ackReplyConsumer) {
+    String messageAttribute = pubsubMessage.getAttributesMap().get("DlpJobName");
+    if (job.getName().equals(messageAttribute)) {
+      done.set(true);
+      ackReplyConsumer.ack();
+    } else {
+      ackReplyConsumer.nack();
     }
   }
 }

--- a/dlp/src/main/java/dlp/snippets/InspectGcsFile.java
+++ b/dlp/src/main/java/dlp/snippets/InspectGcsFile.java
@@ -17,7 +17,7 @@
 package dlp.snippets;
 
 // [START dlp_inspect_gcs]
-
+import com.google.api.core.SettableApiFuture;
 import com.google.cloud.dlp.v2.DlpServiceClient;
 import com.google.cloud.pubsub.v1.AckReplyConsumer;
 import com.google.cloud.pubsub.v1.MessageReceiver;
@@ -52,14 +52,14 @@ public class InspectGcsFile {
     // TODO(developer): Replace these variables before running the sample.
     String projectId = "your-project-id";
     String gcsUri = "gs://" + "your-bucket-name" + "/path/to/your/file.txt";
-    String pubSubTopicId = "your-pubsub-topic-id";
-    String pubSubSubscriptionId = "your-pubsub-subscription-id";
-    inspectGcsFile(projectId, gcsUri, pubSubTopicId, pubSubSubscriptionId);
+    String topicId = "your-pubsub-topic-id";
+    String subscriptionId = "your-pubsub-subscription-id";
+    inspectGcsFile(projectId, gcsUri, topicId, subscriptionId);
   }
 
   // Inspects a file in a Google Cloud Storage Bucket.
   public static void inspectGcsFile(
-      String projectId, String gcsUri, String pubSubTopicId, String pubSubSubscriptionName)
+      String projectId, String gcsUri, String topicId, String subscriptionId)
       throws ExecutionException, InterruptedException, IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
@@ -84,7 +84,7 @@ public class InspectGcsFile {
           InspectConfig.newBuilder().addAllInfoTypes(infoTypes).setIncludeQuote(true).build();
 
       // Specify the action that is triggered when the job completes.
-      String pubSubTopic = String.format("projects/%s/topics/%s", projectId, pubSubTopicId);
+      String pubSubTopic = String.format("projects/%s/topics/%s", projectId, topicId);
       Action.PublishToPubSub publishToPubSub =
           Action.PublishToPubSub.newBuilder().setTopic(pubSubTopic).build();
       Action action = Action.newBuilder().setPubSub(publishToPubSub).build();
@@ -105,36 +105,32 @@ public class InspectGcsFile {
               .build();
 
       // Use the client to send the request.
-      final DlpJob job = dlp.createDlpJob(createDlpJobRequest);
-      System.out.println("Job created: " + job.getName());
+      final DlpJob dlpJob = dlp.createDlpJob(createDlpJobRequest);
+      System.out.println("Job created: " + dlpJob.getName());
 
-      // Set up a Pub/Sub subscriber to listen for the job completion status
-      SettableFuture<Void> jobDone = SettableFuture.create();
+      // Set up a Pub/Sub subscriber to listen on the job completion status
+      final SettableApiFuture<Boolean> done = SettableApiFuture.create();
+
       ProjectSubscriptionName subscriptionName =
-          ProjectSubscriptionName.of(projectId, pubSubSubscriptionName);
-      MessageReceiver handleMessage =
+          ProjectSubscriptionName.of(projectId, subscriptionId);
+
+      MessageReceiver messageHandler =
           (PubsubMessage pubsubMessage, AckReplyConsumer ackReplyConsumer) -> {
-            String messageAttribute = pubsubMessage.getAttributesMap().get("DlpJobName");
-            if (job.getName().equals(messageAttribute)) {
-              jobDone.set(null);
-              ackReplyConsumer.ack();
-            } else {
-              ackReplyConsumer.nack();
-            }
+            handleMessage(dlpJob, done, pubsubMessage, ackReplyConsumer);
           };
-      Subscriber subscriber = Subscriber.newBuilder(subscriptionName, handleMessage).build();
-      subscriber.startAsync(); // Let the subscriber listen to messages
+      Subscriber subscriber = Subscriber.newBuilder(subscriptionName, messageHandler).build();
+      subscriber.startAsync();
 
       // Wait for the original job to complete
       try {
-        jobDone.get(10, TimeUnit.MINUTES);
+        done.get(15, TimeUnit.MINUTES);
       } catch (TimeoutException e) {
-        System.out.println("Job was not completed after 10 minutes.");
+        System.out.println("Job was not completed after 15 minutes.");
         return;
       }
 
       // Get the latest state of the job from the service
-      GetDlpJobRequest request = GetDlpJobRequest.newBuilder().setName(job.getName()).build();
+      GetDlpJobRequest request = GetDlpJobRequest.newBuilder().setName(dlpJob.getName()).build();
       DlpJob completedJob = dlp.getDlpJob(request);
 
       // Parse the response and process results.
@@ -145,6 +141,20 @@ public class InspectGcsFile {
         System.out.print("\tInfo type: " + infoTypeStat.getInfoType().getName());
         System.out.println("\tCount: " + infoTypeStat.getCount());
       }
+    }
+  }
+  // handleMessage injects the job and settableFuture into the message reciever interface
+  private static void handleMessage(
+      DlpJob job,
+      SettableApiFuture<Boolean> done,
+      PubsubMessage pubsubMessage,
+      AckReplyConsumer ackReplyConsumer) {
+    String messageAttribute = pubsubMessage.getAttributesMap().get("DlpJobName");
+    if (job.getName().equals(messageAttribute)) {
+      done.set(true);
+      ackReplyConsumer.ack();
+    } else {
+      ackReplyConsumer.nack();
     }
   }
 }

--- a/dlp/src/main/java/dlp/snippets/InspectGcsFile.java
+++ b/dlp/src/main/java/dlp/snippets/InspectGcsFile.java
@@ -143,6 +143,7 @@ public class InspectGcsFile {
       }
     }
   }
+
   // handleMessage injects the job and settableFuture into the message reciever interface
   private static void handleMessage(
       DlpJob job,


### PR DESCRIPTION
Increased the timeout period for the sample from 10 to 15 min, to resolve #2302 , #2303 , and #2317. Also refactored the Pub/Sub code in the samples to be more consistent with other samples. 