### PR TITLE
chore: add observability team to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,4 @@
 
 /datastore/                     @GoogleCloudPlatform/firestore-dpe @GoogleCloudPlatform/java-samples-reviewers
 /firestore/                     @GoogleCloudPlatform/firestore-dpe @GoogleCloudPlatform/java-samples-reviewers
+/logging/                       @GoogleCloudPlatform/observability-devx


### PR DESCRIPTION
cDPE Observability team owns logging and error reporting APIs and samples

Fixes #4011

> It's a good idea to open an issue first for discussion.

- [ ] Please **merge** this PR for me once it is approved.
