### PR TITLE
Reduce wait on CommuteSearchSample to 1 second from 5.

### DIFF
--- a/jobs/v3/src/main/java/com/google/samples/CommuteSearchSample.java
+++ b/jobs/v3/src/main/java/com/google/samples/CommuteSearchSample.java
@@ -77,7 +77,7 @@ public final class CommuteSearchSample {
     SearchJobsResponse response =
         talentSolutionClient.projects().jobs().search(DEFAULT_PROJECT_ID, searchJobsRequest)
             .execute();
-    Thread.sleep(5000);
+    Thread.sleep(1000);
     System.out.println(response);
   }
   // [END commute_search]


### PR DESCRIPTION
Meant to reduce this before submitting https://github.com/GoogleCloudPlatform/java-docs-samples/pull/2721. I had one test at 5 seconds and the rest at 1 second, just to see if it made a difference when the tests ran, but 1 second is enough.