### PR TITLE
Include locations/global in parent field to fix samples

### DIFF
--- a/dlp/src/main/java/dlp/snippets/DeIdentifyWithDateShift.java
+++ b/dlp/src/main/java/dlp/snippets/DeIdentifyWithDateShift.java
@@ -27,8 +27,8 @@ import com.google.privacy.dlp.v2.DeidentifyContentRequest;
 import com.google.privacy.dlp.v2.DeidentifyContentResponse;
 import com.google.privacy.dlp.v2.FieldId;
 import com.google.privacy.dlp.v2.FieldTransformation;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.PrimitiveTransformation;
-import com.google.privacy.dlp.v2.ProjectName;
 import com.google.privacy.dlp.v2.RecordTransformations;
 import com.google.privacy.dlp.v2.Table;
 import com.google.privacy.dlp.v2.Value;
@@ -98,7 +98,7 @@ public class DeIdentifyWithDateShift {
       // Combine configurations into a request for the service.
       DeidentifyContentRequest request =
           DeidentifyContentRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setItem(item)
               .setDeidentifyConfig(deidentifyConfig)
               .build();

--- a/dlp/src/main/java/dlp/snippets/DeIdentifyWithDateShift.java
+++ b/dlp/src/main/java/dlp/snippets/DeIdentifyWithDateShift.java
@@ -98,7 +98,7 @@ public class DeIdentifyWithDateShift {
       // Combine configurations into a request for the service.
       DeidentifyContentRequest request =
           DeidentifyContentRequest.newBuilder()
-              .setParent(ProjectName.of(projectId).toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setItem(item)
               .setDeidentifyConfig(deidentifyConfig)
               .build();

--- a/dlp/src/main/java/dlp/snippets/DeIdentifyWithFpe.java
+++ b/dlp/src/main/java/dlp/snippets/DeIdentifyWithFpe.java
@@ -104,7 +104,7 @@ public class DeIdentifyWithFpe {
       // Combine configurations into a request for the service.
       DeidentifyContentRequest request =
           DeidentifyContentRequest.newBuilder()
-              .setParent(ProjectName.of(projectId).toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setItem(contentItem)
               .setInspectConfig(inspectConfig)
               .setDeidentifyConfig(deidentifyConfig)

--- a/dlp/src/main/java/dlp/snippets/DeIdentifyWithFpe.java
+++ b/dlp/src/main/java/dlp/snippets/DeIdentifyWithFpe.java
@@ -32,8 +32,8 @@ import com.google.privacy.dlp.v2.InfoTypeTransformations;
 import com.google.privacy.dlp.v2.InfoTypeTransformations.InfoTypeTransformation;
 import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.KmsWrappedCryptoKey;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.PrimitiveTransformation;
-import com.google.privacy.dlp.v2.ProjectName;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.Arrays;
@@ -104,7 +104,7 @@ public class DeIdentifyWithFpe {
       // Combine configurations into a request for the service.
       DeidentifyContentRequest request =
           DeidentifyContentRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setItem(contentItem)
               .setInspectConfig(inspectConfig)
               .setDeidentifyConfig(deidentifyConfig)

--- a/dlp/src/main/java/dlp/snippets/DeIdentifyWithMasking.java
+++ b/dlp/src/main/java/dlp/snippets/DeIdentifyWithMasking.java
@@ -28,8 +28,8 @@ import com.google.privacy.dlp.v2.InfoType;
 import com.google.privacy.dlp.v2.InfoTypeTransformations;
 import com.google.privacy.dlp.v2.InfoTypeTransformations.InfoTypeTransformation;
 import com.google.privacy.dlp.v2.InspectConfig;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.PrimitiveTransformation;
-import com.google.privacy.dlp.v2.ProjectName;
 import com.google.privacy.dlp.v2.ReplaceWithInfoTypeConfig;
 import java.io.IOException;
 import java.util.Arrays;
@@ -82,7 +82,7 @@ public class DeIdentifyWithMasking {
       // Combine configurations into a request for the service.
       DeidentifyContentRequest request =
           DeidentifyContentRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setItem(contentItem)
               .setInspectConfig(inspectConfig)
               .setDeidentifyConfig(deidentifyConfig)

--- a/dlp/src/main/java/dlp/snippets/DeIdentifyWithMasking.java
+++ b/dlp/src/main/java/dlp/snippets/DeIdentifyWithMasking.java
@@ -82,7 +82,7 @@ public class DeIdentifyWithMasking {
       // Combine configurations into a request for the service.
       DeidentifyContentRequest request =
           DeidentifyContentRequest.newBuilder()
-              .setParent(ProjectName.of(projectId).toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setItem(contentItem)
               .setInspectConfig(inspectConfig)
               .setDeidentifyConfig(deidentifyConfig)

--- a/dlp/src/main/java/dlp/snippets/InspectBigQueryTable.java
+++ b/dlp/src/main/java/dlp/snippets/InspectBigQueryTable.java
@@ -34,7 +34,7 @@ import com.google.privacy.dlp.v2.InfoTypeStats;
 import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.InspectDataSourceDetails;
 import com.google.privacy.dlp.v2.InspectJobConfig;
-import com.google.privacy.dlp.v2.ProjectName;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.StorageConfig;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.PubsubMessage;
@@ -113,7 +113,7 @@ public class InspectBigQueryTable {
       // Create the request for the job configured above.
       CreateDlpJobRequest createDlpJobRequest =
           CreateDlpJobRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setInspectJob(inspectJobConfig)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/InspectBigQueryTable.java
+++ b/dlp/src/main/java/dlp/snippets/InspectBigQueryTable.java
@@ -113,7 +113,7 @@ public class InspectBigQueryTable {
       // Create the request for the job configured above.
       CreateDlpJobRequest createDlpJobRequest =
           CreateDlpJobRequest.newBuilder()
-              .setParent(ProjectName.of(projectId).toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setInspectJob(inspectJobConfig)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/InspectDatastoreEntity.java
+++ b/dlp/src/main/java/dlp/snippets/InspectDatastoreEntity.java
@@ -34,8 +34,8 @@ import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.InspectDataSourceDetails;
 import com.google.privacy.dlp.v2.InspectJobConfig;
 import com.google.privacy.dlp.v2.KindExpression;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.PartitionId;
-import com.google.privacy.dlp.v2.ProjectName;
 import com.google.privacy.dlp.v2.StorageConfig;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.PubsubMessage;
@@ -114,7 +114,7 @@ public class InspectDatastoreEntity {
       // Create the request for the job configured above.
       CreateDlpJobRequest createDlpJobRequest =
           CreateDlpJobRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setInspectJob(inspectJobConfig)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/InspectDatastoreEntity.java
+++ b/dlp/src/main/java/dlp/snippets/InspectDatastoreEntity.java
@@ -114,7 +114,7 @@ public class InspectDatastoreEntity {
       // Create the request for the job configured above.
       CreateDlpJobRequest createDlpJobRequest =
           CreateDlpJobRequest.newBuilder()
-              .setParent(ProjectName.of(projectId).toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setInspectJob(inspectJobConfig)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/InspectGcsFile.java
+++ b/dlp/src/main/java/dlp/snippets/InspectGcsFile.java
@@ -17,12 +17,12 @@
 package dlp.snippets;
 
 // [START dlp_inspect_gcs]
+
 import com.google.api.core.SettableApiFuture;
 import com.google.cloud.dlp.v2.DlpServiceClient;
 import com.google.cloud.pubsub.v1.AckReplyConsumer;
 import com.google.cloud.pubsub.v1.MessageReceiver;
 import com.google.cloud.pubsub.v1.Subscriber;
-import com.google.common.util.concurrent.SettableFuture;
 import com.google.privacy.dlp.v2.Action;
 import com.google.privacy.dlp.v2.CloudStorageOptions;
 import com.google.privacy.dlp.v2.CloudStorageOptions.FileSet;
@@ -100,7 +100,7 @@ public class InspectGcsFile {
       // Create the request for the job configured above.
       CreateDlpJobRequest createDlpJobRequest =
           CreateDlpJobRequest.newBuilder()
-              .setParent(ProjectName.of(projectId).toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setInspectJob(inspectJobConfig)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/InspectGcsFile.java
+++ b/dlp/src/main/java/dlp/snippets/InspectGcsFile.java
@@ -34,7 +34,7 @@ import com.google.privacy.dlp.v2.InfoTypeStats;
 import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.InspectDataSourceDetails;
 import com.google.privacy.dlp.v2.InspectJobConfig;
-import com.google.privacy.dlp.v2.ProjectName;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.StorageConfig;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.PubsubMessage;
@@ -100,7 +100,7 @@ public class InspectGcsFile {
       // Create the request for the job configured above.
       CreateDlpJobRequest createDlpJobRequest =
           CreateDlpJobRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setInspectJob(inspectJobConfig)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/InspectImageFile.java
+++ b/dlp/src/main/java/dlp/snippets/InspectImageFile.java
@@ -17,6 +17,7 @@
 package dlp.snippets;
 
 // [START dlp_inspect_image_file]
+
 import com.google.cloud.dlp.v2.DlpServiceClient;
 import com.google.privacy.dlp.v2.ByteContentItem;
 import com.google.privacy.dlp.v2.ByteContentItem.BytesType;
@@ -26,7 +27,7 @@ import com.google.privacy.dlp.v2.InfoType;
 import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.InspectContentRequest;
 import com.google.privacy.dlp.v2.InspectContentResponse;
-import com.google.privacy.dlp.v2.ProjectName;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.protobuf.ByteString;
 import java.io.FileInputStream;
 import java.util.ArrayList;
@@ -47,9 +48,6 @@ public class InspectImageFile {
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
     try (DlpServiceClient dlp = DlpServiceClient.create()) {
-      // Specify the project used for request.
-      ProjectName project = ProjectName.of(projectId);
-
       // Specify the type and content to be inspected.
       ByteString fileBytes = ByteString.readFrom(new FileInputStream(filePath));
       ByteContentItem byteItem =
@@ -70,7 +68,7 @@ public class InspectImageFile {
       // Construct the Inspect request to be sent by the client.
       InspectContentRequest request =
           InspectContentRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setItem(item)
               .setInspectConfig(config)
               .build();

--- a/dlp/src/main/java/dlp/snippets/InspectImageFile.java
+++ b/dlp/src/main/java/dlp/snippets/InspectImageFile.java
@@ -70,7 +70,7 @@ public class InspectImageFile {
       // Construct the Inspect request to be sent by the client.
       InspectContentRequest request =
           InspectContentRequest.newBuilder()
-              .setParent(project.toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setItem(item)
               .setInspectConfig(config)
               .build();

--- a/dlp/src/main/java/dlp/snippets/InspectPhoneNumber.java
+++ b/dlp/src/main/java/dlp/snippets/InspectPhoneNumber.java
@@ -26,7 +26,7 @@ import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.InspectContentRequest;
 import com.google.privacy.dlp.v2.InspectContentResponse;
 import com.google.privacy.dlp.v2.Likelihood;
-import com.google.privacy.dlp.v2.ProjectName;
+import com.google.privacy.dlp.v2.LocationName;
 
 public class InspectPhoneNumber {
 
@@ -43,9 +43,6 @@ public class InspectPhoneNumber {
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
     try (DlpServiceClient dlp = DlpServiceClient.create()) {
-      // Specify the project used for request.
-      ProjectName project = ProjectName.of(projectId);
-
       // Specify the type and content to be inspected.
       ContentItem item = ContentItem.newBuilder()
           .setValue(textToInspect)
@@ -66,7 +63,7 @@ public class InspectPhoneNumber {
       // Construct the Inspect request to be sent by the client.
       InspectContentRequest request =
           InspectContentRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setItem(item)
               .setInspectConfig(config)
               .build();

--- a/dlp/src/main/java/dlp/snippets/InspectPhoneNumber.java
+++ b/dlp/src/main/java/dlp/snippets/InspectPhoneNumber.java
@@ -66,7 +66,7 @@ public class InspectPhoneNumber {
       // Construct the Inspect request to be sent by the client.
       InspectContentRequest request =
           InspectContentRequest.newBuilder()
-              .setParent(project.toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setItem(item)
               .setInspectConfig(config)
               .build();

--- a/dlp/src/main/java/dlp/snippets/InspectString.java
+++ b/dlp/src/main/java/dlp/snippets/InspectString.java
@@ -71,7 +71,7 @@ public class InspectString {
       // Construct the Inspect request to be sent by the client.
       InspectContentRequest request =
           InspectContentRequest.newBuilder()
-              .setParent(project.toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setItem(item)
               .setInspectConfig(config)
               .build();

--- a/dlp/src/main/java/dlp/snippets/InspectString.java
+++ b/dlp/src/main/java/dlp/snippets/InspectString.java
@@ -17,6 +17,7 @@
 package dlp.snippets;
 
 // [START dlp_inspect_string]
+
 import com.google.cloud.dlp.v2.DlpServiceClient;
 import com.google.privacy.dlp.v2.ByteContentItem;
 import com.google.privacy.dlp.v2.ByteContentItem.BytesType;
@@ -26,7 +27,7 @@ import com.google.privacy.dlp.v2.InfoType;
 import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.InspectContentRequest;
 import com.google.privacy.dlp.v2.InspectContentResponse;
-import com.google.privacy.dlp.v2.ProjectName;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.protobuf.ByteString;
 import java.util.ArrayList;
 import java.util.List;
@@ -46,9 +47,6 @@ public class InspectString {
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
     try (DlpServiceClient dlp = DlpServiceClient.create()) {
-      // Specify the project used for request.
-      ProjectName project = ProjectName.of(projectId);
-
       // Specify the type and content to be inspected.
       ByteContentItem byteItem =
           ByteContentItem.newBuilder()
@@ -71,7 +69,7 @@ public class InspectString {
       // Construct the Inspect request to be sent by the client.
       InspectContentRequest request =
           InspectContentRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setItem(item)
               .setInspectConfig(config)
               .build();

--- a/dlp/src/main/java/dlp/snippets/InspectStringWithExclusionDict.java
+++ b/dlp/src/main/java/dlp/snippets/InspectStringWithExclusionDict.java
@@ -32,8 +32,8 @@ import com.google.privacy.dlp.v2.InspectContentRequest;
 import com.google.privacy.dlp.v2.InspectContentResponse;
 import com.google.privacy.dlp.v2.InspectionRule;
 import com.google.privacy.dlp.v2.InspectionRuleSet;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.MatchingType;
-import com.google.privacy.dlp.v2.ProjectName;
 import com.google.protobuf.ByteString;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -56,9 +56,6 @@ public class InspectStringWithExclusionDict {
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
     try (DlpServiceClient dlp = DlpServiceClient.create()) {
-      // Specify the project used for request.
-      ProjectName project = ProjectName.of(projectId);
-
       // Specify the type and content to be inspected.
       ByteContentItem byteItem =
           ByteContentItem.newBuilder()
@@ -98,7 +95,7 @@ public class InspectStringWithExclusionDict {
       // Construct the Inspect request to be sent by the client.
       InspectContentRequest request =
           InspectContentRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setItem(item)
               .setInspectConfig(config)
               .build();

--- a/dlp/src/main/java/dlp/snippets/InspectStringWithExclusionDict.java
+++ b/dlp/src/main/java/dlp/snippets/InspectStringWithExclusionDict.java
@@ -98,7 +98,7 @@ public class InspectStringWithExclusionDict {
       // Construct the Inspect request to be sent by the client.
       InspectContentRequest request =
           InspectContentRequest.newBuilder()
-              .setParent(project.toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setItem(item)
               .setInspectConfig(config)
               .build();

--- a/dlp/src/main/java/dlp/snippets/InspectTextFile.java
+++ b/dlp/src/main/java/dlp/snippets/InspectTextFile.java
@@ -17,6 +17,7 @@
 package dlp.snippets;
 
 // [START dlp_inspect_file]
+
 import com.google.cloud.dlp.v2.DlpServiceClient;
 import com.google.privacy.dlp.v2.ByteContentItem;
 import com.google.privacy.dlp.v2.ByteContentItem.BytesType;
@@ -26,7 +27,7 @@ import com.google.privacy.dlp.v2.InfoType;
 import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.InspectContentRequest;
 import com.google.privacy.dlp.v2.InspectContentResponse;
-import com.google.privacy.dlp.v2.ProjectName;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.protobuf.ByteString;
 import java.io.FileInputStream;
 import java.util.ArrayList;
@@ -47,9 +48,6 @@ public class InspectTextFile {
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
     try (DlpServiceClient dlp = DlpServiceClient.create()) {
-      // Specify the project used for request.
-      ProjectName project = ProjectName.of(projectId);
-
       // Specify the type and content to be inspected.
       ByteString fileBytes = ByteString.readFrom(new FileInputStream(filePath));
       ByteContentItem byteItem =
@@ -70,7 +68,7 @@ public class InspectTextFile {
       // Construct the Inspect request to be sent by the client.
       InspectContentRequest request =
           InspectContentRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setItem(item)
               .setInspectConfig(config)
               .build();

--- a/dlp/src/main/java/dlp/snippets/InspectTextFile.java
+++ b/dlp/src/main/java/dlp/snippets/InspectTextFile.java
@@ -70,7 +70,7 @@ public class InspectTextFile {
       // Construct the Inspect request to be sent by the client.
       InspectContentRequest request =
           InspectContentRequest.newBuilder()
-              .setParent(project.toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setItem(item)
               .setInspectConfig(config)
               .build();

--- a/dlp/src/main/java/dlp/snippets/JobsCreate.java
+++ b/dlp/src/main/java/dlp/snippets/JobsCreate.java
@@ -26,7 +26,7 @@ import com.google.privacy.dlp.v2.InfoType;
 import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.InspectJobConfig;
 import com.google.privacy.dlp.v2.Likelihood;
-import com.google.privacy.dlp.v2.ProjectName;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.StorageConfig;
 import com.google.privacy.dlp.v2.StorageConfig.TimespanConfig;
 import java.io.IOException;
@@ -105,7 +105,7 @@ public class JobsCreate {
       // Construct the job creation request to be sent by the client.
       CreateDlpJobRequest createDlpJobRequest =
           CreateDlpJobRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setInspectJob(inspectJobConfig)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/JobsCreate.java
+++ b/dlp/src/main/java/dlp/snippets/JobsCreate.java
@@ -105,7 +105,7 @@ public class JobsCreate {
       // Construct the job creation request to be sent by the client.
       CreateDlpJobRequest createDlpJobRequest =
           CreateDlpJobRequest.newBuilder()
-              .setParent(ProjectName.of(projectId).toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setInspectJob(inspectJobConfig)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/JobsList.java
+++ b/dlp/src/main/java/dlp/snippets/JobsList.java
@@ -22,7 +22,7 @@ import com.google.cloud.dlp.v2.DlpServiceClient;
 import com.google.privacy.dlp.v2.DlpJob;
 import com.google.privacy.dlp.v2.DlpJobType;
 import com.google.privacy.dlp.v2.ListDlpJobsRequest;
-import com.google.privacy.dlp.v2.ProjectName;
+import com.google.privacy.dlp.v2.LocationName;
 import java.io.IOException;
 
 public class JobsList {
@@ -45,7 +45,7 @@ public class JobsList {
       // see https://cloud.google.com/dlp/docs/reference/rest/v2/projects.dlpJobs/list
       ListDlpJobsRequest listDlpJobsRequest =
           ListDlpJobsRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setFilter("state=DONE")
               .setType(DlpJobType.valueOf("INSPECT_JOB"))
               .build();

--- a/dlp/src/main/java/dlp/snippets/JobsList.java
+++ b/dlp/src/main/java/dlp/snippets/JobsList.java
@@ -45,7 +45,7 @@ public class JobsList {
       // see https://cloud.google.com/dlp/docs/reference/rest/v2/projects.dlpJobs/list
       ListDlpJobsRequest listDlpJobsRequest =
           ListDlpJobsRequest.newBuilder()
-              .setParent(ProjectName.of(projectId).toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setFilter("state=DONE")
               .setType(DlpJobType.valueOf("INSPECT_JOB"))
               .build();

--- a/dlp/src/main/java/dlp/snippets/QuickStart.java
+++ b/dlp/src/main/java/dlp/snippets/QuickStart.java
@@ -28,7 +28,7 @@ import com.google.privacy.dlp.v2.InspectContentRequest;
 import com.google.privacy.dlp.v2.InspectContentResponse;
 import com.google.privacy.dlp.v2.InspectResult;
 import com.google.privacy.dlp.v2.Likelihood;
-import com.google.privacy.dlp.v2.ProjectName;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.List;
@@ -84,7 +84,7 @@ public class QuickStart {
       // Create the request from previous configs
       InspectContentRequest request =
           InspectContentRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setInspectConfig(inspectConfig)
               .setItem(contentItem)
               .build();

--- a/dlp/src/main/java/dlp/snippets/QuickStart.java
+++ b/dlp/src/main/java/dlp/snippets/QuickStart.java
@@ -84,7 +84,7 @@ public class QuickStart {
       // Create the request from previous configs
       InspectContentRequest request =
           InspectContentRequest.newBuilder()
-              .setParent(ProjectName.of(projectId).toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setInspectConfig(inspectConfig)
               .setItem(contentItem)
               .build();

--- a/dlp/src/main/java/dlp/snippets/ReIdentifyWithFpe.java
+++ b/dlp/src/main/java/dlp/snippets/ReIdentifyWithFpe.java
@@ -32,8 +32,8 @@ import com.google.privacy.dlp.v2.InfoTypeTransformations;
 import com.google.privacy.dlp.v2.InfoTypeTransformations.InfoTypeTransformation;
 import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.KmsWrappedCryptoKey;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.PrimitiveTransformation;
-import com.google.privacy.dlp.v2.ProjectName;
 import com.google.privacy.dlp.v2.ReidentifyContentRequest;
 import com.google.privacy.dlp.v2.ReidentifyContentResponse;
 import com.google.protobuf.ByteString;
@@ -111,7 +111,7 @@ public class ReIdentifyWithFpe {
       // Combine configurations into a request for the service.
       ReidentifyContentRequest request =
           ReidentifyContentRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setItem(contentItem)
               .setInspectConfig(inspectConfig)
               .setReidentifyConfig(reidentifyConfig)

--- a/dlp/src/main/java/dlp/snippets/ReIdentifyWithFpe.java
+++ b/dlp/src/main/java/dlp/snippets/ReIdentifyWithFpe.java
@@ -111,7 +111,7 @@ public class ReIdentifyWithFpe {
       // Combine configurations into a request for the service.
       ReidentifyContentRequest request =
           ReidentifyContentRequest.newBuilder()
-              .setParent(ProjectName.of(projectId).toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setItem(contentItem)
               .setInspectConfig(inspectConfig)
               .setReidentifyConfig(reidentifyConfig)

--- a/dlp/src/main/java/dlp/snippets/RedactImageFile.java
+++ b/dlp/src/main/java/dlp/snippets/RedactImageFile.java
@@ -70,7 +70,7 @@ class RedactImageFile {
       // Construct the Redact request to be sent by the client.
       RedactImageRequest request =
           RedactImageRequest.newBuilder()
-              .setParent(project.toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setByteItem(byteItem)
               .setInspectConfig(config)
               .build();

--- a/dlp/src/main/java/dlp/snippets/RedactImageFile.java
+++ b/dlp/src/main/java/dlp/snippets/RedactImageFile.java
@@ -17,13 +17,14 @@
 package dlp.snippets;
 
 // [START dlp_redact_image]
+
 import com.google.cloud.dlp.v2.DlpServiceClient;
 import com.google.privacy.dlp.v2.ByteContentItem;
 import com.google.privacy.dlp.v2.ByteContentItem.BytesType;
 import com.google.privacy.dlp.v2.InfoType;
 import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.Likelihood;
-import com.google.privacy.dlp.v2.ProjectName;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.RedactImageRequest;
 import com.google.privacy.dlp.v2.RedactImageResponse;
 import com.google.protobuf.ByteString;
@@ -47,9 +48,6 @@ class RedactImageFile {
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
     try (DlpServiceClient dlp = DlpServiceClient.create()) {
-      // Specify the project used for request.
-      ProjectName project = ProjectName.of(projectId);
-
       // Specify the content to be inspected.
       ByteString fileBytes = ByteString.readFrom(new FileInputStream(inputPath));
       ByteContentItem byteItem =
@@ -70,7 +68,7 @@ class RedactImageFile {
       // Construct the Redact request to be sent by the client.
       RedactImageRequest request =
           RedactImageRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setByteItem(byteItem)
               .setInspectConfig(config)
               .build();

--- a/dlp/src/main/java/dlp/snippets/RiskAnalysisCategoricalStats.java
+++ b/dlp/src/main/java/dlp/snippets/RiskAnalysisCategoricalStats.java
@@ -97,7 +97,7 @@ class RiskAnalysisCategoricalStats {
       // Build the job creation request to be sent by the client
       CreateDlpJobRequest createDlpJobRequest =
           CreateDlpJobRequest.newBuilder()
-              .setParent(ProjectName.of(projectId).toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setRiskJob(riskAnalysisJobConfig)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/RiskAnalysisCategoricalStats.java
+++ b/dlp/src/main/java/dlp/snippets/RiskAnalysisCategoricalStats.java
@@ -31,9 +31,9 @@ import com.google.privacy.dlp.v2.CreateDlpJobRequest;
 import com.google.privacy.dlp.v2.DlpJob;
 import com.google.privacy.dlp.v2.FieldId;
 import com.google.privacy.dlp.v2.GetDlpJobRequest;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.PrivacyMetric;
 import com.google.privacy.dlp.v2.PrivacyMetric.CategoricalStatsConfig;
-import com.google.privacy.dlp.v2.ProjectName;
 import com.google.privacy.dlp.v2.RiskAnalysisJobConfig;
 import com.google.privacy.dlp.v2.ValueFrequency;
 import com.google.pubsub.v1.ProjectSubscriptionName;
@@ -97,7 +97,7 @@ class RiskAnalysisCategoricalStats {
       // Build the job creation request to be sent by the client
       CreateDlpJobRequest createDlpJobRequest =
           CreateDlpJobRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setRiskJob(riskAnalysisJobConfig)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/RiskAnalysisKAnonymity.java
+++ b/dlp/src/main/java/dlp/snippets/RiskAnalysisKAnonymity.java
@@ -105,7 +105,7 @@ class RiskAnalysisKAnonymity {
       // Build the request to be sent by the client
       CreateDlpJobRequest createDlpJobRequest =
           CreateDlpJobRequest.newBuilder()
-              .setParent(ProjectName.of(projectId).toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setRiskJob(riskAnalysisJobConfig)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/RiskAnalysisKAnonymity.java
+++ b/dlp/src/main/java/dlp/snippets/RiskAnalysisKAnonymity.java
@@ -33,9 +33,9 @@ import com.google.privacy.dlp.v2.CreateDlpJobRequest;
 import com.google.privacy.dlp.v2.DlpJob;
 import com.google.privacy.dlp.v2.FieldId;
 import com.google.privacy.dlp.v2.GetDlpJobRequest;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.PrivacyMetric;
 import com.google.privacy.dlp.v2.PrivacyMetric.KAnonymityConfig;
-import com.google.privacy.dlp.v2.ProjectName;
 import com.google.privacy.dlp.v2.RiskAnalysisJobConfig;
 import com.google.privacy.dlp.v2.Value;
 import com.google.pubsub.v1.ProjectSubscriptionName;
@@ -105,7 +105,7 @@ class RiskAnalysisKAnonymity {
       // Build the request to be sent by the client
       CreateDlpJobRequest createDlpJobRequest =
           CreateDlpJobRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setRiskJob(riskAnalysisJobConfig)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/RiskAnalysisKMap.java
+++ b/dlp/src/main/java/dlp/snippets/RiskAnalysisKMap.java
@@ -33,10 +33,10 @@ import com.google.privacy.dlp.v2.DlpJob;
 import com.google.privacy.dlp.v2.FieldId;
 import com.google.privacy.dlp.v2.GetDlpJobRequest;
 import com.google.privacy.dlp.v2.InfoType;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.PrivacyMetric;
 import com.google.privacy.dlp.v2.PrivacyMetric.KMapEstimationConfig;
 import com.google.privacy.dlp.v2.PrivacyMetric.KMapEstimationConfig.TaggedField;
-import com.google.privacy.dlp.v2.ProjectName;
 import com.google.privacy.dlp.v2.RiskAnalysisJobConfig;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.ProjectTopicName;
@@ -131,7 +131,7 @@ class RiskAnalysisKMap {
       // Build the request to be sent by the client
       CreateDlpJobRequest createDlpJobRequest =
           CreateDlpJobRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setRiskJob(riskAnalysisJobConfig)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/RiskAnalysisKMap.java
+++ b/dlp/src/main/java/dlp/snippets/RiskAnalysisKMap.java
@@ -131,7 +131,7 @@ class RiskAnalysisKMap {
       // Build the request to be sent by the client
       CreateDlpJobRequest createDlpJobRequest =
           CreateDlpJobRequest.newBuilder()
-              .setParent(ProjectName.of(projectId).toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setRiskJob(riskAnalysisJobConfig)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/RiskAnalysisLDiversity.java
+++ b/dlp/src/main/java/dlp/snippets/RiskAnalysisLDiversity.java
@@ -113,7 +113,7 @@ class RiskAnalysisLDiversity {
       // Build the request to be sent by the client
       CreateDlpJobRequest createDlpJobRequest =
           CreateDlpJobRequest.newBuilder()
-              .setParent(ProjectName.of(projectId).toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setRiskJob(riskAnalysisJobConfig)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/RiskAnalysisLDiversity.java
+++ b/dlp/src/main/java/dlp/snippets/RiskAnalysisLDiversity.java
@@ -33,9 +33,9 @@ import com.google.privacy.dlp.v2.CreateDlpJobRequest;
 import com.google.privacy.dlp.v2.DlpJob;
 import com.google.privacy.dlp.v2.FieldId;
 import com.google.privacy.dlp.v2.GetDlpJobRequest;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.PrivacyMetric;
 import com.google.privacy.dlp.v2.PrivacyMetric.LDiversityConfig;
-import com.google.privacy.dlp.v2.ProjectName;
 import com.google.privacy.dlp.v2.RiskAnalysisJobConfig;
 import com.google.privacy.dlp.v2.Value;
 import com.google.privacy.dlp.v2.ValueFrequency;
@@ -113,7 +113,7 @@ class RiskAnalysisLDiversity {
       // Build the request to be sent by the client
       CreateDlpJobRequest createDlpJobRequest =
           CreateDlpJobRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setRiskJob(riskAnalysisJobConfig)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/RiskAnalysisNumericalStats.java
+++ b/dlp/src/main/java/dlp/snippets/RiskAnalysisNumericalStats.java
@@ -97,7 +97,7 @@ class RiskAnalysisNumericalStats {
 
       CreateDlpJobRequest createDlpJobRequest =
           CreateDlpJobRequest.newBuilder()
-              .setParent(ProjectName.of(projectId).toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setRiskJob(riskAnalysisJobConfig)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/RiskAnalysisNumericalStats.java
+++ b/dlp/src/main/java/dlp/snippets/RiskAnalysisNumericalStats.java
@@ -31,9 +31,9 @@ import com.google.privacy.dlp.v2.CreateDlpJobRequest;
 import com.google.privacy.dlp.v2.DlpJob;
 import com.google.privacy.dlp.v2.FieldId;
 import com.google.privacy.dlp.v2.GetDlpJobRequest;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.PrivacyMetric;
 import com.google.privacy.dlp.v2.PrivacyMetric.NumericalStatsConfig;
-import com.google.privacy.dlp.v2.ProjectName;
 import com.google.privacy.dlp.v2.RiskAnalysisJobConfig;
 import com.google.privacy.dlp.v2.Value;
 import com.google.pubsub.v1.ProjectSubscriptionName;
@@ -97,7 +97,7 @@ class RiskAnalysisNumericalStats {
 
       CreateDlpJobRequest createDlpJobRequest =
           CreateDlpJobRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setRiskJob(riskAnalysisJobConfig)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/TemplatesCreate.java
+++ b/dlp/src/main/java/dlp/snippets/TemplatesCreate.java
@@ -68,7 +68,7 @@ class TemplatesCreate {
       // Create the request to be sent by the client
       CreateInspectTemplateRequest createInspectTemplateRequest =
           CreateInspectTemplateRequest.newBuilder()
-              .setParent(ProjectName.of(projectId).toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setInspectTemplate(inspectTemplate)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/TemplatesCreate.java
+++ b/dlp/src/main/java/dlp/snippets/TemplatesCreate.java
@@ -23,7 +23,7 @@ import com.google.privacy.dlp.v2.CreateInspectTemplateRequest;
 import com.google.privacy.dlp.v2.InfoType;
 import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.InspectTemplate;
-import com.google.privacy.dlp.v2.ProjectName;
+import com.google.privacy.dlp.v2.LocationName;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -68,7 +68,7 @@ class TemplatesCreate {
       // Create the request to be sent by the client
       CreateInspectTemplateRequest createInspectTemplateRequest =
           CreateInspectTemplateRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setInspectTemplate(inspectTemplate)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/TemplatesList.java
+++ b/dlp/src/main/java/dlp/snippets/TemplatesList.java
@@ -24,7 +24,7 @@ import com.google.privacy.dlp.v2.InfoType;
 import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.InspectTemplate;
 import com.google.privacy.dlp.v2.ListInspectTemplatesRequest;
-import com.google.privacy.dlp.v2.ProjectName;
+import com.google.privacy.dlp.v2.LocationName;
 import java.io.IOException;
 
 class TemplatesList {
@@ -45,7 +45,7 @@ class TemplatesList {
       // Create the request to be sent by the client
       ListInspectTemplatesRequest request =
           ListInspectTemplatesRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setPageSize(1)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/TemplatesList.java
+++ b/dlp/src/main/java/dlp/snippets/TemplatesList.java
@@ -45,7 +45,7 @@ class TemplatesList {
       // Create the request to be sent by the client
       ListInspectTemplatesRequest request =
           ListInspectTemplatesRequest.newBuilder()
-              .setParent(ProjectName.of(projectId).toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setPageSize(1)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/TriggersCreate.java
+++ b/dlp/src/main/java/dlp/snippets/TriggersCreate.java
@@ -25,7 +25,7 @@ import com.google.privacy.dlp.v2.InfoType;
 import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.InspectJobConfig;
 import com.google.privacy.dlp.v2.JobTrigger;
-import com.google.privacy.dlp.v2.ProjectName;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.Schedule;
 import com.google.privacy.dlp.v2.StorageConfig;
 import com.google.privacy.dlp.v2.StorageConfig.TimespanConfig;
@@ -106,7 +106,7 @@ public class TriggersCreate {
       // Create scan request to be sent by client
       CreateJobTriggerRequest createJobTriggerRequest =
           CreateJobTriggerRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .setJobTrigger(jobTrigger)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/TriggersCreate.java
+++ b/dlp/src/main/java/dlp/snippets/TriggersCreate.java
@@ -106,7 +106,7 @@ public class TriggersCreate {
       // Create scan request to be sent by client
       CreateJobTriggerRequest createJobTriggerRequest =
           CreateJobTriggerRequest.newBuilder()
-              .setParent(ProjectName.of(projectId).toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .setJobTrigger(jobTrigger)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/TriggersList.java
+++ b/dlp/src/main/java/dlp/snippets/TriggersList.java
@@ -37,7 +37,7 @@ class TriggersList {
       // Build the request to be sent by the client
       ListJobTriggersRequest listJobTriggersRequest =
           ListJobTriggersRequest.newBuilder()
-              .setParent(ProjectName.of(projectId).toString())
+              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
               .build();
 
       // Use the client to send the API request.

--- a/dlp/src/main/java/dlp/snippets/TriggersList.java
+++ b/dlp/src/main/java/dlp/snippets/TriggersList.java
@@ -17,10 +17,11 @@
 package dlp.snippets;
 
 // [START dlp_list_triggers]
+
 import com.google.cloud.dlp.v2.DlpServiceClient;
 import com.google.privacy.dlp.v2.JobTrigger;
 import com.google.privacy.dlp.v2.ListJobTriggersRequest;
-import com.google.privacy.dlp.v2.ProjectName;
+import com.google.privacy.dlp.v2.LocationName;
 
 class TriggersList {
   public static void listTriggers() throws Exception {
@@ -37,7 +38,7 @@ class TriggersList {
       // Build the request to be sent by the client
       ListJobTriggersRequest listJobTriggersRequest =
           ListJobTriggersRequest.newBuilder()
-              .setParent(String.format("%s/locations/global", ProjectName.of(projectId).toString()))
+              .setParent(LocationName.of(projectId, "global").toString())
               .build();
 
       // Use the client to send the API request.

--- a/dlp/src/test/java/dlp/snippets/JobsTests.java
+++ b/dlp/src/test/java/dlp/snippets/JobsTests.java
@@ -70,7 +70,8 @@ public class JobsTests {
 
       CreateDlpJobRequest createDlpJobRequest =
           CreateDlpJobRequest.newBuilder()
-              .setParent(ProjectName.of(PROJECT_ID).toString())
+              .setParent(
+                  String.format("%s/locations/global", ProjectName.of(PROJECT_ID).toString()))
               .setInspectJob(inspectJobConfig)
               .setJobId(jobId)
               .build();

--- a/dlp/src/test/java/dlp/snippets/JobsTests.java
+++ b/dlp/src/test/java/dlp/snippets/JobsTests.java
@@ -26,7 +26,7 @@ import com.google.privacy.dlp.v2.CreateDlpJobRequest;
 import com.google.privacy.dlp.v2.DlpJob;
 import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.InspectJobConfig;
-import com.google.privacy.dlp.v2.ProjectName;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.StorageConfig;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -70,8 +70,7 @@ public class JobsTests {
 
       CreateDlpJobRequest createDlpJobRequest =
           CreateDlpJobRequest.newBuilder()
-              .setParent(
-                  String.format("%s/locations/global", ProjectName.of(PROJECT_ID).toString()))
+              .setParent(LocationName.of(PROJECT_ID, "global").toString())
               .setInspectJob(inspectJobConfig)
               .setJobId(jobId)
               .build();

--- a/dlp/src/test/java/dlp/snippets/TemplatesTests.java
+++ b/dlp/src/test/java/dlp/snippets/TemplatesTests.java
@@ -21,13 +21,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 import com.google.cloud.dlp.v2.DlpServiceClient;
-import com.google.cloud.dlp.v2.DlpServiceClient.ListInspectTemplatesPagedResponse;
 import com.google.privacy.dlp.v2.CreateInspectTemplateRequest;
 import com.google.privacy.dlp.v2.DeleteInspectTemplateRequest;
 import com.google.privacy.dlp.v2.InfoType;
 import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.InspectTemplate;
-import com.google.privacy.dlp.v2.ListInspectTemplatesRequest;
 import com.google.privacy.dlp.v2.ProjectName;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -38,7 +36,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -72,7 +69,8 @@ public class TemplatesTests {
 
       CreateInspectTemplateRequest createInspectTemplateRequest =
           CreateInspectTemplateRequest.newBuilder()
-              .setParent(ProjectName.of(PROJECT_ID).toString())
+              .setParent(
+                  String.format("%s/locations/global", ProjectName.of(PROJECT_ID).toString()))
               .setInspectTemplate(inspectTemplate)
               .build();
 

--- a/dlp/src/test/java/dlp/snippets/TemplatesTests.java
+++ b/dlp/src/test/java/dlp/snippets/TemplatesTests.java
@@ -26,7 +26,7 @@ import com.google.privacy.dlp.v2.DeleteInspectTemplateRequest;
 import com.google.privacy.dlp.v2.InfoType;
 import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.InspectTemplate;
-import com.google.privacy.dlp.v2.ProjectName;
+import com.google.privacy.dlp.v2.LocationName;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -69,8 +69,7 @@ public class TemplatesTests {
 
       CreateInspectTemplateRequest createInspectTemplateRequest =
           CreateInspectTemplateRequest.newBuilder()
-              .setParent(
-                  String.format("%s/locations/global", ProjectName.of(PROJECT_ID).toString()))
+              .setParent(LocationName.of(PROJECT_ID, "global").toString())
               .setInspectTemplate(inspectTemplate)
               .build();
 

--- a/dlp/src/test/java/dlp/snippets/TriggersTests.java
+++ b/dlp/src/test/java/dlp/snippets/TriggersTests.java
@@ -26,7 +26,7 @@ import com.google.privacy.dlp.v2.DeleteJobTriggerRequest;
 import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.InspectJobConfig;
 import com.google.privacy.dlp.v2.JobTrigger;
-import com.google.privacy.dlp.v2.ProjectName;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.Schedule;
 import com.google.privacy.dlp.v2.StorageConfig;
 import com.google.protobuf.Duration;
@@ -84,8 +84,7 @@ public class TriggersTests {
 
       CreateJobTriggerRequest createJobTriggerRequest =
           CreateJobTriggerRequest.newBuilder()
-              .setParent(
-                  String.format("%s/locations/global", ProjectName.of(PROJECT_ID).toString()))
+              .setParent(LocationName.of(PROJECT_ID, "global").toString())
               .setJobTrigger(jobTrigger)
               .build();
 

--- a/dlp/src/test/java/dlp/snippets/TriggersTests.java
+++ b/dlp/src/test/java/dlp/snippets/TriggersTests.java
@@ -26,7 +26,6 @@ import com.google.privacy.dlp.v2.DeleteJobTriggerRequest;
 import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.InspectJobConfig;
 import com.google.privacy.dlp.v2.JobTrigger;
-import com.google.privacy.dlp.v2.ListJobTriggersRequest;
 import com.google.privacy.dlp.v2.ProjectName;
 import com.google.privacy.dlp.v2.Schedule;
 import com.google.privacy.dlp.v2.StorageConfig;
@@ -38,7 +37,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -86,7 +84,8 @@ public class TriggersTests {
 
       CreateJobTriggerRequest createJobTriggerRequest =
           CreateJobTriggerRequest.newBuilder()
-              .setParent(ProjectName.of(PROJECT_ID).toString())
+              .setParent(
+                  String.format("%s/locations/global", ProjectName.of(PROJECT_ID).toString()))
               .setJobTrigger(jobTrigger)
               .build();
 


### PR DESCRIPTION
Adds "locations/global" to the parent field specified when calling DLP api. This makes the job name produced consistent with the internal usage and, importantly to these samples, consistent with the job name used in the pubsub message indicating that the job is complete. This should fix certain tests timing out after 15 minutes waiting for the wrong pubsub message.

fixes internal bug b/158100365 (partially: only for Java samples)
Also see internal bug b/158026949 for more context.

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [X] `pom.xml` parent set to latest `shared-configuration`
- [X] Appropriate changes to README are included in PR
- [X] ~~API's need to be enabled to test (tell us)~~ (*Nothing new*)
- [X] ~~Environment Variables need to be set (ask us to set them)~~ (*Nothing new*)
- [X] Tests pass (`mvn -P lint clean verify`)
  * (Note- `Checkstyle` passing is required; `Spotbugs`, `ErrorProne`, `PMD`, etc. `ERROR`'s are advisory only)
- [X] Please **merge** this PR for me once it is approved.
