### PR TITLE
Update static analysis image to include java 8 and 11 runtimes.

### DIFF
--- a/.kokoro/static_analysis/common.cfg
+++ b/.kokoro/static_analysis/common.cfg
@@ -19,11 +19,17 @@ gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 build_file: "java-docs-samples/.kokoro/trampoline.sh"
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+    value: "gcr.io/cloud-devrel-kokoro-resources/java11"
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/java-docs-samples/.kokoro/tests/run_static_analysis.sh"
+}
+
+# Set the JAVA VERSION env var.
+env_vars: {
+    key: "JAVA_VERSION"
+    value: "1.8,11"
 }
 
 # Access btlr binaries used in the tests

--- a/.kokoro/static_analysis/common.cfg
+++ b/.kokoro/static_analysis/common.cfg
@@ -26,12 +26,6 @@ env_vars: {
     value: "github/java-docs-samples/.kokoro/tests/run_static_analysis.sh"
 }
 
-# Set the JAVA VERSION env var.
-env_vars: {
-    key: "JAVA_VERSION"
-    value: "1.8,11"
-}
-
 # Access btlr binaries used in the tests
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/btlr"
 


### PR DESCRIPTION
Fixes #issue

> It's a good idea to open an issue first for discussion.

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [x] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
