### PR TITLE
deps: use libraries bom for spanner on appengine

### DIFF
--- a/appengine-java11/spanner/pom.xml
+++ b/appengine-java11/spanner/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>4.4.1</version>
+        <version>5.2.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/appengine-java8/spanner/pom.xml
+++ b/appengine-java8/spanner/pom.xml
@@ -39,12 +39,23 @@
 
     <failOnMissingWebXml>false</failOnMissingWebXml>
   </properties>
+  
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>5.2.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
-      <version>1.52.0</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>


### PR DESCRIPTION
Changes the appengine examples to use the latest version of the libraries-bom.