### PR TITLE
healthcare API: update datasets/ samples from v1beta1 to v1

### DIFF
--- a/healthcare/v1/pom.xml
+++ b/healthcare/v1/pom.xml
@@ -1,5 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2020 Google LLC
+  Copyright 2019-2020 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -13,7 +14,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/healthcare/v1/pom.xml
+++ b/healthcare/v1/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.samples</groupId>
+  <artifactId>healthcare-samples</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>11</source>
+          <target>11</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <packaging>jar</packaging>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.0.15</version>
+  </parent>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+  </properties>
+
+  <prerequisites>
+    <maven>3.5</maven>
+  </prerequisites>
+
+  <!-- [START dependencies] -->
+  <!--  Using libraries-bom to manage versions.
+  See https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>4.4.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-healthcare</artifactId>
+      <version>v1-rev20200327-1.30.9</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+      <version>1.30.9</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <!-- [END dependencies] -->
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.0.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpmime</artifactId>
+      <version>4.5.12</version>
+    </dependency>
+    <!-- [START dependencies] -->
+  </dependencies>
+  <!-- [END dependencies] -->
+</project>

--- a/healthcare/v1/pom.xml
+++ b/healthcare/v1/pom.xml
@@ -100,6 +100,7 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/healthcare/v1/pom.xml
+++ b/healthcare/v1/pom.xml
@@ -1,3 +1,18 @@
+<!--
+  Copyright 2020 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/healthcare/v1/src/main/java/snippets/healthcare/datasets/DatasetCreate.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/datasets/DatasetCreate.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package snippets.healthcare.datasets;
+
+// [START healthcare_create_dataset]
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.healthcare.v1.CloudHealthcare;
+import com.google.api.services.healthcare.v1.CloudHealthcare.Projects.Locations.Datasets;
+import com.google.api.services.healthcare.v1.CloudHealthcareScopes;
+import com.google.api.services.healthcare.v1.model.Dataset;
+import com.google.api.services.healthcare.v1.model.Operation;
+import java.io.IOException;
+import java.util.Collections;
+
+public class DatasetCreate {
+  private static final String DATASET_NAME = "projects/%s/locations/%s/datasets/%s";
+  private static final JsonFactory JSON_FACTORY = new JacksonFactory();
+  private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
+
+  public static void datasetCreate(String projectId, String regionId, String datasetId)
+      throws IOException {
+    // String projectId = "your-project-id";
+    // String regionId = "us-central1";
+    // String datasetId = "your-dataset-id";
+
+    // Initialize the client, which will be used to interact with the service.
+    CloudHealthcare client = createClient();
+
+    // Configure the dataset to be created.
+    Dataset dataset = new Dataset();
+    dataset.setTimeZone("America/Chicago");
+
+    // Create request and configure any parameters.
+    String parentName = String.format("projects/%s/locations/%s", projectId, regionId);
+    Datasets.Create request = client.projects().locations().datasets().create(parentName, dataset);
+    request.setDatasetId(datasetId);
+
+    // Execute the request, wait for the operation to complete, and process the results.
+    try {
+      Operation operation = request.execute();
+      System.out.println(operation.toPrettyString());
+      while (operation.getDone() == null || !operation.getDone()) {
+        // Update the status of the operation with another request.
+        Thread.sleep(500); // Pause for 500ms between requests.
+        operation =
+            client
+                .projects()
+                .locations()
+                .datasets()
+                .operations()
+                .get(operation.getName())
+                .execute();
+      }
+      System.out.println("Dataset created. Response content: " + operation.getResponse());
+    } catch (Exception ex) {
+      System.out.printf("Error during request execution: %s\n", ex.toString());
+      ex.printStackTrace(System.out);
+    }
+  }
+
+  private static CloudHealthcare createClient() throws IOException {
+    // Use Application Default Credentials (ADC) to authenticate the requests
+    // For more information see https://cloud.google.com/docs/authentication/production
+    GoogleCredential credential =
+        GoogleCredential.getApplicationDefault(HTTP_TRANSPORT, JSON_FACTORY)
+            .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
+
+    // Create a HttpRequestInitializer, which will provide a baseline configuration to all requests.
+    HttpRequestInitializer requestInitializer =
+        request -> {
+          credential.initialize(request);
+          request.setConnectTimeout(60000); // 1 minute connect timeout
+          request.setReadTimeout(60000); // 1 minute read timeout
+        };
+
+    // Build the client for interacting with the service.
+    return new CloudHealthcare.Builder(HTTP_TRANSPORT, JSON_FACTORY, requestInitializer)
+        .setApplicationName("your-application-name")
+        .build();
+  }
+}
+// [END healthcare_create_dataset]

