### PR TITLE
Formatting consistency pass for DLP Inspect* samples

### DIFF
--- a/dlp/src/main/java/dlp/snippets/InspectBigQueryTable.java
+++ b/dlp/src/main/java/dlp/snippets/InspectBigQueryTable.java
@@ -94,7 +94,10 @@ public class InspectBigQueryTable {
 
       // Specify how the content should be inspected.
       InspectConfig inspectConfig =
-          InspectConfig.newBuilder().addAllInfoTypes(infoTypes).setIncludeQuote(true).build();
+          InspectConfig.newBuilder()
+              .addAllInfoTypes(infoTypes)
+              .setIncludeQuote(true)
+              .build();
 
       // Specify the action that is triggered when the job completes.
       String pubSubTopic = String.format("projects/%s/topics/%s", projectId, topicId);
@@ -159,7 +162,7 @@ public class InspectBigQueryTable {
       }
     }
   }
-  
+
   // handleMessage injects the job and settableFuture into the message reciever interface
   private static void handleMessage(
       DlpJob job,

--- a/dlp/src/main/java/dlp/snippets/InspectDatastoreEntity.java
+++ b/dlp/src/main/java/dlp/snippets/InspectDatastoreEntity.java
@@ -95,7 +95,10 @@ public class InspectDatastoreEntity {
 
       // Specify how the content should be inspected.
       InspectConfig inspectConfig =
-          InspectConfig.newBuilder().addAllInfoTypes(infoTypes).setIncludeQuote(true).build();
+          InspectConfig.newBuilder()
+              .addAllInfoTypes(infoTypes)
+              .setIncludeQuote(true)
+              .build();
 
       // Specify the action that is triggered when the job completes.
       String pubSubTopic = String.format("projects/%s/topics/%s", projectId, topicId);

--- a/dlp/src/main/java/dlp/snippets/InspectGcsFile.java
+++ b/dlp/src/main/java/dlp/snippets/InspectGcsFile.java
@@ -81,7 +81,10 @@ public class InspectGcsFile {
 
       // Specify how the content should be inspected.
       InspectConfig inspectConfig =
-          InspectConfig.newBuilder().addAllInfoTypes(infoTypes).setIncludeQuote(true).build();
+          InspectConfig.newBuilder()
+              .addAllInfoTypes(infoTypes)
+              .setIncludeQuote(true)
+              .build();
 
       // Specify the action that is triggered when the job completes.
       String pubSubTopic = String.format("projects/%s/topics/%s", projectId, topicId);

--- a/dlp/src/main/java/dlp/snippets/InspectImageFile.java
+++ b/dlp/src/main/java/dlp/snippets/InspectImageFile.java
@@ -58,13 +58,16 @@ public class InspectImageFile {
       // Specify the type of info the inspection will look for.
       List<InfoType> infoTypes = new ArrayList<>();
       // See https://cloud.google.com/dlp/docs/infotypes-reference for complete list of info types
-      for (String typeName : new String[] {"PHONE_NUMBER", "EMAIL_ADDRESS", "CREDIT_CARD_NUMBER"}) {
+      for (String typeName : new String[]{"PHONE_NUMBER", "EMAIL_ADDRESS", "CREDIT_CARD_NUMBER"}) {
         infoTypes.add(InfoType.newBuilder().setName(typeName).build());
       }
 
       // Construct the configuration for the Inspect request.
       InspectConfig config =
-          InspectConfig.newBuilder().addAllInfoTypes(infoTypes).setIncludeQuote(true).build();
+          InspectConfig.newBuilder()
+              .addAllInfoTypes(infoTypes)
+              .setIncludeQuote(true)
+              .build();
 
       // Construct the Inspect request to be sent by the client.
       InspectContentRequest request =

--- a/dlp/src/main/java/dlp/snippets/InspectImageFileListedInfoTypes.java
+++ b/dlp/src/main/java/dlp/snippets/InspectImageFileListedInfoTypes.java
@@ -61,6 +61,8 @@ class InspectImageFileListedInfoTypes {
           new String[] {"US_SOCIAL_SECURITY_NUMBER", "EMAIL_ADDRESS", "PHONE_NUMBER"}) {
         infoTypes.add(InfoType.newBuilder().setName(typeName).build());
       }
+
+      // Construct the configuration for the Inspect request.
       InspectConfig inspectConfig =
           InspectConfig.newBuilder()
               .addAllInfoTypes(infoTypes)

--- a/dlp/src/main/java/dlp/snippets/InspectString.java
+++ b/dlp/src/main/java/dlp/snippets/InspectString.java
@@ -65,7 +65,10 @@ public class InspectString {
 
       // Construct the configuration for the Inspect request.
       InspectConfig config =
-          InspectConfig.newBuilder().addAllInfoTypes(infoTypes).setIncludeQuote(true).build();
+          InspectConfig.newBuilder()
+              .addAllInfoTypes(infoTypes)
+              .setIncludeQuote(true)
+              .build();
 
       // Construct the Inspect request to be sent by the client.
       InspectContentRequest request =

--- a/dlp/src/main/java/dlp/snippets/InspectStringCustomExcludingSubstring.java
+++ b/dlp/src/main/java/dlp/snippets/InspectStringCustomExcludingSubstring.java
@@ -70,22 +70,25 @@ public class InspectStringCustomExcludingSubstring {
 
       // Specify the type of info the inspection will look for.
       InfoType infoType = InfoType.newBuilder().setName("CUSTOM_NAME_DETECTOR").build();
-      CustomInfoType customInfoType = CustomInfoType.newBuilder()
-          .setInfoType(infoType).setRegex(
-              Regex.newBuilder().setPattern(customDetectorPattern)).build();
+      CustomInfoType customInfoType =
+          CustomInfoType.newBuilder()
+              .setInfoType(infoType).setRegex(Regex.newBuilder().setPattern(customDetectorPattern))
+              .build();
 
       // Exclude partial matches from the specified excludedSubstringList.
-      ExclusionRule exclusionRule = ExclusionRule.newBuilder()
-          .setMatchingType(MatchingType.MATCHING_TYPE_PARTIAL_MATCH)
-          .setDictionary(Dictionary.newBuilder()
-              .setWordList(WordList.newBuilder().addAllWords(excludedSubstringList)))
-          .build();
+      ExclusionRule exclusionRule =
+          ExclusionRule.newBuilder()
+              .setMatchingType(MatchingType.MATCHING_TYPE_PARTIAL_MATCH)
+              .setDictionary(Dictionary.newBuilder()
+                  .setWordList(WordList.newBuilder().addAllWords(excludedSubstringList)))
+              .build();
 
       // Construct a ruleset that applies the exclusion rule to the EMAIL_ADDRESSES infotype.
-      InspectionRuleSet ruleSet = InspectionRuleSet.newBuilder()
-          .addInfoTypes(infoType)
-          .addRules(InspectionRule.newBuilder().setExclusionRule(exclusionRule))
-          .build();
+      InspectionRuleSet ruleSet =
+          InspectionRuleSet.newBuilder()
+              .addInfoTypes(infoType)
+              .addRules(InspectionRule.newBuilder().setExclusionRule(exclusionRule))
+              .build();
 
       // Construct the configuration for the Inspect request, including the ruleset.
       InspectConfig config =

--- a/dlp/src/main/java/dlp/snippets/InspectStringCustomHotword.java
+++ b/dlp/src/main/java/dlp/snippets/InspectStringCustomHotword.java
@@ -64,20 +64,20 @@ public class InspectStringCustomHotword {
       ContentItem item = ContentItem.newBuilder().setByteItem(byteItem).build();
 
       // Increase likelihood of matches that have customHotword nearby
-      HotwordRule hotwordRule = HotwordRule.newBuilder()
-          .setHotwordRegex(Regex.newBuilder()
-              .setPattern(customHotword))
-          .setProximity(Proximity.newBuilder()
-              .setWindowBefore(50))
-          .setLikelihoodAdjustment(LikelihoodAdjustment.newBuilder()
-              .setFixedLikelihood(Likelihood.VERY_LIKELY))
-          .build();
+      HotwordRule hotwordRule =
+          HotwordRule.newBuilder()
+              .setHotwordRegex(Regex.newBuilder().setPattern(customHotword))
+              .setProximity(Proximity.newBuilder().setWindowBefore(50))
+              .setLikelihoodAdjustment(
+                  LikelihoodAdjustment.newBuilder().setFixedLikelihood(Likelihood.VERY_LIKELY))
+              .build();
 
       // Construct a ruleset that applies the hotword rule to the PERSON_NAME infotype.
-      InspectionRuleSet ruleSet = InspectionRuleSet.newBuilder()
-          .addInfoTypes(InfoType.newBuilder().setName("PERSON_NAME").build())
-          .addRules(InspectionRule.newBuilder().setHotwordRule(hotwordRule))
-          .build();
+      InspectionRuleSet ruleSet =
+          InspectionRuleSet.newBuilder()
+              .addInfoTypes(InfoType.newBuilder().setName("PERSON_NAME").build())
+              .addRules(InspectionRule.newBuilder().setHotwordRule(hotwordRule))
+              .build();
 
       // Construct the configuration for the Inspect request.
       InspectConfig config =

--- a/dlp/src/main/java/dlp/snippets/InspectStringCustomOmitOverlap.java
+++ b/dlp/src/main/java/dlp/snippets/InspectStringCustomOmitOverlap.java
@@ -64,24 +64,27 @@ public class InspectStringCustomOmitOverlap {
       ContentItem item = ContentItem.newBuilder().setByteItem(byteItem).build();
 
       // Construct the custom infotype.
-      CustomInfoType customInfoType = CustomInfoType.newBuilder()
-          .setInfoType(InfoType.newBuilder().setName("VIP_DETECTOR"))
-          .setRegex(Regex.newBuilder().setPattern("Larry Page|Sergey Brin"))
-          .setExclusionType(ExclusionType.EXCLUSION_TYPE_EXCLUDE)
-          .build();
+      CustomInfoType customInfoType =
+          CustomInfoType.newBuilder()
+              .setInfoType(InfoType.newBuilder().setName("VIP_DETECTOR"))
+              .setRegex(Regex.newBuilder().setPattern("Larry Page|Sergey Brin"))
+              .setExclusionType(ExclusionType.EXCLUSION_TYPE_EXCLUDE)
+              .build();
 
       // Exclude matches that also match the custom infotype.
-      ExclusionRule exclusionRule = ExclusionRule.newBuilder()
-          .setExcludeInfoTypes(
-              ExcludeInfoTypes.newBuilder().addInfoTypes(customInfoType.getInfoType()))
-          .setMatchingType(MatchingType.MATCHING_TYPE_FULL_MATCH)
-          .build();
+      ExclusionRule exclusionRule =
+          ExclusionRule.newBuilder()
+              .setExcludeInfoTypes(
+                  ExcludeInfoTypes.newBuilder().addInfoTypes(customInfoType.getInfoType()))
+              .setMatchingType(MatchingType.MATCHING_TYPE_FULL_MATCH)
+              .build();
 
       // Construct a ruleset that applies the exclusion rule to the PERSON_NAME infotype.
-      InspectionRuleSet ruleSet = InspectionRuleSet.newBuilder()
-          .addInfoTypes(InfoType.newBuilder().setName("PERSON_NAME"))
-          .addRules(InspectionRule.newBuilder().setExclusionRule(exclusionRule))
-          .build();
+      InspectionRuleSet ruleSet =
+          InspectionRuleSet.newBuilder()
+              .addInfoTypes(InfoType.newBuilder().setName("PERSON_NAME"))
+              .addRules(InspectionRule.newBuilder().setExclusionRule(exclusionRule))
+              .build();
 
       // Construct the configuration for the Inspect request, including the ruleset.
       InspectConfig config =

--- a/dlp/src/main/java/dlp/snippets/InspectStringMultipleRules.java
+++ b/dlp/src/main/java/dlp/snippets/InspectStringMultipleRules.java
@@ -67,40 +67,45 @@ public class InspectStringMultipleRules {
       ContentItem item = ContentItem.newBuilder().setByteItem(byteItem).build();
 
       // Construct hotword rules
-      HotwordRule patientRule = HotwordRule.newBuilder()
-          .setHotwordRegex(Regex.newBuilder().setPattern("patient"))
-          .setProximity(Proximity.newBuilder().setWindowBefore(10))
-          .setLikelihoodAdjustment(
-              LikelihoodAdjustment.newBuilder().setFixedLikelihood(Likelihood.VERY_LIKELY))
-          .build();
+      HotwordRule patientRule =
+          HotwordRule.newBuilder()
+              .setHotwordRegex(Regex.newBuilder().setPattern("patient"))
+              .setProximity(Proximity.newBuilder().setWindowBefore(10))
+              .setLikelihoodAdjustment(
+                  LikelihoodAdjustment.newBuilder().setFixedLikelihood(Likelihood.VERY_LIKELY))
+              .build();
 
-      HotwordRule doctorRule = HotwordRule.newBuilder()
-          .setHotwordRegex(Regex.newBuilder().setPattern("doctor"))
-          .setProximity(Proximity.newBuilder().setWindowBefore(10))
-          .setLikelihoodAdjustment(
-              LikelihoodAdjustment.newBuilder().setFixedLikelihood(Likelihood.UNLIKELY))
-          .build();
+      HotwordRule doctorRule =
+          HotwordRule.newBuilder()
+              .setHotwordRegex(Regex.newBuilder().setPattern("doctor"))
+              .setProximity(Proximity.newBuilder().setWindowBefore(10))
+              .setLikelihoodAdjustment(
+                  LikelihoodAdjustment.newBuilder().setFixedLikelihood(Likelihood.UNLIKELY))
+              .build();
 
       // Construct exclusion rules
-      ExclusionRule quasimodoRule = ExclusionRule.newBuilder()
-          .setDictionary(
-              Dictionary.newBuilder().setWordList(WordList.newBuilder().addWords("Quasimodo")))
-          .setMatchingType(MatchingType.MATCHING_TYPE_PARTIAL_MATCH)
-          .build();
+      ExclusionRule quasimodoRule =
+          ExclusionRule.newBuilder()
+              .setDictionary(
+                  Dictionary.newBuilder().setWordList(WordList.newBuilder().addWords("Quasimodo")))
+              .setMatchingType(MatchingType.MATCHING_TYPE_PARTIAL_MATCH)
+              .build();
 
-      ExclusionRule redactedRule = ExclusionRule.newBuilder()
-          .setRegex(Regex.newBuilder().setPattern("REDACTED"))
-          .setMatchingType(MatchingType.MATCHING_TYPE_PARTIAL_MATCH)
-          .build();
+      ExclusionRule redactedRule =
+          ExclusionRule.newBuilder()
+              .setRegex(Regex.newBuilder().setPattern("REDACTED"))
+              .setMatchingType(MatchingType.MATCHING_TYPE_PARTIAL_MATCH)
+              .build();
 
       // Construct a ruleset that applies the rules to the PERSON_NAME infotype.
-      InspectionRuleSet ruleSet = InspectionRuleSet.newBuilder()
-          .addInfoTypes(InfoType.newBuilder().setName("PERSON_NAME"))
-          .addRules(InspectionRule.newBuilder().setHotwordRule(patientRule))
-          .addRules(InspectionRule.newBuilder().setHotwordRule(doctorRule))
-          .addRules(InspectionRule.newBuilder().setExclusionRule(quasimodoRule))
-          .addRules(InspectionRule.newBuilder().setExclusionRule(redactedRule))
-          .build();
+      InspectionRuleSet ruleSet =
+          InspectionRuleSet.newBuilder()
+              .addInfoTypes(InfoType.newBuilder().setName("PERSON_NAME"))
+              .addRules(InspectionRule.newBuilder().setHotwordRule(patientRule))
+              .addRules(InspectionRule.newBuilder().setHotwordRule(doctorRule))
+              .addRules(InspectionRule.newBuilder().setExclusionRule(quasimodoRule))
+              .addRules(InspectionRule.newBuilder().setExclusionRule(redactedRule))
+              .build();
 
       // Construct the configuration for the Inspect request, including the ruleset.
       InspectConfig config =

--- a/dlp/src/main/java/dlp/snippets/InspectStringOmitOverlap.java
+++ b/dlp/src/main/java/dlp/snippets/InspectStringOmitOverlap.java
@@ -70,20 +70,21 @@ public class InspectStringOmitOverlap {
       }
 
       // Exclude EMAIL_ADDRESS matches
-      ExclusionRule exclusionRule = ExclusionRule.newBuilder()
-          .setExcludeInfoTypes(
-              ExcludeInfoTypes.newBuilder()
+      ExclusionRule exclusionRule =
+          ExclusionRule.newBuilder()
+              .setExcludeInfoTypes(ExcludeInfoTypes.newBuilder()
                   .addInfoTypes(InfoType.newBuilder().setName("EMAIL_ADDRESS")))
-          .setMatchingType(MatchingType.MATCHING_TYPE_PARTIAL_MATCH)
-          .build();
+              .setMatchingType(MatchingType.MATCHING_TYPE_PARTIAL_MATCH)
+              .build();
 
       // Construct a ruleset that applies the exclusion rule to the PERSON_NAME infotype.
       // If a PERSON_NAME match overlaps with an EMAIL_ADDRESS match, the PERSON_NAME match will
       // be excluded.
-      InspectionRuleSet ruleSet = InspectionRuleSet.newBuilder()
-          .addInfoTypes(InfoType.newBuilder().setName("PERSON_NAME"))
-          .addRules(InspectionRule.newBuilder().setExclusionRule(exclusionRule))
-          .build();
+      InspectionRuleSet ruleSet =
+          InspectionRuleSet.newBuilder()
+              .addInfoTypes(InfoType.newBuilder().setName("PERSON_NAME"))
+              .addRules(InspectionRule.newBuilder().setExclusionRule(exclusionRule))
+              .build();
 
       // Construct the configuration for the Inspect request, including the ruleset.
       InspectConfig config =

--- a/dlp/src/main/java/dlp/snippets/InspectStringWithExclusionDict.java
+++ b/dlp/src/main/java/dlp/snippets/InspectStringWithExclusionDict.java
@@ -73,17 +73,19 @@ public class InspectStringWithExclusionDict {
       }
 
       // Exclude matches from the specified excludedMatchList.
-      ExclusionRule exclusionRule = ExclusionRule.newBuilder()
-          .setMatchingType(MatchingType.MATCHING_TYPE_FULL_MATCH)
-          .setDictionary(Dictionary.newBuilder()
-              .setWordList(WordList.newBuilder().addAllWords(excludedMatchList)))
-          .build();
+      ExclusionRule exclusionRule =
+          ExclusionRule.newBuilder()
+              .setMatchingType(MatchingType.MATCHING_TYPE_FULL_MATCH)
+              .setDictionary(Dictionary.newBuilder()
+                  .setWordList(WordList.newBuilder().addAllWords(excludedMatchList)))
+              .build();
 
       // Construct a ruleset that applies the exclusion rule to the EMAIL_ADDRESSES infotype.
-      InspectionRuleSet ruleSet = InspectionRuleSet.newBuilder()
-          .addInfoTypes(InfoType.newBuilder().setName("EMAIL_ADDRESS"))
-          .addRules(InspectionRule.newBuilder().setExclusionRule(exclusionRule))
-          .build();
+      InspectionRuleSet ruleSet =
+          InspectionRuleSet.newBuilder()
+              .addInfoTypes(InfoType.newBuilder().setName("EMAIL_ADDRESS"))
+              .addRules(InspectionRule.newBuilder().setExclusionRule(exclusionRule))
+              .build();
 
       // Construct the configuration for the Inspect request, including the ruleset.
       InspectConfig config =

--- a/dlp/src/main/java/dlp/snippets/InspectStringWithExclusionDictSubstring.java
+++ b/dlp/src/main/java/dlp/snippets/InspectStringWithExclusionDictSubstring.java
@@ -74,17 +74,19 @@ public class InspectStringWithExclusionDictSubstring {
       }
 
       // Exclude partial matches from the specified excludedSubstringList.
-      ExclusionRule exclusionRule = ExclusionRule.newBuilder()
-          .setMatchingType(MatchingType.MATCHING_TYPE_PARTIAL_MATCH)
-          .setDictionary(Dictionary.newBuilder()
-              .setWordList(WordList.newBuilder().addAllWords(excludedSubstringList)))
-          .build();
+      ExclusionRule exclusionRule =
+          ExclusionRule.newBuilder()
+              .setMatchingType(MatchingType.MATCHING_TYPE_PARTIAL_MATCH)
+              .setDictionary(Dictionary.newBuilder()
+                  .setWordList(WordList.newBuilder().addAllWords(excludedSubstringList)))
+              .build();
 
       // Construct a ruleset that applies the exclusion rule to the EMAIL_ADDRESSES infotype.
-      InspectionRuleSet ruleSet = InspectionRuleSet.newBuilder()
-          .addAllInfoTypes(infoTypes)
-          .addRules(InspectionRule.newBuilder().setExclusionRule(exclusionRule))
-          .build();
+      InspectionRuleSet ruleSet =
+          InspectionRuleSet.newBuilder()
+              .addAllInfoTypes(infoTypes)
+              .addRules(InspectionRule.newBuilder().setExclusionRule(exclusionRule))
+              .build();
 
       // Construct the configuration for the Inspect request, including the ruleset.
       InspectConfig config =

--- a/dlp/src/main/java/dlp/snippets/InspectStringWithExclusionRegex.java
+++ b/dlp/src/main/java/dlp/snippets/InspectStringWithExclusionRegex.java
@@ -71,16 +71,18 @@ public class InspectStringWithExclusionRegex {
       }
 
       // Exclude matches from the specified excludedMatchList.
-      ExclusionRule exclusionRule = ExclusionRule.newBuilder()
-          .setMatchingType(MatchingType.MATCHING_TYPE_FULL_MATCH)
-          .setRegex(Regex.newBuilder().setPattern(excludedRegex))
-          .build();
+      ExclusionRule exclusionRule =
+          ExclusionRule.newBuilder()
+              .setMatchingType(MatchingType.MATCHING_TYPE_FULL_MATCH)
+              .setRegex(Regex.newBuilder().setPattern(excludedRegex))
+              .build();
 
       // Construct a ruleset that applies the exclusion rule to the EMAIL_ADDRESSES infotype.
-      InspectionRuleSet ruleSet = InspectionRuleSet.newBuilder()
-          .addInfoTypes(InfoType.newBuilder().setName("EMAIL_ADDRESS"))
-          .addRules(InspectionRule.newBuilder().setExclusionRule(exclusionRule))
-          .build();
+      InspectionRuleSet ruleSet =
+          InspectionRuleSet.newBuilder()
+              .addInfoTypes(InfoType.newBuilder().setName("EMAIL_ADDRESS"))
+              .addRules(InspectionRule.newBuilder().setExclusionRule(exclusionRule))
+              .build();
 
       // Construct the configuration for the Inspect request, including the ruleset.
       InspectConfig config =

--- a/dlp/src/main/java/dlp/snippets/InspectStringWithoutOverlap.java
+++ b/dlp/src/main/java/dlp/snippets/InspectStringWithoutOverlap.java
@@ -72,26 +72,28 @@ public class InspectStringWithoutOverlap {
       }
 
       // Define a custom info type to exclude email addresses
-      CustomInfoType customInfoType = CustomInfoType.newBuilder()
-          .setInfoType(InfoType.newBuilder().setName("EMAIL_ADDRESS"))
-          .setExclusionType(ExclusionType.EXCLUSION_TYPE_EXCLUDE)
-          .build();
+      CustomInfoType customInfoType =
+          CustomInfoType.newBuilder()
+              .setInfoType(InfoType.newBuilder().setName("EMAIL_ADDRESS"))
+              .setExclusionType(ExclusionType.EXCLUSION_TYPE_EXCLUDE)
+              .build();
 
       // Exclude EMAIL_ADDRESS matches
-      ExclusionRule exclusionRule = ExclusionRule.newBuilder()
-          .setExcludeInfoTypes(
-              ExcludeInfoTypes.newBuilder()
+      ExclusionRule exclusionRule =
+          ExclusionRule.newBuilder()
+              .setExcludeInfoTypes(ExcludeInfoTypes.newBuilder()
                   .addInfoTypes(InfoType.newBuilder().setName("EMAIL_ADDRESS")))
-          .setMatchingType(MatchingType.MATCHING_TYPE_PARTIAL_MATCH)
-          .build();
+              .setMatchingType(MatchingType.MATCHING_TYPE_PARTIAL_MATCH)
+              .build();
 
       // Construct a ruleset that applies the exclusion rule to the DOMAIN_NAME infotype.
       // If a DOMAIN_NAME match is part of an EMAIL_ADDRESS match, the DOMAIN_NAME match will
       // be excluded.
-      InspectionRuleSet ruleSet = InspectionRuleSet.newBuilder()
-          .addInfoTypes(InfoType.newBuilder().setName("DOMAIN_NAME"))
-          .addRules(InspectionRule.newBuilder().setExclusionRule(exclusionRule))
-          .build();
+      InspectionRuleSet ruleSet =
+          InspectionRuleSet.newBuilder()
+              .addInfoTypes(InfoType.newBuilder().setName("DOMAIN_NAME"))
+              .addRules(InspectionRule.newBuilder().setExclusionRule(exclusionRule))
+              .build();
 
       // Construct the configuration for the Inspect request, including the ruleset.
       InspectConfig config =

--- a/dlp/src/main/java/dlp/snippets/InspectTextFile.java
+++ b/dlp/src/main/java/dlp/snippets/InspectTextFile.java
@@ -58,13 +58,16 @@ public class InspectTextFile {
       // Specify the type of info the inspection will look for.
       List<InfoType> infoTypes = new ArrayList<>();
       // See https://cloud.google.com/dlp/docs/infotypes-reference for complete list of info types
-      for (String typeName : new String[] {"PHONE_NUMBER", "EMAIL_ADDRESS", "CREDIT_CARD_NUMBER"}) {
+      for (String typeName : new String[]{"PHONE_NUMBER", "EMAIL_ADDRESS", "CREDIT_CARD_NUMBER"}) {
         infoTypes.add(InfoType.newBuilder().setName(typeName).build());
       }
 
       // Construct the configuration for the Inspect request.
       InspectConfig config =
-          InspectConfig.newBuilder().addAllInfoTypes(infoTypes).setIncludeQuote(true).build();
+          InspectConfig.newBuilder()
+              .addAllInfoTypes(infoTypes)
+              .setIncludeQuote(true)
+              .build();
 
       // Construct the Inspect request to be sent by the client.
       InspectContentRequest request =

--- a/dlp/src/main/java/dlp/snippets/InspectWithCustomRegex.java
+++ b/dlp/src/main/java/dlp/snippets/InspectWithCustomRegex.java
@@ -68,7 +68,10 @@ public class InspectWithCustomRegex {
       // Construct the custom regex detector.
       InfoType infoType = InfoType.newBuilder().setName("C_MRN").build();
       CustomInfoType customInfoType =
-          CustomInfoType.newBuilder().setInfoType(infoType).setRegex(regex).build();
+          CustomInfoType.newBuilder()
+              .setInfoType(infoType)
+              .setRegex(regex)
+              .build();
 
       // Construct the configuration for the Inspect request.
       InspectConfig config =


### PR DESCRIPTION
Fix some minor formatting inconsistencies across my last several commits and other samples in the same group.

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [X] `pom.xml` parent set to latest `shared-configuration`
- [X] Appropriate changes to README are included in PR
- [X] API's need to be enabled to test (tell us) (**Nothing New**)
- [X] Environment Variables need to be set (ask us to set them) (**Nothing New**)
- [X] Tests pass (`mvn -P lint clean verify`)
  * (Note- `Checkstyle` passing is required; `Spotbugs`, `ErrorProne`, `PMD`, etc. `ERROR`'s are advisory only)
- [X] Please **merge** this PR for me once it is approved.
