### PR TITLE
fix: explicitly rollback transaction after abort

### DIFF
--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/TransactionWithRetryLoopExample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/TransactionWithRetryLoopExample.java
@@ -76,6 +76,8 @@ class TransactionWithRetryLoopExample {
               "Transaction committed at [%s]%n", spannerConnection.getCommitTimestamp().toString());
           break;
         } catch (JdbcAbortedException e) {
+          // Rollback the current transaction to initiate a new transaction on the next statement.
+          connection.rollback();
           // Transaction aborted, retry.
           System.out.println("Transaction aborted, starting retry");
         }

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/TransactionWithRetryLoopUsingOnlyJdbcExample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/TransactionWithRetryLoopUsingOnlyJdbcExample.java
@@ -68,6 +68,8 @@ class TransactionWithRetryLoopUsingOnlyJdbcExample {
           }
           break;
         } catch (SQLException e) {
+          // Rollback the current transaction to initiate a new transaction on the next statement.
+          connection.rollback();
           if (e.getErrorCode() == Code.ABORTED.value()) {
             // Transaction aborted, retry.
             System.out.println("Transaction aborted, starting retry");


### PR DESCRIPTION
The current transaction should be explicitly rollbacked after an Aborted error to ensure that the connection will start a new transaction on the next statement.

The current version of the JDBC driver does not require the user to rollback the transaction after an `Aborted` error, but it is customary to do so. Future versions of the JDBC driver might also require a `rollback()` call after an `Aborted` error.