### PR TITLE
test: auto-throttle admin requests

### DIFF
--- a/spanner/cloud-client/src/main/java/com/example/spanner/SpannerSample.java
+++ b/spanner/cloud-client/src/main/java/com/example/spanner/SpannerSample.java
@@ -2142,6 +2142,9 @@ public class SpannerSample {
     }
     // [START init_client]
     SpannerOptions options = SpannerOptions.newBuilder().build();
+    // [END init_client]
+    options = options.toBuilder().setAutoThrottleAdministrativeRequests().build();
+    // [START init_client]
     Spanner spanner = options.getService();
     try {
       String command = args[0];

--- a/spanner/cloud-client/src/test/java/com/example/spanner/AsyncExamplesIT.java
+++ b/spanner/cloud-client/src/test/java/com/example/spanner/AsyncExamplesIT.java
@@ -72,7 +72,8 @@ public class AsyncExamplesIT {
 
   @BeforeClass
   public static void createTestDatabase() throws Exception {
-    SpannerOptions options = SpannerOptions.newBuilder().build();
+    SpannerOptions options =
+        SpannerOptions.newBuilder().setAutoThrottleAdministrativeRequests().build();
     spanner = options.getService();
     dbClient = spanner.getDatabaseAdminClient();
     if (instanceId == null) {

--- a/spanner/cloud-client/src/test/java/com/example/spanner/SpannerSampleIT.java
+++ b/spanner/cloud-client/src/test/java/com/example/spanner/SpannerSampleIT.java
@@ -65,7 +65,8 @@ public class SpannerSampleIT {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    SpannerOptions options = SpannerOptions.newBuilder().build();
+    SpannerOptions options =
+        SpannerOptions.newBuilder().setAutoThrottleAdministrativeRequests().build();
     spanner = options.getService();
     dbClient = spanner.getDatabaseAdminClient();
     dbId = DatabaseId.of(options.getProjectId(), instanceId, databaseId);

--- a/spanner/cloud-client/src/test/java/com/example/spanner/SpannerStandaloneExamplesIT.java
+++ b/spanner/cloud-client/src/test/java/com/example/spanner/SpannerStandaloneExamplesIT.java
@@ -67,7 +67,8 @@ public class SpannerStandaloneExamplesIT {
 
   @BeforeClass
   public static void createTestDatabase() throws Exception {
-    SpannerOptions options = SpannerOptions.newBuilder().build();
+    SpannerOptions options =
+        SpannerOptions.newBuilder().setAutoThrottleAdministrativeRequests().build();
     spanner = options.getService();
     dbClient = spanner.getDatabaseAdminClient();
     if (instanceId == null) {


### PR DESCRIPTION
The Spanner client has the option to automatically throttle the number of administrative requests that are generated in order to avoid hitting the [hard limit that Spanner has of max 5 admin requests per second](https://cloud.google.com/spanner/quotas#administrative_limits).

Updates #4144 