--- a/healthcare/v1/src/main/java/snippets/healthcare/datasets/DatasetDeIdentify.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/datasets/DatasetDeIdentify.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package snippets.healthcare.datasets;
+
+// [START healthcare_dicom_keeplist_deidentify_dataset]
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.healthcare.v1.CloudHealthcare;
+import com.google.api.services.healthcare.v1.CloudHealthcare.Projects.Locations.Datasets;
+import com.google.api.services.healthcare.v1.CloudHealthcareScopes;
+import com.google.api.services.healthcare.v1.model.DeidentifyConfig;
+import com.google.api.services.healthcare.v1.model.DeidentifyDatasetRequest;
+import com.google.api.services.healthcare.v1.model.DicomConfig;
+import com.google.api.services.healthcare.v1.model.Operation;
+import com.google.api.services.healthcare.v1.model.TagFilterList;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+public class DatasetDeIdentify {
+  private static final String DATASET_NAME = "projects/%s/locations/%s/datasets/%s";
+  private static final JsonFactory JSON_FACTORY = new JacksonFactory();
+  private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
+
+  public static void datasetDeIdentify(String srcDatasetName, String destDatasetName)
+      throws IOException {
+    // String srcDatasetName =
+    //     String.format(DATASET_NAME, "your-project-id", "your-region-id", "your-src-dataset-id");
+    // String destDatasetName =
+    //    String.format(DATASET_NAME, "your-project-id", "your-region-id", "your-dest-dataset-id");
+
+    // Initialize the client, which will be used to interact with the service.
+    CloudHealthcare client = createClient();
+
+    // Configure what information needs to be De-Identified.
+    // For more information on de-identifying using tags, please see the following:
+    // https://cloud.google.com/healthcare/docs/how-tos/dicom-deidentify#de-identification_using_tags
+    TagFilterList tags = new TagFilterList().setTags(Arrays.asList("PatientID"));
+    DicomConfig dicomConfig = new DicomConfig().setKeepList(tags);
+    DeidentifyConfig config = new DeidentifyConfig().setDicom(dicomConfig);
+
+    // Create the de-identify request and configure any parameters.
+    DeidentifyDatasetRequest deidentifyRequest =
+        new DeidentifyDatasetRequest().setDestinationDataset(destDatasetName).setConfig(config);
+    Datasets.Deidentify request =
+        client.projects().locations().datasets().deidentify(srcDatasetName, deidentifyRequest);
+
+    // Execute the request, wait for the operation to complete, and process the results.
+    try {
+      Operation operation = request.execute();
+      while (operation.getDone() == null || !operation.getDone()) {
+        // Update the status of the operation with another request.
+        Thread.sleep(500); // Pause for 500ms between requests.
+        operation =
+            client
+                .projects()
+                .locations()
+                .datasets()
+                .operations()
+                .get(operation.getName())
+                .execute();
+      }
+      System.out.println(
+          "De-identified Dataset created. Response content: " + operation.getResponse());
+    } catch (Exception ex) {
+      System.out.printf("Error during request execution: %s", ex.toString());
+      ex.printStackTrace(System.out);
+    }
+  }
+
+  private static CloudHealthcare createClient() throws IOException {
+    // Use Application Default Credentials (ADC) to authenticate the requests
+    // For more information see https://cloud.google.com/docs/authentication/production
+    GoogleCredential credential =
+        GoogleCredential.getApplicationDefault(HTTP_TRANSPORT, JSON_FACTORY)
+            .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
+
+    // Create a HttpRequestInitializer, which will provide a baseline configuration to all requests.
+    HttpRequestInitializer requestInitializer =
+        request -> {
+          credential.initialize(request);
+          request.setConnectTimeout(60000); // 1 minute connect timeout
+          request.setReadTimeout(60000); // 1 minute read timeout
+        };
+
+    // Build the client for interacting with the service.
+    return new CloudHealthcare.Builder(HTTP_TRANSPORT, JSON_FACTORY, requestInitializer)
+        .setApplicationName("your-application-name")
+        .build();
+  }
+}
+// [END healthcare_dicom_keeplist_deidentify_dataset]

