### PR TITLE
samples: fixed flaky test of logging

### DIFF
--- a/logging/cloud-client/src/test/java/com/example/logging/LoggingIT.java
+++ b/logging/cloud-client/src/test/java/com/example/logging/LoggingIT.java
@@ -71,7 +71,7 @@ public class LoggingIT {
     assertThat(got).contains("Logged: Hello, world!");
   }
 
-  @Test(timeout = 30000)
+  @Test(timeout = 45000)
   public void testWriteAndListLogs() throws Exception {
     // write a log entry
     LogEntry entry =


### PR DESCRIPTION


I was able to reproduce Linked bug's error by running loggingIT test multiples times. 
Looks like timeout 30000 might be short for this test.

Average time took to run LoggingIT ~ about 20sec
Longest was 35 sec. 
I think increasing to 45 secs should fix this problem otherwise increase to 60sec.

- [X] Please **merge** this PR for me once it is approved.
