### PR TITLE
Add separate lint and static anaylsis tests for presubmits.

### DIFF
--- a/.kokoro/lint/common.cfg
+++ b/.kokoro/lint/common.cfg
@@ -1,0 +1,38 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Use the trampoline to bounce the script into docker.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+build_file: "java-docs-samples/.kokoro/trampoline.sh"
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+}
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/java-docs-samples/.kokoro/tests/run_lint.sh"
+}
+
+# Access btlr binaries used in the tests
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/btlr"
+
+
+# Upload logs to result-store
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.xml"
+  }
+}

--- a/.kokoro/lint/presubmit.cfg
+++ b/.kokoro/lint/presubmit.cfg
@@ -1,0 +1,21 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Tell the trampoline which build file to use.
+env_vars: {
+    key: "GIT_DIFF"
+    value: "origin/master... ."
+}

--- a/.kokoro/static_analysis/common.cfg
+++ b/.kokoro/static_analysis/common.cfg
@@ -1,0 +1,37 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Use the trampoline to bounce the script into docker.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+build_file: "java-docs-samples/.kokoro/trampoline.sh"
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+}
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/java-docs-samples/.kokoro/tests/run_static_analysis.sh"
+}
+
+# Access btlr binaries used in the tests
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/btlr"
+
+# Upload logs to result-store
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.xml"
+  }
+}

--- a/.kokoro/static_analysis/presubmit.cfg
+++ b/.kokoro/static_analysis/presubmit.cfg
@@ -1,0 +1,19 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Format: //devtools/kokoro/config/proto/build.proto
+env_vars: {
+    key: "GIT_DIFF"
+    value: "origin/master... ."
+}

--- a/.kokoro/tests/run_lint.sh
+++ b/.kokoro/tests/run_lint.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# `-e` enables the script to automatically fail when a command fails
+# `-o pipefail` sets the exit code to the rightmost comment to exit with a non-zero
+set -eo pipefail
+
+# If on kokoro, get btlr binary and move into the right directory
+if [ -n "$KOKORO_GFILE_DIR" ]; then
+  bltr_dir="$KOKORO_GFILE_DIR/v0.0.1/btlr"
+  chmod +x "$bltr_dir"
+  export PATH="$PATH:$bltr_dir"
+  cd github/java-docs-samples || exit
+fi
+
+opts=()
+if [ -n "$GIT_DIFF" ]; then
+  opts+=(
+    "--git-diff"
+    "$GIT_DIFF"
+  )
+fi
+
+btlr "${opts[@]}" run "**/pom.xml" -- mvn -P lint checkstyle:check

--- a/.kokoro/tests/run_static_analysis.sh
+++ b/.kokoro/tests/run_static_analysis.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# `-e` enables the script to automatically fail when a command fails
+# `-o pipefail` sets the exit code to the rightmost comment to exit with a non-zero
+set -eo pipefail
+
+# If on kokoro, get btlr binary and move into the right directory
+if [ -n "$KOKORO_GFILE_DIR" ]; then
+  bltr_dir="$KOKORO_GFILE_DIR/v0.0.1/btlr"
+  chmod +x "$bltr_dir"
+  export PATH="$PATH:$bltr_dir"
+  cd github/java-docs-samples || exit
+fi
+
+opts=()
+if [ -n "$GIT_DIFF" ]; then
+  opts+=(
+    "--git-diff"
+    "$GIT_DIFF"
+  )
+fi
+
+btlr "${opts[@]}" run "**/pom.xml" -- mvn -P lint spotbugs:check pmd:cpd-check


### PR DESCRIPTION
Adds two checks - "lint" that runs checkstyle, and "static analysis" that runs spotbugs and pmd

Fixes #2790
