### PR TITLE
deps: use libraries bom for dependencies

### DIFF
--- a/spanner/cloud-client/pom.xml
+++ b/spanner/cloud-client/pom.xml
@@ -42,7 +42,7 @@ limitations under the License.
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>5.1.0</version>
+        <version>5.2.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/spanner/jdbc/pom.xml
+++ b/spanner/jdbc/pom.xml
@@ -28,7 +28,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>4.4.1</version>
+        <version>5.2.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/spanner/leaderboard/complete/pom.xml
+++ b/spanner/leaderboard/complete/pom.xml
@@ -32,8 +32,8 @@
     <dependencies>
       <dependency>
         <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-bom</artifactId>
-        <version>0.83.0-alpha</version>
+        <artifactId>libraries-bom</artifactId>
+        <version>5.2.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/spanner/leaderboard/step4/pom.xml
+++ b/spanner/leaderboard/step4/pom.xml
@@ -32,8 +32,8 @@
     <dependencies>
       <dependency>
         <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-bom</artifactId>
-        <version>0.83.0-alpha</version>
+        <artifactId>libraries-bom</artifactId>
+        <version>5.2.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/spanner/leaderboard/step5/pom.xml
+++ b/spanner/leaderboard/step5/pom.xml
@@ -32,8 +32,8 @@
     <dependencies>
       <dependency>
         <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-bom</artifactId>
-        <version>0.83.0-alpha</version>
+        <artifactId>libraries-bom</artifactId>
+        <version>5.2.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/spanner/leaderboard/step6/pom.xml
+++ b/spanner/leaderboard/step6/pom.xml
@@ -32,8 +32,8 @@
     <dependencies>
       <dependency>
         <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-bom</artifactId>
-        <version>0.83.0-alpha</version>
+        <artifactId>libraries-bom</artifactId>
+        <version>5.2.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
As noted in #2748, the Spanner samples should use the `libraries-bom:5.2.0` to import dependencies.
