### PR TITLE
Add "compile" goal to static check

### DIFF
--- a/.kokoro/tests/run_static_analysis.sh
+++ b/.kokoro/tests/run_static_analysis.sh
@@ -33,4 +33,4 @@ if [ -n "$GIT_DIFF" ]; then
   )
 fi
 
-btlr "${opts[@]}" run "**/pom.xml" -- mvn -P lint --quiet --batch-mode spotbugs:check pmd:cpd-check
+btlr "${opts[@]}" run "**/pom.xml" -- mvn -P lint --quiet --batch-mode compile pmd:cpd-check spotbugs:check

--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -164,7 +164,7 @@ for file in **/pom.xml; do
     fi
 
     # Use maven to execute the tests for the project.
-    mvn -P lint -q --batch-mode --fail-at-end clean verify \
+    mvn --quiet --batch-mode --fail-at-end clean verify \
        -Dfile.encoding="UTF-8" \
        -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
        -Dmaven.test.redirectTestOutputToFile=true \


### PR DESCRIPTION
- Adds "compile" for errorprone + spotbugs to work.
- Removes lint profile from main tests

FYI: Spotbugs will show errors, but will continue to pass until java-repo-tools is updated. 