--- a/healthcare/v1/src/main/java/snippets/healthcare/datasets/DatasetDelete.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/datasets/DatasetDelete.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package snippets.healthcare.datasets;
+
+// [START healthcare_delete_dataset]
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.healthcare.v1.CloudHealthcare;
+import com.google.api.services.healthcare.v1.CloudHealthcare.Projects.Locations.Datasets;
+import com.google.api.services.healthcare.v1.CloudHealthcareScopes;
+import java.io.IOException;
+import java.util.Collections;
+
+public class DatasetDelete {
+  private static final String DATASET_NAME = "projects/%s/locations/%s/datasets/%s";
+  private static final JsonFactory JSON_FACTORY = new JacksonFactory();
+  private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
+
+  public static void datasetDelete(String datasetName) throws IOException {
+    // String datasetName =
+    //     String.format(DATASET_NAME, "your-project-id", "your-region-id", "your-dataset-id");
+
+    // Initialize the client, which will be used to interact with the service.
+    CloudHealthcare client = createClient();
+
+    // Create request and configure any parameters.
+    Datasets.Delete request = client.projects().locations().datasets().delete(datasetName);
+
+    // Execute the request and process the results.
+    request.execute();
+    System.out.println("Dataset deleted.");
+  }
+
+  private static CloudHealthcare createClient() throws IOException {
+    // Use Application Default Credentials (ADC) to authenticate the requests
+    // For more information see https://cloud.google.com/docs/authentication/production
+    GoogleCredential credential =
+        GoogleCredential.getApplicationDefault(HTTP_TRANSPORT, JSON_FACTORY)
+            .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
+
+    // Create a HttpRequestInitializer, which will provide a baseline configuration to all requests.
+    HttpRequestInitializer requestInitializer =
+        request -> {
+          credential.initialize(request);
+          request.setConnectTimeout(60000); // 1 minute connect timeout
+          request.setReadTimeout(60000); // 1 minute read timeout
+        };
+
+    // Build the client for interacting with the service.
+    return new CloudHealthcare.Builder(HTTP_TRANSPORT, JSON_FACTORY, requestInitializer)
+        .setApplicationName("your-application-name")
+        .build();
+  }
+}
+// [END healthcare_delete_dataset]

--- a/healthcare/v1/src/main/java/snippets/healthcare/datasets/DatasetGet.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/datasets/DatasetGet.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package snippets.healthcare.datasets;
+
+// [START healthcare_get_dataset]
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.healthcare.v1.CloudHealthcare;
+import com.google.api.services.healthcare.v1.CloudHealthcare.Projects.Locations.Datasets;
+import com.google.api.services.healthcare.v1.CloudHealthcareScopes;
+import com.google.api.services.healthcare.v1.model.Dataset;
+import java.io.IOException;
+import java.util.Collections;
+
+public class DatasetGet {
+  private static final String DATASET_NAME = "projects/%s/locations/%s/datasets/%s";
+  private static final JsonFactory JSON_FACTORY = new JacksonFactory();
+  private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
+
+  public static void datasetGet(String datasetName) throws IOException {
+    // String datasetName =
+    //     String.format(DATASET_NAME, "your-project-id", "your-region-id", "your-dataset-id");
+
+    // Initialize the client, which will be used to interact with the service.
+    CloudHealthcare client = createClient();
+
+    // Create request and configure any parameters.
+    Datasets.Get request = client.projects().locations().datasets().get(datasetName);
+
+    // Execute the request and process the results.
+    Dataset dataset = request.execute();
+    System.out.println("Dataset retrieved: \n" + dataset.toPrettyString());
+  }
+
+  private static CloudHealthcare createClient() throws IOException {
+    // Use Application Default Credentials (ADC) to authenticate the requests
+    // For more information see https://cloud.google.com/docs/authentication/production
+    GoogleCredential credential =
+        GoogleCredential.getApplicationDefault(HTTP_TRANSPORT, JSON_FACTORY)
+            .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
+
+    // Create a HttpRequestInitializer, which will provide a baseline configuration to all requests.
+    HttpRequestInitializer requestInitializer =
+        request -> {
+          credential.initialize(request);
+          request.setConnectTimeout(60000); // 1 minute connect timeout
+          request.setReadTimeout(60000); // 1 minute read timeout
+        };
+
+    // Build the client for interacting with the service.
+    return new CloudHealthcare.Builder(HTTP_TRANSPORT, JSON_FACTORY, requestInitializer)
+        .setApplicationName("your-application-name")
+        .build();
+  }
+}
+// [END healthcare_get_dataset]

