### PR TITLE
fix: use libraries-bom

### DIFF
--- a/spanner/cloud-client/pom.xml
+++ b/spanner/cloud-client/pom.xml
@@ -34,7 +34,6 @@ limitations under the License.
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <opencensus.version>0.26.0</opencensus.version>
-    <spanner.version>1.52.0</spanner.version>
   </properties>
 
   <!-- Include the BOM to ensure compatibility across multiple google-cloud-* libraries -->
@@ -42,8 +41,8 @@ limitations under the License.
     <dependencies>
       <dependency>
         <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-bom</artifactId>
-        <version>0.122.4-alpha</version>
+        <artifactId>libraries-bom</artifactId>
+        <version>5.1.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -54,22 +53,18 @@ limitations under the License.
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
-      <version>${spanner.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-spanner-admin-instance-v1</artifactId>
-      <version>${spanner.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-spanner-v1</artifactId>
-      <version>${spanner.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-spanner-admin-database-v1</artifactId>
-      <version>${spanner.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Use the libraries-bom for the Spanner cloud client samples.

Fixes #2718
