### PR TITLE
Simplify the `http-form-data` sample and use Java 11 features.

### DIFF
--- a/functions/http/http-form-data/pom.xml
+++ b/functions/http/http-form-data/pom.xml
@@ -57,20 +57,10 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.8.6</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.cloud.functions</groupId>
       <artifactId>functions-framework-api</artifactId>
       <version>1.0.1</version>
+      <scope>provided</scope>
     </dependency>
 
     <!-- The following dependencies are only required for testing -->
@@ -111,12 +101,6 @@
       <version>4.13</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava-testlib</artifactId>
-      <version>29.0-jre</version>
-      <scope>compile</scope>
-    </dependency>
   </dependencies>
 
   <build>
@@ -146,31 +130,6 @@
           <skipTests>${skipTests}</skipTests>
           <reportNameSuffix>sponge_log</reportNameSuffix>
           <trimStackTrace>false</trimStackTrace>
-        </configuration>
-      </plugin>
-      <plugin> <!-- Required for Java 8 (Alpha) functions in the inline editor -->
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>compile</id>
-            <phase>compile</phase>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>testCompile</id>
-            <phase>test-compile</phase>
-            <goals>
-              <goal>testCompile</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <excludes>
-            <exclude>.google/</exclude>
-          </excludes>
         </configuration>
       </plugin>
     </plugins>

--- a/functions/http/http-form-data/src/main/java/functions/HttpFormData.java
+++ b/functions/http/http-form-data/src/main/java/functions/HttpFormData.java
@@ -28,11 +28,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.logging.Logger;
-import javax.servlet.annotation.MultipartConfig;
 
-@MultipartConfig
 public class HttpFormData implements HttpFunction {
-  private static final Logger LOGGER = Logger.getLogger(HttpFormData.class.getName());
+  private static final Logger logger = Logger.getLogger(HttpFormData.class.getName());
 
   @Override
   public void service(HttpRequest request, HttpResponse response)
@@ -51,7 +49,7 @@ public class HttpFormData implements HttpFunction {
         continue;
       }
 
-      LOGGER.info("Processed file: " + filename);
+      logger.info("Processed file: " + filename);
 
       // Note: GCF's temp directory is an in-memory file system
       // Thus, any files in it must fit in the instance's memory.
@@ -66,13 +64,14 @@ public class HttpFormData implements HttpFunction {
     }
 
     // This code will process other form fields.
-    for (String fieldName : request.getQueryParameters().keySet()) {
-      String firstFieldValue = request.getFirstQueryParameter(fieldName).get();
+    request.getQueryParameters().forEach(
+        (fieldName, fieldValues) -> {
+          String firstFieldValue = fieldValues.get(0);
 
-      // TODO(developer): process field values here
-      LOGGER.info(String.format(
-          "Processed field: %s (value: %s)", fieldName, firstFieldValue));
-    }
+          // TODO(developer): process field values here
+          logger.info(String.format(
+              "Processed field: %s (value: %s)", fieldName, firstFieldValue));
+        });
   }
 }
 // [END functions_http_form_data]

--- a/functions/http/http-form-data/src/test/java/functions/HttpFormDataTest.java
+++ b/functions/http/http-form-data/src/test/java/functions/HttpFormDataTest.java
@@ -23,6 +23,7 @@ import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 import com.google.cloud.functions.HttpRequest;
+import com.google.cloud.functions.HttpRequest.HttpPart;
 import com.google.cloud.functions.HttpResponse;
 import com.google.common.testing.TestLogHandler;
 import java.io.BufferedWriter;
@@ -32,10 +33,8 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Logger;
 import org.junit.Before;
@@ -91,17 +90,13 @@ public class HttpFormDataTest {
   public void functionsHttpFormData_shouldSaveFiles() throws IOException {
     when(request.getMethod()).thenReturn("POST");
 
-    ArrayList<HttpRequest.HttpPart> partsList = new ArrayList<>();
-
     InputStream stream = new ByteArrayInputStream("foo text%n".getBytes(StandardCharsets.UTF_8));
 
     MockHttpPart mockHttpPart = new MockHttpPart();
     mockHttpPart.setFileName("foo.txt");
     mockHttpPart.setInputStream(stream);
-    partsList.add(mockHttpPart);
 
-    HashMap<String, HttpRequest.HttpPart> httpParts = new HashMap<>();
-    httpParts.put("mock", mockHttpPart);
+    Map<String, HttpPart> httpParts = Map.of("mock", mockHttpPart);
     when(request.getParts()).thenReturn(httpParts);
 
     new HttpFormData().service(request, response);
@@ -113,10 +108,9 @@ public class HttpFormDataTest {
   @Test
   public void functionsHttpFormData_shouldProcessFields() throws IOException {
     when(request.getMethod()).thenReturn("POST");
-    when(request.getParts()).thenReturn(new HashMap<>());
+    when(request.getParts()).thenReturn(Map.of());
 
-    HashMap<String, List<String>> queryParams = new HashMap<>();
-    queryParams.put("foo", Arrays.asList(new String[]{"bar"}));
+    Map<String, List<String>> queryParams = Map.of("foo", List.of("bar"));
 
     when(request.getQueryParameters()).thenReturn(queryParams);
     when(request.getFirstQueryParameter("foo")).thenReturn(Optional.of("bar"));

--- a/functions/http/http-form-data/src/test/java/functions/MockHttpPart.java
+++ b/functions/http/http-form-data/src/test/java/functions/MockHttpPart.java
@@ -18,7 +18,6 @@ package functions;
 
 import com.google.cloud.functions.HttpRequest;
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +41,7 @@ public class MockHttpPart implements HttpRequest.HttpPart {
   }
 
   @Override
-  public InputStream getInputStream() throws IOException {
+  public InputStream getInputStream() {
     return inputStream;
   }
 
@@ -63,7 +62,7 @@ public class MockHttpPart implements HttpRequest.HttpPart {
   }
 
   @Override
-  public BufferedReader getReader() throws IOException {
+  public BufferedReader getReader() {
     return null;
   }
 


### PR DESCRIPTION
* Remove unused dependencies from `pom.xml`.
* Remove `@MultipartConfig`, an attempted workaround for a bug in multipart handling that unfortunately doesn't help.
* Use conventional spelling for `logger` field. It is not a constant so it should not be spelled `LOGGER`.
* Use `Map.forEach` to iterate over a map.
* Use `List.of(...)` and `Map.of(...)` instead of constructing lists and maps with statements.
* Remove unnecessary `throws IOException`.

Multipart handling is currently broken on GCF. A fix has been prepared but will not be active until it is rolled out. This sample won't work on GCF until that happens.
