### PR TITLE
Handle undefined environment variables.

### DIFF
--- a/functions/ocr/ocr-translate-text/src/main/java/functions/OcrTranslateText.java
+++ b/functions/ocr/ocr-translate-text/src/main/java/functions/OcrTranslateText.java
@@ -36,10 +36,11 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class OcrTranslateText implements BackgroundFunction<PubSubMessage> {
-  // TODO<developer> set these environment variables
-  private static final String PROJECT_ID = System.getenv("GCP_PROJECT");
-  private static final String RESULTS_TOPIC_NAME = System.getenv("RESULT_TOPIC");
   private static final Logger LOGGER = Logger.getLogger(OcrTranslateText.class.getName());
+
+  // TODO<developer> set these environment variables
+  private static final String PROJECT_ID = getenv("GCP_PROJECT");
+  private static final String RESULTS_TOPIC_NAME = getenv("RESULT_TOPIC");
   private static final String LOCATION_NAME = LocationName.of(PROJECT_ID, "global").toString();
 
   private Publisher publisher;
@@ -96,6 +97,15 @@ public class OcrTranslateText implements BackgroundFunction<PubSubMessage> {
       // Log error (since these exception types cannot be thrown by a function)
       LOGGER.log(Level.SEVERE, "Error publishing translation save request: " + e.getMessage(), e);
     }
+  }
+
+  private static String getenv(String name) {
+    String value = System.getenv(name);
+    if (value == null) {
+      logger.warning("Environment variable " + name + " is undefined");
+      value = "MISSING";
+    }
+    return value;
   }
 }
 // [END functions_ocr_translate]

--- a/functions/slack/src/main/java/functions/SlackSlashCommand.java
+++ b/functions/slack/src/main/java/functions/SlackSlashCommand.java
@@ -32,13 +32,15 @@ import java.net.HttpURLConnection;
 import java.security.GeneralSecurityException;
 import java.util.HashMap;
 import java.util.List;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 public class SlackSlashCommand implements HttpFunction {
 
   // [START functions_slack_setup]
-  private static final String API_KEY = System.getenv("KG_API_KEY");
-  private static final String SLACK_SECRET = System.getenv("SLACK_SECRET");
+  private static final Logger logger = Logger.getLogger("functions.SlackSlashCommand");
+  private static final String API_KEY = getenv("KG_API_KEY");
+  private static final String SLACK_SECRET = getenv("SLACK_SECRET");
   private static final Gson gson = new Gson();
 
   private Kgsearch kgClient;
@@ -49,6 +51,15 @@ public class SlackSlashCommand implements HttpFunction {
         GoogleNetHttpTransport.newTrustedTransport(), new JacksonFactory(), null).build();
 
     verifier = new SlackSignature.Verifier(new SlackSignature.Generator(SLACK_SECRET));
+  }
+
+  private static String getenv(String name) {
+    String value = System.getenv(name);
+    if (value == null) {
+      logger.warning("Environment variable " + name + " is undefined");
+      value = "MISSING";
+    }
+    return value;
   }
   // [END functions_slack_setup]
 


### PR DESCRIPTION
Avoid getting an exception in certain samples when environment variables
are not defined. Exceptions end up being translated into HTTP 500 status
codes, which in turn causes deployment of these functions to fail the
post-deployment health check.