### PR TITLE
 Create Java code sample for custom regex 

### DIFF
--- a/dlp/src/main/java/dlp/snippets/InspectWithCustomRegex.java
+++ b/dlp/src/main/java/dlp/snippets/InspectWithCustomRegex.java
@@ -32,10 +32,11 @@ import com.google.privacy.dlp.v2.InspectContentResponse;
 import com.google.privacy.dlp.v2.Likelihood;
 import com.google.privacy.dlp.v2.ProjectName;
 import com.google.protobuf.ByteString;
+import java.io.IOException;
 
 public class InspectWithCustomRegex {
 
-  public static void inspectWithCustomRegex() {
+  public static void inspectWithCustomRegex() throws IOException {
     // TODO(developer): Replace these variables before running the sample.
     String projectId = "your-project-id";
     String textToInspect = "Patients MRN 444-5-22222";
@@ -45,7 +46,7 @@ public class InspectWithCustomRegex {
 
   // Inspects a BigQuery Table
   public static void inspectWithCustomRegex(
-      String projectId, String textToInspect, String customRegexPattern) {
+      String projectId, String textToInspect, String customRegexPattern) throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
@@ -95,8 +96,6 @@ public class InspectWithCustomRegex {
         System.out.println("\tInfo type: " + f.getInfoType().getName());
         System.out.println("\tLikelihood: " + f.getLikelihood());
       }
-    } catch (Exception e) {
-      System.out.println("Error during inspectString: \n" + e.toString());
     }
   }
 }

--- a/dlp/src/main/java/dlp/snippets/InspectWithCustomRegex.java
+++ b/dlp/src/main/java/dlp/snippets/InspectWithCustomRegex.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dlp.snippets;
+
+// [START dlp_inspect_custom_regex]
+
+import com.google.cloud.dlp.v2.DlpServiceClient;
+import com.google.privacy.dlp.v2.ByteContentItem;
+import com.google.privacy.dlp.v2.ByteContentItem.BytesType;
+import com.google.privacy.dlp.v2.ContentItem;
+import com.google.privacy.dlp.v2.CustomInfoType;
+import com.google.privacy.dlp.v2.CustomInfoType.Regex;
+import com.google.privacy.dlp.v2.Finding;
+import com.google.privacy.dlp.v2.InfoType;
+import com.google.privacy.dlp.v2.InspectConfig;
+import com.google.privacy.dlp.v2.InspectContentRequest;
+import com.google.privacy.dlp.v2.InspectContentResponse;
+import com.google.privacy.dlp.v2.Likelihood;
+import com.google.privacy.dlp.v2.ProjectName;
+import com.google.protobuf.ByteString;
+
+public class InspectWithCustomRegex {
+
+  public static void inspectWithCustomRegex() {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String textToInspect = "Patients MRN 444-5-22222";
+    String customRegexPattern = "[1-9]{3}-[1-9]{1}-[1-9]{5}";
+    inspectWithCustomRegex(projectId, textToInspect, customRegexPattern);
+  }
+
+  // Inspects a BigQuery Table
+  public static void inspectWithCustomRegex(
+      String projectId, String textToInspect, String customRegexPattern) {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (DlpServiceClient dlp = DlpServiceClient.create()) {
+      // Specify the project used for request.
+      ProjectName project = ProjectName.of(projectId);
+
+      // Specify the type and content to be inspected.
+      ByteContentItem byteItem =
+          ByteContentItem.newBuilder()
+              .setType(BytesType.TEXT_UTF8)
+              .setData(ByteString.copyFromUtf8(textToInspect))
+              .build();
+      ContentItem item = ContentItem.newBuilder().setByteItem(byteItem).build();
+
+      // Specify the regex pattern the inspection will look for.
+      Regex regex = Regex.newBuilder().setPattern(customRegexPattern).build();
+
+      // Construct the custom regex detector.
+      InfoType infoType = InfoType.newBuilder().setName("C_MRN").build();
+      CustomInfoType customInfoType =
+          CustomInfoType.newBuilder().setInfoType(infoType).setRegex(regex).build();
+
+      // Construct the configuration for the Inspect request.
+      InspectConfig config =
+          InspectConfig.newBuilder()
+              .addCustomInfoTypes(customInfoType)
+              .setIncludeQuote(true)
+              .setMinLikelihood(Likelihood.POSSIBLE)
+              .build();
+
+      // Construct the Inspect request to be sent by the client.
+      InspectContentRequest request =
+          InspectContentRequest.newBuilder()
+              .setParent(project.toString())
+              .setItem(item)
+              .setInspectConfig(config)
+              .build();
+
+      // Use the client to send the API request.
+      InspectContentResponse response = dlp.inspectContent(request);
+
+      // Parse the response and process results
+      System.out.println("Findings: " + response.getResult().getFindingsCount());
+      for (Finding f : response.getResult().getFindingsList()) {
+        System.out.println("\tQuote: " + f.getQuote());
+        System.out.println("\tInfo type: " + f.getInfoType().getName());
+        System.out.println("\tLikelihood: " + f.getLikelihood());
+      }
+    } catch (Exception e) {
+      System.out.println("Error during inspectString: \n" + e.toString());
+    }
+  }
+}
+// [END dlp_inspect_custom_regex]

--- a/dlp/src/test/java/dlp/snippets/InspectTests.java
+++ b/dlp/src/test/java/dlp/snippets/InspectTests.java
@@ -143,6 +143,14 @@ public class InspectTests {
     assertThat(output, containsString("Info type: EMAIL_ADDRESS"));
   }
 
+  @Test
+  public void testInspectWithCustomRegex() throws Exception {
+    InspectWithCustomRegex.inspectWithCustomRegex(
+        PROJECT_ID, "Patients MRN 444-5-22222", "[1-9]{3}-[1-9]{1}-[1-9]{5}");
+
+    String output = bout.toString();
+    assertThat(output, containsString("Info type: C_MRN"));
+  }
 
   @Test
   public void testInspectStringWithExclusionDict() throws Exception {


### PR DESCRIPTION
To be linked from https://cloud.google.com/dlp/docs/creating-custom-infotypes-regex#regex-example

Fixes #issue

It's a good idea to open an issue first for discussion.

[yes] I have followed Sample Format Guide
[yes] pom.xml parent set to latest shared-configuration
[nothing new] Appropriate changes to README are included in PR
[nothing new] API's need to be enabled to test (tell us)
[nothing new] Environment Variables need to be set (ask us to set them)
[yes] Tests pass (mvn -P lint clean verify)
(Note- Checkstyle passing is required; Spotbugs, ErrorProne, PMD, etc. ERROR's are advisory only)
[yes] Please merge this PR for me once it is approved.