### PR TITLE
chore(functions/slack): update Slack sample

### DIFF
--- a/functions/slack/pom.xml
+++ b/functions/slack/pom.xml
@@ -58,19 +58,14 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.8.6</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-kgsearch</artifactId>
       <version>v1-rev20200809-1.30.10</version>
     </dependency>
     <dependency>
-      <groupId>com.github.seratch</groupId>
-      <artifactId>jslack</artifactId>
-      <version>3.4.2</version>
+      <groupId>com.slack.api</groupId>
+      <artifactId>slack-app-backend</artifactId>
+      <version>1.1.3</version>
     </dependency>
 
     <!-- The following dependencies are only required for testing -->

--- a/functions/slack/src/test/java/functions/SlackSlashCommandTest.java
+++ b/functions/slack/src/test/java/functions/SlackSlashCommandTest.java
@@ -24,11 +24,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.github.seratch.jslack.app_backend.SlackSignature;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.cloud.functions.HttpRequest;
 import com.google.cloud.functions.HttpResponse;
 import com.google.gson.Gson;
+import com.slack.api.app_backend.SlackSignature;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -91,8 +91,8 @@ public class SlackSlashCommandTest {
 
   @Test
   public void requiresSlackAuthHeadersTest() throws IOException, GeneralSecurityException {
-    String jsonStr = gson.toJson(Map.of("text", "foo"));
-    StringReader requestReadable = new StringReader(jsonStr);
+    String urlEncodedStr = "text=foo";
+    StringReader requestReadable = new StringReader(urlEncodedStr);
 
     when(request.getMethod()).thenReturn("POST");
     when(request.getReader()).thenReturn(new BufferedReader(requestReadable));
@@ -105,7 +105,7 @@ public class SlackSlashCommandTest {
 
   @Test
   public void recognizesValidSlackTokenTest() throws IOException, GeneralSecurityException {
-    StringReader requestReadable = new StringReader("{}");
+    StringReader requestReadable = new StringReader("");
 
     when(request.getReader()).thenReturn(new BufferedReader(requestReadable));
     when(request.getMethod()).thenReturn("POST");
@@ -117,8 +117,8 @@ public class SlackSlashCommandTest {
 
   @Test
   public void handlesSearchErrorTest() throws IOException, GeneralSecurityException {
-    String jsonStr = gson.toJson(Map.of("text", "foo"));
-    StringReader requestReadable = new StringReader(jsonStr);
+    String urlEncodedStr = "text=foo";
+    StringReader requestReadable = new StringReader(urlEncodedStr);
 
     when(request.getReader()).thenReturn(new BufferedReader(requestReadable));
     when(request.getMethod()).thenReturn("POST");
@@ -132,8 +132,8 @@ public class SlackSlashCommandTest {
 
   @Test
   public void handlesEmptyKgResultsTest() throws IOException, GeneralSecurityException {
-    String jsonStr = gson.toJson(Map.of("text", "asdfjkl13579"));
-    StringReader requestReadable = new StringReader(jsonStr);
+    String urlEncodedStr = "text=asdfjkl13579";
+    StringReader requestReadable = new StringReader(urlEncodedStr);
 
     when(request.getReader()).thenReturn(new BufferedReader(requestReadable));
     when(request.getMethod()).thenReturn("POST");
@@ -148,8 +148,24 @@ public class SlackSlashCommandTest {
 
   @Test
   public void handlesPopulatedKgResultsTest() throws IOException, GeneralSecurityException {
-    String jsonStr = gson.toJson(Map.of("text", "lion"));
-    StringReader requestReadable = new StringReader(jsonStr);
+    String urlEncodedStr = "text=lion";
+    StringReader requestReadable = new StringReader(urlEncodedStr);
+
+    when(request.getReader()).thenReturn(new BufferedReader(requestReadable));
+    when(request.getMethod()).thenReturn("POST");
+
+    SlackSlashCommand functionInstance = new SlackSlashCommand(alwaysValidVerifier);
+
+    functionInstance.service(request, response);
+
+    writerOut.flush();
+    assertThat(responseOut.toString()).contains("https://en.wikipedia.org/wiki/Lion");
+  }
+
+  @Test
+  public void handlesMultipleUrlParamsTest() throws IOException, GeneralSecurityException {
+    String urlEncodedStr = "unused=foo&text=lion";
+    StringReader requestReadable = new StringReader(urlEncodedStr);
 
     when(request.getReader()).thenReturn(new BufferedReader(requestReadable));
     when(request.getMethod()).thenReturn("POST");


### PR DESCRIPTION
- Use URL encoding instead of JSON for incoming (from Slack) requests
- Fix improperly formatted outgoing (to Slack) JSON response
- Move to official (and largely identical) Slack API package

cc @jskeet as FYI