--- a/healthcare/v1/src/main/java/snippets/healthcare/datasets/DatasetGetIamPolicy.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/datasets/DatasetGetIamPolicy.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package snippets.healthcare.datasets;
+
+// [START healthcare_dataset_get_iam_policy]
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.healthcare.v1.CloudHealthcare;
+import com.google.api.services.healthcare.v1.CloudHealthcare.Projects.Locations.Datasets;
+import com.google.api.services.healthcare.v1.CloudHealthcareScopes;
+import com.google.api.services.healthcare.v1.model.Policy;
+import java.io.IOException;
+import java.util.Collections;
+
+public class DatasetGetIamPolicy {
+  private static final String DATASET_NAME = "projects/%s/locations/%s/datasets/%s";
+  private static final JsonFactory JSON_FACTORY = new JacksonFactory();
+  private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
+
+  public static void datasetGetIamPolicy(String datasetName) throws IOException {
+    // String datasetName =
+    //     String.format(DATASET_NAME, "your-project-id", "your-region-id", "your-dataset-id");
+
+    // Initialize the client, which will be used to interact with the service.
+    CloudHealthcare client = createClient();
+
+    // Create request and configure any parameters.
+    Datasets.GetIamPolicy request =
+        client.projects().locations().datasets().getIamPolicy(datasetName);
+
+    // Execute the request and process the results.
+    Policy policy = request.execute();
+    System.out.println("Dataset IAMPolicy retrieved: \n" + policy.toPrettyString());
+  }
+
+  private static CloudHealthcare createClient() throws IOException {
+    // Use Application Default Credentials (ADC) to authenticate the requests
+    // For more information see https://cloud.google.com/docs/authentication/production
+    GoogleCredential credential =
+        GoogleCredential.getApplicationDefault(HTTP_TRANSPORT, JSON_FACTORY)
+            .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
+
+    // Create a HttpRequestInitializer, which will provide a baseline configuration to all requests.
+    HttpRequestInitializer requestInitializer =
+        request -> {
+          credential.initialize(request);
+          request.setConnectTimeout(60000); // 1 minute connect timeout
+          request.setReadTimeout(60000); // 1 minute read timeout
+        };
+
+    // Build the client for interacting with the service.
+    return new CloudHealthcare.Builder(HTTP_TRANSPORT, JSON_FACTORY, requestInitializer)
+        .setApplicationName("your-application-name")
+        .build();
+  }
+}
+// [END healthcare_dataset_get_iam_policy]

