### PR TITLE
Add Java code samples for fpe

### DIFF
--- a/dlp/src/main/java/dlp/snippets/DeIdentifyTableWithFpe.java
+++ b/dlp/src/main/java/dlp/snippets/DeIdentifyTableWithFpe.java
@@ -49,6 +49,12 @@ public class DeIdentifyTableWithFpe {
   public static void deIdentifyTableWithFpe() throws IOException {
     // TODO(developer): Replace these variables before running the sample.
     String projectId = "your-project-id";
+    String kmsKeyName =
+        "projects/YOUR_PROJECT/"
+            + "locations/YOUR_KEYRING_REGION/"
+            + "keyRings/YOUR_KEYRING_NAME/"
+            + "cryptoKeys/YOUR_KEY_NAME";
+    String wrappedAesKey = "YOUR_ENCRYPTED_AES_256_KEY";
     Table tableToDeIdentify = Table.newBuilder()
         .addHeaders(FieldId.newBuilder().setName("Employee ID").build())
         .addHeaders(FieldId.newBuilder().setName("Date").build())
@@ -69,12 +75,6 @@ public class DeIdentifyTableWithFpe {
             .addValues(Value.newBuilder().setStringValue("$15").build())
             .build())
         .build();
-    String kmsKeyName =
-        "projects/YOUR_PROJECT/"
-            + "locations/YOUR_KEYRING_REGION/"
-            + "keyRings/YOUR_KEYRING_NAME/"
-            + "cryptoKeys/YOUR_KEY_NAME";
-    String wrappedAesKey = "YOUR_ENCRYPTED_AES_256_KEY";
     deIdentifyTableWithFpe(projectId, tableToDeIdentify, kmsKeyName, wrappedAesKey);
   }
 

--- a/dlp/src/main/java/dlp/snippets/DeIdentifyTableWithFpe.java
+++ b/dlp/src/main/java/dlp/snippets/DeIdentifyTableWithFpe.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dlp.snippets;
+
+// [START dlp_deidentify_table_fpe]
+
+import com.google.cloud.dlp.v2.DlpServiceClient;
+import com.google.common.io.BaseEncoding;
+import com.google.privacy.dlp.v2.ContentItem;
+import com.google.privacy.dlp.v2.CryptoKey;
+import com.google.privacy.dlp.v2.CryptoReplaceFfxFpeConfig;
+import com.google.privacy.dlp.v2.CryptoReplaceFfxFpeConfig.FfxCommonNativeAlphabet;
+import com.google.privacy.dlp.v2.DeidentifyConfig;
+import com.google.privacy.dlp.v2.DeidentifyContentRequest;
+import com.google.privacy.dlp.v2.DeidentifyContentResponse;
+import com.google.privacy.dlp.v2.FieldId;
+import com.google.privacy.dlp.v2.FieldTransformation;
+import com.google.privacy.dlp.v2.InfoType;
+import com.google.privacy.dlp.v2.InfoTypeTransformations;
+import com.google.privacy.dlp.v2.InfoTypeTransformations.InfoTypeTransformation;
+import com.google.privacy.dlp.v2.InspectConfig;
+import com.google.privacy.dlp.v2.KmsWrappedCryptoKey;
+import com.google.privacy.dlp.v2.LocationName;
+import com.google.privacy.dlp.v2.PrimitiveTransformation;
+import com.google.privacy.dlp.v2.RecordTransformations;
+import com.google.privacy.dlp.v2.Table;
+import com.google.privacy.dlp.v2.Table.Row;
+import com.google.privacy.dlp.v2.Value;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class DeIdentifyTableWithFpe {
+
+  public static void deIdentifyTableWithFpe() throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    Table tableToDeIdentify = Table.newBuilder()
+        .addHeaders(FieldId.newBuilder().setName("Employee ID").build())
+        .addHeaders(FieldId.newBuilder().setName("Date").build())
+        .addHeaders(FieldId.newBuilder().setName("Compensation").build())
+        .addRows(Row.newBuilder()
+            .addValues(Value.newBuilder().setStringValue("11111").build())
+            .addValues(Value.newBuilder().setStringValue("2015").build())
+            .addValues(Value.newBuilder().setStringValue("$10").build())
+            .build())
+        .addRows(Row.newBuilder()
+            .addValues(Value.newBuilder().setStringValue("11111").build())
+            .addValues(Value.newBuilder().setStringValue("2016").build())
+            .addValues(Value.newBuilder().setStringValue("$20").build())
+            .build())
+        .addRows(Row.newBuilder()
+            .addValues(Value.newBuilder().setStringValue("22222").build())
+            .addValues(Value.newBuilder().setStringValue("2016").build())
+            .addValues(Value.newBuilder().setStringValue("$15").build())
+            .build())
+        .build();
+    String kmsKeyName =
+        "projects/YOUR_PROJECT/"
+            + "locations/YOUR_KEYRING_REGION/"
+            + "keyRings/YOUR_KEYRING_NAME/"
+            + "cryptoKeys/YOUR_KEY_NAME";
+    String wrappedAesKey = "YOUR_ENCRYPTED_AES_256_KEY";
+    deIdentifyTableWithFpe(projectId, tableToDeIdentify, kmsKeyName, wrappedAesKey);
+  }
+
+  public static void deIdentifyTableWithFpe(
+      String projectId, Table tableToDeIdentify, String kmsKeyName, String wrappedAesKey)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (DlpServiceClient dlp = DlpServiceClient.create()) {
+      // Specify what content you want the service to de-identify.
+      ContentItem contentItem = ContentItem.newBuilder().setTable(tableToDeIdentify).build();
+
+      // Specify an encrypted AES-256 key and the name of the Cloud KMS key that encrypted it
+      KmsWrappedCryptoKey kmsWrappedCryptoKey =
+          KmsWrappedCryptoKey.newBuilder()
+              .setWrappedKey(ByteString.copyFrom(BaseEncoding.base64().decode(wrappedAesKey)))
+              .setCryptoKeyName(kmsKeyName)
+              .build();
+      CryptoKey cryptoKey = CryptoKey.newBuilder().setKmsWrapped(kmsWrappedCryptoKey).build();
+
+      // Specify how the content should be encrypted.
+      CryptoReplaceFfxFpeConfig cryptoReplaceFfxFpeConfig =
+          CryptoReplaceFfxFpeConfig.newBuilder()
+              .setCryptoKey(cryptoKey)
+              // Set of characters in the input text. For more info, see
+              // https://cloud.google.com/dlp/docs/reference/rest/v2/organizations.deidentifyTemplates#DeidentifyTemplate.FfxCommonNativeAlphabet
+              .setCommonAlphabet(FfxCommonNativeAlphabet.NUMERIC)
+              .build();
+      PrimitiveTransformation primitiveTransformation =
+          PrimitiveTransformation.newBuilder()
+              .setCryptoReplaceFfxFpeConfig(cryptoReplaceFfxFpeConfig)
+              .build();
+
+      // Specify field to be encrypted.
+      FieldId fieldId = FieldId.newBuilder().setName("Employee ID").build();
+
+      // Associate the encryption with the specified field.
+      FieldTransformation fieldTransformation =
+          FieldTransformation.newBuilder()
+              .setPrimitiveTransformation(primitiveTransformation)
+              .addFields(fieldId)
+              .build();
+      RecordTransformations transformations =
+          RecordTransformations.newBuilder().addFieldTransformations(fieldTransformation).build();
+
+      DeidentifyConfig deidentifyConfig =
+          DeidentifyConfig.newBuilder().setRecordTransformations(transformations).build();
+
+      // Combine configurations into a request for the service.
+      DeidentifyContentRequest request =
+          DeidentifyContentRequest.newBuilder()
+              .setParent(LocationName.of(projectId, "global").toString())
+              .setItem(contentItem)
+              .setDeidentifyConfig(deidentifyConfig)
+              .build();
+
+      // Send the request and receive response from the service.
+      DeidentifyContentResponse response = dlp.deidentifyContent(request);
+
+      // Print the results.
+      System.out.println(
+          "Table after format-preserving encryption: " + response.getItem().getTable());
+    }
+  }
+}
+// [END dlp_deidentify_table_fpe]

