### PR TITLE
Adjust region tags for Gradle functions sample.

### DIFF
--- a/functions/helloworld/hello-http-gradle/build.gradle
+++ b/functions/helloworld/hello-http-gradle/build.gradle
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// START functions_build_gradle
 apply plugin: 'java'
 
 repositories {
@@ -38,3 +39,4 @@ jar {
   // There must be a jar {} section, though the archiveBaseName does not have to be 'function'.
   archiveBaseName = 'function'
 }
+// END functions_build_gradle

--- a/functions/helloworld/hello-http-gradle/src/main/java/functions/HelloHttp.java
+++ b/functions/helloworld/hello-http-gradle/src/main/java/functions/HelloHttp.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package functions;
-
 // [START functions_helloworld_http]
+package functions;
 
 import com.google.cloud.functions.HttpFunction;
 import com.google.cloud.functions.HttpRequest;


### PR DESCRIPTION
Include the `package` declaration in the Java file,
and exclude the copyright notice in `build.gradle`.