### PR TITLE
fix: close Spanner instance after tests

### DIFF
--- a/spanner/cloud-client/src/test/java/com/example/spanner/SpannerSampleIT.java
+++ b/spanner/cloud-client/src/test/java/com/example/spanner/SpannerSampleIT.java
@@ -79,6 +79,7 @@ public class SpannerSampleIT {
     dbClient.dropDatabase(dbId.getInstanceId().getInstance(), dbId.getDatabase());
     dbClient.dropDatabase(
         dbId.getInstanceId().getInstance(), SpannerSample.createRestoredSampleDbId(dbId));
+    spanner.close();
   }
 
   @Test


### PR DESCRIPTION
Close the `Spanner` instance after all tests have been executed. This ensures that all sessions that have been opened by the tests will be deleted on the backend.