--- a/dlp/src/main/java/dlp/snippets/DeIdentifyTextWithFpe.java
+++ b/dlp/src/main/java/dlp/snippets/DeIdentifyTextWithFpe.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dlp.snippets;
+
+// [START dlp_deidentify_text_fpe]
+
+import com.google.cloud.dlp.v2.DlpServiceClient;
+import com.google.common.io.BaseEncoding;
+import com.google.privacy.dlp.v2.ContentItem;
+import com.google.privacy.dlp.v2.CryptoKey;
+import com.google.privacy.dlp.v2.CryptoReplaceFfxFpeConfig;
+import com.google.privacy.dlp.v2.CryptoReplaceFfxFpeConfig.FfxCommonNativeAlphabet;
+import com.google.privacy.dlp.v2.DeidentifyConfig;
+import com.google.privacy.dlp.v2.DeidentifyContentRequest;
+import com.google.privacy.dlp.v2.DeidentifyContentResponse;
+import com.google.privacy.dlp.v2.InfoType;
+import com.google.privacy.dlp.v2.InfoTypeTransformations;
+import com.google.privacy.dlp.v2.InfoTypeTransformations.InfoTypeTransformation;
+import com.google.privacy.dlp.v2.InspectConfig;
+import com.google.privacy.dlp.v2.KmsWrappedCryptoKey;
+import com.google.privacy.dlp.v2.LocationName;
+import com.google.privacy.dlp.v2.PrimitiveTransformation;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class DeIdentifyTextWithFpe {
+
+  public static void deIdentifyTextWithFpe() throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String textToDeIdentify = "I'm Gary and my email is gary@example.com";
+    String kmsKeyName =
+        "projects/YOUR_PROJECT/"
+            + "locations/YOUR_KEYRING_REGION/"
+            + "keyRings/YOUR_KEYRING_NAME/"
+            + "cryptoKeys/YOUR_KEY_NAME";
+    String wrappedAesKey = "YOUR_ENCRYPTED_AES_256_KEY";
+    deIdentifyTextWithFpe(projectId, textToDeIdentify, kmsKeyName, wrappedAesKey);
+  }
+
+  public static void deIdentifyTextWithFpe(
+      String projectId, String textToDeIdentify, String kmsKeyName, String wrappedAesKey)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (DlpServiceClient dlp = DlpServiceClient.create()) {
+      // Specify what content you want the service to de-identify.
+      ContentItem contentItem = ContentItem.newBuilder().setValue(textToDeIdentify).build();
+
+      // Specify the type of info you want the service to de-identify.
+      // See https://cloud.google.com/dlp/docs/infotypes-reference for complete list of info types.
+      InfoType infoType = InfoType.newBuilder().setName("PHONE_NUMBER").build();
+      InspectConfig inspectConfig =
+          InspectConfig.newBuilder().addAllInfoTypes(Arrays.asList(infoType)).build();
+
+      // Specify an encrypted AES-256 key and the name of the Cloud KMS key that encrypted it.
+      KmsWrappedCryptoKey kmsWrappedCryptoKey =
+          KmsWrappedCryptoKey.newBuilder()
+              .setWrappedKey(ByteString.copyFrom(BaseEncoding.base64().decode(wrappedAesKey)))
+              .setCryptoKeyName(kmsKeyName)
+              .build();
+      CryptoKey cryptoKey = CryptoKey.newBuilder().setKmsWrapped(kmsWrappedCryptoKey).build();
+
+      // Specify how the info from the inspection should be encrypted.
+      InfoType surrogateInfoType = InfoType.newBuilder().setName("PHONE_TOKEN").build();
+      CryptoReplaceFfxFpeConfig cryptoReplaceFfxFpeConfig =
+          CryptoReplaceFfxFpeConfig.newBuilder()
+              .setCryptoKey(cryptoKey)
+              // Set of characters in the input text. For more info, see
+              // https://cloud.google.com/dlp/docs/reference/rest/v2/organizations.deidentifyTemplates#DeidentifyTemplate.FfxCommonNativeAlphabet
+              .setCommonAlphabet(FfxCommonNativeAlphabet.NUMERIC)
+              .setSurrogateInfoType(surrogateInfoType)
+              .build();
+      PrimitiveTransformation primitiveTransformation =
+          PrimitiveTransformation.newBuilder()
+              .setCryptoReplaceFfxFpeConfig(cryptoReplaceFfxFpeConfig)
+              .build();
+      InfoTypeTransformation infoTypeTransformation =
+          InfoTypeTransformation.newBuilder()
+              .setPrimitiveTransformation(primitiveTransformation)
+              .build();
+      InfoTypeTransformations transformations =
+          InfoTypeTransformations.newBuilder().addTransformations(infoTypeTransformation).build();
+
+      DeidentifyConfig deidentifyConfig =
+          DeidentifyConfig.newBuilder().setInfoTypeTransformations(transformations).build();
+
+      // Combine configurations into a request for the service.
+      DeidentifyContentRequest request =
+          DeidentifyContentRequest.newBuilder()
+              .setParent(LocationName.of(projectId, "global").toString())
+              .setItem(contentItem)
+              .setInspectConfig(inspectConfig)
+              .setDeidentifyConfig(deidentifyConfig)
+              .build();
+
+      // Send the request and receive response from the service.
+      DeidentifyContentResponse response = dlp.deidentifyContent(request);
+
+      // Print the results.
+      System.out.println(
+          "Text after format-preserving encryption: " + response.getItem().getValue());
+    }
+  }
+}
+// [END dlp_deidentify_text_fpe]

