### PR TITLE
Add Java code sample for concepts-infotypes

### DIFF
--- a/dlp/src/main/java/dlp/snippets/InspectPhoneNumber.java
+++ b/dlp/src/main/java/dlp/snippets/InspectPhoneNumber.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dlp.snippets;
+
+// [START dlp_inspect_phone_number]
+
+import com.google.cloud.dlp.v2.DlpServiceClient;
+import com.google.privacy.dlp.v2.ContentItem;
+import com.google.privacy.dlp.v2.Finding;
+import com.google.privacy.dlp.v2.InfoType;
+import com.google.privacy.dlp.v2.InspectConfig;
+import com.google.privacy.dlp.v2.InspectContentRequest;
+import com.google.privacy.dlp.v2.InspectContentResponse;
+import com.google.privacy.dlp.v2.Likelihood;
+import com.google.privacy.dlp.v2.ProjectName;
+
+public class InspectPhoneNumber {
+
+  public static void inspectString() {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String textToInspect = "My name is Gary and my email is gary@example.com";
+    inspectString(projectId, textToInspect);
+  }
+
+  // Inspects the provided text.
+  public static void inspectString(String projectId, String textToInspect) {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (DlpServiceClient dlp = DlpServiceClient.create()) {
+      // Specify the project used for request.
+      ProjectName project = ProjectName.of(projectId);
+
+      // Specify the type and content to be inspected.
+      ContentItem item = ContentItem.newBuilder()
+          .setValue(textToInspect)
+          .build();
+
+      // Specify the type of info the inspection will look for.
+      // See https://cloud.google.com/dlp/docs/infotypes-reference for complete list of info types
+      InfoType infoType = InfoType.newBuilder().setName("PHONE_NUMBER").build();
+
+      // Construct the configuration for the Inspect request.
+      InspectConfig config =
+          InspectConfig.newBuilder()
+              .setIncludeQuote(true)
+              .setMinLikelihood(Likelihood.POSSIBLE)
+              .addInfoTypes(infoType)
+              .build();
+
+      // Construct the Inspect request to be sent by the client.
+      InspectContentRequest request =
+          InspectContentRequest.newBuilder()
+              .setParent(project.toString())
+              .setItem(item)
+              .setInspectConfig(config)
+              .build();
+
+      // Use the client to send the API request.
+      InspectContentResponse response = dlp.inspectContent(request);
+
+      // Parse the response and process results
+      System.out.println("Findings: " + response.getResult().getFindingsCount());
+      for (Finding f : response.getResult().getFindingsList()) {
+        System.out.println("\tQuote: " + f.getQuote());
+        System.out.println("\tInfo type: " + f.getInfoType().getName());
+        System.out.println("\tLikelihood: " + f.getLikelihood());
+      }
+    } catch (Exception e) {
+      System.out.println("Error during inspectString: \n" + e.toString());
+    }
+  }
+}
+// [END dlp_inspect_phone_number]

--- a/dlp/src/test/java/dlp/snippets/InspectTests.java
+++ b/dlp/src/test/java/dlp/snippets/InspectTests.java
@@ -77,6 +77,14 @@ public class InspectTests {
   }
 
   @Test
+  public void testInspectPhoneNumber() {
+    InspectString.inspectString(PROJECT_ID, "My phone number is (415) 555-0890");
+
+    String output = bout.toString();
+    assertThat(output, containsString("Info type: PHONE_NUMBER"));
+  }
+
+  @Test
   public void testInspectString() {
     InspectString.inspectString(PROJECT_ID, "I'm Gary and my email is gary@example.com");
 


### PR DESCRIPTION
https://cloud.google.com/dlp/docs/concepts-infotypes

Fixes <no github issue associated>

> It's a good idea to open an issue first for discussion.

- [yes, except where consistency made more sense] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [yes] `pom.xml` parent set to latest `shared-configuration`
- [yes] Appropriate changes to README are included in PR
- [nothing new] API's need to be enabled to test (tell us)
- [nothing new] Environment Variables need to be set (ask us to set them)
- [yes] Tests pass (`mvn -P lint clean verify`)
  * (Note- `Checkstyle` passing is required; `Spotbugs`, `ErrorProne`, `PMD`, etc. `ERROR`'s are advisory only)
- [yes] Please **merge** this PR for me once it is approved.
