### PR TITLE
Remove signatures from UberJAR for Beam SQL

### DIFF
--- a/dataflow/flex-templates/streaming_beam_sql/pom.xml
+++ b/dataflow/flex-templates/streaming_beam_sql/pom.xml
@@ -95,6 +95,16 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Hello,

I tried to run the example and unfortunately, there were problems with them. I got the following exception:
```
Executing: java -cp /template/pipeline.jar org.apache.beam.samples.StreamingBeamSQL --region=us-central1 --inputSubscription=ratings --project=polidea-airflow --serviceAccount=198907790164-compute@developer.gserviceaccount.com --templateLocation=gs://dataflow-staging-us-central1-198907790164/staging/template_launches/2020-04-20_14_05_05-10138518335536770368/job_object --tempLocation=gs://dataflow-staging-us-central1-198907790164/tmp --stagingLocation=gs://dataflow-staging-us-central1-198907790164/staging --outputTable=polidea-airflow:beam_samples.streaming_beam_sql --runner=DataflowRunner --jobName=streaming-beam-sql-20200420-230503
Error: A JNI error has occurred, please check your installation and try again
Exception
in thread "main"
java.lang.SecurityException: Invalid signature file digest for Manifest main attributes
	at java.base/sun.security.util.SignatureFileVerifier.processImpl(SignatureFileVerifier.java:336)
	at java.base/sun.security.util.SignatureFileVerifier.process(SignatureFileVerifier.java:269)
	at java.base/java.util.jar.JarVerifier.processEntry(JarVerifier.java:316)
	at java.base/java.util.jar.JarVerifier.update(JarVerifier.java:230)
	at java.base/java.util.jar.JarFile.initializeVerifier(JarFile.java:757)
	at java.base/java.util.jar.JarFile.ensureInitialization(JarFile.java:1034)
	at java.base/java.util.jar.JavaUtilJarAccessImpl.ensureInitialization(JavaUtilJarAccessImpl.java:69)
	at java.base/jdk.internal.loader.URLClassPath$JarLoader$2.getManifest(URLClassPath.java:870)
	at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:788)
	at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:700)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:623)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:398)
	at java.base/sun.launcher.LauncherHelper.loadMainClass(LauncherHelper.java:760)
	at java.base/sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:655)
java failed with exit status 1
Template launch failed: exit status 1
Uploading console logs to gcs location: gs://dataflow-staging-us-central1-198907790164/staging/template_launches/2020-04-20_14_05_05-10138518335536770368/console_logs
```
I checked the JAR content and found a possible source of problem
```
streaming-beam-sql-1.0/META-INF/SIGNINGC.SF
```

After my change is made, the new JAR file does not contain the following files.
```
META-INF/DUMMY.DSA
META-INF/DUMMY.SF
META-INF/SIGNINGC.RSA
META-INF/SIGNINGC.SF
```


> It's a good idea to open an issue first for discussion.

- [X] `pom.xml` parent set to latest `shared-configuration`
- [X] Appropriate changes to README are included in PR
- X] API's need to be enabled to test (tell us)
- [X] Environment Variables need to be set (ask us to set them)
- [X] Tests pass (`mvn -P lint clean verify`)
  * (Note- `Checkstyle` passing is required; `Spotbugs`, `ErrorProne`, `PMD`, etc. `ERROR`'s are advisory only)
