### PR TITLE
Fix issues with DLP readme and samples used in it

### DIFF
--- a/dlp/README.md
+++ b/dlp/README.md
@@ -69,7 +69,7 @@ Commands:
 TODO: Verify / fix me
 - Redact phone numbers and email addresses from `test.png`:
   ```
-    java -cp dlp/target/dlp-samples-1.0-jar-with-dependencies.jar com.example.dlp.Redact -f src/test/resources/test.png -o test-redacted.png -infoTypes PHONE_NUMBER EMAIL_ADDRESS
+    java -cp target/dlp-samples-1.0-jar-with-dependencies.jar dlp.snippets.RedactImageFile MY_PROJECT_ID src/test/resources/test.png test-redacted.png
   ```
 
 ## Integration tests

--- a/dlp/README.md
+++ b/dlp/README.md
@@ -34,12 +34,8 @@ An [InfoType identifier](https://cloud.google.com/dlp/docs/infotypes-categories)
 
 The Quickstart demonstrates using the DLP API to identify an InfoType in a given string.
 
-Note that you will need to set the `projectId` in
-[QuickStart.java](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/dlp/src/main/java/dlp/snippets/QuickStart.java)
-for this to work correctly. If you forget this, you will see a `PERMISSION_DENIED` error.
-
 ```
-   java -cp target/dlp-samples-1.0-jar-with-dependencies.jar dlp.snippets.QuickStart
+   java -cp target/dlp-samples-1.0-jar-with-dependencies.jar dlp.snippets.QuickStart MY_PROJECT_ID
 ```
 
 ## Inspect data for sensitive elements

--- a/dlp/README.md
+++ b/dlp/README.md
@@ -27,7 +27,7 @@ An [InfoType identifier](https://cloud.google.com/dlp/docs/infotypes-categories)
 
 [InfoTypes](https://cloud.google.com/dlp/docs/infotypes-reference#global) are updated periodically. Use the API to retrieve the most current InfoTypes.
   ```
-    java -cp dlp/target/dlp-samples-1.0-jar-with-dependencies.jar dlp.snippets.InfoTypesList
+    java -cp target/dlp-samples-1.0-jar-with-dependencies.jar dlp.snippets.InfoTypesList
   ``` 
 
 ## Run the quickstart

--- a/dlp/README.md
+++ b/dlp/README.md
@@ -27,14 +27,19 @@ An [InfoType identifier](https://cloud.google.com/dlp/docs/infotypes-categories)
 
 [InfoTypes](https://cloud.google.com/dlp/docs/infotypes-reference#global) are updated periodically. Use the API to retrieve the most current InfoTypes.
   ```
-    java -cp dlp/target/dlp-samples-1.0-jar-with-dependencies.jar com.example.dlp.Metadata
+    java -cp dlp/target/dlp-samples-1.0-jar-with-dependencies.jar dlp.snippets.InfoTypesList
   ``` 
 
 ## Run the quickstart
 
 The Quickstart demonstrates using the DLP API to identify an InfoType in a given string.
+
+Note that you will need to set the `projectId` in
+[QuickStart.java](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/dlp/src/main/java/dlp/snippets/QuickStart.java)
+for this to work correctly. If you forget this, you will see a `PERMISSION_DENIED` error.
+
 ```
-   java -cp dlp/target/dlp-samples-1.0-jar-with-dependencies.jar dlp.snippets.QuickStart
+   java -cp target/dlp-samples-1.0-jar-with-dependencies.jar dlp.snippets.QuickStart
 ```
 
 ## Inspect data for sensitive elements
@@ -61,6 +66,7 @@ Commands:
 ```
 
 ### Example
+TODO: Verify / fix me
 - Redact phone numbers and email addresses from `test.png`:
   ```
     java -cp dlp/target/dlp-samples-1.0-jar-with-dependencies.jar com.example.dlp.Redact -f src/test/resources/test.png -o test-redacted.png -infoTypes PHONE_NUMBER EMAIL_ADDRESS

--- a/dlp/README.md
+++ b/dlp/README.md
@@ -34,8 +34,12 @@ An [InfoType identifier](https://cloud.google.com/dlp/docs/infotypes-categories)
 
 The Quickstart demonstrates using the DLP API to identify an InfoType in a given string.
 
+Note that you will need to set the `projectId` in
+[QuickStart.java](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/dlp/src/main/java/dlp/snippets/QuickStart.java)
+for this to work correctly. If you forget this, you will see a `PERMISSION_DENIED` error.
+
 ```
-   java -cp target/dlp-samples-1.0-jar-with-dependencies.jar dlp.snippets.QuickStart MY_PROJECT_ID
+   java -cp target/dlp-samples-1.0-jar-with-dependencies.jar dlp.snippets.QuickStart
 ```
 
 ## Inspect data for sensitive elements
@@ -48,24 +52,15 @@ Optional flags are explained in [this resource](https://cloud.google.com/dlp/doc
 ## Automatic redaction of sensitive data from images
 [Automatic redaction](https://cloud.google.com/dlp/docs/redacting-sensitive-data-images) produces an output image with sensitive data matches removed.
 
-```
-Commands:
-  -f <string>                   Source image file
-  -o <string>                   Destination image file
- Options:
-  --help               Show help
-  -minLikelihood       choices: "LIKELIHOOD_UNSPECIFIED", "VERY_UNLIKELY", "UNLIKELY", "POSSIBLE", "LIKELY", "VERY_LIKELY"]
-                       [default: "LIKELIHOOD_UNSPECIFIED"]
-                       specifies the minimum reporting likelihood threshold.
-  
-  -infoTypes      set of infoTypes to search for [eg. PHONE_NUMBER US_PASSPORT]
-```
-
 ### Example
-TODO: Verify / fix me
-- Redact phone numbers and email addresses from `test.png`:
+- Redact phone numbers and email addresses from `src/test/resources/test.png`:
+
+  Note that you will need to set the `projectId` in
+  [RedactImageFile.java](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/dlp/src/main/java/dlp/snippets/RedactImageFilet.java)
+  for this to work correctly. If you forget this, you will see a `PERMISSION_DENIED` error.
+
   ```
-    java -cp target/dlp-samples-1.0-jar-with-dependencies.jar dlp.snippets.RedactImageFile MY_PROJECT_ID src/test/resources/test.png test-redacted.png
+    java -cp target/dlp-samples-1.0-jar-with-dependencies.jar dlp.snippets.RedactImageFile
   ```
 
 ## Integration tests

--- a/dlp/pom.xml
+++ b/dlp/pom.xml
@@ -15,7 +15,6 @@
  limitations under the License.
 -->
 <!-- [START dlp_pom] -->
-
 <project>
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>

--- a/dlp/pom.xml
+++ b/dlp/pom.xml
@@ -15,6 +15,7 @@
  limitations under the License.
 -->
 <!-- [START dlp_pom] -->
+
 <project>
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>
@@ -37,6 +38,29 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id> <!-- this is used for inheritance merges -->
+            <phase>package</phase> <!-- bind to the packaging phase -->
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
   <dependencyManagement>
     <dependencies>

--- a/dlp/src/main/java/dlp/snippets/InfoTypesList.java
+++ b/dlp/src/main/java/dlp/snippets/InfoTypesList.java
@@ -26,6 +26,10 @@ import java.io.IOException;
 
 public class InfoTypesList {
 
+  public static void main(String[] args) throws IOException {
+    listInfoTypes();
+  }
+
   // Lists the types of sensitive information the DLP API supports.
   public static void listInfoTypes() throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created

--- a/dlp/src/main/java/dlp/snippets/QuickStart.java
+++ b/dlp/src/main/java/dlp/snippets/QuickStart.java
@@ -38,7 +38,9 @@ import java.util.stream.Stream;
 public class QuickStart {
 
   public static void main(String[] args) throws IOException {
-    quickstart(args[0]);
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    quickstart(projectId);
   }
 
   public static void quickstart(String projectId) throws IOException {

--- a/dlp/src/main/java/dlp/snippets/QuickStart.java
+++ b/dlp/src/main/java/dlp/snippets/QuickStart.java
@@ -38,9 +38,7 @@ import java.util.stream.Stream;
 public class QuickStart {
 
   public static void main(String[] args) throws IOException {
-    // TODO(developer): Replace these variables before running the sample.
-    String projectId = "your-project-id";
-    quickstart(projectId);
+    quickstart(args[0]);
   }
 
   public static void quickstart(String projectId) throws IOException {

--- a/dlp/src/main/java/dlp/snippets/RedactImageFile.java
+++ b/dlp/src/main/java/dlp/snippets/RedactImageFile.java
@@ -34,14 +34,11 @@ import java.util.List;
 
 class RedactImageFile {
 
-  public static void redactImageFile() {
-    // TODO(developer): Replace these variables before running the sample.
-    String projectId = "your-project-id";
-    String filePath = "path/to/image.png";
-    redactImageFile(projectId, filePath);
+  public static void main(String[] args) {
+    redactImageFile(args[0], args[1], args[2]);
   }
 
-  static void redactImageFile(String projectId, String filePath) {
+  static void redactImageFile(String projectId, String inputPath, String outputPath) {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
@@ -50,7 +47,7 @@ class RedactImageFile {
       ProjectName project = ProjectName.of(projectId);
 
       // Specify the content to be inspected.
-      ByteString fileBytes = ByteString.readFrom(new FileInputStream(filePath));
+      ByteString fileBytes = ByteString.readFrom(new FileInputStream(inputPath));
       ByteContentItem byteItem =
           ByteContentItem.newBuilder().setType(BytesType.IMAGE).setData(fileBytes).build();
 
@@ -78,7 +75,6 @@ class RedactImageFile {
       RedactImageResponse response = dlp.redactImage(request);
 
       // Parse the response and process results.
-      String outputPath = "redacted.png";
       FileOutputStream redacted = new FileOutputStream(outputPath);
       redacted.write(response.getRedactedImage().toByteArray());
       redacted.close();

--- a/dlp/src/main/java/dlp/snippets/RedactImageFile.java
+++ b/dlp/src/main/java/dlp/snippets/RedactImageFile.java
@@ -35,7 +35,11 @@ import java.util.List;
 class RedactImageFile {
 
   public static void main(String[] args) {
-    redactImageFile(args[0], args[1], args[2]);
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project-id";
+    String inputPath = "src/test/resources/test.png";
+    String outputPath = "redacted.png";
+    redactImageFile(projectId, inputPath, outputPath);
   }
 
   static void redactImageFile(String projectId, String inputPath, String outputPath) {

--- a/dlp/src/test/java/dlp/snippets/RedactTests.java
+++ b/dlp/src/test/java/dlp/snippets/RedactTests.java
@@ -37,6 +37,8 @@ import org.junit.runners.JUnit4;
 public class RedactTests {
 
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static final String INPUT_FILE = "src/test/resources/test.png";
+  private static final String OUTPUT_FILE = "redacted.png";
   private ByteArrayOutputStream bout;
 
   private static void requireEnvVar(String varName) {
@@ -65,13 +67,13 @@ public class RedactTests {
 
   @After
   public void cleanUp() throws IOException {
-    Path outputFile = Paths.get("redacted.png");
+    Path outputFile = Paths.get(OUTPUT_FILE);
     Files.delete(outputFile);
   }
 
   @Test
   public void testRedactImage() {
-    RedactImageFile.redactImageFile(PROJECT_ID, "src/test/resources/test.png");
+    RedactImageFile.redactImageFile(PROJECT_ID, INPUT_FILE, OUTPUT_FILE);
 
     String output = bout.toString();
     assertThat(output, containsString("Redacted image written"));


### PR DESCRIPTION
Fixes some problems with the DLP readme and the examples referenced from it.

* Fix `pom.xml` so we produce the expected jar with dependencies. 
* Fix package names in CLI examples to match what actually exists.
* Add notes to README reminding users they need to replace the projectId vars in the samples before running
* Make InfoTypesList example runnable
* Fix RedactImageFile example to use an existing image file by default, update the readme to match the sample code that exists. 

Internal bug: b/156125412


- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [X] `pom.xml` parent set to latest `shared-configuration`
- [X] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [X] Tests pass (`mvn -P lint clean verify`)
  * (Note- `Checkstyle` passing is required; `Spotbugs`, `ErrorProne`, `PMD`, etc. `ERROR`'s are advisory only)
- [X] Please **merge** this PR for me once it is approved.
