### PR TITLE
healthcare API: add resource types to remaining FHIR resource code

### DIFF
--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceDelete.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceDelete.java
@@ -38,7 +38,7 @@ import org.apache.http.impl.client.HttpClients;
 
 public class FhirResourceDelete {
   private static final String FHIR_NAME =
-      "projects/%s/locations/%s/datasets/%s/fhirStores/%s/fhir/%s";
+      "projects/%s/locations/%s/datasets/%s/fhirStores/%s/fhir/%s/%s";
   private static final JsonFactory JSON_FACTORY = new JacksonFactory();
   private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
 
@@ -46,7 +46,8 @@ public class FhirResourceDelete {
       throws IOException, URISyntaxException {
     // String resourceName =
     //    String.format(
-    //        FHIR_NAME, "project-id", "region-id", "dataset-id", "store-id", "fhir-id");
+    //        FHIR_NAME, "project-id", "region-id", "dataset-id", "store-id", "resource-type",
+    // "resource-id");
 
     // Initialize the client, which will be used to interact with the service.
     CloudHealthcare client = createClient();

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceDeletePurge.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceDeletePurge.java
@@ -75,7 +75,7 @@ public class FhirResourceDeletePurge {
       responseEntity.writeTo(System.err);
       throw new RuntimeException(errorMessage);
     }
-    System.out.println("FHIR resource purged.");
+    System.out.println("FHIR resource history purged.");
     responseEntity.writeTo(System.out);
   }
 

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceGet.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceGet.java
@@ -38,14 +38,15 @@ import org.apache.http.impl.client.HttpClients;
 
 public class FhirResourceGet {
   private static final String FHIR_NAME =
-      "projects/%s/locations/%s/datasets/%s/fhirStores/%s/fhir/%s";
+      "projects/%s/locations/%s/datasets/%s/fhirStores/%s/fhir/%s/%s";
   private static final JsonFactory JSON_FACTORY = new JacksonFactory();
   private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
 
   public static void fhirResourceGet(String resourceName) throws IOException, URISyntaxException {
     // String resourceName =
     //    String.format(
-    //        FHIR_NAME, "project-id", "region-id", "dataset-id", "store-id", "fhir-id");
+    //        FHIR_NAME, "project-id", "region-id", "dataset-id", "store-id", "resource-type",
+    //  "resource-id");
 
     // Initialize the client, which will be used to interact with the service.
     CloudHealthcare client = createClient();

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceGetPatientEverything.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceGetPatientEverything.java
@@ -38,7 +38,7 @@ import org.apache.http.impl.client.HttpClients;
 
 public class FhirResourceGetPatientEverything {
   private static final String FHIR_NAME =
-      "projects/%s/locations/%s/datasets/%s/fhirStores/%s/fhir/%s";
+      "projects/%s/locations/%s/datasets/%s/fhirStores/%s/fhir/Patient/%s";
   private static final JsonFactory JSON_FACTORY = new JacksonFactory();
   private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
 
@@ -46,7 +46,7 @@ public class FhirResourceGetPatientEverything {
       throws IOException, URISyntaxException {
     // String resourceName =
     //    String.format(
-    //        FHIR_NAME, "project-id", "region-id", "dataset-id", "store-id", "fhir-id");
+    //        FHIR_NAME, "project-id", "region-id", "dataset-id", "store-id", "patient-id");
 
     // Initialize the client, which will be used to interact with the service.
     CloudHealthcare client = createClient();
@@ -74,7 +74,7 @@ public class FhirResourceGetPatientEverything {
       responseEntity.writeTo(System.err);
       throw new RuntimeException();
     }
-    System.out.println("FHIR resource search results: ");
+    System.out.println("Patient compartment results: ");
     responseEntity.writeTo(System.out);
   }
 

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceListHistory.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceListHistory.java
@@ -38,7 +38,8 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.HttpClients;
 
 public class FhirResourceListHistory {
-  private static final String FHIR_NAME = "projects/%s/locations/%s/datasets/%s/fhirStores/%s";
+  private static final String FHIR_NAME =
+      "projects/%s/locations/%s/datasets/%s/fhirStores/%s/fhir/%s/%s";
   private static final JsonFactory JSON_FACTORY = new JacksonFactory();
   private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
 
@@ -46,7 +47,8 @@ public class FhirResourceListHistory {
       throws IOException, URISyntaxException {
     // String resourceName =
     //    String.format(
-    //        FHIR_NAME, "project-id", "region-id", "dataset-id", "store-id", "fhir-id");
+    //        FHIR_NAME, "project-id", "region-id", "dataset-id", "store-id", "resource-type",
+    //  "resource-id");
 
     // Initialize the client, which will be used to interact with the service.
     CloudHealthcare client = createClient();

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourcePatch.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourcePatch.java
@@ -39,7 +39,7 @@ import org.apache.http.impl.client.HttpClients;
 
 public class FhirResourcePatch {
   private static final String FHIR_NAME =
-      "projects/%s/locations/%s/datasets/%s/fhirStores/%s/fhir/%s";
+      "projects/%s/locations/%s/datasets/%s/fhirStores/%s/fhir/%s/%s";
   private static final JsonFactory JSON_FACTORY = new JacksonFactory();
   private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
 
@@ -47,7 +47,8 @@ public class FhirResourcePatch {
       throws IOException, URISyntaxException {
     // String resourceName =
     //    String.format(
-    //        FHIR_NAME, "project-id", "region-id", "dataset-id", "store-id", "fhir-id");
+    //        FHIR_NAME, "project-id", "region-id", "dataset-id", "store-id", "resource-type",
+    // "resource-id");
     // String data = "[{\"op\": \"replace\", \"path\": \"/active\", \"value\": false}]";
 
     // Initialize the client, which will be used to interact with the service.

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchGet.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchGet.java
@@ -46,7 +46,7 @@ public class FhirResourceSearchGet {
       throws IOException, URISyntaxException {
     // String resourceName =
     //    String.format(
-    //        FHIR_NAME, "project-id", "region-id", "dataset-id", "store-id", "fhir-id");
+    //        FHIR_NAME, "project-id", "region-id", "dataset-id", "store-id", "resource-type");
 
     // Initialize the client, which will be used to interact with the service.
     CloudHealthcare client = createClient();
@@ -70,7 +70,7 @@ public class FhirResourceSearchGet {
     HttpEntity responseEntity = response.getEntity();
     if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
       System.err.print(String.format(
-          "Exception searching FHIR resources: %s\n", response.getStatusLine().toString()));
+          "Exception searching GET FHIR resources: %s\n", response.getStatusLine().toString()));
       responseEntity.writeTo(System.err);
       throw new RuntimeException();
     }

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchPost.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchPost.java
@@ -43,19 +43,18 @@ public class FhirResourceSearchPost {
   private static final JsonFactory JSON_FACTORY = new JacksonFactory();
   private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
 
-  public static void fhirResourceSearchPost(String fhirStoreName, String resourceType)
+  public static void fhirResourceSearchPost(String resourceName)
       throws IOException, URISyntaxException {
     // String resourceName =
     //    String.format(
-    //        FHIR_NAME, "project-id", "region-id", "dataset-id", "store-id", "fhir-id");
-    // String resourceType = "Patient";
+    //        FHIR_NAME, "project-id", "region-id", "dataset-id", "store-id", "resource-type");
 
     // Initialize the client, which will be used to interact with the service.
     CloudHealthcare client = createClient();
 
     HttpClient httpClient = HttpClients.createDefault();
     String uri = String.format(
-        "%sv1/%s/fhir/%s/_search", client.getRootUrl(), fhirStoreName, resourceType);
+        "%sv1/%s/_search", client.getRootUrl(), resourceName);
     URIBuilder uriBuilder = new URIBuilder(uri)
         .setParameter("access_token", getAccessToken());
     StringEntity requestEntity = new StringEntity("");
@@ -74,7 +73,7 @@ public class FhirResourceSearchPost {
     HttpEntity responseEntity = response.getEntity();
     if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
       System.err.print(String.format(
-          "Exception searching FHIR resources: %s\n", response.getStatusLine().toString()));
+          "Exception searching POST FHIR resources: %s\n", response.getStatusLine().toString()));
       responseEntity.writeTo(System.err);
       throw new RuntimeException();
     }


### PR DESCRIPTION
Fixes b/155972712

Also:

* Removed skip from FhirResourcePatch test because it now works
* Changed instances of "fhir-id" comment to "resource-id" for clarity
* Changed some outputs for clarity/correctness
* Changed patientType to resourceType in tests for correctness
* Add a new resourcePath variable to tests for search GET/POST
* Remove 404 check for delete resource--server returns 200 even on deleted resources and never returns 404