### PR TITLE
Remove PowerMock from the Slack GCF sample.

### DIFF
--- a/functions/slack/pom.xml
+++ b/functions/slack/pom.xml
@@ -31,7 +31,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.7</powermock.version>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -99,24 +98,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <version>29.0-jre</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/slack/src/main/java/functions/SlackSlashCommand.java
+++ b/functions/slack/src/main/java/functions/SlackSlashCommand.java
@@ -30,10 +30,8 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.security.GeneralSecurityException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.logging.Logger;
 import java.util.Optional;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 public class SlackSlashCommand implements HttpFunction {

--- a/functions/slack/src/main/java/functions/SlackSlashCommand.java
+++ b/functions/slack/src/main/java/functions/SlackSlashCommand.java
@@ -33,6 +33,7 @@ import java.security.GeneralSecurityException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.logging.Logger;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class SlackSlashCommand implements HttpFunction {
@@ -43,14 +44,24 @@ public class SlackSlashCommand implements HttpFunction {
   private static final String SLACK_SECRET = getenv("SLACK_SECRET");
   private static final Gson gson = new Gson();
 
-  private Kgsearch kgClient;
-  private SlackSignature.Verifier verifier;
+  private final String apiKey;
+  private final Kgsearch kgClient;
+  private final SlackSignature.Verifier verifier;
 
   public SlackSlashCommand() throws IOException, GeneralSecurityException {
-    kgClient = new Kgsearch.Builder(
-        GoogleNetHttpTransport.newTrustedTransport(), new JacksonFactory(), null).build();
+    this(new SlackSignature.Verifier(new SlackSignature.Generator(SLACK_SECRET)));
+  }
 
-    verifier = new SlackSignature.Verifier(new SlackSignature.Generator(SLACK_SECRET));
+  SlackSlashCommand(SlackSignature.Verifier verifier) throws IOException, GeneralSecurityException {
+    this(verifier, API_KEY);
+  }
+
+  SlackSlashCommand(SlackSignature.Verifier verifier, String apiKey)
+      throws IOException, GeneralSecurityException {
+    this.verifier = verifier;
+    this.apiKey = apiKey;
+    this.kgClient = new Kgsearch.Builder(
+        GoogleNetHttpTransport.newTrustedTransport(), new JacksonFactory(), null).build();
   }
 
   // Avoid ungraceful deployment failures due to unset environment variables.
@@ -73,18 +84,13 @@ public class SlackSlashCommand implements HttpFunction {
    * @return true if the provided request came from Slack, false otherwise
    */
   boolean isValidSlackWebhook(HttpRequest request, String requestBody) {
-
     // Check for headers
-    HashMap<String, List<String>> headers = new HashMap(request.getHeaders());
-    if (!headers.containsKey("X-Slack-Request-Timestamp")
-        || !headers.containsKey("X-Slack-Signature")) {
+    Optional<String> maybeTimestamp = request.getFirstHeader("X-Slack-Request-Timestamp");
+    Optional<String> maybeSignature = request.getFirstHeader("X-Slack-Signature");
+    if (!maybeTimestamp.isPresent() || !maybeSignature.isPresent()) {
       return false;
     }
-    return verifier.isValid(
-        headers.get("X-Slack-Request-Timestamp").get(0),
-        requestBody,
-        headers.get("X-Slack-Signature").get(0),
-        1L);
+    return verifier.isValid(maybeTimestamp.get(), requestBody, maybeSignature.get(), 1L);
   }
   // [END functions_verify_webhook]
 
@@ -158,7 +164,7 @@ public class SlackSlashCommand implements HttpFunction {
   JsonObject searchKnowledgeGraph(String query) throws IOException {
     Kgsearch.Entities.Search kgRequest = kgClient.entities().search();
     kgRequest.setQuery(query);
-    kgRequest.setKey(API_KEY);
+    kgRequest.setKey(apiKey);
 
     return gson.fromJson(kgRequest.execute().toString(), JsonObject.class);
   }

--- a/functions/slack/src/test/java/functions/SlackSlashCommandTest.java
+++ b/functions/slack/src/test/java/functions/SlackSlashCommandTest.java
@@ -17,10 +17,12 @@
 package functions;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 import com.github.seratch.jslack.app_backend.SlackSignature;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
@@ -33,14 +35,12 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.security.GeneralSecurityException;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.powermock.reflect.Whitebox;
+import org.mockito.MockitoAnnotations;
 
 public class SlackSlashCommandTest {
 
@@ -54,36 +54,26 @@ public class SlackSlashCommandTest {
 
   @Before
   public void beforeTest() throws IOException {
-    request = mock(HttpRequest.class);
-    when(request.getReader()).thenReturn(new BufferedReader(new StringReader("")));
+    MockitoAnnotations.initMocks(this);
 
-    response = mock(HttpResponse.class);
+    when(request.getReader()).thenReturn(new BufferedReader(new StringReader("")));
 
     responseOut = new StringWriter();
 
     writerOut = new BufferedWriter(responseOut);
     when(response.getWriter()).thenReturn(writerOut);
 
-    alwaysValidVerifier = mock(SlackSignature.Verifier.class);
-    when(alwaysValidVerifier.isValid(
-          ArgumentMatchers.any(),
-          ArgumentMatchers.any(),
-          ArgumentMatchers.any(),
-          ArgumentMatchers.anyLong())
-    ).thenReturn(true);
+    when(alwaysValidVerifier.isValid(any(), any(), any(), anyLong())).thenReturn(true);
 
     // Construct valid header list
-    HashMap<String, List<String>> validHeaders = new HashMap<String, List<String>>();
     String validSlackSignature = System.getenv("SLACK_TEST_SIGNATURE");
     String timestamp = "0"; // start of Unix epoch
 
-    validHeaders.put("X-Slack-Signature", Arrays.asList(validSlackSignature));
-    validHeaders.put("X-Slack-Request-Timestamp", Arrays.asList(timestamp));
+    Map<String, List<String>> validHeaders = Map.of(
+        "X-Slack-Signature", List.of(validSlackSignature),
+        "X-Slack-Request-Timestamp", List.of(timestamp));
 
     when(request.getHeaders()).thenReturn(validHeaders);
-
-    // Reset knowledge graph API key
-    Whitebox.setInternalState(SlackSlashCommand.class, "API_KEY", System.getenv("KG_API_KEY"));
   }
 
   @Test
@@ -120,19 +110,18 @@ public class SlackSlashCommandTest {
     verify(response, times(1)).setStatusCode(HttpURLConnection.HTTP_BAD_REQUEST);
   }
 
-  @Test(expected = GoogleJsonResponseException.class)
+  @Test
   public void handlesSearchErrorTest() throws IOException, GeneralSecurityException {
     StringReader requestReadable = new StringReader("{ \"text\": \"foo\" }\n");
 
     when(request.getReader()).thenReturn(new BufferedReader(requestReadable));
     when(request.getMethod()).thenReturn("POST");
 
-    SlackSlashCommand functionInstance = new SlackSlashCommand();
-    Whitebox.setInternalState(functionInstance, "verifier", alwaysValidVerifier);
-    Whitebox.setInternalState(SlackSlashCommand.class, "API_KEY", "gibberish");
+    SlackSlashCommand functionInstance = new SlackSlashCommand(alwaysValidVerifier, "gibberish");
 
     // Should throw a GoogleJsonResponseException (due to invalid API key)
-    functionInstance.service(request, response);
+    assertThrows(
+        GoogleJsonResponseException.class, () -> functionInstance.service(request, response));
   }
 
   @Test
@@ -142,9 +131,7 @@ public class SlackSlashCommandTest {
     when(request.getReader()).thenReturn(new BufferedReader(requestReadable));
     when(request.getMethod()).thenReturn("POST");
 
-    SlackSlashCommand functionInstance = new SlackSlashCommand();
-    Whitebox.setInternalState(functionInstance, "verifier", alwaysValidVerifier);
-
+    SlackSlashCommand functionInstance = new SlackSlashCommand(alwaysValidVerifier);
 
     functionInstance.service(request, response);
 
@@ -159,9 +146,7 @@ public class SlackSlashCommandTest {
     when(request.getReader()).thenReturn(new BufferedReader(requestReadable));
     when(request.getMethod()).thenReturn("POST");
 
-    SlackSlashCommand functionInstance = new SlackSlashCommand();
-    Whitebox.setInternalState(functionInstance, "verifier", alwaysValidVerifier);
-
+    SlackSlashCommand functionInstance = new SlackSlashCommand(alwaysValidVerifier);
 
     functionInstance.service(request, response);
 

--- a/functions/slack/src/test/java/functions/SlackSlashCommandTest.java
+++ b/functions/slack/src/test/java/functions/SlackSlashCommandTest.java
@@ -74,6 +74,7 @@ public class SlackSlashCommandTest {
         "X-Slack-Request-Timestamp", List.of(timestamp));
 
     when(request.getHeaders()).thenReturn(validHeaders);
+    when(request.getFirstHeader(any())).thenCallRealMethod();
   }
 
   @Test


### PR DESCRIPTION
Cherry-picked and rebased from @eamonnmcmanus's https://github.com/GoogleCloudPlatform/java-docs-samples/pull/2854

Instead of using Whitebox, use package-private constructor overloads
to supply the values needed by the test.

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [x] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [x] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] Please **merge** this PR for me once it is approved.
