### PR TITLE
samples: increased wait time for undeployed model prediction

### DIFF
--- a/vision/automl/src/test/java/com/google/cloud/vision/samples/automl/PredictionApiIT.java
+++ b/vision/automl/src/test/java/com/google/cloud/vision/samples/automl/PredictionApiIT.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,7 +48,8 @@ public class PredictionApiIT {
   private PrintStream out;
 
   @Before
-  public void setUp() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+  public void setUp()
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
     // Verify that the model is deployed for prediction
     try (AutoMlClient client = AutoMlClient.create()) {
       ModelName modelFullId = ModelName.of(PROJECT_ID, "us-central1", modelId);

--- a/vision/automl/src/test/java/com/google/cloud/vision/samples/automl/PredictionApiIT.java
+++ b/vision/automl/src/test/java/com/google/cloud/vision/samples/automl/PredictionApiIT.java
@@ -26,6 +26,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,7 +49,7 @@ public class PredictionApiIT {
   private PrintStream out;
 
   @Before
-  public void setUp() throws IOException, ExecutionException, InterruptedException {
+  public void setUp() throws IOException, ExecutionException, InterruptedException, TimeoutException {
     // Verify that the model is deployed for prediction
     try (AutoMlClient client = AutoMlClient.create()) {
       ModelName modelFullId = ModelName.of(PROJECT_ID, "us-central1", modelId);
@@ -54,7 +58,8 @@ public class PredictionApiIT {
         // Deploy the model if not deployed
         DeployModelRequest request =
             DeployModelRequest.newBuilder().setName(modelFullId.toString()).build();
-        client.deployModelAsync(request).get();
+        Future future = client.deployModelAsync(request);
+        future.get(30, TimeUnit.MINUTES);
       }
     }
 


### PR DESCRIPTION
Fixes #2469 

I was able to reproduce the error with the following steps:
1. undeploy model
2. run predict the test --> which will go into setup of the test (tries to deploy the model again) and since deploying model takes 5-30 min. 

Then, the actual test runs while the deployment is not finished.