### PR TITLE
Add Java code samples for image inspection

### DIFF
--- a/dlp/src/main/java/dlp/snippets/InspectImageFileAllInfoTypes.java
+++ b/dlp/src/main/java/dlp/snippets/InspectImageFileAllInfoTypes.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dlp.snippets;
+
+// [START dlp_inspect_image_all_infotypes]
+
+import com.google.cloud.dlp.v2.DlpServiceClient;
+import com.google.privacy.dlp.v2.ByteContentItem;
+import com.google.privacy.dlp.v2.ByteContentItem.BytesType;
+import com.google.privacy.dlp.v2.ContentItem;
+import com.google.privacy.dlp.v2.Finding;
+import com.google.privacy.dlp.v2.InspectContentRequest;
+import com.google.privacy.dlp.v2.InspectContentResponse;
+import com.google.privacy.dlp.v2.LocationName;
+import com.google.protobuf.ByteString;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+class InspectImageFileAllInfoTypes {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project-id";
+    String inputPath = "src/test/resources/sensitive-data-image.jpeg";
+    inspectImageFileAllInfoTypes(projectId, inputPath);
+  }
+
+  static void inspectImageFileAllInfoTypes(String projectId, String inputPath)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (DlpServiceClient dlp = DlpServiceClient.create()) {
+      // Specify the content to be inspected.
+      ByteString fileBytes = ByteString.readFrom(new FileInputStream(inputPath));
+      ByteContentItem byteItem =
+          ByteContentItem.newBuilder().setType(BytesType.IMAGE_JPEG).setData(fileBytes).build();
+
+      // Construct the Inspect request to be sent by the client.
+      // Do not specify the type of info to inspect.
+      InspectContentRequest request =
+          InspectContentRequest.newBuilder()
+              .setParent(LocationName.of(projectId, "global").toString())
+              .setItem(ContentItem.newBuilder().setByteItem(byteItem).build())
+              .build();
+
+      // Use the client to send the API request.
+      InspectContentResponse response = dlp.inspectContent(request);
+
+      // Parse the response and process results.
+      System.out.println("Findings: " + response.getResult().getFindingsCount());
+      for (Finding f : response.getResult().getFindingsList()) {
+        System.out.println("\tQuote: " + f.getQuote());
+        System.out.println("\tInfo type: " + f.getInfoType().getName());
+        System.out.println("\tLikelihood: " + f.getLikelihood());
+      }
+    }
+  }
+}
+// [END dlp_inspect_image_all_infotypes]

--- a/dlp/src/main/java/dlp/snippets/InspectImageFileListedInfoTypes.java
+++ b/dlp/src/main/java/dlp/snippets/InspectImageFileListedInfoTypes.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dlp.snippets;
+
+// [START dlp_inspect_image_listed_infotypes]
+
+import com.google.cloud.dlp.v2.DlpServiceClient;
+import com.google.privacy.dlp.v2.ByteContentItem;
+import com.google.privacy.dlp.v2.ByteContentItem.BytesType;
+import com.google.privacy.dlp.v2.ContentItem;
+import com.google.privacy.dlp.v2.Finding;
+import com.google.privacy.dlp.v2.InfoType;
+import com.google.privacy.dlp.v2.InspectConfig;
+import com.google.privacy.dlp.v2.InspectContentRequest;
+import com.google.privacy.dlp.v2.InspectContentResponse;
+import com.google.privacy.dlp.v2.LocationName;
+import com.google.protobuf.ByteString;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+class InspectImageFileListedInfoTypes {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project-id";
+    String inputPath = "src/test/resources/sensitive-data-image.jpeg";
+    inspectImageFileListedInfoTypes(projectId, inputPath);
+  }
+
+  static void inspectImageFileListedInfoTypes(String projectId, String inputPath)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (DlpServiceClient dlp = DlpServiceClient.create()) {
+      // Specify the content to be inspected.
+      ByteString fileBytes = ByteString.readFrom(new FileInputStream(inputPath));
+      ByteContentItem byteItem =
+          ByteContentItem.newBuilder().setType(BytesType.IMAGE_JPEG).setData(fileBytes).build();
+
+      // Specify the type of info the inspection will look for.
+      List<InfoType> infoTypes = new ArrayList<>();
+      // See https://cloud.google.com/dlp/docs/infotypes-reference for complete list of info types
+      for (String typeName :
+          new String[] {"US_SOCIAL_SECURITY_NUMBER", "EMAIL_ADDRESS", "PHONE_NUMBER"}) {
+        infoTypes.add(InfoType.newBuilder().setName(typeName).build());
+      }
+      InspectConfig inspectConfig =
+          InspectConfig.newBuilder()
+              .addAllInfoTypes(infoTypes)
+              .build();
+
+      // Construct the Inspect request to be sent by the client.
+      InspectContentRequest request =
+          InspectContentRequest.newBuilder()
+              .setParent(LocationName.of(projectId, "global").toString())
+              .setItem(ContentItem.newBuilder().setByteItem(byteItem).build())
+              .setInspectConfig(inspectConfig)
+              .build();
+
+      // Use the client to send the API request.
+      InspectContentResponse response = dlp.inspectContent(request);
+
+      // Parse the response and process results.
+      System.out.println("Findings: " + response.getResult().getFindingsCount());
+      for (Finding f : response.getResult().getFindingsList()) {
+        System.out.println("\tQuote: " + f.getQuote());
+        System.out.println("\tInfo type: " + f.getInfoType().getName());
+        System.out.println("\tLikelihood: " + f.getLikelihood());
+      }
+    }
+  }
+}
+// [END dlp_inspect_image_listed_infotypes]

