### PR TITLE
Fixes product names and a link reference

### DIFF
--- a/appengine-java8/bigquery/README.md
+++ b/appengine-java8/bigquery/README.md
@@ -1,13 +1,13 @@
 <a href="https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=appengine-java8/bigquery/README.md">
 <img alt="Open in Cloud Shell" src ="http://gstatic.com/cloudssh/images/open-btn.png"></a>
 
-# Google Cloud API Showcase: Cloud BigQuery & StackDriver Monitoring in App Engine Standard Environment for Java 8
+# Google Cloud API Showcase: BigQuery & Cloud Monitoring in App Engine standard environment for Java 8
 
-This API Showcase demonstrates how to run an AppEngine standard environment application with dependencies on both 
-[Google BigQuery][bigquery] and [StackDriver Monitoring][stackdriver].
+This API Showcase demonstrates how to run an App Engine standard environment application with dependencies on both 
+[Google BigQuery][bigquery] and [StackDriver Monitoring][monitoring].
 
 [bigquery]: https://cloud.google.com/bigquery/docs
-[stackdriver]: https://cloud.google.com/monitoring/docs
+[monitoring]: https://cloud.google.com/monitoring/docs
 
 The home page of this application provides a form to initiate a query of public data, in this case StackOverflow
 questions tagged with `google-bigquery`.
@@ -35,12 +35,10 @@ cd appengine-java8/bigquery
 ```
 - For local development, [set up][set-up] authentication
 - Enable [BigQuery][bigquery-api] and [Monitoring][monitoring-api] APIs
-- If you have not already enabled your project for StackDriver, do so by following [these instructions][stackdriver-setup].
   
 [set-up]: https://cloud.google.com/docs/authentication/getting-started
 [bigquery-api]: https://console.cloud.google.com/launcher/details/google/bigquery-json.googleapis.com
 [monitoring-api]: https://console.cloud.google.com/launcher/details/google/monitoring.googleapis.com
-[stackdriver-setup]: https://cloud.google.com/monitoring/accounts/tiers#not-enabled
 
 ## Run locally
 Run using shown Maven command. You can then direct your browser to `http://localhost:8080/` to see the most recent query
@@ -56,12 +54,12 @@ few moments and try again.
 
 ## Deploy
 
-- Deploy to AppEngine standard environment using the following Maven command.
+- Deploy to App Engine standard environment using the following Maven command.
 ```
    mvn clean package appengine:deploy
 ```
 - Direct your browser to `https://<your-project-id>.appspot.com`.
-- View more in-depth metrics data on the [StackDriver Monitoring Dashboard][dashboard]
+- View more in-depth metrics data on the [Cloud Monitoring Dashboard][dashboard]
 
 [dashboard]: https://pantheon.corp.google.com/monitoring
 


### PR DESCRIPTION
The enablement link appears to be no longer necessary and has been broken for quite some time.

Fixes product names and broken link in the README

- [ NA] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [ NA] `pom.xml` parent set to latest `shared-configuration`
- [ NA] Appropriate changes to README are included in PR
- [ NA] API's need to be enabled to test (tell us)
- [ NA] Environment Variables need to be set (ask us to set them)
- [ NA] **Tests** pass:   `mvn clean verify` **required**
- [ NA] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ NA] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ X] Please **merge** this PR for me once it is approved.
