### PR TITLE
Remove PowerMock from nearly all samples, in favour of plain Mockito.

### DIFF
--- a/functions/concepts/env-vars/pom.xml
+++ b/functions/concepts/env-vars/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -72,24 +71,6 @@
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <version>1.0.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/concepts/env-vars/src/test/java/functions/EnvVarsTest.java
+++ b/functions/concepts/env-vars/src/test/java/functions/EnvVarsTest.java
@@ -17,7 +17,7 @@
 package functions;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.functions.HttpRequest;
 import com.google.cloud.functions.HttpResponse;
@@ -31,8 +31,7 @@ import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class EnvVarsTest {
@@ -47,14 +46,11 @@ public class EnvVarsTest {
 
   @Before
   public void beforeTest() throws IOException {
-    Mockito.mockitoSession().initMocks(this);
-
-    request = mock(HttpRequest.class);
-    response = mock(HttpResponse.class);
+    MockitoAnnotations.initMocks(this);
 
     responseOut = new StringWriter();
     writerOut = new BufferedWriter(responseOut);
-    PowerMockito.when(response.getWriter()).thenReturn(writerOut);
+    when(response.getWriter()).thenReturn(writerOut);
   }
 
   @Test

--- a/functions/concepts/execution-count/pom.xml
+++ b/functions/concepts/execution-count/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -67,21 +66,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.3.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/concepts/execution-count/src/test/java/functions/ExecutionCountTest.java
+++ b/functions/concepts/execution-count/src/test/java/functions/ExecutionCountTest.java
@@ -17,7 +17,8 @@
 package functions;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.functions.HttpRequest;
 import com.google.cloud.functions.HttpResponse;
@@ -29,7 +30,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
 
 @RunWith(JUnit4.class)
 public class ExecutionCountTest {
@@ -46,7 +46,7 @@ public class ExecutionCountTest {
 
     responseOut = new StringWriter();
     writerOut = new BufferedWriter(responseOut);
-    PowerMockito.when(response.getWriter()).thenReturn(writerOut);
+    when(response.getWriter()).thenReturn(writerOut);
   }
 
   @Test

--- a/functions/concepts/file-system/pom.xml
+++ b/functions/concepts/file-system/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -60,29 +59,10 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Required for mocking env vars -->
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <version>1.0.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/concepts/file-system/src/test/java/functions/FileSystemTest.java
+++ b/functions/concepts/file-system/src/test/java/functions/FileSystemTest.java
@@ -17,8 +17,7 @@
 package functions;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.functions.HttpRequest;
 import com.google.cloud.functions.HttpResponse;
@@ -33,7 +32,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class FileSystemTest {
@@ -45,14 +44,11 @@ public class FileSystemTest {
 
   @Before
   public void beforeTest() throws IOException {
-    Mockito.mockitoSession().initMocks(this);
-
-    request = mock(HttpRequest.class);
-    response = mock(HttpResponse.class);
+    MockitoAnnotations.initMocks(this);
 
     responseOut = new StringWriter();
     writerOut = new BufferedWriter(responseOut);
-    PowerMockito.when(response.getWriter()).thenReturn(writerOut);
+    when(response.getWriter()).thenReturn(writerOut);
   }
 
   @Test

--- a/functions/concepts/lazy-fields/pom.xml
+++ b/functions/concepts/lazy-fields/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -64,24 +63,6 @@
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <version>1.0.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/concepts/lazy-fields/src/test/java/functions/LazyFieldsTest.java
+++ b/functions/concepts/lazy-fields/src/test/java/functions/LazyFieldsTest.java
@@ -17,23 +17,20 @@
 package functions;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.functions.HttpRequest;
 import com.google.cloud.functions.HttpResponse;
-import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.io.StringReader;
 import java.io.StringWriter;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class LazyFieldsTest {
@@ -45,14 +42,14 @@ public class LazyFieldsTest {
 
   @Before
   public void beforeTest() throws IOException {
-    Mockito.mockitoSession().initMocks(this);
+    MockitoAnnotations.initMocks(this);
 
     request = mock(HttpRequest.class);
     response = mock(HttpResponse.class);
 
     responseOut = new StringWriter();
     writerOut = new BufferedWriter(responseOut);
-    PowerMockito.when(response.getWriter()).thenReturn(writerOut);
+    when(response.getWriter()).thenReturn(writerOut);
   }
 
   @Test

--- a/functions/concepts/retry-pubsub/pom.xml
+++ b/functions/concepts/retry-pubsub/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -69,24 +68,6 @@
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <version>1.0.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/functions/concepts/retry-pubsub/src/test/java/functions/RetryPubSubTest.java
+++ b/functions/concepts/retry-pubsub/src/test/java/functions/RetryPubSubTest.java
@@ -25,7 +25,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.logging.Logger;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/functions/concepts/retry-timeout/pom.xml
+++ b/functions/concepts/retry-timeout/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -70,24 +69,6 @@
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <version>1.0.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/functions/concepts/retry-timeout/src/test/java/functions/RetryTimeoutTest.java
+++ b/functions/concepts/retry-timeout/src/test/java/functions/RetryTimeoutTest.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.TestLogHandler;
 import functions.eventpojos.PubSubMessage;
-import java.io.IOException;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -31,7 +30,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class RetryTimeoutTest {
@@ -48,8 +47,8 @@ public class RetryTimeoutTest {
   }
 
   @Before
-  public void beforeTest() throws IOException {
-    Mockito.mockitoSession().initMocks(this);
+  public void beforeTest() {
+    MockitoAnnotations.initMocks(this);
 
     LOG_HANDLER.clear();
   }
@@ -61,7 +60,7 @@ public class RetryTimeoutTest {
   }
 
   @Test
-  public void retryTimeout_handlesRetryMsg() throws IOException {
+  public void retryTimeout_handlesRetryMsg() {
     String timestampData = String.format(
         "{\"timestamp\":\"%s\"}", ZonedDateTime.now(ZoneOffset.UTC).toString());
 
@@ -75,7 +74,7 @@ public class RetryTimeoutTest {
   }
 
   @Test
-  public void retryTimeout_handlesStopMsg() throws IOException {
+  public void retryTimeout_handlesStopMsg() {
     String timestamp = ZonedDateTime.ofInstant(Instant.ofEpochMilli(0), ZoneOffset.UTC).toString();
     String timestampData = String.format("{\"timestamp\":\"%s\"}", timestamp);
 
@@ -90,7 +89,7 @@ public class RetryTimeoutTest {
   }
 
   @Test
-  public void retryTimeout_handlesEmptyMsg() throws IOException {
+  public void retryTimeout_handlesEmptyMsg() {
     PubSubMessage pubsubMessage = new PubSubMessage();
     pubsubMessage.setData("");
 

--- a/functions/concepts/scopes/pom.xml
+++ b/functions/concepts/scopes/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -64,24 +63,6 @@
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <version>1.0.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/concepts/scopes/src/test/java/functions/ScopesTest.java
+++ b/functions/concepts/scopes/src/test/java/functions/ScopesTest.java
@@ -17,8 +17,7 @@
 package functions;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.functions.HttpRequest;
 import com.google.cloud.functions.HttpResponse;
@@ -32,8 +31,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class ScopesTest {
@@ -45,17 +43,14 @@ public class ScopesTest {
 
   @Before
   public void beforeTest() throws IOException {
-    Mockito.mockitoSession().initMocks(this);
-
-    request = mock(HttpRequest.class);
-    response = mock(HttpResponse.class);
+    MockitoAnnotations.initMocks(this);
 
     BufferedReader reader = new BufferedReader(new StringReader("{}"));
     when(request.getReader()).thenReturn(reader);
 
     responseOut = new StringWriter();
     writerOut = new BufferedWriter(responseOut);
-    PowerMockito.when(response.getWriter()).thenReturn(writerOut);
+    when(response.getWriter()).thenReturn(writerOut);
   }
 
   @Test

--- a/functions/firebase/firestore-reactive/pom.xml
+++ b/functions/firebase/firestore-reactive/pom.xml
@@ -35,7 +35,6 @@
 
   <!-- [START functions_java_example_pom] -->
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -58,24 +57,6 @@
 
     <!-- The following dependencies are only required for testing -->
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>5.6.2</version>
@@ -85,6 +66,12 @@
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <version>1.0.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.3.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/functions/firebase/firestore-reactive/src/main/java/functions/FirebaseFirestoreReactive.java
+++ b/functions/firebase/firestore-reactive/src/main/java/functions/FirebaseFirestoreReactive.java
@@ -40,6 +40,16 @@ public class FirebaseFirestoreReactive implements RawBackgroundFunction {
   private static final Logger logger = Logger.getLogger(FirebaseFirestoreReactive.class.getName());
   private static final Firestore FIRESTORE = FirestoreOptions.getDefaultInstance().getService();
 
+  private final Firestore firestore;
+
+  public FirebaseFirestoreReactive() {
+    this(FIRESTORE);
+  }
+
+  FirebaseFirestoreReactive(Firestore firestore) {
+    this.firestore = firestore;
+  }
+
   @Override
   public void accept(String json, Context context) {
     // Get the recently-written value

--- a/functions/firebase/firestore-reactive/src/test/java/functions/FirebaseFirestoreReactiveTest.java
+++ b/functions/firebase/firestore-reactive/src/test/java/functions/FirebaseFirestoreReactiveTest.java
@@ -16,15 +16,14 @@
 
 package functions;
 
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.firestore.DocumentReference;
 import com.google.cloud.firestore.Firestore;
 import com.google.common.testing.TestLogHandler;
 import com.google.common.truth.Truth;
 import functions.eventpojos.MockContext;
-import java.io.IOException;
 import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
@@ -33,11 +32,8 @@ import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.reflect.Whitebox;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class FirebaseFirestoreReactiveTest {
@@ -57,14 +53,12 @@ public class FirebaseFirestoreReactiveTest {
   }
 
   @Before
-  public void beforeTest() throws IOException {
-    Mockito.mockitoSession().initMocks(this);
+  public void beforeTest() {
+    MockitoAnnotations.initMocks(this);
 
-    referenceMock = mock(DocumentReference.class, Mockito.RETURNS_DEEP_STUBS);
-    when(referenceMock.set(ArgumentMatchers.any())).thenReturn(null);
+    when(referenceMock.set(any())).thenReturn(null);
 
-    firestoreMock = PowerMockito.mock(Firestore.class);
-    when(firestoreMock.document(ArgumentMatchers.any())).thenReturn(referenceMock);
+    when(firestoreMock.document(any())).thenReturn(referenceMock);
 
     LOG_HANDLER.clear();
   }
@@ -82,8 +76,7 @@ public class FirebaseFirestoreReactiveTest {
     MockContext context = new MockContext();
     context.resource = "projects/_/databases/(default)/documents/messages/ABCDE12345";
 
-    FirebaseFirestoreReactive functionInstance = new FirebaseFirestoreReactive();
-    Whitebox.setInternalState(FirebaseFirestoreReactive.class, "FIRESTORE", firestoreMock);
+    FirebaseFirestoreReactive functionInstance = new FirebaseFirestoreReactive(firestoreMock);
 
     functionInstance.accept(jsonStr, context);
 
@@ -98,8 +91,7 @@ public class FirebaseFirestoreReactiveTest {
     MockContext context = new MockContext();
     context.resource = "projects/_/databases/(default)/documents/messages/ABCDE12345";
 
-    FirebaseFirestoreReactive functionInstance = new FirebaseFirestoreReactive();
-    Whitebox.setInternalState(FirebaseFirestoreReactive.class, "FIRESTORE", firestoreMock);
+    FirebaseFirestoreReactive functionInstance = new FirebaseFirestoreReactive(firestoreMock);
 
     IllegalArgumentException e = Assertions.assertThrows(
         IllegalArgumentException.class, () -> functionInstance.accept(jsonStr, context));

--- a/functions/helloworld/groovy-helloworld/pom.xml
+++ b/functions/helloworld/groovy-helloworld/pom.xml
@@ -34,9 +34,6 @@
   
   <!-- [START functions_groovy_pom] -->
   <properties>
-    <!-- [END functions_groovy_pom] -->
-    <powermock.version>2.0.7</powermock.version>
-    <!-- [START functions_groovy_pom] -->
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -74,7 +71,6 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Required for mocking env vars -->
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
@@ -85,24 +81,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <version>29.0-jre</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- [START functions_groovy_pom] -->

--- a/functions/helloworld/groovy-helloworld/src/test/java/functions/GroovyHelloWorldTest.java
+++ b/functions/helloworld/groovy-helloworld/src/test/java/functions/GroovyHelloWorldTest.java
@@ -17,6 +17,7 @@
 package functions;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.functions.HttpRequest;
 import com.google.cloud.functions.HttpResponse;
@@ -28,8 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class GroovyHelloWorldTest {
@@ -41,14 +41,11 @@ public class GroovyHelloWorldTest {
 
   @Before
   public void beforeTest() throws IOException {
-    Mockito.mockitoSession().initMocks(this);
-
-    request = PowerMockito.mock(HttpRequest.class);
-    response = PowerMockito.mock(HttpResponse.class);
+    MockitoAnnotations.initMocks(this);
 
     responseOut = new StringWriter();
     writerOut = new BufferedWriter(responseOut);
-    PowerMockito.when(response.getWriter()).thenReturn(writerOut);
+    when(response.getWriter()).thenReturn(writerOut);
   }
 
   @Test

--- a/functions/helloworld/hello-http/pom.xml
+++ b/functions/helloworld/hello-http/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -53,24 +52,6 @@
     </dependency>
 
     <!-- The following dependencies are only required for testing -->
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
@@ -103,6 +84,12 @@
       <groupId>com.google.cloud.functions</groupId>
       <artifactId>function-maven-plugin</artifactId>
       <version>0.9.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.3.3</version>
       <scope>test</scope>
     </dependency>
 

--- a/functions/helloworld/hello-http/src/test/java/functions/ExampleSystemTest.java
+++ b/functions/helloworld/hello-http/src/test/java/functions/ExampleSystemTest.java
@@ -24,8 +24,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/functions/helloworld/hello-http/src/test/java/functions/HelloHttpTest.java
+++ b/functions/helloworld/hello-http/src/test/java/functions/HelloHttpTest.java
@@ -19,8 +19,7 @@ package functions;
 // [START functions_http_unit_test]
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.functions.HttpRequest;
 import com.google.cloud.functions.HttpResponse;
@@ -35,7 +34,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class HelloHttpTest {
@@ -47,10 +46,7 @@ public class HelloHttpTest {
 
   @Before
   public void beforeTest() throws IOException {
-    Mockito.mockitoSession().initMocks(this);
-
-    request = mock(HttpRequest.class);
-    response = mock(HttpResponse.class);
+    MockitoAnnotations.initMocks(this);
 
     // use an empty string as the default request content
     BufferedReader reader = new BufferedReader(new StringReader(""));

--- a/functions/helloworld/hello-pubsub/pom.xml
+++ b/functions/helloworld/hello-pubsub/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -60,24 +59,6 @@
     </dependency>
 
     <!-- The following dependencies are only required for testing -->
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>

--- a/functions/helloworld/hello-pubsub/src/test/java/functions/HelloPubSubTest.java
+++ b/functions/helloworld/hello-pubsub/src/test/java/functions/HelloPubSubTest.java
@@ -28,14 +28,12 @@ import java.util.logging.Logger;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.junit.runners.JUnit4;
 
 /**
  * Unit tests for main.java.com.example.functions.helloworld.HelloPubSub.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(HelloPubSub.class)
+@RunWith(JUnit4.class)
 public class HelloPubSubTest {
 
   private HelloPubSub sampleUnderTest;
@@ -44,14 +42,14 @@ public class HelloPubSubTest {
   private static final TestLogHandler LOG_HANDLER = new TestLogHandler();
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     sampleUnderTest = new HelloPubSub();
     logger.addHandler(LOG_HANDLER);
     LOG_HANDLER.clear();
   }
 
   @Test
-  public void helloPubSub_shouldPrintName() throws Exception {
+  public void helloPubSub_shouldPrintName() {
     PubSubMessage pubSubMessage = new PubSubMessage();
     pubSubMessage.setData(Base64.getEncoder().encodeToString(
         "John".getBytes(StandardCharsets.UTF_8)));
@@ -62,7 +60,7 @@ public class HelloPubSubTest {
   }
 
   @Test
-  public void helloPubSub_shouldPrintHelloWorld() throws Exception {
+  public void helloPubSub_shouldPrintHelloWorld() {
     PubSubMessage pubSubMessage = new PubSubMessage();
     sampleUnderTest.accept(pubSubMessage, null);
 

--- a/functions/helloworld/helloworld/pom.xml
+++ b/functions/helloworld/helloworld/pom.xml
@@ -34,9 +34,6 @@
 
   <!-- [START functions_example_pom] -->
   <properties>
-    <!-- [END functions_example_pom] -->
-    <powermock.version>2.0.7</powermock.version>
-    <!-- [START functions_example_pom] -->
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -54,24 +51,6 @@
 
     <!-- The following dependencies are only required for testing -->
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <version>1.0.1</version>
@@ -81,6 +60,12 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <version>29.0-jre</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.3.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/helloworld/helloworld/src/test/java/functions/HelloWorldTest.java
+++ b/functions/helloworld/helloworld/src/test/java/functions/HelloWorldTest.java
@@ -17,8 +17,7 @@
 package functions;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.functions.HttpRequest;
 import com.google.cloud.functions.HttpResponse;
@@ -30,7 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class HelloWorldTest {
@@ -42,10 +41,7 @@ public class HelloWorldTest {
 
   @Before
   public void beforeTest() throws IOException {
-    Mockito.mockitoSession().initMocks(this);
-
-    request = mock(HttpRequest.class);
-    response = mock(HttpResponse.class);
+    MockitoAnnotations.initMocks(this);
 
     responseOut = new StringWriter();
     writerOut = new BufferedWriter(responseOut);

--- a/functions/helloworld/kotlin-helloworld/pom.xml
+++ b/functions/helloworld/kotlin-helloworld/pom.xml
@@ -34,9 +34,6 @@
   <!-- [START functions_kotlin_pom] -->
 
   <properties>
-    <!-- [END functions_kotlin_pom] -->
-    <powermock.version>2.0.7</powermock.version>
-    <!-- [START functions_kotlin_pom] -->
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -78,7 +75,6 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Required for mocking env vars -->
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
@@ -89,24 +85,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <version>29.0-jre</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- [START functions_kotlin_pom] -->

--- a/functions/helloworld/kotlin-helloworld/src/test/java/functions/KotlinHelloWorldTest.java
+++ b/functions/helloworld/kotlin-helloworld/src/test/java/functions/KotlinHelloWorldTest.java
@@ -17,6 +17,7 @@
 package functions;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.functions.HttpRequest;
 import com.google.cloud.functions.HttpResponse;
@@ -28,8 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class KotlinHelloWorldTest {
@@ -41,14 +41,11 @@ public class KotlinHelloWorldTest {
 
   @Before
   public void beforeTest() throws IOException {
-    Mockito.mockitoSession().initMocks(this);
-
-    request = PowerMockito.mock(HttpRequest.class);
-    response = PowerMockito.mock(HttpResponse.class);
+    MockitoAnnotations.initMocks(this);
 
     responseOut = new StringWriter();
     writerOut = new BufferedWriter(responseOut);
-    PowerMockito.when(response.getWriter()).thenReturn(writerOut);
+    when(response.getWriter()).thenReturn(writerOut);
   }
 
   @Test

--- a/functions/helloworld/scala-hello-pubsub/pom.xml
+++ b/functions/helloworld/scala-hello-pubsub/pom.xml
@@ -60,7 +60,6 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Required for mocking env vars -->
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>

--- a/functions/helloworld/scala-helloworld/pom.xml
+++ b/functions/helloworld/scala-helloworld/pom.xml
@@ -34,9 +34,6 @@
   
   <!-- [START functions_scala_pom] -->
   <properties>
-    <!-- [END functions_scala_pom] -->
-    <powermock.version>2.0.7</powermock.version>
-    <!-- [START functions_scala_pom] -->
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -72,7 +69,6 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Required for mocking env vars -->
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
@@ -83,24 +79,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <version>29.0-jre</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- [START functions_scala_pom] -->

--- a/functions/helloworld/scala-helloworld/src/test/java/functions/ScalaHelloWorldTest.java
+++ b/functions/helloworld/scala-helloworld/src/test/java/functions/ScalaHelloWorldTest.java
@@ -17,13 +17,12 @@
 package functions;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.functions.HttpRequest;
 import com.google.cloud.functions.HttpResponse;
-import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.io.StringReader;
 import java.io.StringWriter;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,7 +30,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class ScalaHelloWorldTest {
@@ -43,14 +42,11 @@ public class ScalaHelloWorldTest {
 
   @Before
   public void beforeTest() throws IOException {
-    Mockito.mockitoSession().initMocks(this);
-
-    request = PowerMockito.mock(HttpRequest.class);
-    response = PowerMockito.mock(HttpResponse.class);
+    MockitoAnnotations.initMocks(this);
 
     responseOut = new StringWriter();
     writerOut = new BufferedWriter(responseOut);
-    PowerMockito.when(response.getWriter()).thenReturn(writerOut);
+    when(response.getWriter()).thenReturn(writerOut);
   }
 
   @Test

--- a/functions/http/bearer-token-http/pom.xml
+++ b/functions/http/bearer-token-http/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/functions/http/cors-enabled-auth/pom.xml
+++ b/functions/http/cors-enabled-auth/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -70,29 +69,17 @@
       <version>1.0.1</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.3.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/http/cors-enabled-auth/src/test/java/functions/CorsEnabledAuthTest.java
+++ b/functions/http/cors-enabled-auth/src/test/java/functions/CorsEnabledAuthTest.java
@@ -17,8 +17,7 @@
 package functions;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.functions.HttpRequest;
 import com.google.cloud.functions.HttpResponse;
@@ -31,7 +30,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class CorsEnabledAuthTest {
@@ -43,14 +42,11 @@ public class CorsEnabledAuthTest {
 
   @Before
   public void beforeTest() throws IOException {
-    Mockito.mockitoSession().initMocks(this);
-
-    request = mock(HttpRequest.class);
-    response = mock(HttpResponse.class);
+    MockitoAnnotations.initMocks(this);
 
     responseOut = new StringWriter();
     writerOut = new BufferedWriter(responseOut);
-    PowerMockito.when(response.getWriter()).thenReturn(writerOut);
+    when(response.getWriter()).thenReturn(writerOut);
   }
 
   @Test

--- a/functions/http/cors-enabled/pom.xml
+++ b/functions/http/cors-enabled/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -70,29 +69,17 @@
       <version>1.0.1</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.3.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/http/cors-enabled/src/test/java/functions/CorsEnabledTest.java
+++ b/functions/http/cors-enabled/src/test/java/functions/CorsEnabledTest.java
@@ -17,8 +17,7 @@
 package functions;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.functions.HttpRequest;
 import com.google.cloud.functions.HttpResponse;
@@ -30,8 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class CorsEnabledTest {
@@ -43,14 +41,11 @@ public class CorsEnabledTest {
 
   @Before
   public void beforeTest() throws IOException {
-    Mockito.mockitoSession().initMocks(this);
-
-    request = mock(HttpRequest.class);
-    response = mock(HttpResponse.class);
+    MockitoAnnotations.initMocks(this);
 
     responseOut = new StringWriter();
     writerOut = new BufferedWriter(responseOut);
-    PowerMockito.when(response.getWriter()).thenReturn(writerOut);
+    when(response.getWriter()).thenReturn(writerOut);
   }
 
   @Test

--- a/functions/http/http-form-data/pom.xml
+++ b/functions/http/http-form-data/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -71,24 +70,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <version>29.0-jre</version>
@@ -99,6 +80,12 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.3.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/http/http-form-data/src/test/java/functions/HttpFormDataTest.java
+++ b/functions/http/http-form-data/src/test/java/functions/HttpFormDataTest.java
@@ -19,8 +19,7 @@ package functions;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.functions.HttpRequest;
 import com.google.cloud.functions.HttpRequest.HttpPart;
@@ -44,7 +43,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class HttpFormDataTest {
@@ -64,14 +63,11 @@ public class HttpFormDataTest {
 
   @Before
   public void beforeTest() throws IOException {
-    Mockito.mockitoSession().initMocks(this);
-
-    request = mock(HttpRequest.class);
-    response = mock(HttpResponse.class);
+    MockitoAnnotations.initMocks(this);
 
     responseOut = new StringWriter();
     writerOut = new BufferedWriter(responseOut);
-    PowerMockito.when(response.getWriter()).thenReturn(writerOut);
+    when(response.getWriter()).thenReturn(writerOut);
 
     logHandler.clear();
   }

--- a/functions/http/http-method/pom.xml
+++ b/functions/http/http-method/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -71,28 +70,15 @@
 
     <!-- The following dependencies are only required for testing -->
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.3.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/http/http-method/src/test/java/functions/HttpMethodTest.java
+++ b/functions/http/http-method/src/test/java/functions/HttpMethodTest.java
@@ -19,29 +19,20 @@ package functions;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.functions.HttpRequest;
 import com.google.cloud.functions.HttpResponse;
-import java.io.BufferedReader;
 import java.io.BufferedWriter;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.HttpURLConnection;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class HttpMethodTest {
@@ -53,14 +44,11 @@ public class HttpMethodTest {
 
   @Before
   public void beforeTest() throws IOException {
-    Mockito.mockitoSession().initMocks(this);
-
-    request = mock(HttpRequest.class);
-    response = mock(HttpResponse.class);
+    MockitoAnnotations.initMocks(this);
 
     responseOut = new StringWriter();
     writerOut = new BufferedWriter(responseOut);
-    PowerMockito.when(response.getWriter()).thenReturn(writerOut);
+    when(response.getWriter()).thenReturn(writerOut);
   }
 
   @Test

--- a/functions/http/parse-content-type/pom.xml
+++ b/functions/http/parse-content-type/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -75,29 +74,17 @@
       <version>1.0.1</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.3.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/http/parse-content-type/src/test/java/functions/ParseContentTypeTest.java
+++ b/functions/http/parse-content-type/src/test/java/functions/ParseContentTypeTest.java
@@ -17,10 +17,7 @@
 package functions;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.functions.HttpRequest;
 import com.google.cloud.functions.HttpResponse;
@@ -31,7 +28,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Optional;
@@ -40,8 +36,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class ParseContentTypeTest {
@@ -53,14 +48,11 @@ public class ParseContentTypeTest {
 
   @Before
   public void beforeTest() throws IOException {
-    Mockito.mockitoSession().initMocks(this);
-
-    request = mock(HttpRequest.class);
-    response = mock(HttpResponse.class);
+    MockitoAnnotations.initMocks(this);
 
     responseOut = new StringWriter();
     writerOut = new BufferedWriter(responseOut);
-    PowerMockito.when(response.getWriter()).thenReturn(writerOut);
+    when(response.getWriter()).thenReturn(writerOut);
   }
 
   @Test

--- a/functions/http/send-http-request/pom.xml
+++ b/functions/http/send-http-request/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -70,29 +69,17 @@
       <version>1.0.1</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.3.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/http/send-http-request/src/test/java/functions/SendHttpRequestTest.java
+++ b/functions/http/send-http-request/src/test/java/functions/SendHttpRequestTest.java
@@ -17,7 +17,7 @@
 package functions;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.functions.HttpRequest;
 import com.google.cloud.functions.HttpResponse;
@@ -29,8 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class SendHttpRequestTest {
@@ -42,14 +41,11 @@ public class SendHttpRequestTest {
 
   @Before
   public void beforeTest() throws IOException {
-    Mockito.mockitoSession().initMocks(this);
-
-    request = mock(HttpRequest.class);
-    response = mock(HttpResponse.class);
+    MockitoAnnotations.initMocks(this);
 
     responseOut = new StringWriter();
     writerOut = new BufferedWriter(responseOut);
-    PowerMockito.when(response.getWriter()).thenReturn(writerOut);
+    when(response.getWriter()).thenReturn(writerOut);
   }
 
   @Test

--- a/functions/logging/log-helloworld/pom.xml
+++ b/functions/logging/log-helloworld/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/functions/logging/retrieve-logs/pom.xml
+++ b/functions/logging/retrieve-logs/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -65,24 +64,6 @@
 
     <!-- The following dependencies are only required for testing -->
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>5.6.2</version>
@@ -98,6 +79,12 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <version>29.0-jre</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.3.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/logging/retrieve-logs/src/test/java/functions/RetrieveLogsTest.java
+++ b/functions/logging/retrieve-logs/src/test/java/functions/RetrieveLogsTest.java
@@ -17,7 +17,7 @@
 package functions;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.functions.HttpRequest;
 import com.google.cloud.functions.HttpResponse;
@@ -32,8 +32,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class RetrieveLogsTest {
@@ -56,14 +55,11 @@ public class RetrieveLogsTest {
 
   @Before
   public void beforeTest() throws IOException {
-    Mockito.mockitoSession().initMocks(this);
-
-    request = mock(HttpRequest.class);
-    response = mock(HttpResponse.class);
+    MockitoAnnotations.initMocks(this);
 
     responseOut = new StringWriter();
     writerOut = new BufferedWriter(responseOut);
-    PowerMockito.when(response.getWriter()).thenReturn(writerOut);
+    when(response.getWriter()).thenReturn(writerOut);
   }
 
   @Test

--- a/functions/ocr/ocr-process-image/pom.xml
+++ b/functions/ocr/ocr-process-image/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/functions/ocr/ocr-save-result/pom.xml
+++ b/functions/ocr/ocr-save-result/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/functions/ocr/ocr-translate-text/pom.xml
+++ b/functions/ocr/ocr-translate-text/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/functions/ocr/ocr-translate-text/src/test/java/functions/OcrTranslateTextTest.java
+++ b/functions/ocr/ocr-translate-text/src/test/java/functions/OcrTranslateTextTest.java
@@ -29,7 +29,10 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class OcrTranslateTextTest {
   private static final Logger logger = Logger.getLogger(
       OcrTranslateText.class.getName());

--- a/functions/pubsub/publish-message/pom.xml
+++ b/functions/pubsub/publish-message/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -70,24 +69,6 @@
 
     <!-- The following dependencies are only required for testing -->
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <version>1.0.1</version>
@@ -97,6 +78,12 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <version>29.0-jre</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.3.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/pubsub/publish-message/src/test/java/functions/PublishMessageTest.java
+++ b/functions/pubsub/publish-message/src/test/java/functions/PublishMessageTest.java
@@ -35,8 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class PublishMessageTest {
@@ -58,17 +57,14 @@ public class PublishMessageTest {
 
   @Before
   public void beforeTest() throws IOException {
-    Mockito.mockitoSession().initMocks(this);
-
-    request = PowerMockito.mock(HttpRequest.class);
-    response = PowerMockito.mock(HttpResponse.class);
+    MockitoAnnotations.initMocks(this);
 
     BufferedReader reader = new BufferedReader(new StringReader("{}"));
-    PowerMockito.when(request.getReader()).thenReturn(reader);
+    when(request.getReader()).thenReturn(reader);
 
     responseOut = new StringWriter();
     writerOut = new BufferedWriter(responseOut);
-    PowerMockito.when(response.getWriter()).thenReturn(writerOut);
+    when(response.getWriter()).thenReturn(writerOut);
 
     logHandler.clear();
   }

--- a/functions/spanner/pom.xml
+++ b/functions/spanner/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <mockito.version>3.3.3</mockito.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Also use the more usual `MockitoAnnotations.initMocks(this)` rather than
`Mockito.mockitoSession().initMocks(this)`. Remove some unnecessary
`throws` clauses. Pass a value through a second constructor rather than
bashing a field with PowerMock's Whitebox.