--- a/dlp/src/test/java/dlp/snippets/InspectTests.java
+++ b/dlp/src/test/java/dlp/snippets/InspectTests.java
@@ -54,6 +54,7 @@ public class InspectTests {
   // TODO: Update as ENV_VARs
   private static final String datastoreNamespace = "";
   private static final String datastoreKind = "dlp";
+  private static final String DOCUMENT_INPUT_FILE = "src/test/resources/sensitive-data-image.jpg";
 
   private ByteArrayOutputStream bout;
   private UUID testRunUuid = UUID.randomUUID();
@@ -265,6 +266,27 @@ public class InspectTests {
     String output = bout.toString();
     assertThat(output, containsString("Info type: PHONE_NUMBER"));
     assertThat(output, containsString("Info type: EMAIL_ADDRESS"));
+  }
+
+  @Test
+  public void testRedactImageAllInfoTypes() throws Exception {
+    InspectImageFileAllInfoTypes.inspectImageFileAllInfoTypes(PROJECT_ID, DOCUMENT_INPUT_FILE);
+
+    String output = bout.toString();
+    assertThat(output, containsString("Info type: PHONE_NUMBER"));
+    assertThat(output, containsString("Info type: EMAIL_ADDRESS"));
+    assertThat(output, containsString("Info type: DATE"));
+  }
+
+  @Test
+  public void testRedactImageListedInfoTypes() throws Exception {
+    InspectImageFileListedInfoTypes.inspectImageFileListedInfoTypes(
+        PROJECT_ID, DOCUMENT_INPUT_FILE);
+
+    String output = bout.toString();
+    assertThat(output, containsString("Info type: PHONE_NUMBER"));
+    assertThat(output, containsString("Info type: EMAIL_ADDRESS"));
+    assertThat(output, not(containsString("Info type: DATE")));
   }
 
   @Test


### PR DESCRIPTION
To be linked from https://cloud.google.com/dlp/docs/inspecting-images

Fixes #issue

> It's a good idea to open an issue first for discussion.

- [yes] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [yes] `pom.xml` parent set to latest `shared-configuration`
- [nothing new] Appropriate changes to README are included in PR
- [nothing new] API's need to be enabled to test (tell us)
- [nothing new] Environment Variables need to be set (ask us to set them)
- [yes] Tests pass (`mvn -P lint clean verify`)
  * (Note- `Checkstyle` passing is required; `Spotbugs`, `ErrorProne`, `PMD`, etc. `ERROR`'s are advisory only)
- [yes] Please **merge** this PR for me once it is approved.
