### PR TITLE
chore: add region tags for Spanner JDBC samples

### DIFF
--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/BatchDmlExample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/BatchDmlExample.java
@@ -16,6 +16,7 @@
 
 package com.example.spanner.jdbc;
 
+//[START spanner_jdbc_batch_transaction]
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -56,3 +57,4 @@ class BatchDmlExample {
     }
   }
 }
+//[END spanner_jdbc_batch_transaction]

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/BatchDmlExample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/BatchDmlExample.java
@@ -42,18 +42,21 @@ class BatchDmlExample {
         String.format(
             "jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s",
             projectId, instanceId, databaseId);
-    try (Connection connection = DriverManager.getConnection(connectionUrl);
-        Statement statement = connection.createStatement()) {
-      statement.addBatch(
-          "INSERT INTO Singers (SingerId, FirstName, LastName)\n"
-              + "VALUES (10, 'Marc', 'Richards')");
-      statement.addBatch(
-          "INSERT INTO Singers (SingerId, FirstName, LastName)\n"
-              + "VALUES (11, 'Amirah', 'Finney')");
-      statement.addBatch(
-          "INSERT INTO Singers (SingerId, FirstName, LastName)\n" + "VALUES (12, 'Reece', 'Dunn')");
-      int[] updateCounts = statement.executeBatch();
-      System.out.printf("Batch insert counts: %s%n", Arrays.toString(updateCounts));
+    try (Connection connection = DriverManager.getConnection(connectionUrl)) {
+      connection.setAutoCommit(false);
+      try (Statement statement = connection.createStatement()) {
+        statement.addBatch(
+            "INSERT INTO Singers (SingerId, FirstName, LastName)\n"
+                + "VALUES (10, 'Marc', 'Richards')");
+        statement.addBatch(
+            "INSERT INTO Singers (SingerId, FirstName, LastName)\n"
+                + "VALUES (11, 'Amirah', 'Finney')");
+        statement.addBatch(
+            "INSERT INTO Singers (SingerId, FirstName, LastName)\n" + "VALUES (12, 'Reece', 'Dunn')");
+        int[] updateCounts = statement.executeBatch();
+        connection.commit();
+        System.out.printf("Batch insert counts: %s%n", Arrays.toString(updateCounts));
+      }
     }
   }
 }

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/BatchDmlExample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/BatchDmlExample.java
@@ -52,7 +52,8 @@ class BatchDmlExample {
             "INSERT INTO Singers (SingerId, FirstName, LastName)\n"
                 + "VALUES (11, 'Amirah', 'Finney')");
         statement.addBatch(
-            "INSERT INTO Singers (SingerId, FirstName, LastName)\n" + "VALUES (12, 'Reece', 'Dunn')");
+            "INSERT INTO Singers (SingerId, FirstName, LastName)\n"
+                + "VALUES (12, 'Reece', 'Dunn')");
         int[] updateCounts = statement.executeBatch();
         connection.commit();
         System.out.printf("Batch insert counts: %s%n", Arrays.toString(updateCounts));

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/CreateTableExample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/CreateTableExample.java
@@ -16,6 +16,7 @@
 
 package com.example.spanner.jdbc;
 
+//[START spanner_jdbc_create_table]
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -55,3 +56,4 @@ class CreateTableExample {
     System.out.println("Created table [Singers]");
   }
 }
+//[END spanner_jdbc_create_table]

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/InsertDataExample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/InsertDataExample.java
@@ -66,7 +66,6 @@ class InsertDataExample {
             "jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s",
             projectId, instanceId, databaseId);
     try (Connection connection = DriverManager.getConnection(connectionUrl)) {
-      connection.setAutoCommit(false);
       try (PreparedStatement ps =
           connection.prepareStatement(
               "INSERT INTO Singers\n"
@@ -81,7 +80,6 @@ class InsertDataExample {
           ps.addBatch();
         }
         int[] updateCounts = ps.executeBatch();
-        connection.commit();
         System.out.printf("Insert counts: %s%n", Arrays.toString(updateCounts));
       }
     }

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/InsertDataExample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/InsertDataExample.java
@@ -16,6 +16,7 @@
 
 package com.example.spanner.jdbc;
 
+//[START spanner_jdbc_insert]
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -86,3 +87,4 @@ class InsertDataExample {
     }
   }
 }
+//[END spanner_jdbc_insert]

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/SingleUseReadOnlyExample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/SingleUseReadOnlyExample.java
@@ -16,6 +16,7 @@
 
 package com.example.spanner.jdbc;
 
+//[START spanner_jdbc_query]
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -57,3 +58,4 @@ public class SingleUseReadOnlyExample {
     }
   }
 }
+//[END spanner_jdbc_query]


### PR DESCRIPTION
Currently the [public docs](https://cloud.google.com/spanner/docs/use-oss-jdbc) don't point to the samples on GitHub so adding the relevant region tags here to enable the docs to point to these samples.

Also made changes to the following samples to match those of the existing samples:
- InsertDataExample.java to use autocommit to be equivalent to [existing sample](https://cloud.google.com/spanner/docs/use-oss-jdbc#use_a_transaction_in_autocommit_mode_to_add_and_delete_rows).
- BatchDmlExample.java to turn off autocommit to be equivalent to [existing sample](https://cloud.google.com/spanner/docs/use-oss-jdbc#use_a_batch_transaction_to_add_and_delete_rows).

If the changes in 3d5e6158e81de4ffce786e5699f1817eaf2cf168 don't make sense, happy to revert.