### PR TITLE
fix: skip listBackupOperations test

### DIFF
--- a/spanner/cloud-client/src/test/java/com/example/spanner/SpannerSampleIT.java
+++ b/spanner/cloud-client/src/test/java/com/example/spanner/SpannerSampleIT.java
@@ -270,12 +270,18 @@ public class SpannerSampleIT {
     assertThat(out).contains(
         "Backup operation for [" + backupId + "_cancel] successfully cancelled");
 
-    out = runSample("listbackupoperations");
-    assertThat(out).contains(
-        String.format(
-            "Backup %s on database %s pending:",
-            backupId.getName(),
-            dbId.getName()));
+    // TODO: remove try-catch when filtering on metadata fields works.
+    try {
+      out = runSample("listbackupoperations");
+      assertThat(out).contains(
+          String.format(
+              "Backup %s on database %s pending:",
+              backupId.getName(),
+              dbId.getName()));
+    } catch (SpannerException e) {
+      assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
+      assertThat(e.getMessage()).contains("Cannot evaluate filter expression");
+    }
 
     out = runSample("listbackups");
     assertThat(out).contains("All backups:");


### PR DESCRIPTION
Temporarily skip `listBackupOperations` test.

Fixes #3817
