### PR TITLE
clean up grammar and spelling

### DIFF
--- a/SAMPLE_FORMAT.md
+++ b/SAMPLE_FORMAT.md
@@ -30,17 +30,17 @@
     * [Time](#time)
     * [Logging](#logging)
 
-This doc maintains an outline for 'snippet' samples specific to Java. Currently, the java canonical
+This doc maintains an outline for 'snippet' samples specific to Java. Currently, the Java canonical
 samples in this format are located 
 [here](../../tree/master/dlp/src/main/java/dlp/snippets).
 
-Larger sample applications should attempt to follow many of these guidelines as well, but some may
+Larger sample applications should attempt to follow these guidelines as well, but some may
 be ignored or waived as there can be many structural differences between applications and snippets.
 
 ## Java Version
 
-All samples should be written to run on both Java 8 and Java 11, samples that don't run on Java 8 
-should clearly says so in their README and specifically set Java 11 in their `pom`.  There should be
+All samples should be written to run on both Java 8 and Java 11. Samples that don't run on Java 8 
+should clearly say so in their README and specifically set Java 11 in their `pom`. There should be
 a clear reason why Java 8 isn't supported.
 
 ## Specific Goals
@@ -64,7 +64,7 @@ All new samples should build and run integration tests with [Maven](https://mave
 
 ## Testing
 Any infrastructure required to run the test (such as a GCS bucket or a Cloud SQL instance) should
-be passed in as an environment variable. Tests should clearly indicated which environment variables
+be passed in as an environment variable. Tests should clearly indicate which environment variables
 are required for the tests to pass.
 
 Resources required outside of this infrastructure should be generated and cleaned up (even on 
@@ -132,14 +132,14 @@ mind when setting up tests.
   in your PR.
 
 * **IAM**
-  Some API's require that the service account have some additional capibilities, these should also
+  Some API's require that the service account have some additional capibilities. These should also
   be mentioned in both the PR and the README.
 
 * **Cloud resources**  
   Most Java samples create the Cloud resources that they need to run. If this
   is resource intensive or not possible, add instructions to the directory's README.md file
   to add the resource to the testing project. Tests that create cloud resources should also delete
-  those resources when they are done testing, particularly in a way that will ensure the deletion
+  those resources when they are done testing in a way that ensures the deletion
   of the resource even if the test fails, such as with with a `finally` block or in an `@After`
   or `@AfterClass` function.  Also, resources should not used fixed names, but prefer UUID's as
   we have many tests that run at the same time.
@@ -193,7 +193,7 @@ test {
 ## Format Guidelines
 ### Project Location
 Samples should be in a project folder under the name of the technology the snippet represents. 
-Additional subfolder's should be used to differentiate groups of samples. Execution technologies,
+Additional subfolders should be used to differentiate groups of samples. Execution technologies,
 like Compute, Cloud Run, Dataproc, Dataflow, Functions may have subfolder's for other technologies to
 show using the two technologies together.
 
@@ -264,7 +264,7 @@ Samples should generally follow the "Arrange, Act, Assert" outline to:
   as complex, nested builders can be hard to read.
 * _Act_ - Send the request and receive the response.
 * _Assert_ - Verify the call was successful or that the response is correct. This is often done by
-  print the contents of the response to `stdout`.
+  printing the contents of the response to `stdout`.
 
 ## Style
 Samples in this repository follow the [Google Java Style Guide][java-style].
@@ -293,15 +293,16 @@ builds and adheres to the style guide without waiting for tests to complete.
 ### Package Names
 Samples should use package names in the following formats:
 
-  `<PRODUCT>`, `<PRODUCT1>.<PRODUCT2>`, `<PRODUCT>.<IDEA>` is preferred, fewer levels is prefered.
+  `<PRODUCT>`, `<PRODUCT1>.<PRODUCT2>`, `<PRODUCT>.<IDEA>` is preferred; fewer levels are preferred.
 Legacy samples that use `com.example.<YOUR_PRODUCT>.<FOLDER>`, such as `com.example.dlp.snippets` or 
-`com.example.functions.snippets` are still accepted and do not need to migrate to the perfered system (above).
+`com.example.functions.snippets` are still accepted and do not need to migrate to the preferred system (above).
+
   **NEVER** use `com.google.*` for samples or snippets. Use of the default package is **strongly** discouraged.
 
 ### Class Structure
 Each snippet should be be contained in its own file, within a class with a name descriptive of the
-snippet and a similarly named function. Region tags should start below the `package` (if there is 
-one), but should include the class and any imports in full. Additional functions can be used if it
+snippet and a similarly named method. Region tags should start below the `package` (if there is 
+one), but should include the class and any imports in full. Additional methods can be used if it
 improves readability of the sample.
 
 ```java
@@ -309,32 +310,32 @@ improves readability of the sample.
 import com.example.resource;
 
 public class exampleSnippet {
-  // Snippet functions ...
+  // Snippet methods ...
 }
 // [END product_example]
 ```
-### Function Comment
+### Method Comment
 Include a short, descriptive comment detailing what action the snippet it attempting to perform.
 Avoid using the javadoc format, as these samples are not used to generate documentation and it can
 be redundant.
 ```java
-// This is an example snippet for show best practices.
+// This is an example snippet for showing best practices.
 public static void exampleSnippet(String projectId, String filePath) {
     // Snippet content ...
 }
 ```
-### Function Structure
-Function parameters should be limited to what is absolutely required for testing (ideally having at
-most 4 parameters). In most cases, this is project specific information or the path to an external
+### Method Structure
+Method arguments should be limited to what is absolutely required for testing (ideally having at
+most 4 arguments). In most cases, this is project specific information or the path to an external
 file. For example, project specific information (such as `projectId`) or a `filePath` for an
-external file is acceptable, while a parameter for the type of a file or a specific action is not.
+external file is acceptable, while an argument for the type of a file or a specific action is not.
  
-Any declared function parameters should include a no-arg, main function with examples for how
-the user can initialize the function parameters and call the entrypoint for the snippet. If the
-values for these variables need to be replaced by the user, attempt to make it explicitly clear that
+Any declared function arguments should include a no-arg, main method with examples for how
+the user can initialize the method arguments and call the entrypoint for the snippet. If the
+values for these variables need to be replaced by the user, be explicit that
 they are example values only.
 
-Snippet functions should specify a return type of `void` and avoid returning any value wherever
+Snippet methods should specify a return type of `void` and avoid returning any value wherever
 possible. Instead, show the user how to interact with a returned object programmatically by printing
 some example attributes to the console. 
 ```java
@@ -345,7 +346,7 @@ public static void main(main(String[] args) {
     inspectImageFile(projectId, filePath);
 }
 
-// This is an example snippet for show best practices.
+// This is an example snippet for showing best practices.
 public static void exampleSnippet(String projectId, String filePath) {
     // Snippet content ...
 }
@@ -373,7 +374,7 @@ try {
 }
 ```
 
-For example looking at the code in googleapis/java-dialogflow searching for `throws` and `catch`, I see lots of specific enhanced exceptions - our samples should reflect the richness of those. For example, [ApiException](http://googleapis.github.io/gax-java/1.7.1/apidocs/com/google/api/gax/rpc/ApiException.html) has 16 known subclasses that Gax throws. gRPC also throws [`io.grpc.StatusException`](https://grpc.github.io/grpc-java/javadoc/io/grpc/StatusException.html) which has additional info to help developers understand the cause of their errors. There is also [`io.grpc.StatusRuntimeException`](https://grpc.github.io/grpc-java/javadoc/io/grpc/StatusRuntimeException.html) and [`io.grpc.ManagedChannelProvider.ProviderNotFoundException`](https://grpc.github.io/grpc-java/javadoc/io/grpc/ManagedChannelProvider.ProviderNotFoundException.html).  By listing them explicitly, users are clued into looking them up to understand how the API works and what might happen in production. 
+For example, looking at the code in googleapis/java-dialogflow searching for `throws` and `catch`, I see lots of specific enhanced exceptions - our samples should reflect the richness of those. For example, [ApiException](http://googleapis.github.io/gax-java/1.7.1/apidocs/com/google/api/gax/rpc/ApiException.html) has 16 known subclasses that Gax throws. gRPC also throws [`io.grpc.StatusException`](https://grpc.github.io/grpc-java/javadoc/io/grpc/StatusException.html) which has additional info to help developers understand the cause of their errors. There is also [`io.grpc.StatusRuntimeException`](https://grpc.github.io/grpc-java/javadoc/io/grpc/StatusRuntimeException.html) and [`io.grpc.ManagedChannelProvider.ProviderNotFoundException`](https://grpc.github.io/grpc-java/javadoc/io/grpc/ManagedChannelProvider.ProviderNotFoundException.html).  By listing them explicitly, users are clued into looking them up to understand how the API works and what might happen in production. 
 
 
 ### Client Initialization
@@ -391,7 +392,7 @@ try (DlpServiceClient dlp = DlpServiceClient.create()) {
 ```
 ### Command-Line Arguments
 **NOTE:** Snippet should be optimized to run directly from a user's IDE. Command-Line arguments are
-considered an anti-patern, and new samples should not implement them. 
+considered an anti-pattern, and new samples should not implement them. 
 
 **Dataflow** samples are an exception to this guideline.
 
@@ -400,7 +401,7 @@ Prefer using modern idioms / language features over older styles.
 
 ### Lambdas
 Should be about 1-3 lines at most, otherwise it should be in a named method.
-* Prefer lambdas to annonymous classes
+* Prefer lambdas to anonymous classes
   
 ### Streams
 Streams can be extremely compact, efficient, and easy to use - consider using them.
@@ -409,7 +410,7 @@ Streams can be extremely compact, efficient, and easy to use - consider using th
 * Checked Exceptions can be problematic inside streams.
   
 ### Parallel Streams
-Parallel Streams make sense in a few situations. There are many situations where there use is a
+Parallel Streams make sense in a few situations. However, there are many situations where their use is a
 net loss.  Really think through your usage and consider what they might mean if you are already
 doing concurrent operations.
 
@@ -418,7 +419,7 @@ The following are some general Java best practices that should be followed in sa
 idiomatic. 
 
 ### Time
-Use the `java.time` package when dealing with units of time in some manner. 
+Use the `java.time` package when dealing with units of time in some manner.
 
 ### Logging
 Use [slf4j](http://www.slf4j.org/) as shown [here](https://cloud.google.com/logging/docs/setup/java#example) for consistent logging. Unless you are demonstrating how


### PR DESCRIPTION
@lesv  Most notably, Java has "method arguments" instead of "function parameters", but overall good advice.
