### PR TITLE
Fix java quickstart

### DIFF
--- a/firestore/src/main/java/com/example/firestore/Quickstart.java
+++ b/firestore/src/main/java/com/example/firestore/Quickstart.java
@@ -63,9 +63,8 @@ public class Quickstart {
         .setProjectId(projectId)
         .setCredentials(GoogleCredentials.fromStream(serviceAccountKeyInputStream))
         .build();
-    Firestore db = firestoreOptions.getService();
     // [END fs_initialize_project_id]
-    this.db = db;
+    this.db = firestoreOptions.getService();
   }
 
   Firestore getDb() {

--- a/firestore/src/main/java/com/example/firestore/Quickstart.java
+++ b/firestore/src/main/java/com/example/firestore/Quickstart.java
@@ -17,6 +17,7 @@
 package com.example.firestore;
 
 import com.google.api.core.ApiFuture;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.firestore.DocumentReference;
 // [START fs_include_dependencies]
 import com.google.cloud.firestore.Firestore;
@@ -63,7 +64,7 @@ public class Quickstart {
         .setCredentials(GoogleCredentials.fromStream(serviceAccountKeyInputStream))
         .build();
     // [END fs_initialize_project_id]
-    this.db = db;
+    this.db = firestoreOptions.getService();
   }
 
   Firestore getDb() {

--- a/firestore/src/main/java/com/example/firestore/Quickstart.java
+++ b/firestore/src/main/java/com/example/firestore/Quickstart.java
@@ -17,7 +17,6 @@
 package com.example.firestore;
 
 import com.google.api.core.ApiFuture;
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.firestore.DocumentReference;
 // [START fs_include_dependencies]
 import com.google.cloud.firestore.Firestore;
@@ -64,7 +63,7 @@ public class Quickstart {
         .setCredentials(GoogleCredentials.fromStream(serviceAccountKeyInputStream))
         .build();
     // [END fs_initialize_project_id]
-    this.db = firestoreOptions.getService();
+    this.db = db;
   }
 
   Firestore getDb() {

--- a/firestore/src/main/java/com/example/firestore/Quickstart.java
+++ b/firestore/src/main/java/com/example/firestore/Quickstart.java
@@ -26,6 +26,9 @@ import com.google.cloud.firestore.QueryDocumentSnapshot;
 import com.google.cloud.firestore.QuerySnapshot;
 import com.google.cloud.firestore.WriteResult;
 import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,13 +51,17 @@ public class Quickstart {
     this.db = db;
   }
 
-  public Quickstart(String projectId) {
+  public Quickstart(String projectId) throws Exception {
     // [START fs_initialize_project_id]
-    FirestoreOptions firestoreOptions =
-        FirestoreOptions.getDefaultInstance().toBuilder()
-            .setProjectId(projectId)
-            .build();
-    Firestore db = firestoreOptions.getService();
+    String serviceAccountKeyFilename = "<fill_in_with_path_to_service_account_key.json>";
+
+    InputStream serviceAccountKeyInputStream = new FileInputStream(
+        new File(serviceAccountKeyFilename));
+
+    FirestoreOptions firestoreOptions = FirestoreOptions.newBuilder()
+        .setProjectId(projectId)
+        .setCredentials(GoogleCredentials.fromStream(serviceAccountKeyInputStream))
+        .build();
     // [END fs_initialize_project_id]
     this.db = db;
   }

--- a/firestore/src/main/java/com/example/firestore/Quickstart.java
+++ b/firestore/src/main/java/com/example/firestore/Quickstart.java
@@ -63,8 +63,9 @@ public class Quickstart {
         .setProjectId(projectId)
         .setCredentials(GoogleCredentials.fromStream(serviceAccountKeyInputStream))
         .build();
+    Firestore db = firestoreOptions.getService();
     // [END fs_initialize_project_id]
-    this.db = firestoreOptions.getService();
+    this.db = db;
   }
 
   Firestore getDb() {

--- a/firestore/src/main/java/com/example/firestore/Quickstart.java
+++ b/firestore/src/main/java/com/example/firestore/Quickstart.java
@@ -53,6 +53,7 @@ public class Quickstart {
     FirestoreOptions firestoreOptions =
         FirestoreOptions.getDefaultInstance().toBuilder()
             .setProjectId(projectId)
+            .setCredentials(GoogleCredentials.getApplicationDefault())
             .build();
     Firestore db = firestoreOptions.getService();
     // [END fs_initialize_project_id]

--- a/firestore/src/main/java/com/example/firestore/Quickstart.java
+++ b/firestore/src/main/java/com/example/firestore/Quickstart.java
@@ -17,6 +17,7 @@
 package com.example.firestore;
 
 import com.google.api.core.ApiFuture;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.firestore.DocumentReference;
 // [START fs_include_dependencies]
 import com.google.cloud.firestore.Firestore;
@@ -48,7 +49,7 @@ public class Quickstart {
     this.db = db;
   }
 
-  public Quickstart(String projectId) {
+  public Quickstart(String projectId) throws Exception {
     // [START fs_initialize_project_id]
     FirestoreOptions firestoreOptions =
         FirestoreOptions.getDefaultInstance().toBuilder()

--- a/firestore/src/main/java/com/example/firestore/Quickstart.java
+++ b/firestore/src/main/java/com/example/firestore/Quickstart.java
@@ -26,9 +26,6 @@ import com.google.cloud.firestore.QueryDocumentSnapshot;
 import com.google.cloud.firestore.QuerySnapshot;
 import com.google.cloud.firestore.WriteResult;
 import com.google.common.collect.ImmutableMap;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,17 +48,13 @@ public class Quickstart {
     this.db = db;
   }
 
-  public Quickstart(String projectId) throws Exception {
+  public Quickstart(String projectId) {
     // [START fs_initialize_project_id]
-    String serviceAccountKeyFilename = "<fill_in_with_path_to_service_account_key.json>";
-
-    InputStream serviceAccountKeyInputStream = new FileInputStream(
-        new File(serviceAccountKeyFilename));
-
-    FirestoreOptions firestoreOptions = FirestoreOptions.newBuilder()
-        .setProjectId(projectId)
-        .setCredentials(GoogleCredentials.fromStream(serviceAccountKeyInputStream))
-        .build();
+    FirestoreOptions firestoreOptions =
+        FirestoreOptions.getDefaultInstance().toBuilder()
+            .setProjectId(projectId)
+            .build();
+    Firestore db = firestoreOptions.getService();
     // [END fs_initialize_project_id]
     this.db = db;
   }

--- a/firestore/src/test/java/com/example/firestore/BaseIntegrationTest.java
+++ b/firestore/src/test/java/com/example/firestore/BaseIntegrationTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import com.example.firestore.snippets.ManageDataSnippetsIT;
 import com.example.firestore.snippets.model.City;
 import com.google.api.core.ApiFuture;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.firestore.DocumentReference;
 import com.google.cloud.firestore.DocumentSnapshot;
 import com.google.cloud.firestore.Firestore;
@@ -49,6 +50,7 @@ public class BaseIntegrationTest {
   public static void baseSetup() throws Exception {
     projectId = getEnvVar("FIRESTORE_PROJECT_ID");
     FirestoreOptions firestoreOptions = FirestoreOptions.getDefaultInstance().toBuilder()
+        .setCredentials(GoogleCredentials.getApplicationDefault())
         .setProjectId(projectId)
         .build();
     db = firestoreOptions.getService();


### PR DESCRIPTION
These lines of code are referenced in this quickstart guide:
https://cloud.google.com/firestore/docs/quickstart-servers#java_1

The docs suggest that the credentials file will be read from the env variable, but that doesn't seem to be the case.  This change sets the credentials in the builder, using a Google credential utility to read it from the file specified by the env variable.