### PR TITLE
Specify member type

### DIFF
--- a/iam/api-client/src/main/java/iam/snippets/QuickstartV2.java
+++ b/iam/api-client/src/main/java/iam/snippets/QuickstartV2.java
@@ -36,7 +36,7 @@ public class QuickstartV2 {
   public static void main(String[] args) {
     // TODO: Replace with your project ID.
     String projectId = "your-project";
-    // TODO: Replace with the ID of your member in the form "member:user@example.com"
+    // TODO: Replace with the ID of your member in the form "user:member@example.com"
     String member = "your-member";
     // The role to be granted.
     String role = "roles/logging.logWriter";


### PR DESCRIPTION
Saying "member:user@example.com" isn't helpful, since the prefix needs to be "user", "serviceAccount", or "group", not "member'"

Since this is a quickstart, we should just pick one type and stick with that. "user" is a good way to demonstrate core functionality, so I picked that type.