### PR TITLE
Add connection pooling comment + region tag

### DIFF
--- a/functions/http/send-http-request/src/main/java/functions/SendHttpRequest.java
+++ b/functions/http/send-http-request/src/main/java/functions/SendHttpRequest.java
@@ -17,6 +17,7 @@
 package functions;
 
 // [START functions_concepts_requests]
+// [START functions_tips_connection_pooling]
 
 import com.google.cloud.functions.HttpFunction;
 import com.google.cloud.functions.HttpRequest;
@@ -31,6 +32,7 @@ import java.time.Duration;
 public class SendHttpRequest implements HttpFunction {
 
   // Create a client with some reasonable defaults. This client can be reused for multiple requests.
+  // (java.net.httpClient also pools connections automatically by default.)
   private static HttpClient client =
       HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
 
@@ -52,3 +54,4 @@ public class SendHttpRequest implements HttpFunction {
   }
 }
 // [END functions_concepts_requests]
+// [END functions_tips_connection_pooling]


### PR DESCRIPTION
The Apache `httpclient` offers a more configurable implementation, but `java.net.httpClient` seems to [support connection pooling as well.](https://stackoverflow.com/questions/53617574/how-to-keep-connection-alive-in-java-11-http-client)

I suspect this simpler, automatic implementation is fine for our docs - but I'll let @kurtisvg and @labtopia be the judges of that.