### PR TITLE
Update READMEs with source deploy functionality

### DIFF
--- a/appengine-java11/README.md
+++ b/appengine-java11/README.md
@@ -47,11 +47,14 @@ To switch to an Open JDK 11 in a Cloud shell session, you can use:
 ```
 
 ## Java 11 runtime
+One way to deploy to App Engine Java 11 is directly from source.
 
-The simplest way to deploy to App Engine Java 11 is using an executable [Uber JAR][uber-jar]. App Engine will automatically configure the `entrypoint` to run the JAR file.
+* [`springboot-helloworld`](springboot-helloworld): Deploy a spring-boot application from source
+* [`http-server`](http-server): Deploy an http application from source
 
-* [`springboot-helloworld`](springboot-helloworld): Build a fat JAR with Spring Boot
-* [`http-server`](http-server): Build a JAR using the Maven JAR Plugin
+Another way is using the Maven App Engine Plugin to deploy an executable [Uber JAR][uber-jar]. App Engine will automatically configure the `entrypoint` to run the JAR file. Use this method when your application requires dependencies that are located locally, such as the [`appengine-simple-jetty-main`](appengine-simple-jetty-main) artifact.
+
+* [`gaeinfo`](gaeinfo): Build a JAR using the Maven JAR Plugin
 
 In addition, App Engine allows you to execute the `java` command directly in the `app.yaml` `entrypoint` field, so you can further customize your app's startup.
 

--- a/appengine-java11/http-server/README.md
+++ b/appengine-java11/http-server/README.md
@@ -1,8 +1,7 @@
 # Standalone HTTP Server on Google App Engine Standard with Java 11
 
-This sample shows how to deploy an application to Google App Engine using the
-a fat jar. There is no `entrypoint` field listed in the [`app.yaml`](src/main/appengine/app.yaml),
-as the application is a single fat jar with the correct MainClass field in the MANIFEST.
+This sample shows how to deploy an application to Google App Engine from source. The `entrypoint` field listed in the [`app.yaml`](src/main/appengine/app.yaml) is not required,
+as GAE will determine the entrypoint by searching the `target` directory for the .jar file with a Main-Class Manifest entry.
 
 ## Setup
 
@@ -11,7 +10,7 @@ See [Prerequisites](../README.md#Prerequisites).
 ## Deploy to App Engine Standard
 
 ```
-mvn clean package appengine:deploy
+gcloud app deploy
 ```
 
 To view your app, use command:

--- a/appengine-java11/kotlin-ktor/README.md
+++ b/appengine-java11/kotlin-ktor/README.md
@@ -10,7 +10,7 @@ See [Prerequisites](../README.md#Prerequisites).
 ## Deploying
 
 ```bash
- mvn clean package appengine:deploy
+gcloud app deploy
 ```
 
 To view your app, use command:

--- a/appengine-java11/micronaut-helloworld/README.md
+++ b/appengine-java11/micronaut-helloworld/README.md
@@ -10,7 +10,7 @@ See [Prerequisites](../README.md#Prerequisites).
 ## Deploying
 
 ```bash
- mvn clean package appengine:deploy
+gcloud app deploy
 ```
 
 To view your app, use command:

--- a/appengine-java11/quarkus-helloworld/README.md
+++ b/appengine-java11/quarkus-helloworld/README.md
@@ -10,7 +10,7 @@ See [Prerequisites](../README.md#Prerequisites).
 ## Deploying
 
 ```bash
- mvn clean package appengine:deploy
+gcloud app deploy
 ```
 
 To view your app, use command:

--- a/appengine-java11/sparkjava-helloworld/README.md
+++ b/appengine-java11/sparkjava-helloworld/README.md
@@ -10,7 +10,7 @@ See [Prerequisites](../README.md#Prerequisites).
 ## Deploying
 
 ```bash
- mvn clean package appengine:deploy
+gcloud app deploy
 ```
 
 To view your app, use command:

--- a/appengine-java11/springboot-helloworld/README.md
+++ b/appengine-java11/springboot-helloworld/README.md
@@ -10,7 +10,7 @@ See [Prerequisites](../README.md#Prerequisites).
 ## Deploying
 
 ```bash
- mvn clean package appengine:deploy
+gcloud app deploy
 ```
 
 To view your app, use command:

--- a/appengine-java11/tasks/README.md
+++ b/appengine-java11/tasks/README.md
@@ -51,7 +51,7 @@ cd java-docs-samples/appengine-java11/task-handler
 
 - Deploy the app
 ```
-mvn clean package appengine:deploy
+gcloud app deploy
 ```
 
 ## Run the Sample Using the Command Line

--- a/appengine-java11/vertx-helloworld/README.md
+++ b/appengine-java11/vertx-helloworld/README.md
@@ -10,7 +10,7 @@ See [Prerequisites](../README.md#Prerequisites).
 ## Deploying
 
 ```bash
- mvn clean package appengine:deploy
+gcloud app deploy
 ```
 
 ## See the application page


### PR DESCRIPTION
Modifies the deployment methods to the new source deploy functionality
for those applications that do not have a dependency on the
appengine-simple-jetty-main artifact.

The public GAE documentation reference these samples and will reflect these changes as well.
