### PR TITLE
Update POM to use smaller Bigtable dependency

### DIFF
--- a/appengine-java8/bigtable/pom.xml
+++ b/appengine-java8/bigtable/pom.xml
@@ -45,7 +45,8 @@ limitations under the License.
   <dependencies>
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
-      <artifactId>bigtable-hbase-1.x</artifactId>
+      <!-- Use the hadoop client instead of 1.x due to file size. -->
+      <artifactId>bigtable-hbase-1.x-hadoop</artifactId>
       <version>1.16.0</version>
     </dependency>
 


### PR DESCRIPTION
Addresses issue as described here: https://github.com/googleapis/java-bigtable-hbase/issues/2039

> It's a good idea to open an issue first for discussion.

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] Please **merge** this PR for me once it is approved.
