### PR TITLE
healthcare API: fix FHIR store metadata FHIR_NAME pattern, move file …

### DIFF
--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/FhirStoreGetMetadata.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/FhirStoreGetMetadata.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package snippets.healthcare.fhir.resources;
+package snippets.healthcare.fhir;
 
 // [START healthcare_get_metadata]
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/FhirStoreGetMetadata.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/FhirStoreGetMetadata.java
@@ -29,27 +29,27 @@ import com.google.api.services.healthcare.v1.model.HttpBody;
 import java.io.IOException;
 import java.util.Collections;
 
-public class FhirResourceGetMetadata {
+public class FhirStoreGetMetadata {
   private static final String FHIR_NAME =
-      "projects/%s/locations/%s/datasets/%s/fhirStores/%s/fhir/%s";
+      "projects/%s/locations/%s/datasets/%s/fhirStores/%s";
   private static final JsonFactory JSON_FACTORY = new JacksonFactory();
   private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
 
-  public static void fhirResourceGetMetadata(String resourceName) throws IOException {
-    // String resourceName =
+  public static void fhirStoreGetMetadata(String fhirStoreName) throws IOException {
+    // String fhirStoreName =
     //    String.format(
-    //        FHIR_NAME, "project-id", "region-id", "dataset-id", "store-id", "fhir-id");
+    //        FHIR_NAME, "project-id", "region-id", "dataset-id", "store-id");
 
     // Initialize the client, which will be used to interact with the service.
     CloudHealthcare client = createClient();
 
     // Create request and configure any parameters.
     Capabilities request =
-        client.projects().locations().datasets().fhirStores().fhir().capabilities(resourceName);
+        client.projects().locations().datasets().fhirStores().fhir().capabilities(fhirStoreName);
 
     // Execute the request and process the results.
     HttpBody response = request.execute();
-    System.out.println("FHIR resource metadata retrieved: " + response.toPrettyString());
+    System.out.println("FHIR store metadata retrieved: " + response.toPrettyString());
   }
 
   private static CloudHealthcare createClient() throws IOException {

--- a/healthcare/v1/src/test/java/snippets/healthcare/FhirResourceTests.java
+++ b/healthcare/v1/src/test/java/snippets/healthcare/FhirResourceTests.java
@@ -49,7 +49,6 @@ import snippets.healthcare.fhir.resources.FhirResourceDelete;
 import snippets.healthcare.fhir.resources.FhirResourceDeletePurge;
 import snippets.healthcare.fhir.resources.FhirResourceGet;
 import snippets.healthcare.fhir.resources.FhirResourceGetHistory;
-import snippets.healthcare.fhir.resources.FhirResourceGetMetadata;
 import snippets.healthcare.fhir.resources.FhirResourceGetPatientEverything;
 import snippets.healthcare.fhir.resources.FhirResourceListHistory;
 import snippets.healthcare.fhir.resources.FhirResourcePatch;
@@ -182,14 +181,6 @@ public class FhirResourceTests {
 
     String output = bout.toString();
     assertThat(output, containsString("FHIR resource search results:"));
-  }
-
-  @Test
-  public void test_GetFhirResourceMetadata() throws Exception {
-    FhirResourceGetMetadata.fhirResourceGetMetadata(fhirStoreName);
-
-    String output = bout.toString();
-    assertThat(output, containsString("FHIR resource metadata retrieved:"));
   }
 
   @Test

--- a/healthcare/v1/src/test/java/snippets/healthcare/FhirStoreTests.java
+++ b/healthcare/v1/src/test/java/snippets/healthcare/FhirStoreTests.java
@@ -39,6 +39,7 @@ import snippets.healthcare.fhir.FhirStoreExecuteBundle;
 import snippets.healthcare.fhir.FhirStoreExport;
 import snippets.healthcare.fhir.FhirStoreGet;
 import snippets.healthcare.fhir.FhirStoreGetIamPolicy;
+import snippets.healthcare.fhir.FhirStoreGetMetadata;
 import snippets.healthcare.fhir.FhirStoreImport;
 import snippets.healthcare.fhir.FhirStoreList;
 import snippets.healthcare.fhir.FhirStorePatch;
@@ -119,6 +120,14 @@ public class FhirStoreTests {
 
     String output = bout.toString();
     assertThat(output, containsString("FHIR store retrieved:"));
+  }
+
+  @Test
+  public void test_FhirStoreGetMetadata() throws Exception {
+    FhirStoreGetMetadata.fhirStoreGetMetadata(fhirStoreName);
+
+    String output = bout.toString();
+    assertThat(output, containsString("FHIR store metadata retrieved:"));
   }
 
   @Test


### PR DESCRIPTION
…from resources/ directory and rename because it applies more to FHIR stores than FHIR resources, move its test

Fixes b/155927040