--- a/dlp/src/main/java/dlp/snippets/ReIdentifyTableWithFpe.java
+++ b/dlp/src/main/java/dlp/snippets/ReIdentifyTableWithFpe.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dlp.snippets;
+
+// [START dlp_reidentify_table_fpe]
+
+import com.google.cloud.dlp.v2.DlpServiceClient;
+import com.google.common.io.BaseEncoding;
+import com.google.privacy.dlp.v2.ContentItem;
+import com.google.privacy.dlp.v2.CryptoKey;
+import com.google.privacy.dlp.v2.CryptoReplaceFfxFpeConfig;
+import com.google.privacy.dlp.v2.CryptoReplaceFfxFpeConfig.FfxCommonNativeAlphabet;
+import com.google.privacy.dlp.v2.CustomInfoType;
+import com.google.privacy.dlp.v2.CustomInfoType.SurrogateType;
+import com.google.privacy.dlp.v2.DeidentifyConfig;
+import com.google.privacy.dlp.v2.FieldId;
+import com.google.privacy.dlp.v2.FieldTransformation;
+import com.google.privacy.dlp.v2.InfoType;
+import com.google.privacy.dlp.v2.InfoTypeTransformations;
+import com.google.privacy.dlp.v2.InfoTypeTransformations.InfoTypeTransformation;
+import com.google.privacy.dlp.v2.InspectConfig;
+import com.google.privacy.dlp.v2.KmsWrappedCryptoKey;
+import com.google.privacy.dlp.v2.LocationName;
+import com.google.privacy.dlp.v2.PrimitiveTransformation;
+import com.google.privacy.dlp.v2.RecordTransformations;
+import com.google.privacy.dlp.v2.ReidentifyContentRequest;
+import com.google.privacy.dlp.v2.ReidentifyContentResponse;
+import com.google.privacy.dlp.v2.Table;
+import com.google.privacy.dlp.v2.Table.Row;
+import com.google.privacy.dlp.v2.Value;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+
+public class ReIdentifyTableWithFpe {
+
+  public static void reIdentifyTableWithFpe() throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    Table tableToReIdentify = Table.newBuilder()
+        .addHeaders(FieldId.newBuilder().setName("Employee ID").build())
+        .addRows(
+            Row.newBuilder().addValues(
+                Value.newBuilder().setStringValue("28777").build())
+                .build())
+        .build();
+    String kmsKeyName =
+        "projects/YOUR_PROJECT/"
+            + "locations/YOUR_KEYRING_REGION/"
+            + "keyRings/YOUR_KEYRING_NAME/"
+            + "cryptoKeys/YOUR_KEY_NAME";
+    String wrappedAesKey = "YOUR_ENCRYPTED_AES_256_KEY";
+    reIdentifyTableWithFpe(projectId, tableToReIdentify, kmsKeyName, wrappedAesKey);
+  }
+
+  public static void reIdentifyTableWithFpe(
+      String projectId, Table tableToReIdentify, String kmsKeyName, String wrappedAesKey)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (DlpServiceClient dlp = DlpServiceClient.create()) {
+      // Specify what content you want the service to re-identify.
+      ContentItem contentItem = ContentItem.newBuilder().setTable(tableToReIdentify).build();
+
+      // Specify an encrypted AES-256 key and the name of the Cloud KMS key that encrypted it.
+      KmsWrappedCryptoKey kmsWrappedCryptoKey =
+          KmsWrappedCryptoKey.newBuilder()
+              .setWrappedKey(ByteString.copyFrom(BaseEncoding.base64().decode(wrappedAesKey)))
+              .setCryptoKeyName(kmsKeyName)
+              .build();
+      CryptoKey cryptoKey = CryptoKey.newBuilder().setKmsWrapped(kmsWrappedCryptoKey).build();
+
+      // Specify how to un-encrypt the previously de-identified information.
+      CryptoReplaceFfxFpeConfig cryptoReplaceFfxFpeConfig =
+          CryptoReplaceFfxFpeConfig.newBuilder()
+              .setCryptoKey(cryptoKey)
+              // Set of characters in the input text. For more info, see
+              // https://cloud.google.com/dlp/docs/reference/rest/v2/organizations.deidentifyTemplates#DeidentifyTemplate.FfxCommonNativeAlphabet
+              .setCommonAlphabet(FfxCommonNativeAlphabet.NUMERIC)
+              .build();
+      PrimitiveTransformation primitiveTransformation =
+          PrimitiveTransformation.newBuilder()
+              .setCryptoReplaceFfxFpeConfig(cryptoReplaceFfxFpeConfig)
+              .build();
+
+      // Specify field to be decrypted.
+      FieldId fieldId = FieldId.newBuilder().setName("Employee ID").build();
+
+      // Associate the decryption with the specified field.
+      FieldTransformation fieldTransformation =
+          FieldTransformation.newBuilder()
+              .setPrimitiveTransformation(primitiveTransformation)
+              .addFields(fieldId)
+              .build();
+      RecordTransformations transformations =
+          RecordTransformations.newBuilder().addFieldTransformations(fieldTransformation).build();
+
+      DeidentifyConfig reidentifyConfig =
+          DeidentifyConfig.newBuilder().setRecordTransformations(transformations).build();
+
+      // Combine configurations into a request for the service.
+      ReidentifyContentRequest request =
+          ReidentifyContentRequest.newBuilder()
+              .setParent(LocationName.of(projectId, "global").toString())
+              .setItem(contentItem)
+              .setReidentifyConfig(reidentifyConfig)
+              .build();
+
+      // Send the request and receive response from the service
+      ReidentifyContentResponse response = dlp.reidentifyContent(request);
+
+      // Print the results
+      System.out.println("Table after re-identification: " + response.getItem().getValue());
+    }
+  }
+}
+// [END dlp_reidentify_table_fpe]

