### PR TITLE
Moved XMLDecl to first line to prevent parsing err

### DIFF
--- a/flexible/websocket-jetty/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/flexible/websocket-jetty/src/main/webapp/WEB-INF/jetty-web.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2019 Google LLC
 
@@ -13,7 +14,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="parentLoaderPriority">true</Set>


### PR DESCRIPTION
Jetty fails to start with
 mvn jetty:run
with a 
 org.xml.sax.SAXParseException: The processing instruction target matching "[xX][mM][lL]" is not allowed.

This is because jetty-web.xml starts with a comment instead of a XMLDecl which is syntactically wrong according to
https://www.w3.org/TR/REC-xml/#sec-prolog-dtd and
https://www.w3.org/TR/2008/REC-xml-20081126/#sec-guessing-no-ext-info

Fixes #issue

> It's a good idea to open an issue first for discussion.

- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] Tests pass (`mvn -P lint clean verify`)
  * (Note- `Checkstyle` passing is required; `Spotbugs`, `ErrorProne`, `PMD`, etc. `ERROR`'s are advisory only)
