### PR TITLE
dataflow: update "Open in Cloud Shell" links

### DIFF
--- a/dataflow/README.md
+++ b/dataflow/README.md
@@ -1,6 +1,6 @@
 # Getting started with Google Cloud Dataflow
 
-[![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor)
+[![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=dataflow/README.md)
 
 [Apache Beam](https://beam.apache.org/)
 is an open source, unified model for defining both batch and streaming

--- a/dataflow/encryption-keys/README.md
+++ b/dataflow/encryption-keys/README.md
@@ -1,6 +1,6 @@
 # Using customer-managed encryption keys
 
-[![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor)
+[![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=dataflow/encryption-keys/README.md)
 
 This sample demonstrate how to use
 [cryptographic encryption keys](https://cloud.google.com/kms/)

--- a/dataflow/flex-templates/README.md
+++ b/dataflow/flex-templates/README.md
@@ -1,6 +1,6 @@
 # Dataflow flex templates
 
-[![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor)
+[![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=dataflow/flex-templates/README.md)
 
 Samples showing how to create and run an
 [Apache Beam](https://beam.apache.org/) template with a custom Docker image on

--- a/dataflow/flex-templates/kafka_to_bigquery/README.md
+++ b/dataflow/flex-templates/kafka_to_bigquery/README.md
@@ -1,6 +1,6 @@
 # Dataflow Flex templates - Kafka to BigQuery
 
-[![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor)
+[![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=dataflow/flex-templates/kafka_to_bigquery/README.md)
 
 Samples showing how to create and run an
 [Apache Beam](https://beam.apache.org/) template with a custom Docker image on

--- a/dataflow/flex-templates/streaming_beam_sql/README.md
+++ b/dataflow/flex-templates/streaming_beam_sql/README.md
@@ -1,6 +1,6 @@
 # Dataflow flex templates - Streaming Beam SQL
 
-[![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor)
+[![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=dataflow/flex-templates/streaming_beam_sql/README.md)
 
 📝 Docs: [Using Flex Templates](https://cloud.google.com/dataflow/docs/guides/templates/using-flex-templates)
 

--- a/dataflow/templates/README.md
+++ b/dataflow/templates/README.md
@@ -1,6 +1,6 @@
 # Cloud Dataflow Templates
 
-[![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor)
+[![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=dataflow/templates/README.md)
 
 Samples showing how to create and run an
 [Apache Beam](https://beam.apache.org/) template on


### PR DESCRIPTION
Updating the "Open in Cloud Shell" links to clone the repo and open the correct README file

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] Please **merge** this PR for me once it is approved.
