### PR TITLE
Fix DLP inspect tests to fail on timeout

### DIFF
--- a/dlp/src/test/java/dlp/snippets/InspectTests.java
+++ b/dlp/src/test/java/dlp/snippets/InspectTests.java
@@ -24,10 +24,8 @@ import static org.junit.Assert.assertNotNull;
 import com.google.cloud.dlp.v2.DlpServiceClient;
 import com.google.privacy.dlp.v2.CancelDlpJobRequest;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Arrays;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
@@ -146,60 +144,30 @@ public class InspectTests {
   }
 
   @Test
-  public void testInspectGcsFile() throws InterruptedException, ExecutionException, IOException {
-
+  public void testInspectGcsFile() throws Exception {
     InspectGcsFile.inspectGcsFile(PROJECT_ID, GCS_PATH, TOPIC_ID, SUBSCRIPTION_ID);
-    // Await job creation
-    TimeUnit.SECONDS.sleep(3);
 
     String output = bout.toString();
-    assertThat(output, containsString("Job created: "));
-
-    // Cancelling the job early to conserve quota
-    String jobId = output.split("Job created: ")[1].split("\n")[0];
-    CancelDlpJobRequest request = CancelDlpJobRequest.newBuilder().setName(jobId).build();
-    try (DlpServiceClient client = DlpServiceClient.create()) {
-      client.cancelDlpJob(request);
-    }
+    assertThat(output, containsString("Job status: DONE"));
   }
 
   @Test
-  public void testInspectDatastoreEntity()
-      throws InterruptedException, ExecutionException, IOException {
+  public void testInspectDatastoreEntity() throws Exception {
 
     InspectDatastoreEntity.insepctDatastoreEntity(
         PROJECT_ID, datastoreNamespace, datastoreKind, TOPIC_ID, SUBSCRIPTION_ID);
-    // Await job creation
-    TimeUnit.SECONDS.sleep(3);
 
     String output = bout.toString();
-    assertThat(output, containsString("Job created: "));
-
-    // Cancelling the job early to conserve quota
-    String jobId = output.split("Job created: ")[1].split("\n")[0];
-    CancelDlpJobRequest request = CancelDlpJobRequest.newBuilder().setName(jobId).build();
-    try (DlpServiceClient client = DlpServiceClient.create()) {
-      client.cancelDlpJob(request);
-    }
+    assertThat(output, containsString("Job status: DONE"));
   }
 
   @Test
-  public void testInspectBigQueryTable()
-      throws InterruptedException, ExecutionException, IOException {
+  public void testInspectBigQueryTable() throws Exception {
 
-    InspectBigQueryTable.inspectBigQueryTable(
-        PROJECT_ID, DATASET_ID, TABLE_ID, TOPIC_ID, SUBSCRIPTION_ID);
-    // Await job creation
-    TimeUnit.SECONDS.sleep(3);
+    InspectBigQueryTable
+        .inspectBigQueryTable(PROJECT_ID, DATASET_ID, TABLE_ID, TOPIC_ID, SUBSCRIPTION_ID);
 
     String output = bout.toString();
-    assertThat(output, containsString("Job created: "));
-
-    // Cancelling the job early to conserve quota
-    String jobId = output.split("Job created: ")[1].split("\n")[0];
-    CancelDlpJobRequest request = CancelDlpJobRequest.newBuilder().setName(jobId).build();
-    try (DlpServiceClient client = DlpServiceClient.create()) {
-      client.cancelDlpJob(request);
-    }
+    assertThat(output, containsString("Job status: DONE"));
   }
 }


### PR DESCRIPTION
Update DLP inspect tests to fail properly, instead of timing out after 15 minutes and passing. 
Also remove some broken code that tried to cancel early. 

Fixes internal bug b/158026949

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [X] `pom.xml` parent set to latest `shared-configuration`
- [X] Appropriate changes to README are included in PR
- [X] API's need to be enabled to test (tell us)
- [X] Environment Variables need to be set (ask us to set them)
- [X] Tests pass (`mvn -P lint clean verify`)
  * (Note- `Checkstyle` passing is required; `Spotbugs`, `ErrorProne`, `PMD`, etc. `ERROR`'s are advisory only)
- [X] Please **merge** this PR for me once it is approved.