--- a/dlp/src/main/java/dlp/snippets/ReIdentifyTableWithFpe.java
+++ b/dlp/src/main/java/dlp/snippets/ReIdentifyTableWithFpe.java
@@ -50,6 +50,12 @@ public class ReIdentifyTableWithFpe {
   public static void reIdentifyTableWithFpe() throws IOException {
     // TODO(developer): Replace these variables before running the sample.
     String projectId = "your-project-id";
+    String kmsKeyName =
+        "projects/YOUR_PROJECT/"
+            + "locations/YOUR_KEYRING_REGION/"
+            + "keyRings/YOUR_KEYRING_NAME/"
+            + "cryptoKeys/YOUR_KEY_NAME";
+    String wrappedAesKey = "YOUR_ENCRYPTED_AES_256_KEY";
     Table tableToReIdentify = Table.newBuilder()
         .addHeaders(FieldId.newBuilder().setName("Employee ID").build())
         .addRows(
@@ -57,12 +63,6 @@ public class ReIdentifyTableWithFpe {
                 Value.newBuilder().setStringValue("28777").build())
                 .build())
         .build();
-    String kmsKeyName =
-        "projects/YOUR_PROJECT/"
-            + "locations/YOUR_KEYRING_REGION/"
-            + "keyRings/YOUR_KEYRING_NAME/"
-            + "cryptoKeys/YOUR_KEY_NAME";
-    String wrappedAesKey = "YOUR_ENCRYPTED_AES_256_KEY";
     reIdentifyTableWithFpe(projectId, tableToReIdentify, kmsKeyName, wrappedAesKey);
   }
 

--- a/dlp/src/main/java/dlp/snippets/ReIdentifyTextWithFpe.java
+++ b/dlp/src/main/java/dlp/snippets/ReIdentifyTextWithFpe.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dlp.snippets;
+
+// [START dlp_reidentify_text_fpe]
+
+import com.google.cloud.dlp.v2.DlpServiceClient;
+import com.google.common.io.BaseEncoding;
+import com.google.privacy.dlp.v2.ContentItem;
+import com.google.privacy.dlp.v2.CryptoKey;
+import com.google.privacy.dlp.v2.CryptoReplaceFfxFpeConfig;
+import com.google.privacy.dlp.v2.CryptoReplaceFfxFpeConfig.FfxCommonNativeAlphabet;
+import com.google.privacy.dlp.v2.CustomInfoType;
+import com.google.privacy.dlp.v2.CustomInfoType.SurrogateType;
+import com.google.privacy.dlp.v2.DeidentifyConfig;
+import com.google.privacy.dlp.v2.InfoType;
+import com.google.privacy.dlp.v2.InfoTypeTransformations;
+import com.google.privacy.dlp.v2.InfoTypeTransformations.InfoTypeTransformation;
+import com.google.privacy.dlp.v2.InspectConfig;
+import com.google.privacy.dlp.v2.KmsWrappedCryptoKey;
+import com.google.privacy.dlp.v2.LocationName;
+import com.google.privacy.dlp.v2.PrimitiveTransformation;
+import com.google.privacy.dlp.v2.ReidentifyContentRequest;
+import com.google.privacy.dlp.v2.ReidentifyContentResponse;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+
+public class ReIdentifyTextWithFpe {
+
+  public static void reIdentifyTextWithFpe() throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String textToReIdentify = "My phone number is PHONE_TOKEN(10):9617256398";
+    String kmsKeyName =
+        "projects/YOUR_PROJECT/"
+            + "locations/YOUR_KEYRING_REGION/"
+            + "keyRings/YOUR_KEYRING_NAME/"
+            + "cryptoKeys/YOUR_KEY_NAME";
+    String wrappedAesKey = "YOUR_ENCRYPTED_AES_256_KEY";
+    reIdentifyTextWithFpe(projectId, textToReIdentify, kmsKeyName, wrappedAesKey);
+  }
+
+  public static void reIdentifyTextWithFpe(
+      String projectId, String textToReIdentify, String kmsKeyName, String wrappedAesKey)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (DlpServiceClient dlp = DlpServiceClient.create()) {
+      // Specify what content you want the service to re-identify.
+      ContentItem contentItem = ContentItem.newBuilder().setValue(textToReIdentify).build();
+
+      // Specify the type of info the inspection will re-identify. This must use the same custom
+      // into type that was used as a surrogate during the initial encryption.
+      InfoType surrogateInfoType = InfoType.newBuilder().setName("PHONE_NUMBER").build();
+
+      CustomInfoType customInfoType =
+          CustomInfoType.newBuilder()
+              .setInfoType(surrogateInfoType)
+              .setSurrogateType(SurrogateType.getDefaultInstance())
+              .build();
+      InspectConfig inspectConfig =
+          InspectConfig.newBuilder().addCustomInfoTypes(customInfoType).build();
+
+      // Specify an encrypted AES-256 key and the name of the Cloud KMS key that encrypted it.
+      KmsWrappedCryptoKey kmsWrappedCryptoKey =
+          KmsWrappedCryptoKey.newBuilder()
+              .setWrappedKey(ByteString.copyFrom(BaseEncoding.base64().decode(wrappedAesKey)))
+              .setCryptoKeyName(kmsKeyName)
+              .build();
+      CryptoKey cryptoKey = CryptoKey.newBuilder().setKmsWrapped(kmsWrappedCryptoKey).build();
+
+      // Specify how to un-encrypt the previously de-identified information.
+      CryptoReplaceFfxFpeConfig cryptoReplaceFfxFpeConfig =
+          CryptoReplaceFfxFpeConfig.newBuilder()
+              .setCryptoKey(cryptoKey)
+              // Set of characters in the input text. For more info, see
+              // https://cloud.google.com/dlp/docs/reference/rest/v2/organizations.deidentifyTemplates#DeidentifyTemplate.FfxCommonNativeAlphabet
+              .setCommonAlphabet(FfxCommonNativeAlphabet.NUMERIC)
+              .setSurrogateInfoType(surrogateInfoType)
+              .build();
+      PrimitiveTransformation primitiveTransformation =
+          PrimitiveTransformation.newBuilder()
+              .setCryptoReplaceFfxFpeConfig(cryptoReplaceFfxFpeConfig)
+              .build();
+      InfoTypeTransformation infoTypeTransformation =
+          InfoTypeTransformation.newBuilder()
+              .setPrimitiveTransformation(primitiveTransformation)
+              .addInfoTypes(surrogateInfoType)
+              .build();
+      InfoTypeTransformations transformations =
+          InfoTypeTransformations.newBuilder().addTransformations(infoTypeTransformation).build();
+
+      DeidentifyConfig reidentifyConfig =
+          DeidentifyConfig.newBuilder().setInfoTypeTransformations(transformations).build();
+
+      // Combine configurations into a request for the service.
+      ReidentifyContentRequest request =
+          ReidentifyContentRequest.newBuilder()
+              .setParent(LocationName.of(projectId, "global").toString())
+              .setItem(contentItem)
+              .setInspectConfig(inspectConfig)
+              .setReidentifyConfig(reidentifyConfig)
+              .build();
+
+      // Send the request and receive response from the service
+      ReidentifyContentResponse response = dlp.reidentifyContent(request);
+
+      // Print the results
+      System.out.println("Text after re-identification: " + response.getItem().getValue());
+    }
+  }
+}
+// [END dlp_reidentify_text_fpe]


### PR DESCRIPTION
To be linked from https://cloud.google.com/dlp/docs/pseudonymization

Fixes #issue

> It's a good idea to open an issue first for discussion.

- [yes] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [yes] `pom.xml` parent set to latest `shared-configuration`
- [nothing new] Appropriate changes to README are included in PR
- [nothing new] API's need to be enabled to test (tell us)
- [nothing new] Environment Variables need to be set (ask us to set them)
- [yes] Tests pass (`mvn -P lint clean verify`)
  * (Note- `Checkstyle` passing is required; `Spotbugs`, `ErrorProne`, `PMD`, etc. `ERROR`'s are advisory only)
- [yes] Please **merge** this PR for me once it is approved.
