### PR TITLE
Fix pubsub handling for DLP samples and tests

### DIFF
--- a/dlp/src/main/java/dlp/snippets/InspectBigQueryTable.java
+++ b/dlp/src/main/java/dlp/snippets/InspectBigQueryTable.java
@@ -140,6 +140,9 @@ public class InspectBigQueryTable {
       } catch (TimeoutException e) {
         System.out.println("Job was not completed after 15 minutes.");
         return;
+      } finally {
+        subscriber.stopAsync();
+        subscriber.awaitTerminated();
       }
 
       // Get the latest state of the job from the service

--- a/dlp/src/main/java/dlp/snippets/InspectDatastoreEntity.java
+++ b/dlp/src/main/java/dlp/snippets/InspectDatastoreEntity.java
@@ -141,6 +141,9 @@ public class InspectDatastoreEntity {
       } catch (TimeoutException e) {
         System.out.println("Job was not completed after 15 minutes.");
         return;
+      } finally {
+        subscriber.stopAsync();
+        subscriber.awaitTerminated();
       }
 
       // Get the latest state of the job from the service

--- a/dlp/src/main/java/dlp/snippets/InspectGcsFile.java
+++ b/dlp/src/main/java/dlp/snippets/InspectGcsFile.java
@@ -127,6 +127,9 @@ public class InspectGcsFile {
       } catch (TimeoutException e) {
         System.out.println("Job was not completed after 15 minutes.");
         return;
+      } finally {
+        subscriber.stopAsync();
+        subscriber.awaitTerminated();
       }
 
       // Get the latest state of the job from the service

--- a/dlp/src/main/java/dlp/snippets/InspectStringOmitOverlap.java
+++ b/dlp/src/main/java/dlp/snippets/InspectStringOmitOverlap.java
@@ -16,7 +16,7 @@
 
 package dlp.snippets;
 
-// [START dlp_inspect_string_with_exclusion_dict]
+// [START dlp_inspect_string_omit_overlap]
 
 import com.google.cloud.dlp.v2.DlpServiceClient;
 import com.google.privacy.dlp.v2.ByteContentItem;
@@ -114,4 +114,4 @@ public class InspectStringOmitOverlap {
     }
   }
 }
-// [END dlp_inspect_string_with_exclusion_dict]
+// [END dlp_inspect_string_omit_overlap]

--- a/dlp/src/main/java/dlp/snippets/InspectStringWithoutOverlap.java
+++ b/dlp/src/main/java/dlp/snippets/InspectStringWithoutOverlap.java
@@ -16,7 +16,7 @@
 
 package dlp.snippets;
 
-// [START dlp_inspect_string_with_exclusion_dict]
+// [START dlp_inspect_string_without_overlap]
 
 import com.google.cloud.dlp.v2.DlpServiceClient;
 import com.google.privacy.dlp.v2.ByteContentItem;
@@ -123,4 +123,4 @@ public class InspectStringWithoutOverlap {
     }
   }
 }
-// [END dlp_inspect_string_with_exclusion_dict]
+// [END dlp_inspect_string_without_overlap]

--- a/dlp/src/main/java/dlp/snippets/RiskAnalysisCategoricalStats.java
+++ b/dlp/src/main/java/dlp/snippets/RiskAnalysisCategoricalStats.java
@@ -127,6 +127,9 @@ class RiskAnalysisCategoricalStats {
         Thread.sleep(500); // Wait for the job to become available
       } catch (TimeoutException e) {
         System.out.println("Unable to verify job completion.");
+      } finally {
+        subscriber.stopAsync();
+        subscriber.awaitTerminated();
       }
 
       // Build a request to get the completed job

--- a/dlp/src/main/java/dlp/snippets/RiskAnalysisKAnonymity.java
+++ b/dlp/src/main/java/dlp/snippets/RiskAnalysisKAnonymity.java
@@ -135,6 +135,9 @@ class RiskAnalysisKAnonymity {
         Thread.sleep(500); // Wait for the job to become available
       } catch (TimeoutException e) {
         System.out.println("Unable to verify job completion.");
+      } finally {
+        subscriber.stopAsync();
+        subscriber.awaitTerminated();
       }
 
       // Build a request to get the completed job

