### PR TITLE
Fix [some] GCF spotbugs errors

### DIFF
--- a/functions/snippets/src/main/groovy/com/example/functions/GroovyHelloBackground.groovy
+++ b/functions/snippets/src/main/groovy/com/example/functions/GroovyHelloBackground.groovy
@@ -12,10 +12,7 @@ class GroovyHelloBackground implements BackgroundFunction<HttpRequest> {
 
     @Override
     void accept(HttpRequest request, Context context) {
-        String name = "world"
-        if (request.getFirstQueryParameter("name").isPresent()) {
-            name = request.getFirstQueryParameter("name").get()
-        }
+        String name = request.getFirstQueryParameter("name").orElse("world");
         LOGGER.info(String.format("Hello %s!", name))
     }
 }

--- a/functions/snippets/src/main/java/com/example/functions/CorsEnabled.java
+++ b/functions/snippets/src/main/java/com/example/functions/CorsEnabled.java
@@ -33,7 +33,7 @@ public class CorsEnabled implements HttpFunction {
   public void service(HttpRequest request, HttpResponse response)
       throws IOException {
     // Set CORS headers for preflight requests
-    if (request.getMethod().equals("OPTIONS")) {
+    if ("OPTIONS".equals(request.getMethod())) {
       response.appendHeader("Access-Control-Allow-Origin", "*");
       response.appendHeader("Access-Control-Allow-Methods", "POST");
       response.appendHeader("Access-Control-Allow-Headers", "Content-Type");

--- a/functions/snippets/src/main/java/com/example/functions/FileSystem.java
+++ b/functions/snippets/src/main/java/com/example/functions/FileSystem.java
@@ -34,9 +34,9 @@ public class FileSystem implements HttpFunction {
     File currentDirectory = new File(".");
     File[] files = currentDirectory.listFiles();
     BufferedWriter writer = response.getWriter();
-    writer.write("Files: \n");
+    writer.write("Files: %n");
     for (File f : files) {
-      writer.write(String.format("\t%s\n", f.getName()));
+      writer.write(String.format("\t%s%n", f.getName()));
     }
   }
 }

--- a/functions/snippets/src/main/java/com/example/functions/FirebaseAuth.java
+++ b/functions/snippets/src/main/java/com/example/functions/FirebaseAuth.java
@@ -24,11 +24,10 @@ import com.google.gson.JsonObject;
 import java.util.logging.Logger;
 
 public class FirebaseAuth implements RawBackgroundFunction {
+  private static final Logger LOGGER = Logger.getLogger(FirebaseAuth.class.getName());
 
   // Use GSON (https://github.com/google/gson) to parse JSON content.
   private Gson gsonParser = new Gson();
-
-  private static final Logger LOGGER = Logger.getLogger(FirebaseAuth.class.getName());
 
   @Override
   public void accept(String json, Context context) {

--- a/functions/snippets/src/main/java/com/example/functions/FirebaseFirestore.java
+++ b/functions/snippets/src/main/java/com/example/functions/FirebaseFirestore.java
@@ -24,11 +24,10 @@ import com.google.gson.JsonObject;
 import java.util.logging.Logger;
 
 public class FirebaseFirestore implements RawBackgroundFunction {
+  private static final Logger LOGGER = Logger.getLogger(FirebaseFirestore.class.getName());
 
   // Use GSON (https://github.com/google/gson) to parse JSON content.
   private Gson gsonParser = new Gson();
-
-  private static final Logger LOGGER = Logger.getLogger(FirebaseFirestore.class.getName());
 
   @Override
   public void accept(String json, Context context) {

--- a/functions/snippets/src/main/java/com/example/functions/FirebaseRemoteConfig.java
+++ b/functions/snippets/src/main/java/com/example/functions/FirebaseRemoteConfig.java
@@ -17,21 +17,18 @@
 package com.example.functions;
 
 // [START functions_firebase_remote_config]
-import com.google.cloud.functions.BackgroundFunction;
+
 import com.google.cloud.functions.Context;
 import com.google.cloud.functions.RawBackgroundFunction;
-import com.google.cloud.logging.LoggingHandler;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import java.util.ArrayList;
 import java.util.logging.Logger;
 
 public class FirebaseRemoteConfig implements RawBackgroundFunction {
+  private static final Logger LOGGER = Logger.getLogger(FirebaseRemoteConfig.class.getName());
 
   // Use GSON (https://github.com/google/gson) to parse JSON content.
   private Gson gsonParser = new Gson();
-
-  private static final Logger LOGGER = Logger.getLogger(FirebaseRemoteConfig.class.getName());
 
   @Override
   public void accept(String json, Context context) {

--- a/functions/snippets/src/main/java/com/example/functions/FirebaseRtdb.java
+++ b/functions/snippets/src/main/java/com/example/functions/FirebaseRtdb.java
@@ -17,21 +17,18 @@
 package com.example.functions;
 
 // [START functions_firebase_rtdb]
-import com.google.cloud.functions.BackgroundFunction;
+
 import com.google.cloud.functions.Context;
 import com.google.cloud.functions.RawBackgroundFunction;
-import com.google.cloud.logging.LoggingHandler;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import java.util.ArrayList;
 import java.util.logging.Logger;
 
 public class FirebaseRtdb implements RawBackgroundFunction {
+  private static final Logger LOGGER = Logger.getLogger(FirebaseRtdb.class.getName());
 
   // Use GSON (https://github.com/google/gson) to parse JSON content.
   private Gson gsonParser = new Gson();
-
-  private static final Logger LOGGER = Logger.getLogger(FirebaseRtdb.class.getName());
 
   @Override
   public void accept(String json, Context context) {

--- a/functions/snippets/src/main/java/com/example/functions/HelloBackground.java
+++ b/functions/snippets/src/main/java/com/example/functions/HelloBackground.java
@@ -28,10 +28,7 @@ public class HelloBackground implements BackgroundFunction<HttpRequest> {
 
   @Override
   public void accept(HttpRequest request, Context context) {
-    String name = "world";
-    if (request.getFirstQueryParameter("name").isPresent()) {
-      name = request.getFirstQueryParameter("name").get();
-    }
+    String name = request.getFirstQueryParameter("name").orElse("world");
     LOGGER.info(String.format("Hello %s!", name));
   }
 }

--- a/functions/snippets/src/main/java/com/example/functions/HelloHttp.java
+++ b/functions/snippets/src/main/java/com/example/functions/HelloHttp.java
@@ -37,12 +37,8 @@ public class HelloHttp implements HttpFunction {
   @Override
   public void service(HttpRequest request, HttpResponse response)
       throws IOException {
-    String name = "world";
-
     // Check URL parameters for "name" field
-    if (request.getFirstQueryParameter("name").isPresent()) {
-      name = request.getFirstQueryParameter("name").get();
-    }
+    String name = request.getFirstQueryParameter("name").orElse("world");
 
     // Parse JSON request and check for "name" field
     try {

--- a/functions/snippets/src/main/java/com/example/functions/ImageMagick.java
+++ b/functions/snippets/src/main/java/com/example/functions/ImageMagick.java
@@ -73,7 +73,7 @@ public class ImageMagick implements BackgroundFunction<GcsEvent> {
       List<AnnotateImageResponse> responses = response.getResponsesList();
       for (AnnotateImageResponse res : responses) {
         if (res.hasError()) {
-          LOGGER.info(String.format("Error: %s\n", res.getError().getMessage()));
+          LOGGER.info(String.format("Error: %s%n", res.getError().getMessage()));
           return;
         }
         // Get Safe Search Annotations
@@ -85,7 +85,7 @@ public class ImageMagick implements BackgroundFunction<GcsEvent> {
           LOGGER.info(String.format("Detected %s as OK.", gcsEvent.getName()));
         }
       }
-    } catch (Exception e) {
+    } catch (IOException e) {
       LOGGER.info(String.format("Error with Vision API: %s", e.getMessage()));
     }
   }
@@ -94,7 +94,7 @@ public class ImageMagick implements BackgroundFunction<GcsEvent> {
   // [START functions_imagemagick_blur]
   // Blurs the file described by blobInfo using ImageMagick,
   // and uploads it to the blurred bucket.
-  public static void blur(BlobInfo blobInfo) throws IOException {
+  private static void blur(BlobInfo blobInfo) throws IOException {
     String bucketName = blobInfo.getBucket();
     String fileName = blobInfo.getName();
     // Download image
@@ -124,7 +124,7 @@ public class ImageMagick implements BackgroundFunction<GcsEvent> {
         BlobInfo.newBuilder(blurredBlobId).setContentType(blob.getContentType()).build();
     try {
       byte[] blurredFile = Files.readAllBytes(upload);
-      Blob blurredBlob = storage.create(blurredBlobInfo, blurredFile);
+      storage.create(blurredBlobInfo, blurredFile);
       LOGGER.info(
           String.format("Blurred image uploaded to: gs://%s/%s", BLURRED_BUCKET_NAME, fileName));
     } catch (Exception e) {

--- a/functions/snippets/src/main/java/com/example/functions/LazyFields.java
+++ b/functions/snippets/src/main/java/com/example/functions/LazyFields.java
@@ -38,12 +38,13 @@ public class LazyFields implements HttpFunction {
   public void service(HttpRequest request, HttpResponse response)
       throws IOException {
     // This value is initialized only if (and when) the function is called
-    if (lazyGlobal == null) {
-      lazyGlobal = functionSpecificComputation();
+    if (LazyFields.lazyGlobal == null) {
+      LazyFields.lazyGlobal = functionSpecificComputation();
     }
 
     BufferedWriter writer = response.getWriter();
-    writer.write(String.format("Lazy global: %s; non-lazy global: %s", lazyGlobal, nonLazyGlobal));
+    writer.write(String.format(
+        "Lazy global: %s; non-lazy global: %s", LazyFields.lazyGlobal, LazyFields.nonLazyGlobal));
   }
 
   private static int functionSpecificComputation() {

--- a/functions/snippets/src/main/java/com/example/functions/ParseContentType.java
+++ b/functions/snippets/src/main/java/com/example/functions/ParseContentType.java
@@ -26,6 +26,7 @@ import com.google.gson.JsonObject;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 public class ParseContentType implements HttpFunction {
@@ -40,7 +41,7 @@ public class ParseContentType implements HttpFunction {
       throws IOException {
     String name = null;
     String contentType = request.getContentType().get();
-    if (contentType.equals("application/json")) {
+    if ("application/json".equals(contentType)) {
       // '{"name":"John"}'
       JsonObject body = gsonParser.fromJson(request.getReader(), JsonObject.class);
       if (body.has("name")) {
@@ -50,13 +51,15 @@ public class ParseContentType implements HttpFunction {
         response.setStatusCode(HttpURLConnection.HTTP_BAD_REQUEST);
         return;
       }
-    } else if (contentType.equals("application/octet-stream")) {
+    } else if ("application/octet-stream".equals(contentType)) {
       // 'John', stored in a Buffer
-      name = new String(Base64.getDecoder().decode(request.getInputStream().readAllBytes()));
-    } else if (contentType.equals("text/plain")) {
+      name = new String(
+          Base64.getDecoder().decode(request.getInputStream().readAllBytes()),
+          StandardCharsets.UTF_8);
+    } else if ("text/plain".equals(contentType)) {
       // 'John'
       name = request.getReader().readLine();
-    } else if (contentType.equals("application/x-www-form-urlencoded")
+    } else if ("application/x-www-form-urlencoded".equals(contentType)
         && request.getFirstQueryParameter("name").isPresent()) {
       // 'name=John' in the body of a POST request (not the URL)
       name = request.getFirstQueryParameter("name").get();

--- a/functions/snippets/src/main/java/com/example/functions/RetrieveLogs.java
+++ b/functions/snippets/src/main/java/com/example/functions/RetrieveLogs.java
@@ -50,9 +50,9 @@ public class RetrieveLogs implements HttpFunction {
 
     BufferedWriter writer = response.getWriter();
     for (LogEntry entry : entriesResponse.getPage().getValues()) {
-      writer.write(String.format("%s: %s\n", entry.getLogName(), entry.getTextPayload()));
+      writer.write(String.format("%s: %s%n", entry.getLogName(), entry.getTextPayload()));
     }
-    writer.write("\n\nLogs retrieved successfully.\n");
+    writer.write("%n%nLogs retrieved successfully.%n");
   }
 
   // Returns a client for interacting with the Logging API. The client is stored in the global scope

--- a/functions/snippets/src/main/java/com/example/functions/RetryPubSub.java
+++ b/functions/snippets/src/main/java/com/example/functions/RetryPubSub.java
@@ -22,6 +22,7 @@ import com.google.cloud.functions.Context;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.logging.Logger;
 
@@ -33,7 +34,7 @@ public class RetryPubSub implements BackgroundFunction<PubSubMessage> {
 
   @Override
   public void accept(PubSubMessage message, Context context) {
-    String bodyJson = new String(Base64.getDecoder().decode(message.data));
+    String bodyJson = new String(Base64.getDecoder().decode(message.data), StandardCharsets.UTF_8);
     JsonElement bodyElement = gsonParser.fromJson(bodyJson, JsonElement.class);
 
     // Get the value of the "retry" JSON parameter, if one exists

--- a/functions/snippets/src/main/java/com/example/functions/ScalaHelloBackground.scala
+++ b/functions/snippets/src/main/java/com/example/functions/ScalaHelloBackground.scala
@@ -9,10 +9,7 @@ class ScalaHelloBackground extends BackgroundFunction[HttpRequest] {
   val LOGGER = Logger.getLogger(this.getClass.getName)
 
   override def accept(t: HttpRequest, context: Context): Unit = {
-    var name = "world"
-    if (t.getFirstQueryParameter("name").isPresent) {
-      name = t.getFirstQueryParameter("name").get()
-    }
+    val name = t.getFirstQueryParameter("name").orElse("world")
     LOGGER.info(String.format("Hello %s!", name))
   }
 }

--- a/functions/snippets/src/main/java/com/example/functions/SlackSlashCommand.java
+++ b/functions/snippets/src/main/java/com/example/functions/SlackSlashCommand.java
@@ -38,10 +38,10 @@ import java.util.stream.Collectors;
 public class SlackSlashCommand implements HttpFunction {
 
   // [START functions_slack_setup]
-  private Kgsearch kgClient;
   private static final String API_KEY = System.getenv("KG_API_KEY");
   private static final String SLACK_SECRET = System.getenv("SLACK_SECRET");
-  private static final Logger LOGGER = Logger.getLogger(SlackSlashCommand.class.getName());
+
+  private Kgsearch kgClient;
   private SlackSignature.Verifier verifier;
   private Gson gson = new Gson();
 
@@ -168,14 +168,14 @@ public class SlackSlashCommand implements HttpFunction {
   public void service(HttpRequest request, HttpResponse response) throws IOException {
 
     // Validate request
-    if (request.getMethod() != "POST") {
+    if (!"POST".equals(request.getMethod())) {
       response.setStatusCode(HttpURLConnection.HTTP_BAD_METHOD);
       return;
     }
 
     // reader can only be read once per request, so we preserve its contents
     String bodyString = request.getReader().lines().collect(Collectors.joining());
-    JsonObject body = (new Gson()).fromJson(bodyString, JsonObject.class);
+    JsonObject body = new Gson().fromJson(bodyString, JsonObject.class);
 
     if (body == null || !body.has("text")) {
       response.setStatusCode(HttpURLConnection.HTTP_BAD_REQUEST);

--- a/functions/snippets/src/main/java/com/example/functions/StackdriverLogging.java
+++ b/functions/snippets/src/main/java/com/example/functions/StackdriverLogging.java
@@ -32,7 +32,10 @@ public class StackdriverLogging implements BackgroundFunction<PubSubMessage> {
     String name = "World";
 
     if (!message.data.isEmpty()) {
-      name = new String(Base64.getDecoder().decode(message.data.getBytes(StandardCharsets.UTF_8)));
+      name = new String(
+          Base64.getDecoder().decode(message.data.getBytes(StandardCharsets.UTF_8)),
+          StandardCharsets.UTF_8
+      );
     }
     String res = String.format("Hello, %s", name);
     LOGGER.info(res);


### PR DESCRIPTION
This fixes **some** of the GCF `spotbugs` errors. The others likely need to be whitelisted, either globally or on a per-class basis.

The following rules were creating lots of false positives, and should (probably) be whitelisted globally:
- `IMC_IMMATURE_CLASS_NO_TOSTRING`
- `CRLF_INJECTION_LOGS`
- _possibly_ `CLI_CONSTANT_LIST_INDEX`

Once these rules are whitelisted (and `shared-configuration` is updated accordingly), I'll re-run `spotbugs` and fix any issues I missed. 🙂