### PR TITLE
fix error The processing instruction target matching "[xX][mM][lL]" 

### DIFF
--- a/flexible/websocket-jetty/pom.xml
+++ b/flexible/websocket-jetty/pom.xml
@@ -15,7 +15,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.eclipse.jetty.demo</groupId>

--- a/flexible/websocket-jetty/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/flexible/websocket-jetty/src/main/webapp/WEB-INF/jetty-web.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2019 Google LLC
 
@@ -13,7 +14,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="parentLoaderPriority">true</Set>


### PR DESCRIPTION
I was getting the error below when trying to run this app. Need to move the <?xml ... ?> header to the first line of the file "jetty-web.xml"


[WARNING] FATAL@null line:16 col:6 : org.xml.sax.SAXParseException; lineNumber: 16; columnNumber: 6; The processing instruction target matching "[xX][mM][lL]" is not allowed.
[WARNING] Failed startup of context o.e.j.m.p.JettyWebAppContext@28757abd{/,file:///D:/NetBeansProjects/GoogleCloudPlatform/java-docs-samples/flexible/websocket-jetty/target/native-jetty-websocket-example-1.0-SNAPSHOT/,UNAVAILABLE}{D:\NetBeansProjects\GoogleCloudPlatform\java-docs-samples\flexible\websocket-jetty\target\native-jetty-websocket-example-1.0-SNAPSHOT}
org.xml.sax.SAXParseException: The processing instruction target matching "[xX][mM][lL]" is not allowed.
    at com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.createSAXParseException (ErrorHandlerWrapper.java:203)
    at com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.fatalError (ErrorHandlerWrapper.java:177)
    at com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError (XMLErrorReporter.java:400)
    at com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError (XMLErrorReporter.java:327)
    at com.sun.org.apache.xerces.internal.impl.XMLScanner.reportFatalError (XMLScanner.java:1472)
    at com.sun.org.apache.xerces.internal.impl.XMLScanner.scanPIData (XMLScanner.java:746)
    at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanPIData (XMLDocumentFragmentScannerImpl.java:1014)
    at com.sun.org.apache.xerces.internal.impl.XMLScanner.scanPI (XMLScanner.java:714)
    at com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl$PrologDriver.next (XMLDocumentScannerImpl.java:907)
    at com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next (XMLDocumentScannerImpl.java:602)
    at com.sun.org.apache.xerces.internal.impl.XMLNSDocumentScannerImpl.next (XMLNSDocumentScannerImpl.java:112)
    at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument (XMLDocumentFragmentScannerImpl.java:505)
    at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse (XML11Configuration.java:842)
    at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse (XML11Configuration.java:771)
    at com.sun.org.apache.xerces.internal.parsers.XMLParser.parse (XMLParser.java:141)
    at com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.parse (AbstractSAXParser.java:1213)
    at com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl$JAXPSAXParser.parse (SAXParserImpl.java:643)
    at com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl.parse (SAXParserImpl.java:327)
    at org.eclipse.jetty.xml.XmlParser.parse (XmlParser.java:244)
    at org.eclipse.jetty.xml.XmlConfiguration.<init> (XmlConfiguration.java:226)
    at org.eclipse.jetty.xml.XmlConfiguration.<init> (XmlConfiguration.java:242)
    at org.eclipse.jetty.webapp.JettyWebXmlConfiguration.configure (JettyWebXmlConfiguration.java:86)
    at org.eclipse.jetty.webapp.WebAppContext.configure (WebAppContext.java:498)
    at org.eclipse.jetty.webapp.WebAppContext.startContext (WebAppContext.java:1417)
    at org.eclipse.jetty.server.handler.ContextHandler.doStart (ContextHandler.java:911)
    at org.eclipse.jetty.servlet.ServletContextHandler.doStart (ServletContextHandler.java:288)
    at org.eclipse.jetty.webapp.WebAppContext.doStart (WebAppContext.java:524)
    at org.eclipse.jetty.maven.plugin.JettyWebAppContext.doStart (JettyWebAppContext.java:397)
    at org.eclipse.jetty.util.component.AbstractLifeCycle.start (AbstractLifeCycle.java:73)
    at org.eclipse.jetty.util.component.ContainerLifeCycle.start (ContainerLifeCycle.java:169)
    at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart (ContainerLifeCycle.java:117)
    at org.eclipse.jetty.server.handler.AbstractHandler.doStart (AbstractHandler.java:97)
    at org.eclipse.jetty.util.component.AbstractLifeCycle.start (AbstractLifeCycle.java:73)
    at org.eclipse.jetty.util.component.ContainerLifeCycle.start (ContainerLifeCycle.java:169)
    at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart (ContainerLifeCycle.java:117)
    at org.eclipse.jetty.server.handler.AbstractHandler.doStart (AbstractHandler.java:97)
    at org.eclipse.jetty.util.component.AbstractLifeCycle.start (AbstractLifeCycle.java:73)
    at org.eclipse.jetty.util.component.ContainerLifeCycle.start (ContainerLifeCycle.java:169)
    at org.eclipse.jetty.server.Server.start (Server.java:423)
    at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart (ContainerLifeCycle.java:110)
    at org.eclipse.jetty.server.handler.AbstractHandler.doStart (AbstractHandler.java:97)
    at org.eclipse.jetty.server.Server.doStart (Server.java:387)
    at org.eclipse.jetty.util.component.AbstractLifeCycle.start (AbstractLifeCycle.java:73)
    at org.eclipse.jetty.maven.plugin.AbstractJettyMojo.startJetty (AbstractJettyMojo.java:449)
    at org.eclipse.jetty.maven.plugin.AbstractJettyMojo.execute (AbstractJettyMojo.java:310)
    at org.eclipse.jetty.maven.plugin.JettyRunWarExplodedMojo.execute (JettyRunWarExplodedMojo.java:59)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
[INFO] Started ServerConnector@50eb4a2c{HTTP/1.1, (http/1.1)}{0.0.0.0:8080}