--- a/dlp/src/main/java/dlp/snippets/RiskAnalysisKMap.java
+++ b/dlp/src/main/java/dlp/snippets/RiskAnalysisKMap.java
@@ -159,6 +159,9 @@ class RiskAnalysisKMap {
         Thread.sleep(500); // Wait for the job to become available
       } catch (TimeoutException e) {
         System.out.println("Unable to verify job completion.");
+      } finally {
+        subscriber.stopAsync();
+        subscriber.awaitTerminated();
       }
 
       // Build a request to get the completed job

--- a/dlp/src/main/java/dlp/snippets/RiskAnalysisLDiversity.java
+++ b/dlp/src/main/java/dlp/snippets/RiskAnalysisLDiversity.java
@@ -143,6 +143,9 @@ class RiskAnalysisLDiversity {
         Thread.sleep(500); // Wait for the job to become available
       } catch (TimeoutException e) {
         System.out.println("Unable to verify job completion.");
+      } finally {
+        subscriber.stopAsync();
+        subscriber.awaitTerminated();
       }
 
       // Build a request to get the completed job

--- a/dlp/src/main/java/dlp/snippets/RiskAnalysisNumericalStats.java
+++ b/dlp/src/main/java/dlp/snippets/RiskAnalysisNumericalStats.java
@@ -127,6 +127,9 @@ class RiskAnalysisNumericalStats {
         Thread.sleep(500); // Wait for the job to become available
       } catch (TimeoutException e) {
         System.out.println("Unable to verify job completion.");
+      } finally {
+        subscriber.stopAsync();
+        subscriber.awaitTerminated();
       }
 
       // Build a request to get the completed job

