### PR TITLE
docs: Update securitycenter samples to v1

### DIFF
--- a/securitycenter/src/main/java/com/google/cloud/examples/securitycenter/snippets/CreateNotificationConfigSnippets.java
+++ b/securitycenter/src/main/java/com/google/cloud/examples/securitycenter/snippets/CreateNotificationConfigSnippets.java
@@ -17,11 +17,10 @@
 package com.google.cloud.examples.securitycenter.snippets;
 
 // [START scc_create_notification_config]
-import com.google.cloud.securitycenter.v1p1beta1.CreateNotificationConfigRequest;
-import com.google.cloud.securitycenter.v1p1beta1.NotificationConfig;
-import com.google.cloud.securitycenter.v1p1beta1.NotificationConfig.EventType;
-import com.google.cloud.securitycenter.v1p1beta1.NotificationConfig.StreamingConfig;
-import com.google.cloud.securitycenter.v1p1beta1.SecurityCenterClient;
+import com.google.cloud.securitycenter.v1.CreateNotificationConfigRequest;
+import com.google.cloud.securitycenter.v1.NotificationConfig;
+import com.google.cloud.securitycenter.v1.NotificationConfig.StreamingConfig;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
 import java.io.IOException;
 // [END scc_create_notification_config]
 
@@ -52,7 +51,6 @@ final class CreateNotificationConfigSnippets {
                   NotificationConfig.newBuilder()
                       .setDescription("Java notification config")
                       .setPubsubTopic(pubsubTopic)
-                      .setEventType(EventType.FINDING)
                       .setStreamingConfig(
                           StreamingConfig.newBuilder().setFilter("state = \"ACTIVE\"").build())
                       .build())

--- a/securitycenter/src/main/java/com/google/cloud/examples/securitycenter/snippets/DeleteNotificationConfigSnippets.java
+++ b/securitycenter/src/main/java/com/google/cloud/examples/securitycenter/snippets/DeleteNotificationConfigSnippets.java
@@ -17,8 +17,8 @@
 package com.google.cloud.examples.securitycenter.snippets;
 
 // [START scc_delete_notification_config]
-import com.google.cloud.securitycenter.v1p1beta1.NotificationConfigName;
-import com.google.cloud.securitycenter.v1p1beta1.SecurityCenterClient;
+import com.google.cloud.securitycenter.v1.NotificationConfigName;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
 import java.io.IOException;
 // [END scc_delete_notification_config]
 

--- a/securitycenter/src/main/java/com/google/cloud/examples/securitycenter/snippets/GetNotificationConfigSnippets.java
+++ b/securitycenter/src/main/java/com/google/cloud/examples/securitycenter/snippets/GetNotificationConfigSnippets.java
@@ -17,9 +17,9 @@
 package com.google.cloud.examples.securitycenter.snippets;
 
 // [START scc_get_notification_config]
-import com.google.cloud.securitycenter.v1p1beta1.NotificationConfig;
-import com.google.cloud.securitycenter.v1p1beta1.NotificationConfigName;
-import com.google.cloud.securitycenter.v1p1beta1.SecurityCenterClient;
+import com.google.cloud.securitycenter.v1.NotificationConfig;
+import com.google.cloud.securitycenter.v1.NotificationConfigName;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
 import java.io.IOException;
 // [END scc_get_notification_config]
 

--- a/securitycenter/src/main/java/com/google/cloud/examples/securitycenter/snippets/ListNotificationConfigSnippets.java
+++ b/securitycenter/src/main/java/com/google/cloud/examples/securitycenter/snippets/ListNotificationConfigSnippets.java
@@ -17,10 +17,10 @@
 package com.google.cloud.examples.securitycenter.snippets;
 
 // [START scc_list_notification_configs]
-import com.google.cloud.securitycenter.v1p1beta1.NotificationConfig;
-import com.google.cloud.securitycenter.v1p1beta1.OrganizationName;
-import com.google.cloud.securitycenter.v1p1beta1.SecurityCenterClient;
-import com.google.cloud.securitycenter.v1p1beta1.SecurityCenterClient.ListNotificationConfigsPagedResponse;
+import com.google.cloud.securitycenter.v1.NotificationConfig;
+import com.google.cloud.securitycenter.v1.OrganizationName;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient.ListNotificationConfigsPagedResponse;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 // [END scc_list_notification_configs]

--- a/securitycenter/src/main/java/com/google/cloud/examples/securitycenter/snippets/NotificationReceiver.java
+++ b/securitycenter/src/main/java/com/google/cloud/examples/securitycenter/snippets/NotificationReceiver.java
@@ -21,7 +21,7 @@ package com.google.cloud.examples.securitycenter.snippets;
 import com.google.cloud.pubsub.v1.AckReplyConsumer;
 import com.google.cloud.pubsub.v1.MessageReceiver;
 import com.google.cloud.pubsub.v1.Subscriber;
-import com.google.cloud.securitycenter.v1p1beta1.NotificationMessage;
+import com.google.cloud.securitycenter.v1.NotificationMessage;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import com.google.pubsub.v1.ProjectSubscriptionName;

--- a/securitycenter/src/main/java/com/google/cloud/examples/securitycenter/snippets/UpdateNotificationConfigSnippets.java
+++ b/securitycenter/src/main/java/com/google/cloud/examples/securitycenter/snippets/UpdateNotificationConfigSnippets.java
@@ -17,8 +17,8 @@
 package com.google.cloud.examples.securitycenter.snippets;
 
 // [START scc_update_notification_config]
-import com.google.cloud.securitycenter.v1p1beta1.NotificationConfig;
-import com.google.cloud.securitycenter.v1p1beta1.SecurityCenterClient;
+import com.google.cloud.securitycenter.v1.NotificationConfig;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
 import com.google.protobuf.FieldMask;
 import java.io.IOException;
 // [END scc_update_notification_config]


### PR DESCRIPTION
Notification feature work has been merged into v1, so we need to update the samples to match the updated version.
