### PR TITLE
chore(functions/firebase): Add infinite-loop guard + test

### DIFF
--- a/functions/firebase/firestore-reactive/src/main/java/functions/FirebaseFirestoreReactive.java
+++ b/functions/firebase/firestore-reactive/src/main/java/functions/FirebaseFirestoreReactive.java
@@ -79,11 +79,17 @@ public class FirebaseFirestoreReactive implements RawBackgroundFunction {
 
     String affectedDoc = context.resource().split("/documents/")[1].replace("\"", "");
 
-    logger.info(String.format("Replacing value: %s --> %s", currentValue, newValue));
-    try {
-      FIRESTORE.document(affectedDoc).set(newFields, SetOptions.merge()).get();
-    } catch (ExecutionException | InterruptedException e) {
-      logger.log(Level.SEVERE, "Error updating Firestore document: " + e.getMessage(), e);
+    if (!currentValue.equals(newValue)) {
+      logger.info(String.format("Replacing value: %s --> %s", currentValue, newValue));
+      try {
+        FIRESTORE.document(affectedDoc).set(newFields, SetOptions.merge()).get();
+      } catch (ExecutionException | InterruptedException e) {
+        logger.log(Level.SEVERE, "Error updating Firestore document: " + e.getMessage(), e);
+      }
+    } else {
+      // Value is already upper-case
+      // Don't perform a(nother) write to avoid infinite loops
+      logger.info(String.format("Value is already upper-case."));
     }
   }
 }

--- a/functions/firebase/firestore-reactive/src/main/java/functions/FirebaseFirestoreReactive.java
+++ b/functions/firebase/firestore-reactive/src/main/java/functions/FirebaseFirestoreReactive.java
@@ -80,6 +80,8 @@ public class FirebaseFirestoreReactive implements RawBackgroundFunction {
     String affectedDoc = context.resource().split("/documents/")[1].replace("\"", "");
 
     if (!currentValue.equals(newValue)) {
+      // The stored value needs to be updated
+      // Write the upper-cased value to Firestore
       logger.info(String.format("Replacing value: %s --> %s", currentValue, newValue));
       try {
         FIRESTORE.document(affectedDoc).set(newFields, SetOptions.merge()).get();
@@ -87,8 +89,8 @@ public class FirebaseFirestoreReactive implements RawBackgroundFunction {
         logger.log(Level.SEVERE, "Error updating Firestore document: " + e.getMessage(), e);
       }
     } else {
-      // Value is already upper-case
-      // Don't perform a(nother) write to avoid infinite loops
+      // The stored value is already upper-case, and doesn't need updating.
+      // (Don't perform a "second" write, since that could trigger an infinite loop.)
       logger.info(String.format("Value is already upper-case."));
     }
   }

--- a/functions/firebase/firestore-reactive/src/test/java/functions/FirebaseFirestoreReactiveTest.java
+++ b/functions/firebase/firestore-reactive/src/test/java/functions/FirebaseFirestoreReactiveTest.java
@@ -93,6 +93,25 @@ public class FirebaseFirestoreReactiveTest {
   }
 
   @Test
+  public void functionsFirebaseReactive_shouldIgnoreCapitalizedValues()  {
+
+    String jsonStr = gson.toJson(Map.of("value",
+        Map.of("fields",
+            Map.of("original",
+                Map.of("stringValue", "FOO")))));
+
+    MockContext context = new MockContext();
+    context.resource = "projects/_/databases/(default)/documents/messages/ABCDE12345";
+
+    FirebaseFirestoreReactive functionInstance = new FirebaseFirestoreReactive(firestoreMock);
+
+    functionInstance.accept(jsonStr, context);
+
+    Truth.assertThat(LOG_HANDLER.getStoredLogRecords().get(0).getMessage()).isEqualTo(
+        "Value is already upper-case.");
+  }
+
+  @Test
   public void functionsFirebaseReactive_shouldReportBadJson()  {
     String jsonStr = gson.toJson(Map.of("value",
         Map.of("fields",


### PR DESCRIPTION
As requested by @jskeet

(N.B: this isn't _actually_ broken on Cloud Functions itself, but it depends on undocumented behavior.)