### PR TITLE
fix: SampleTests: customAttributeSampleTest

### DIFF
--- a/jobs/v3/src/test/java/SampleTests.java
+++ b/jobs/v3/src/test/java/SampleTests.java
@@ -39,6 +39,7 @@ import org.junit.runners.JUnit4;
 public class SampleTests {
 
   private static ByteArrayOutputStream bout;
+  private long timeInMillis;
 
   @BeforeClass
   public static void setUp() {
@@ -111,6 +112,13 @@ public class SampleTests {
   @Test
   public void customAttributeSampleTest() throws Exception {
     CustomAttributeSample.main();
+
+    // wait for 10 seconds to elapse and then run it.
+    timeInMillis = System.currentTimeMillis();
+    while (System.currentTimeMillis() < timeInMillis + 10000) {
+      Thread.sleep(1000);
+    }
+
     assertThat(bout.toString())
         .containsMatch(
             ".*Job created:.*jobWithACustomAttribute.*\n"


### PR DESCRIPTION
Fixing this issue: https://github.com/GoogleCloudPlatform/java-docs-samples/issues/2261

Since there is Thread.sleep(10000) in the main, the problem is that JUnit needs to wait until the whole thing is finished.
