### PR TITLE
Clean up some ProjectName uses in DLP

### DIFF
--- a/dlp/src/main/java/dlp/snippets/DeIdentifyWithExceptionList.java
+++ b/dlp/src/main/java/dlp/snippets/DeIdentifyWithExceptionList.java
@@ -30,8 +30,8 @@ import com.google.privacy.dlp.v2.InfoType;
 import com.google.privacy.dlp.v2.InfoTypeTransformations;
 import com.google.privacy.dlp.v2.InfoTypeTransformations.InfoTypeTransformation;
 import com.google.privacy.dlp.v2.InspectConfig;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.PrimitiveTransformation;
-import com.google.privacy.dlp.v2.ProjectName;
 import com.google.privacy.dlp.v2.ReplaceWithInfoTypeConfig;
 import java.io.IOException;
 
@@ -100,7 +100,7 @@ public class DeIdentifyWithExceptionList {
       // Combine configurations into a request for the service.
       DeidentifyContentRequest request =
           DeidentifyContentRequest.newBuilder()
-              .setParent(ProjectName.of(projectId).toString())
+              .setParent(LocationName.of(projectId, "global").toString())
               .setItem(contentItem)
               .setInspectConfig(inspectConfig)
               .setDeidentifyConfig(deidentifyConfig)

--- a/dlp/src/main/java/dlp/snippets/DeIdentifyWithSimpleWordList.java
+++ b/dlp/src/main/java/dlp/snippets/DeIdentifyWithSimpleWordList.java
@@ -30,8 +30,8 @@ import com.google.privacy.dlp.v2.InfoType;
 import com.google.privacy.dlp.v2.InfoTypeTransformations;
 import com.google.privacy.dlp.v2.InfoTypeTransformations.InfoTypeTransformation;
 import com.google.privacy.dlp.v2.InspectConfig;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.PrimitiveTransformation;
-import com.google.privacy.dlp.v2.ProjectName;
 import com.google.privacy.dlp.v2.ReplaceWithInfoTypeConfig;
 import java.io.IOException;
 
@@ -95,7 +95,7 @@ public class DeIdentifyWithSimpleWordList {
       // Combine configurations into a request for the service.
       DeidentifyContentRequest request =
           DeidentifyContentRequest.newBuilder()
-              .setParent(ProjectName.of(projectId).toString())
+              .setParent(LocationName.of(projectId, "global").toString())
               .setItem(contentItem)
               .setInspectConfig(inspectConfig)
               .setDeidentifyConfig(deidentifyConfig)

--- a/dlp/src/main/java/dlp/snippets/InspectWithCustomRegex.java
+++ b/dlp/src/main/java/dlp/snippets/InspectWithCustomRegex.java
@@ -30,7 +30,7 @@ import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.InspectContentRequest;
 import com.google.privacy.dlp.v2.InspectContentResponse;
 import com.google.privacy.dlp.v2.Likelihood;
-import com.google.privacy.dlp.v2.ProjectName;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 
@@ -51,9 +51,6 @@ public class InspectWithCustomRegex {
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
     try (DlpServiceClient dlp = DlpServiceClient.create()) {
-      // Specify the project used for request.
-      ProjectName project = ProjectName.of(projectId);
-
       // Specify the type and content to be inspected.
       ByteContentItem byteItem =
           ByteContentItem.newBuilder()
@@ -84,8 +81,7 @@ public class InspectWithCustomRegex {
       // Construct the Inspect request to be sent by the client.
       InspectContentRequest request =
           InspectContentRequest.newBuilder()
-              .setParent(project.toString())
-              .setItem(item)
+              .setParent(LocationName.of(projectId, "global").toString()).setItem(item)
               .setInspectConfig(config)
               .build();
 

--- a/dlp/src/main/java/dlp/snippets/InspectWithHotwordRules.java
+++ b/dlp/src/main/java/dlp/snippets/InspectWithHotwordRules.java
@@ -35,7 +35,7 @@ import com.google.privacy.dlp.v2.InspectContentResponse;
 import com.google.privacy.dlp.v2.InspectionRule;
 import com.google.privacy.dlp.v2.InspectionRuleSet;
 import com.google.privacy.dlp.v2.Likelihood;
-import com.google.privacy.dlp.v2.ProjectName;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 
@@ -58,9 +58,6 @@ public class InspectWithHotwordRules {
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
     try (DlpServiceClient dlp = DlpServiceClient.create()) {
-      // Specify the project used for request.
-      ProjectName project = ProjectName.of(projectId);
-
       // Specify the type and content to be inspected.
       ByteContentItem byteItem =
           ByteContentItem.newBuilder()
@@ -111,7 +108,7 @@ public class InspectWithHotwordRules {
       // Construct the Inspect request to be sent by the client.
       InspectContentRequest request =
           InspectContentRequest.newBuilder()
-              .setParent(project.toString())
+              .setParent(LocationName.of(projectId, "global").toString())
               .setItem(item)
               .setInspectConfig(config)
               .build();


### PR DESCRIPTION
Clean up some samples that got added with the old way of setting the parent field. See internal bug b/158100365 for context.

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [X] `pom.xml` parent set to latest `shared-configuration`
- [X] Appropriate changes to README are included in PR
- [X] API's need to be enabled to test (tell us)
- [X] Environment Variables need to be set (ask us to set them)
- [X] **Tests** pass:   `mvn clean verify` **required**
- [X] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [X] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [X] Please **merge** this PR for me once it is approved.
