### PR TITLE
fix: only run test if restore succeeded

### DIFF
--- a/spanner/cloud-client/pom.xml
+++ b/spanner/cloud-client/pom.xml
@@ -42,7 +42,7 @@ limitations under the License.
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>8.1.0</version>
+        <version>9.0.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/spanner/cloud-client/src/test/java/com/example/spanner/SpannerSampleIT.java
+++ b/spanner/cloud-client/src/test/java/com/example/spanner/SpannerSampleIT.java
@@ -296,6 +296,7 @@ public class SpannerSampleIT {
     // Try the restore operation in a retry loop, as there is a limit on the number of restore
     // operations that is allowed to execute simultaneously, and we should retry if we hit this
     // limit.
+    boolean restored = false;
     int restoreAttempts = 0;
     while (true) {
       try {
@@ -306,6 +307,7 @@ public class SpannerSampleIT {
                 + "] from ["
                 + backupId.getName()
                 + "]");
+        restored = true;
         break;
       } catch (SpannerException e) {
         if (e.getErrorCode() == ErrorCode.FAILED_PRECONDITION
@@ -325,14 +327,16 @@ public class SpannerSampleIT {
       }
     }
 
-    out = runSample("listdatabaseoperations");
-    assertThat(out).contains(
-        String.format(
-            "Database %s restored from backup",
-            DatabaseId.of(
-                dbId.getInstanceId(),
-                SpannerSample.createRestoredSampleDbId(dbId))
-            .getName()));
+    if (restored) {
+      out = runSample("listdatabaseoperations");
+      assertThat(out).contains(
+          String.format(
+              "Database %s restored from backup",
+              DatabaseId.of(
+                  dbId.getInstanceId(),
+                  SpannerSample.createRestoredSampleDbId(dbId))
+              .getName()));
+    }
 
     out = runSample("updatebackup");
     assertThat(out).contains(


### PR DESCRIPTION
The database restore operation could be given up by the test if it fails too many times with an error indicating that too many restore operations are running. The test for listing database operations would still be executed and would then look for the optimize operation of the previous restore. This operation would not be found, as the restore operation was skipped.

Fixes #3541
