### PR TITLE
docs: update set custom timeout sample

### DIFF
--- a/spanner/cloud-client/pom.xml
+++ b/spanner/cloud-client/pom.xml
@@ -53,6 +53,7 @@ limitations under the License.
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
+      <version>2.0.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>

--- a/spanner/cloud-client/src/main/java/com/example/spanner/CustomTimeoutAndRetrySettingsExample.java
+++ b/spanner/cloud-client/src/main/java/com/example/spanner/CustomTimeoutAndRetrySettingsExample.java
@@ -16,8 +16,8 @@
 
 package com.example.spanner;
 
+//[START spanner_set_custom_timeout_and_retry]
 import com.google.api.gax.grpc.GrpcCallContext;
-// [START spanner_set_custom_timeout_and_retry]
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.DatabaseId;
@@ -28,10 +28,10 @@ import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.TransactionContext;
 import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
 import com.google.spanner.v1.SpannerGrpc;
-import java.util.concurrent.TimeUnit;
 import io.grpc.CallOptions;
 import io.grpc.Context;
 import io.grpc.MethodDescriptor;
+import java.util.concurrent.TimeUnit;
 
 class CustomTimeoutAndRetrySettingsExample {
 

--- a/spanner/cloud-client/src/test/java/com/example/spanner/SpannerStandaloneExamplesIT.java
+++ b/spanner/cloud-client/src/test/java/com/example/spanner/SpannerStandaloneExamplesIT.java
@@ -117,7 +117,7 @@ public class SpannerStandaloneExamplesIT {
         runExample(
             () ->
                 CustomTimeoutAndRetrySettingsExample.executeSqlWithCustomTimeoutAndRetrySettings(
-                    projectId, instanceId, databaseId));
+                    spanner.getDatabaseClient(DatabaseId.of(projectId, instanceId, databaseId))));
     assertThat(out).contains("1 record inserted.");
   }
 


### PR DESCRIPTION
Updates the 'Set custom timeout and retry settings' sample to one that uses the possibility of setting a specific timeout for one method call. This does however not support setting retry settings.

Fixes #3805 