### PR TITLE
Use correct java flag for Language API readme

### DIFF
--- a/language/cloud-client/README.md
+++ b/language/cloud-client/README.md
@@ -27,6 +27,6 @@ mvn clean compile assembly:single
 ### Analyze a string for sentiment (using the quickstart sample)
 
 ```
-java -cp target/language-google-cloud-samples-1.0.9-jar-with-dependencies.jar \
+java -jar target/language-google-cloud-samples-1.0.9-jar-with-dependencies.jar \
     com.example.language.QuickstartSample
 ```


### PR DESCRIPTION
When run with the existing command it returns an error:
```
Error: Could not find or load main class com.example.language.QuickstartSample
```

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [x] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [x] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [x] Please **merge** this PR for me once it is approved.
