### PR TITLE
dataflow: have consistent metadata names in camelCase

### DIFF
--- a/dataflow/flex-templates/kafka_to_bigquery/metadata.json
+++ b/dataflow/flex-templates/kafka_to_bigquery/metadata.json
@@ -6,7 +6,7 @@
       "name": "inputTopic",
       "label": "Kafka input topic.",
       "helpText": "Apache Kafka topic to read from.",
-      "is_optional": true,
+      "isOptional": true,
       "regexes": [
         "[-_.a-zA-Z0-9]+"
       ]
@@ -23,7 +23,7 @@
       "name": "bootstrapServer",
       "label": "Kafka bootstrap server",
       "helpText": "Apache Kafka bootstrap server in the form 'hostname:port'.",
-      "is_optional": true,
+      "isOptional": true,
       "regexes": [
         "[-_.:a-zA-Z0-9]+"
       ]

--- a/dataflow/flex-templates/streaming_beam_sql/metadata.json
+++ b/dataflow/flex-templates/streaming_beam_sql/metadata.json
@@ -14,7 +14,7 @@
       "name": "outputTable",
       "label": "BigQuery output table",
       "helpText": "BigQuery table spec to write to, in the form 'project:dataset.table'.",
-      "is_optional": true,
+      "isOptional": true,
       "regexes": [
         "[^:]+:[^.]+[.].+"
       ]

--- a/dataflow/templates/WordCount_metadata
+++ b/dataflow/templates/WordCount_metadata
@@ -18,21 +18,21 @@
     {
       "name": "inputFile",
       "label": "Input GCS File Pattern",
-      "help_text: "Google Cloud Storage file pattern glob of the file(s) to read from.",
+      "helpText: "Google Cloud Storage file pattern glob of the file(s) to read from.",
       "regexes": ["^gs:\/\/[^\n\r]+$"],
-      "is_optional": true
+      "isOptional": true
     },
     {
       "name": "outputBucket",
       "label": "Output GCS Bucket",
-      "help_text: "Google Cloud Storage bucket to store the outputs.",
+      "helpText: "Google Cloud Storage bucket to store the outputs.",
       "regexes": ["^[a-z0-9][-_.a-z0-9]+[a-z0-9]$"]
     },
     {
       "name": "withSubstring",
       "label": "With Substring",
-      "help_text: "Filter only words containing the specified substring.",
-      "is_optional": true
+      "helpText: "Filter only words containing the specified substring.",
+      "isOptional": true
     },
   ]
 }


### PR DESCRIPTION
Fixes #3514 -- making parameters consistent (camelCase for Java, and snake_case for Python).

Both snake_case and camelCase names are supported.

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] Please **merge** this PR for me once it is approved.
