### PR TITLE
Fix Flaky DLP tests

### DIFF
--- a/dlp/src/test/java/dlp/snippets/InspectTests.java
+++ b/dlp/src/test/java/dlp/snippets/InspectTests.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -102,7 +103,9 @@ public class InspectTests {
 
   @Test
   public void testInspectGcsFile() throws InterruptedException, ExecutionException, IOException {
+
     InspectGcsFile.inspectGcsFile(PROJECT_ID, GCS_PATH, TOPIC_ID, SUBSCRIPTION_ID);
+    TimeUnit.SECONDS.sleep(3);
 
     String output = bout.toString();
     assertThat(output, containsString("Job created: "));
@@ -117,8 +120,10 @@ public class InspectTests {
   @Test
   public void testInspectDatastoreEntity()
       throws InterruptedException, ExecutionException, IOException {
+
     InspectDatastoreEntity.insepctDatastoreEntity(
         PROJECT_ID, datastoreNamespace, datastoreKind, TOPIC_ID, SUBSCRIPTION_ID);
+    TimeUnit.SECONDS.sleep(3);
 
     String output = bout.toString();
     assertThat(output, containsString("Job created: "));
@@ -133,8 +138,10 @@ public class InspectTests {
   @Test
   public void testInspectBigQueryTable()
       throws InterruptedException, ExecutionException, IOException {
+
     InspectBigQueryTable.inspectBigQueryTable(
         PROJECT_ID, DATASET_ID, TABLE_ID, TOPIC_ID, SUBSCRIPTION_ID);
+    TimeUnit.SECONDS.sleep(3);
 
     String output = bout.toString();
     assertThat(output, containsString("Job created: "));

--- a/dlp/src/test/java/dlp/snippets/InspectTests.java
+++ b/dlp/src/test/java/dlp/snippets/InspectTests.java
@@ -20,6 +20,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertNotNull;
 
+import com.google.cloud.dlp.v2.DlpServiceClient;
+import com.google.privacy.dlp.v2.CancelDlpJobRequest;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -103,8 +105,13 @@ public class InspectTests {
     InspectGcsFile.inspectGcsFile(PROJECT_ID, GCS_PATH, TOPIC_ID, SUBSCRIPTION_ID);
 
     String output = bout.toString();
-    assertThat(output, containsString("Info type: PHONE_NUMBER"));
-    assertThat(output, containsString("Info type: EMAIL_ADDRESS"));
+    assertThat(output, containsString("Job created: "));
+
+    String jobId = output.split("Job created: ")[1].split("\n")[0];
+    CancelDlpJobRequest request = CancelDlpJobRequest.newBuilder().setName(jobId).build();
+    try (DlpServiceClient client = DlpServiceClient.create()) {
+      client.cancelDlpJob(request);
+    }
   }
 
   @Test
@@ -114,8 +121,13 @@ public class InspectTests {
         PROJECT_ID, datastoreNamespace, datastoreKind, TOPIC_ID, SUBSCRIPTION_ID);
 
     String output = bout.toString();
-    assertThat(output, containsString("Info type: PHONE_NUMBER"));
-    assertThat(output, containsString("Info type: EMAIL_ADDRESS"));
+    assertThat(output, containsString("Job created: "));
+
+    String jobId = output.split("Job created: ")[1].split("\n")[0];
+    CancelDlpJobRequest request = CancelDlpJobRequest.newBuilder().setName(jobId).build();
+    try (DlpServiceClient client = DlpServiceClient.create()) {
+      client.cancelDlpJob(request);
+    }
   }
 
   @Test
@@ -125,6 +137,12 @@ public class InspectTests {
         PROJECT_ID, DATASET_ID, TABLE_ID, TOPIC_ID, SUBSCRIPTION_ID);
 
     String output = bout.toString();
-    assertThat(output, containsString("Info type: PHONE_NUMBER"));
+    assertThat(output, containsString("Job created: "));
+
+    String jobId = output.split("Job created: ")[1].split("\n")[0];
+    CancelDlpJobRequest request = CancelDlpJobRequest.newBuilder().setName(jobId).build();
+    try (DlpServiceClient client = DlpServiceClient.create()) {
+      client.cancelDlpJob(request);
+    }
   }
 }

--- a/dlp/src/test/java/dlp/snippets/InspectTests.java
+++ b/dlp/src/test/java/dlp/snippets/InspectTests.java
@@ -105,11 +105,13 @@ public class InspectTests {
   public void testInspectGcsFile() throws InterruptedException, ExecutionException, IOException {
 
     InspectGcsFile.inspectGcsFile(PROJECT_ID, GCS_PATH, TOPIC_ID, SUBSCRIPTION_ID);
+    // Await job creation
     TimeUnit.SECONDS.sleep(3);
 
     String output = bout.toString();
     assertThat(output, containsString("Job created: "));
 
+    // Cancelling the job early to conserve quota
     String jobId = output.split("Job created: ")[1].split("\n")[0];
     CancelDlpJobRequest request = CancelDlpJobRequest.newBuilder().setName(jobId).build();
     try (DlpServiceClient client = DlpServiceClient.create()) {
@@ -123,11 +125,13 @@ public class InspectTests {
 
     InspectDatastoreEntity.insepctDatastoreEntity(
         PROJECT_ID, datastoreNamespace, datastoreKind, TOPIC_ID, SUBSCRIPTION_ID);
+    // Await job creation
     TimeUnit.SECONDS.sleep(3);
 
     String output = bout.toString();
     assertThat(output, containsString("Job created: "));
 
+    // Cancelling the job early to conserve quota
     String jobId = output.split("Job created: ")[1].split("\n")[0];
     CancelDlpJobRequest request = CancelDlpJobRequest.newBuilder().setName(jobId).build();
     try (DlpServiceClient client = DlpServiceClient.create()) {
@@ -141,11 +145,13 @@ public class InspectTests {
 
     InspectBigQueryTable.inspectBigQueryTable(
         PROJECT_ID, DATASET_ID, TABLE_ID, TOPIC_ID, SUBSCRIPTION_ID);
+    // Await job creation
     TimeUnit.SECONDS.sleep(3);
 
     String output = bout.toString();
     assertThat(output, containsString("Job created: "));
 
+    // Cancelling the job early to conserve quota
     String jobId = output.split("Job created: ")[1].split("\n")[0];
     CancelDlpJobRequest request = CancelDlpJobRequest.newBuilder().setName(jobId).build();
     try (DlpServiceClient client = DlpServiceClient.create()) {


### PR DESCRIPTION
Fixes: #2302, #2303, #2317 

The tests keep timing out, so I followed the pattern implemented in the corresponding python samples to create a job and immediately cancel it.