--- a/healthcare/v1/src/main/java/snippets/healthcare/datasets/DatasetList.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/datasets/DatasetList.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package snippets.healthcare.datasets;
+
+// [START healthcare_list_datasets]
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.healthcare.v1.CloudHealthcare;
+import com.google.api.services.healthcare.v1.CloudHealthcare.Projects.Locations.Datasets;
+import com.google.api.services.healthcare.v1.CloudHealthcareScopes;
+import com.google.api.services.healthcare.v1.model.Dataset;
+import com.google.api.services.healthcare.v1.model.ListDatasetsResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class DatasetList {
+  private static final JsonFactory JSON_FACTORY = new JacksonFactory();
+  private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
+
+  public static void datasetList(String projectId, String regionId) throws IOException {
+    // String projectId = "your-project-id";
+    // String regionId = "us-central1";
+
+    // Initialize the client, which will be used to interact with the service.
+    CloudHealthcare client = createClient();
+
+    // Results are paginated, so multiple queries may be required.
+    String parentName = String.format("projects/%s/locations/%s", projectId, regionId);
+    String pageToken = null;
+    List<Dataset> datasets = new ArrayList<>();
+    do {
+      // Create request and configure any parameters.
+      Datasets.List request =
+          client
+              .projects()
+              .locations()
+              .datasets()
+              .list(parentName)
+              .setPageSize(100) // Specify pageSize up to 1000
+              .setPageToken(pageToken);
+
+      // Execute response and collect results.
+      ListDatasetsResponse response = request.execute();
+      datasets.addAll(response.getDatasets());
+
+      // Update the page token for the next request.
+      pageToken = response.getNextPageToken();
+    } while (pageToken != null);
+
+    // Print results.
+    System.out.printf("Retrieved %s datasets: \n", datasets.size());
+    for (Dataset data : datasets) {
+      System.out.println("\t" + data.toPrettyString());
+    }
+  }
+
+  private static CloudHealthcare createClient() throws IOException {
+    // Use Application Default Credentials (ADC) to authenticate the requests
+    // For more information see https://cloud.google.com/docs/authentication/production
+    GoogleCredential credential =
+        GoogleCredential.getApplicationDefault(HTTP_TRANSPORT, JSON_FACTORY)
+            .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
+
+    // Create a HttpRequestInitializer, which will provide a baseline configuration to all requests.
+    HttpRequestInitializer requestInitializer =
+        request -> {
+          credential.initialize(request);
+          request.setConnectTimeout(60000); // 1 minute connect timeout
+          request.setReadTimeout(60000); // 1 minute read timeout
+        };
+
+    // Build the client for interacting with the service.
+    return new CloudHealthcare.Builder(HTTP_TRANSPORT, JSON_FACTORY, requestInitializer)
+        .setApplicationName("your-application-name")
+        .build();
+  }
+}
+// [END healthcare_list_datasets]

--- a/healthcare/v1/src/main/java/snippets/healthcare/datasets/DatasetPatch.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/datasets/DatasetPatch.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package snippets.healthcare.datasets;
+
+// [START healthcare_patch_dataset]
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.healthcare.v1.CloudHealthcare;
+import com.google.api.services.healthcare.v1.CloudHealthcare.Projects.Locations.Datasets;
+import com.google.api.services.healthcare.v1.CloudHealthcareScopes;
+import com.google.api.services.healthcare.v1.model.Dataset;
+import java.io.IOException;
+import java.util.Collections;
+
+public class DatasetPatch {
+  private static final JsonFactory JSON_FACTORY = new JacksonFactory();
+  private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
+
+  public static void datasetPatch(String datasetName) throws IOException {
+    // String datasetName =
+    //     String.format(DATASET_NAME, "your-project-id", "your-region-id", "your-dataset-id");
+
+    // Initialize the client, which will be used to interact with the service.
+    CloudHealthcare client = createClient();
+
+    // Fetch the initial state of the dataset.
+    Datasets.Get getRequest = client.projects().locations().datasets().get(datasetName);
+    Dataset dataset = getRequest.execute();
+
+    // Update the Dataset fields as needed as needed. For a full list of dataset fields, see:
+    // https://cloud.google.com/healthcare/docs/reference/rest/v1beta1/projects.locations.datasets#Dataset
+    dataset.setTimeZone("America/New_York");
+
+    // Create request and configure any parameters.
+    Datasets.Patch request =
+        client
+            .projects()
+            .locations()
+            .datasets()
+            .patch(datasetName, dataset)
+            .setUpdateMask("timeZone");
+
+    // Execute the request and process the results.
+    dataset = request.execute();
+    System.out.println("Dataset patched: \n" + dataset.toPrettyString());
+  }
+
+  private static CloudHealthcare createClient() throws IOException {
+    // Use Application Default Credentials (ADC) to authenticate the requests
+    // For more information see https://cloud.google.com/docs/authentication/production
+    GoogleCredential credential =
+        GoogleCredential.getApplicationDefault(HTTP_TRANSPORT, JSON_FACTORY)
+            .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
+
+    // Create a HttpRequestInitializer, which will provide a baseline configuration to all requests.
+    HttpRequestInitializer requestInitializer =
+        request -> {
+          credential.initialize(request);
+          request.setConnectTimeout(60000); // 1 minute connect timeout
+          request.setReadTimeout(60000); // 1 minute read timeout
+        };
+
+    // Build the client for interacting with the service.
+    return new CloudHealthcare.Builder(HTTP_TRANSPORT, JSON_FACTORY, requestInitializer)
+        .setApplicationName("your-application-name")
+        .build();
+  }
+}
+// [END healthcare_patch_dataset]

