### PR TITLE
kms: add attestation and rotation schedule sample

### DIFF
--- a/kms/src/main/java/kms/GetKeyVersionAttestation.java
+++ b/kms/src/main/java/kms/GetKeyVersionAttestation.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kms;
+
+// [START kms_get_key_version_attestation]
+import com.google.cloud.kms.v1.CryptoKeyVersion;
+import com.google.cloud.kms.v1.CryptoKeyVersionName;
+import com.google.cloud.kms.v1.KeyManagementServiceClient;
+import com.google.cloud.kms.v1.KeyOperationAttestation;
+import java.io.IOException;
+import java.util.Base64;
+
+public class GetKeyVersionAttestation {
+
+  public void getKeyVersionAttestation() throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String locationId = "us-east1";
+    String keyRingId = "my-key-ring";
+    String keyId = "my-key";
+    String keyVersionId = "123";
+    getKeyVersionAttestation(projectId, locationId, keyRingId, keyId, keyVersionId);
+  }
+
+  // Get the attestations for a key version
+  public void getKeyVersionAttestation(
+      String projectId, String locationId, String keyRingId, String keyId, String keyVersionId)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only
+    // needs to be created once, and can be reused for multiple requests. After
+    // completing all of your requests, call the "close" method on the client to
+    // safely clean up any remaining background resources.
+    try (KeyManagementServiceClient client = KeyManagementServiceClient.create()) {
+      // Build the name from the project, location, key ring, and keyId.
+      CryptoKeyVersionName keyVersionName =
+          CryptoKeyVersionName.of(projectId, locationId, keyRingId, keyId, keyVersionId);
+
+      // Get the key version.
+      CryptoKeyVersion keyVersion = client.getCryptoKeyVersion(keyVersionName);
+
+      // Only HSM keys have an attestation. For other key types, the attestion
+      // will be nil.
+      if (!keyVersion.hasAttestation()) {
+        System.out.println("no attestation");
+        return;
+      }
+
+      // Print the attestation, base64-encoded.
+      KeyOperationAttestation attestation = keyVersion.getAttestation();
+      String format = attestation.getFormat().toString();
+      byte[] content = attestation.getContent().toByteArray();
+      System.out.printf("%s: %s", format, Base64.getEncoder().encodeToString(content));
+    }
+  }
+}
+// [END kms_get_key_version_attestation]

--- a/kms/src/main/java/kms/UpdateKeyRemoveRotation.java
+++ b/kms/src/main/java/kms/UpdateKeyRemoveRotation.java
@@ -16,7 +16,7 @@
 
 package kms;
 
-// [START kms_update_key_remove_labels]
+// [START kms_update_key_remove_rotation_schedule]
 import com.google.cloud.kms.v1.CryptoKey;
 import com.google.cloud.kms.v1.CryptoKeyName;
 import com.google.cloud.kms.v1.KeyManagementServiceClient;
@@ -24,19 +24,19 @@ import com.google.protobuf.FieldMask;
 import com.google.protobuf.util.FieldMaskUtil;
 import java.io.IOException;
 
-public class UpdateKeyRemoveLabels {
+public class UpdateKeyRemoveRotation {
 
-  public void updateKeyRemoveLabels() throws IOException {
+  public void updateKeyRemoveRotation() throws IOException {
     // TODO(developer): Replace these variables before running the sample.
     String projectId = "your-project-id";
     String locationId = "us-east1";
     String keyRingId = "my-key-ring";
     String keyId = "my-key";
-    updateKeyRemoveLabels(projectId, locationId, keyRingId, keyId);
+    updateKeyRemoveRotation(projectId, locationId, keyRingId, keyId);
   }
 
   // Update a key to remove all labels.
-  public void updateKeyRemoveLabels(
+  public void updateKeyRemoveRotation(
       String projectId, String locationId, String keyRingId, String keyId) throws IOException {
     // Initialize client that will be used to send requests. This client only
     // needs to be created once, and can be reused for multiple requests. After
@@ -47,10 +47,15 @@ public class UpdateKeyRemoveLabels {
       CryptoKeyName cryptoKeyName = CryptoKeyName.of(projectId, locationId, keyRingId, keyId);
 
       // Build an empty key with no labels.
-      CryptoKey key = CryptoKey.newBuilder().setName(cryptoKeyName.toString()).build();
+      CryptoKey key =
+          CryptoKey.newBuilder()
+              .setName(cryptoKeyName.toString())
+              .clearRotationPeriod()
+              .clearNextRotationTime()
+              .build();
 
       // Construct the field mask.
-      FieldMask fieldMask = FieldMaskUtil.fromString("labels");
+      FieldMask fieldMask = FieldMaskUtil.fromString("rotation_period,next_rotation_time");
 
       // Create the key.
       CryptoKey createdKey = client.updateCryptoKey(key, fieldMask);
@@ -58,4 +63,4 @@ public class UpdateKeyRemoveLabels {
     }
   }
 }
-// [END kms_update_key_remove_labels]
+// [END kms_update_key_remove_rotation_schedule]


### PR DESCRIPTION
Add two new samples: get attestation on an hsm key, remove rotation schedule from an existing key.