--- a/dlp/src/test/java/dlp/snippets/InspectTests.java
+++ b/dlp/src/test/java/dlp/snippets/InspectTests.java
@@ -21,11 +21,19 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertNotNull;
 
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PushConfig;
+import com.google.pubsub.v1.TopicName;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Arrays;
+import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -42,7 +50,15 @@ public class InspectTests {
   // TODO: Update as ENV_VARs
   private static final String datastoreNamespace = "";
   private static final String datastoreKind = "dlp";
+
   private ByteArrayOutputStream bout;
+  private UUID testRunUuid = UUID.randomUUID();
+  private TopicName topicName = TopicName.of(
+      PROJECT_ID,
+      String.format("%s-%s", TOPIC_ID, testRunUuid.toString()));
+  private ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of(
+      PROJECT_ID,
+      String.format("%s-%s", SUBSCRIPTION_ID, testRunUuid.toString()));
 
   private static void requireEnvVar(String varName) {
     assertNotNull(
@@ -50,8 +66,8 @@ public class InspectTests {
         System.getenv(varName));
   }
 
-  @Before
-  public void checkRequirements() {
+  @BeforeClass
+  public static void checkRequirements() {
     requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
     requireEnvVar("GOOGLE_CLOUD_PROJECT");
     requireEnvVar("GCS_PATH");
@@ -62,15 +78,46 @@ public class InspectTests {
   }
 
   @Before
-  public void captureOut() {
+  public void setUp() throws Exception {
+    // Capture stdout
     bout = new ByteArrayOutputStream();
     System.setOut(new PrintStream(bout));
+
+    // Create a new topic
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+      topicAdminClient.createTopic(topicName);
+    }
+    // Create a new subscription
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      subscriptionAdminClient
+          .createSubscription(subscriptionName, topicName, PushConfig.getDefaultInstance(), 0);
+    }
   }
 
+
   @After
-  public void releaseOut() {
+  public void tearDown() throws Exception {
+    // Restore stdout
     System.setOut(null);
     bout.reset();
+
+    // Delete the test topic
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+      topicAdminClient.deleteTopic(topicName);
+    } catch (ApiException e) {
+      System.out.println(String.format("Error deleting test pubsub topic %s: %s",
+          topicName.getTopic(), e));
+      // Keep trying to clean up
+    }
+
+    // Delete the test subscription
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      subscriptionAdminClient.deleteSubscription(subscriptionName);
+    } catch (ApiException e) {
+      System.out.println(String.format("Error deleting test pubsub subscription %s: %s",
+          subscriptionName.getSubscription(), e));
+      // Keep trying to clean up
+    }
   }
 
   @Test
@@ -183,7 +230,9 @@ public class InspectTests {
 
   @Test
   public void testInspectGcsFile() throws Exception {
-    InspectGcsFile.inspectGcsFile(PROJECT_ID, GCS_PATH, TOPIC_ID, SUBSCRIPTION_ID);
+    InspectGcsFile
+        .inspectGcsFile(PROJECT_ID, GCS_PATH, topicName.getTopic(),
+            subscriptionName.getSubscription());
 
     String output = bout.toString();
     assertThat(output, containsString("Job status: DONE"));
@@ -191,9 +240,9 @@ public class InspectTests {
 
   @Test
   public void testInspectDatastoreEntity() throws Exception {
-
-    InspectDatastoreEntity.insepctDatastoreEntity(
-        PROJECT_ID, datastoreNamespace, datastoreKind, TOPIC_ID, SUBSCRIPTION_ID);
+    InspectDatastoreEntity
+        .insepctDatastoreEntity(PROJECT_ID, datastoreNamespace, datastoreKind, topicName.getTopic(),
+            subscriptionName.getSubscription());
 
     String output = bout.toString();
     assertThat(output, containsString("Job status: DONE"));
@@ -201,9 +250,9 @@ public class InspectTests {
 
   @Test
   public void testInspectBigQueryTable() throws Exception {
-
     InspectBigQueryTable
-        .inspectBigQueryTable(PROJECT_ID, DATASET_ID, TABLE_ID, TOPIC_ID, SUBSCRIPTION_ID);
+        .inspectBigQueryTable(PROJECT_ID, DATASET_ID, TABLE_ID, topicName.getTopic(),
+            subscriptionName.getSubscription());
 
     String output = bout.toString();
     assertThat(output, containsString("Job status: DONE"));

--- a/dlp/src/test/java/dlp/snippets/InspectTests.java
+++ b/dlp/src/test/java/dlp/snippets/InspectTests.java
@@ -28,6 +28,8 @@ import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.PushConfig;
 import com.google.pubsub.v1.TopicName;
 import java.io.ByteArrayOutputStream;
+import java.io.FileDescriptor;
+import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.UUID;
@@ -101,7 +103,7 @@ public class InspectTests {
   @After
   public void tearDown() throws Exception {
     // Restore stdout
-    System.setOut(null);
+    System.setOut(new PrintStream(new FileOutputStream(FileDescriptor.out)));
     bout.reset();
 
     // Delete the test topic

--- a/dlp/src/test/java/dlp/snippets/InspectTests.java
+++ b/dlp/src/test/java/dlp/snippets/InspectTests.java
@@ -28,8 +28,6 @@ import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.PushConfig;
 import com.google.pubsub.v1.TopicName;
 import java.io.ByteArrayOutputStream;
-import java.io.FileDescriptor;
-import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.UUID;
@@ -61,6 +59,7 @@ public class InspectTests {
   private ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of(
       PROJECT_ID,
       String.format("%s-%s", SUBSCRIPTION_ID, testRunUuid.toString()));
+  private PrintStream originalOut = System.out;
 
   private static void requireEnvVar(String varName) {
     assertNotNull(
@@ -81,13 +80,11 @@ public class InspectTests {
 
   @Before
   public void setUp() throws Exception {
-    System.out.println(String.format("Using topic '%s' and subscription '%s'",
-        topicName.getTopic(), subscriptionName.getSubscription()));
-
     // Create a new topic
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.createTopic(topicName);
     }
+
     // Create a new subscription
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       subscriptionAdminClient
@@ -103,14 +100,14 @@ public class InspectTests {
   @After
   public void tearDown() throws Exception {
     // Restore stdout
-    System.setOut(new PrintStream(new FileOutputStream(FileDescriptor.out)));
+    System.setOut(originalOut);
     bout.reset();
 
     // Delete the test topic
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(topicName);
     } catch (ApiException e) {
-      System.out.println(String.format("Error deleting topic %s: %s",
+      System.err.println(String.format("Error deleting topic %s: %s",
           topicName.getTopic(), e));
       // Keep trying to clean up
     }
@@ -119,7 +116,7 @@ public class InspectTests {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       subscriptionAdminClient.deleteSubscription(subscriptionName);
     } catch (ApiException e) {
-      System.out.println(String.format("Error deleting subscription %s: %s",
+      System.err.println(String.format("Error deleting subscription %s: %s",
           subscriptionName.getSubscription(), e));
       // Keep trying to clean up
     }

--- a/dlp/src/test/java/dlp/snippets/InspectTests.java
+++ b/dlp/src/test/java/dlp/snippets/InspectTests.java
@@ -79,9 +79,8 @@ public class InspectTests {
 
   @Before
   public void setUp() throws Exception {
-    // Capture stdout
-    bout = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(bout));
+    System.out.println(String.format("Using topic '%s' and subscription '%s'",
+        topicName.getTopic(), subscriptionName.getSubscription()));
 
     // Create a new topic
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
@@ -92,6 +91,10 @@ public class InspectTests {
       subscriptionAdminClient
           .createSubscription(subscriptionName, topicName, PushConfig.getDefaultInstance(), 0);
     }
+
+    // Capture stdout
+    bout = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(bout));
   }
 
 
@@ -105,7 +108,7 @@ public class InspectTests {
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(topicName);
     } catch (ApiException e) {
-      System.out.println(String.format("Error deleting test pubsub topic %s: %s",
+      System.out.println(String.format("Error deleting topic %s: %s",
           topicName.getTopic(), e));
       // Keep trying to clean up
     }
@@ -114,7 +117,7 @@ public class InspectTests {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       subscriptionAdminClient.deleteSubscription(subscriptionName);
     } catch (ApiException e) {
-      System.out.println(String.format("Error deleting test pubsub subscription %s: %s",
+      System.out.println(String.format("Error deleting subscription %s: %s",
           subscriptionName.getSubscription(), e));
       // Keep trying to clean up
     }

--- a/dlp/src/test/java/dlp/snippets/RiskAnalysisTests.java
+++ b/dlp/src/test/java/dlp/snippets/RiskAnalysisTests.java
@@ -28,6 +28,8 @@ import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.PushConfig;
 import com.google.pubsub.v1.TopicName;
 import java.io.ByteArrayOutputStream;
+import java.io.FileDescriptor;
+import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -74,9 +76,8 @@ public class RiskAnalysisTests {
 
   @Before
   public void setUp() throws Exception {
-    // Capture stdout
-    bout = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(bout));
+    System.out.println(String.format("Using topic '%s' and subscription '%s'",
+        topicName.getTopic(), subscriptionName.getSubscription()));
 
     // Create a new topic
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
@@ -87,20 +88,24 @@ public class RiskAnalysisTests {
       subscriptionAdminClient
           .createSubscription(subscriptionName, topicName, PushConfig.getDefaultInstance(), 0);
     }
+
+    // Capture stdout
+    bout = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(bout));
   }
 
 
   @After
   public void tearDown() throws Exception {
     // Restore stdout
-    System.setOut(null);
+    System.setOut(new PrintStream(new FileOutputStream(FileDescriptor.out)));
     bout.reset();
 
     // Delete the test topic
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(topicName);
     } catch (ApiException e) {
-      System.out.println(String.format("Error deleting test pubsub topic %s: %s",
+      System.out.println(String.format("Error deleting topic %s: %s",
           topicName.getTopic(), e));
       // Keep trying to clean up
     }
@@ -109,7 +114,7 @@ public class RiskAnalysisTests {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       subscriptionAdminClient.deleteSubscription(subscriptionName);
     } catch (ApiException e) {
-      System.out.println(String.format("Error deleting test pubsub subscription %s: %s",
+      System.out.println(String.format("Error deleting subscription %s: %s",
           subscriptionName.getSubscription(), e));
       // Keep trying to clean up
     }

--- a/dlp/src/test/java/dlp/snippets/RiskAnalysisTests.java
+++ b/dlp/src/test/java/dlp/snippets/RiskAnalysisTests.java
@@ -21,8 +21,15 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PushConfig;
+import com.google.pubsub.v1.TopicName;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.UUID;
 import java.util.regex.Pattern;
 import org.junit.After;
 import org.junit.Before;
@@ -39,7 +46,15 @@ public class RiskAnalysisTests {
   private static final String SUBSCRIPTION_ID = System.getenv("PUB_SUB_SUBSCRIPTION");
   private static final String DATASET_ID = System.getenv("BIGQUERY_DATASET");
   private static final String TABLE_ID = System.getenv("BIGQUERY_TABLE");
+
   private ByteArrayOutputStream bout;
+  private UUID testRunUuid = UUID.randomUUID();
+  private TopicName topicName = TopicName.of(
+      PROJECT_ID,
+      String.format("%s-%s", TOPIC_ID, testRunUuid.toString()));
+  private ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of(
+      PROJECT_ID,
+      String.format("%s-%s", SUBSCRIPTION_ID, testRunUuid.toString()));
 
   private static void requireEnvVar(String varName) {
     assertNotNull(
@@ -58,15 +73,52 @@ public class RiskAnalysisTests {
   }
 
   @Before
-  public void setUp() {
+  public void setUp() throws Exception {
+    // Capture stdout
     bout = new ByteArrayOutputStream();
     System.setOut(new PrintStream(bout));
+
+    // Create a new topic
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+      topicAdminClient.createTopic(topicName);
+    }
+    // Create a new subscription
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      subscriptionAdminClient
+          .createSubscription(subscriptionName, topicName, PushConfig.getDefaultInstance(), 0);
+    }
+  }
+
+
+  @After
+  public void tearDown() throws Exception {
+    // Restore stdout
+    System.setOut(null);
+    bout.reset();
+
+    // Delete the test topic
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+      topicAdminClient.deleteTopic(topicName);
+    } catch (ApiException e) {
+      System.out.println(String.format("Error deleting test pubsub topic %s: %s",
+          topicName.getTopic(), e));
+      // Keep trying to clean up
+    }
+
+    // Delete the test subscription
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      subscriptionAdminClient.deleteSubscription(subscriptionName);
+    } catch (ApiException e) {
+      System.out.println(String.format("Error deleting test pubsub subscription %s: %s",
+          subscriptionName.getSubscription(), e));
+      // Keep trying to clean up
+    }
   }
 
   @Test
   public void testNumericalStats() throws Exception {
     RiskAnalysisNumericalStats.numericalStatsAnalysis(
-        PROJECT_ID, DATASET_ID, TABLE_ID, TOPIC_ID, SUBSCRIPTION_ID);
+        PROJECT_ID, DATASET_ID, TABLE_ID, topicName.getTopic(), subscriptionName.getSubscription());
     String output = bout.toString();
     assertThat(output, containsString("Value at "));
   }
@@ -74,7 +126,7 @@ public class RiskAnalysisTests {
   @Test
   public void testCategoricalStats() throws Exception {
     RiskAnalysisCategoricalStats.categoricalStatsAnalysis(
-        PROJECT_ID, DATASET_ID, TABLE_ID, TOPIC_ID, SUBSCRIPTION_ID);
+        PROJECT_ID, DATASET_ID, TABLE_ID, topicName.getTopic(), subscriptionName.getSubscription());
 
     String output = bout.toString();
 
@@ -85,7 +137,7 @@ public class RiskAnalysisTests {
   @Test
   public void testKAnonymity() throws Exception {
     RiskAnalysisKAnonymity.calculateKAnonymity(
-        PROJECT_ID, DATASET_ID, TABLE_ID, TOPIC_ID, SUBSCRIPTION_ID);
+        PROJECT_ID, DATASET_ID, TABLE_ID, topicName.getTopic(), subscriptionName.getSubscription());
     String output = bout.toString();
     assertTrue(Pattern.compile("Bucket size range: \\[\\d, \\d\\]").matcher(output).find());
     assertTrue(output.contains("Quasi-ID values: integer_value: 19"));
@@ -95,7 +147,7 @@ public class RiskAnalysisTests {
   @Test
   public void testLDiversity() throws Exception {
     RiskAnalysisLDiversity.calculateLDiversity(
-        PROJECT_ID, DATASET_ID, TABLE_ID, TOPIC_ID, SUBSCRIPTION_ID);
+        PROJECT_ID, DATASET_ID, TABLE_ID, topicName.getTopic(), subscriptionName.getSubscription());
     String output = bout.toString();
     assertTrue(output.contains("Quasi-ID values: integer_value: 19"));
     assertTrue(output.contains("Class size: 1"));
@@ -104,18 +156,13 @@ public class RiskAnalysisTests {
 
   @Test
   public void testKMap() throws Exception {
-    RiskAnalysisKMap.calculateKMap(PROJECT_ID, DATASET_ID, TABLE_ID, TOPIC_ID, SUBSCRIPTION_ID);
+    RiskAnalysisKMap.calculateKMap(
+        PROJECT_ID, DATASET_ID, TABLE_ID, topicName.getTopic(), subscriptionName.getSubscription());
 
     String output = bout.toString();
 
     assertTrue(Pattern.compile("Anonymity range: \\[\\d, \\d]").matcher(output).find());
     assertTrue(Pattern.compile("Size: \\d").matcher(output).find());
     assertTrue(Pattern.compile("Values: \\{\\d{2}, \"Female\"\\}").matcher(output).find());
-  }
-
-  @After
-  public void tearDown() {
-    System.setOut(null);
-    bout.reset();
   }
 }

--- a/dlp/src/test/java/dlp/snippets/RiskAnalysisTests.java
+++ b/dlp/src/test/java/dlp/snippets/RiskAnalysisTests.java
@@ -28,8 +28,6 @@ import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.PushConfig;
 import com.google.pubsub.v1.TopicName;
 import java.io.ByteArrayOutputStream;
-import java.io.FileDescriptor;
-import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -57,6 +55,7 @@ public class RiskAnalysisTests {
   private ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of(
       PROJECT_ID,
       String.format("%s-%s", SUBSCRIPTION_ID, testRunUuid.toString()));
+  private PrintStream originalOut = System.out;
 
   private static void requireEnvVar(String varName) {
     assertNotNull(
@@ -76,9 +75,6 @@ public class RiskAnalysisTests {
 
   @Before
   public void setUp() throws Exception {
-    System.out.println(String.format("Using topic '%s' and subscription '%s'",
-        topicName.getTopic(), subscriptionName.getSubscription()));
-
     // Create a new topic
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.createTopic(topicName);
@@ -98,14 +94,14 @@ public class RiskAnalysisTests {
   @After
   public void tearDown() throws Exception {
     // Restore stdout
-    System.setOut(new PrintStream(new FileOutputStream(FileDescriptor.out)));
+    System.setOut(originalOut);
     bout.reset();
 
     // Delete the test topic
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(topicName);
     } catch (ApiException e) {
-      System.out.println(String.format("Error deleting topic %s: %s",
+      System.err.println(String.format("Error deleting topic %s: %s",
           topicName.getTopic(), e));
       // Keep trying to clean up
     }
@@ -114,7 +110,7 @@ public class RiskAnalysisTests {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       subscriptionAdminClient.deleteSubscription(subscriptionName);
     } catch (ApiException e) {
-      System.out.println(String.format("Error deleting subscription %s: %s",
+      System.err.println(String.format("Error deleting subscription %s: %s",
           subscriptionName.getSubscription(), e));
       // Keep trying to clean up
     }


### PR DESCRIPTION
Fixes internal bug b/158322296

1. Update DLP java tests to use unique topic/subscription for each test. This should help avoid flakes caused by concurrent test runs competing for resources. The PUBSUB_ env vars are still required, but used as a prefix instead of as a shared single topic/sub. 
2. Properly close the subscription in each sample before returning. This avoids a race condition with topic/subscription cleanup, in addition to being good hygiene. 

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [X] `pom.xml` parent set to latest `shared-configuration`
- [X] Appropriate changes to README are included in PR
- [X] API's need to be enabled to test (tell us) (**Nothing new**)
- [X] Environment Variables need to be set (ask us to set them) (**Nothing new**)
- [X] Tests pass (`mvn -P lint clean verify`)
  * (Note- `Checkstyle` passing is required; `Spotbugs`, `ErrorProne`, `PMD`, etc. `ERROR`'s are advisory only)
- [X] Please **merge** this PR for me once it is approved.