--- a/healthcare/v1/src/main/java/snippets/healthcare/datasets/DatasetSetIamPolicy.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/datasets/DatasetSetIamPolicy.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package snippets.healthcare.datasets;
+
+// [START healthcare_dataset_set_iam_policy]
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.healthcare.v1.CloudHealthcare;
+import com.google.api.services.healthcare.v1.CloudHealthcare.Projects.Locations.Datasets;
+import com.google.api.services.healthcare.v1.CloudHealthcareScopes;
+import com.google.api.services.healthcare.v1.model.Binding;
+import com.google.api.services.healthcare.v1.model.Policy;
+import com.google.api.services.healthcare.v1.model.SetIamPolicyRequest;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+public class DatasetSetIamPolicy {
+  private static final JsonFactory JSON_FACTORY = new JacksonFactory();
+  private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
+
+  public static void datasetSetIamPolicy(String datasetName) throws IOException {
+    // String datasetName =
+    //     String.format(DATASET_NAME, "your-project-id", "your-region-id", "your-dataset-id");
+
+    // Initialize the client, which will be used to interact with the service.
+    CloudHealthcare client = createClient();
+
+    // Configure the IAMPolicy to apply to the dataset.
+    // For more information on understanding IAM roles, see the following:
+    // https://cloud.google.com/iam/docs/understanding-roles
+    Binding binding =
+        new Binding()
+            .setRole("roles/healthcare.datasetViewer")
+            .setMembers(Arrays.asList("domain:google.com"));
+    Policy policy = new Policy().setBindings(Arrays.asList(binding));
+    SetIamPolicyRequest policyRequest = new SetIamPolicyRequest().setPolicy(policy);
+
+    // Create request and configure any parameters.
+    Datasets.SetIamPolicy request =
+        client.projects().locations().datasets().setIamPolicy(datasetName, policyRequest);
+
+    // Execute the request and process the results.
+    Policy updatedPolicy = request.execute();
+    System.out.println("Dataset policy has been updated: " + updatedPolicy.toPrettyString());
+  }
+
+  private static CloudHealthcare createClient() throws IOException {
+    // Use Application Default Credentials (ADC) to authenticate the requests
+    // For more information see https://cloud.google.com/docs/authentication/production
+    GoogleCredential credential =
+        GoogleCredential.getApplicationDefault(HTTP_TRANSPORT, JSON_FACTORY)
+            .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
+
+    // Create a HttpRequestInitializer, which will provide a baseline configuration to all requests.
+    HttpRequestInitializer requestInitializer =
+        request -> {
+          credential.initialize(request);
+          request.setConnectTimeout(60000); // 1 minute connect timeout
+          request.setReadTimeout(60000); // 1 minute read timeout
+        };
+
+    // Build the client for interacting with the service.
+    return new CloudHealthcare.Builder(HTTP_TRANSPORT, JSON_FACTORY, requestInitializer)
+        .setApplicationName("your-application-name")
+        .build();
+  }
+}
+// [END healthcare_dataset_set_iam_policy]

