### PR TITLE
fix: firestore projectId is hardcoded in the tests

### DIFF
--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -73,8 +73,11 @@ if [[ "$SCRIPT_DEBUG" != "true" ]]; then
     source "${KOKORO_GFILE_DIR}/automl_secrets.txt"
     # shellcheck source=src/functions_secrets.txt
     source "${KOKORO_GFILE_DIR}/functions_secrets.txt"
+    # spellcheck source=src/firestore_secrets.txt
+    source "${KOKORO_GFILE_DIR}/firestore_secrets.txt"
     # spellcheck source=src/cts_v4_secrets.txt
     source "${KOKORO_GFILE_DIR}/cts_v4_secrets.txt"
+
     # Activate service account
     gcloud auth activate-service-account \
         --key-file="$GOOGLE_APPLICATION_CREDENTIALS" \

--- a/firestore/README.md
+++ b/firestore/README.md
@@ -46,7 +46,7 @@ the Firestore [documentation](https://cloud.google.com/firestore/docs).
 ## Tests
 Run all tests:
 
-Set the `GOOGLE_CLOUD_PROJECT` environment variable and run the command:
+Set the `PROJECT_ID` environment variable and run the command:
 ```
    mvn clean verify
 ```

--- a/firestore/README.md
+++ b/firestore/README.md
@@ -46,7 +46,7 @@ the Firestore [documentation](https://cloud.google.com/firestore/docs).
 ## Tests
 Run all tests:
 
-Set the `FIRESTORE_PROJECT_ID` environment variable and run the command:
+Set the `GOOGLE_CLOUD_PROJECT` environment variable and run the command:
 ```
    mvn clean verify
 ```

--- a/firestore/README.md
+++ b/firestore/README.md
@@ -45,7 +45,9 @@ the Firestore [documentation](https://cloud.google.com/firestore/docs).
 
 ## Tests
 Run all tests:
+
+Set the `FIRESTORE_PROJECT_ID` environment variable and run the command:
 ```
-   mvn -Dfirestore.project.id="your-firestore-project-id" clean verify
+   mvn clean verify
 ```
 

--- a/firestore/README.md
+++ b/firestore/README.md
@@ -46,7 +46,7 @@ the Firestore [documentation](https://cloud.google.com/firestore/docs).
 ## Tests
 Run all tests:
 
-Set the `PROJECT_ID` environment variable and run the command:
+Set the `FIRESTORE_PROJECT_ID` environment variable and run the command:
 ```
    mvn clean verify
 ```

--- a/firestore/README.md
+++ b/firestore/README.md
@@ -46,6 +46,6 @@ the Firestore [documentation](https://cloud.google.com/firestore/docs).
 ## Tests
 Run all tests:
 ```
-   mvn clean verify
+   mvn -Dfirestore.project.id="your-firestore-project-id" clean verify
 ```
 

--- a/firestore/src/test/java/com/example/firestore/BaseIntegrationTest.java
+++ b/firestore/src/test/java/com/example/firestore/BaseIntegrationTest.java
@@ -47,7 +47,7 @@ public class BaseIntegrationTest {
 
   @BeforeClass
   public static void baseSetup() throws Exception {
-    projectId = getEnvVar("PROJECT_ID");
+    projectId = getEnvVar("FIRESTORE_PROJECT_ID");
     FirestoreOptions firestoreOptions = FirestoreOptions.getDefaultInstance().toBuilder()
         .setProjectId(projectId)
         .build();

--- a/firestore/src/test/java/com/example/firestore/BaseIntegrationTest.java
+++ b/firestore/src/test/java/com/example/firestore/BaseIntegrationTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertNotNull;
  */
 public class BaseIntegrationTest {
 
-  protected static final String projectId = getEnvVar("FIRESTORE_PROJECT_ID");
+  protected static String projectId;
   protected static Firestore db;
 
   private static String getEnvVar(String varName) {
@@ -47,6 +47,7 @@ public class BaseIntegrationTest {
 
   @BeforeClass
   public static void baseSetup() throws Exception {
+    projectId = getEnvVar("FIRESTORE_PROJECT_ID");
     FirestoreOptions firestoreOptions = FirestoreOptions.getDefaultInstance().toBuilder()
         .setProjectId(projectId)
         .build();

--- a/firestore/src/test/java/com/example/firestore/BaseIntegrationTest.java
+++ b/firestore/src/test/java/com/example/firestore/BaseIntegrationTest.java
@@ -32,8 +32,20 @@ import org.junit.BeforeClass;
  */
 public class BaseIntegrationTest {
 
-  protected static String projectId = "java-docs-samples-firestore";
+  protected static final String projectId = detectProjectId();
   protected static Firestore db;
+
+  private static String detectProjectId() {
+    String id = System.getProperty("firestore.project.id");
+    if (id != null) {
+      return id;
+    }
+    id = System.getenv("FIRESTORE_PROJECT_ID");
+    if (id != null) {
+      return id;
+    }
+    return "java-docs-samples-firestore";
+  }
 
   @BeforeClass
   public static void baseSetup() throws Exception {

--- a/firestore/src/test/java/com/example/firestore/BaseIntegrationTest.java
+++ b/firestore/src/test/java/com/example/firestore/BaseIntegrationTest.java
@@ -47,7 +47,7 @@ public class BaseIntegrationTest {
 
   @BeforeClass
   public static void baseSetup() throws Exception {
-    projectId = getEnvVar("GOOGLE_CLOUD_PROJECT");
+    projectId = getEnvVar("PROJECT_ID");
     FirestoreOptions firestoreOptions = FirestoreOptions.getDefaultInstance().toBuilder()
         .setProjectId(projectId)
         .build();

--- a/firestore/src/test/java/com/example/firestore/BaseIntegrationTest.java
+++ b/firestore/src/test/java/com/example/firestore/BaseIntegrationTest.java
@@ -27,24 +27,22 @@ import com.google.cloud.firestore.QuerySnapshot;
 import java.util.Map;
 import org.junit.BeforeClass;
 
+import static org.junit.Assert.assertNotNull;
+
 /**
  * Base class for tests like {@link ManageDataSnippetsIT}.
  */
 public class BaseIntegrationTest {
 
-  protected static final String projectId = detectProjectId();
+  protected static final String projectId = getEnvVar("FIRESTORE_PROJECT_ID");
   protected static Firestore db;
 
-  private static String detectProjectId() {
-    String id = System.getProperty("firestore.project.id");
-    if (id != null) {
-      return id;
-    }
-    id = System.getenv("FIRESTORE_PROJECT_ID");
-    if (id != null) {
-      return id;
-    }
-    return "java-docs-samples-firestore";
+  private static String getEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+            String.format("Environment variable '%s' must be set to perform these tests.", varName),
+            value);
+    return value;
   }
 
   @BeforeClass

--- a/firestore/src/test/java/com/example/firestore/BaseIntegrationTest.java
+++ b/firestore/src/test/java/com/example/firestore/BaseIntegrationTest.java
@@ -47,7 +47,7 @@ public class BaseIntegrationTest {
 
   @BeforeClass
   public static void baseSetup() throws Exception {
-    projectId = getEnvVar("FIRESTORE_PROJECT_ID");
+    projectId = getEnvVar("GOOGLE_CLOUD_PROJECT");
     FirestoreOptions firestoreOptions = FirestoreOptions.getDefaultInstance().toBuilder()
         .setProjectId(projectId)
         .build();

--- a/firestore/src/test/java/com/example/firestore/BaseIntegrationTest.java
+++ b/firestore/src/test/java/com/example/firestore/BaseIntegrationTest.java
@@ -16,6 +16,8 @@
 
 package com.example.firestore;
 
+import static org.junit.Assert.assertNotNull;
+
 import com.example.firestore.snippets.ManageDataSnippetsIT;
 import com.example.firestore.snippets.model.City;
 import com.google.api.core.ApiFuture;
@@ -26,8 +28,6 @@ import com.google.cloud.firestore.FirestoreOptions;
 import com.google.cloud.firestore.QuerySnapshot;
 import java.util.Map;
 import org.junit.BeforeClass;
-
-import static org.junit.Assert.assertNotNull;
 
 /**
  * Base class for tests like {@link ManageDataSnippetsIT}.


### PR DESCRIPTION
Fixes #2881

- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] Tests pass (`mvn -P lint clean verify`)
  * (Note- `Checkstyle` passing is required; `Spotbugs`, `ErrorProne`, `PMD`, etc. `ERROR`'s are advisory only)
- [x] Please **merge** this PR for me once it is approved.
