### PR TITLE
Update AuthExample.java

### DIFF
--- a/auth/src/main/java/com/google/cloud/auth/samples/AuthExample.java
+++ b/auth/src/main/java/com/google/cloud/auth/samples/AuthExample.java
@@ -26,6 +26,7 @@ import com.google.cloud.storage.StorageOptions;
 import com.google.common.collect.Lists;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Collections;
 
 /**
  * Demonstrate various ways to authenticate requests using Cloud Storage as an example call.

--- a/auth/src/main/java/com/google/cloud/auth/samples/AuthExample.java
+++ b/auth/src/main/java/com/google/cloud/auth/samples/AuthExample.java
@@ -50,7 +50,7 @@ public class AuthExample {
     // You can specify a credential file by providing a path to GoogleCredentials.
     // Otherwise credentials are read from the GOOGLE_APPLICATION_CREDENTIALS environment variable.
     GoogleCredentials credentials = GoogleCredentials.fromStream(new FileInputStream(jsonPath))
-          .createScoped(Lists.newArrayList("https://www.googleapis.com/auth/cloud-platform"));
+          .createScoped(Lists.newArrayList(Collections.singleton("https://www.googleapis.com/auth/cloud-platform")));
     Storage storage = StorageOptions.newBuilder().setCredentials(credentials).build().getService();
 
     System.out.println("Buckets:");


### PR DESCRIPTION
wrap hardcoded string in Collections.singleton to allow Lists util to make a new ArrayList from it

When I tried to use this authExplicit example in IntelliJ IDEA, I was met with a static code analysis error and this change fixed it.

> It's a good idea to open an issue first for discussion.

- [ x] `pom.xml` parent set to latest `shared-configuration`
- [ x] Appropriate changes to README are included in PR
- [x ] API's need to be enabled to test (tell us)
- [ x] Environment Variables need to be set (ask us to set them)
- [x ] Tests pass (`mvn -P lint clean verify`)
  * (Note- `Checkstyle` passing is required; `Spotbugs`, `ErrorProne`, `PMD`, etc. `ERROR`'s are advisory only)
- [x ] Please **merge** this PR for me once it is approved.