--- a/healthcare/v1/src/test/java/snippets/healthcare/DatasetTests.java
+++ b/healthcare/v1/src/test/java/snippets/healthcare/DatasetTests.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package snippets.healthcare;
+
+import static junit.framework.TestCase.assertNotNull;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import snippets.healthcare.datasets.DatasetCreate;
+import snippets.healthcare.datasets.DatasetDeIdentify;
+import snippets.healthcare.datasets.DatasetDelete;
+import snippets.healthcare.datasets.DatasetGet;
+import snippets.healthcare.datasets.DatasetGetIamPolicy;
+import snippets.healthcare.datasets.DatasetList;
+import snippets.healthcare.datasets.DatasetPatch;
+import snippets.healthcare.datasets.DatasetSetIamPolicy;
+
+@RunWith(JUnit4.class)
+public class DatasetTests {
+  private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static final String REGION_ID = "us-central1";
+
+  private static String datasetName;
+
+  private final PrintStream originalOut = System.out;
+  private ByteArrayOutputStream bout;
+
+  private static void requireEnvVar(String varName) {
+    assertNotNull(
+        System.getenv(varName),
+        String.format("Environment variable '%s' is required to perform these tests.", varName));
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void beforeTest() throws IOException {
+    bout = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(bout));
+
+    String datasetId = "dataset-" + UUID.randomUUID().toString().replaceAll("-", "_");
+    datasetName =
+        String.format("projects/%s/locations/%s/datasets/%s", PROJECT_ID, REGION_ID, datasetId);
+
+    DatasetCreate.datasetCreate(PROJECT_ID, REGION_ID, datasetId);
+
+    bout = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(bout));
+  }
+
+  @After
+  public void tearDown() {
+    System.setOut(originalOut);
+    bout.reset();
+  }
+
+  @Test
+  public void test_DatasetCreate() throws IOException {
+    String newDatasetName =
+        String.format("projects/%s/locations/%s/datasets/new-dataset", PROJECT_ID, REGION_ID);
+    try {
+      DatasetDelete.datasetDelete(newDatasetName);
+    } catch (GoogleJsonResponseException gjre) {
+      // Expected if new-dataset does not exist.
+    }
+    DatasetCreate.datasetCreate(PROJECT_ID, REGION_ID, "new-dataset");
+
+    String output = bout.toString(StandardCharsets.UTF_8);
+    assertThat(output, containsString("Dataset created."));
+  }
+
+  @Test
+  public void test_DatasetGet() throws IOException {
+    DatasetGet.datasetGet(datasetName);
+
+    String output = bout.toString();
+    assertThat(output, containsString("Dataset retrieved:"));
+  }
+
+  @Test
+  public void test_DatasetList() throws IOException {
+    DatasetList.datasetList(PROJECT_ID, REGION_ID);
+
+    String output = bout.toString();
+    assertThat(output, containsString("Retrieved"));
+  }
+
+  @Test
+  public void test_DataSetPatch() throws IOException {
+    DatasetPatch.datasetPatch(datasetName);
+
+    String output = bout.toString();
+    assertThat(output, containsString("Dataset patched:"));
+  }
+
+  @Test
+  public void test_DatasetDeidentify() throws IOException {
+    DatasetDeIdentify.datasetDeIdentify(datasetName, datasetName + "-died");
+
+    String output = bout.toString();
+    assertThat(output, containsString("De-identified Dataset created."));
+  }
+
+  @Test
+  public void test_DatasetGetIamPolicy() throws IOException {
+    DatasetGetIamPolicy.datasetGetIamPolicy(datasetName);
+
+    String output = bout.toString();
+    assertThat(output, containsString("Dataset IAMPolicy retrieved:"));
+  }
+
+  @Test
+  public void test_DatasetSetIamPolicy() throws IOException {
+    DatasetSetIamPolicy.datasetSetIamPolicy(datasetName);
+
+    String output = bout.toString();
+    assertThat(output, containsString("Dataset policy has been updated: "));
+  }
+
+  @Test
+  public void test_DatasetDelete() throws IOException {
+    DatasetDelete.datasetDelete(datasetName);
+
+    String output = bout.toString();
+    assertThat(output, containsString("Dataset deleted."));
+  }
+}


### PR DESCRIPTION
NOTE: This PR is fundamentally a branch of https://github.com/GoogleCloudPlatform/java-docs-samples/tree/master/healthcare/v1beta1 to v1. The code has been previously reviewed in this repository.
Updates for fhir/, dicom/, and hl7v2/ are coming but I wanted to keep the PRs separate.

After all healthcare/v1 samples are approved, I'll delete the existing v1beta1/ directory.