### PR TITLE
chore: updates to Cloud SQL samples

### DIFF
--- a/cloud-sql/mysql/servlet/src/main/java/com/example/cloudsql/ConnectionPoolContextListener.java
+++ b/cloud-sql/mysql/servlet/src/main/java/com/example/cloudsql/ConnectionPoolContextListener.java
@@ -66,6 +66,11 @@ public class ConnectionPoolContextListener implements ServletContextListener {
     config.addDataSourceProperty("socketFactory", "com.google.cloud.sql.mysql.SocketFactory");
     config.addDataSourceProperty("cloudSqlInstance", CLOUD_SQL_CONNECTION_NAME);
 
+    // The ipTypes argument can be used to specify a comma delimited list of preferred IP types 
+    // for connecting to a Cloud SQL instance. The argument ipTypes=PRIVATE will force the 
+    // SocketFactory to connect with an instance's associated private IP. 
+    config.addDataSourceProperty("ipTypes", "PUBLIC,PRIVATE");
+
     // ... Specify additional connection properties here.
     // [START_EXCLUDE]
 

--- a/cloud-sql/postgres/servlet/src/main/java/com/example/cloudsql/ConnectionPoolContextListener.java
+++ b/cloud-sql/postgres/servlet/src/main/java/com/example/cloudsql/ConnectionPoolContextListener.java
@@ -66,7 +66,10 @@ public class ConnectionPoolContextListener implements ServletContextListener {
     config.addDataSourceProperty("socketFactory", "com.google.cloud.sql.postgres.SocketFactory");
     config.addDataSourceProperty("cloudSqlInstance", CLOUD_SQL_CONNECTION_NAME);
 
-
+    // The ipTypes argument can be used to specify a comma delimited list of preferred IP types 
+    // for connecting to a Cloud SQL instance. The argument ipTypes=PRIVATE will force the 
+    // SocketFactory to connect with an instance's associated private IP. 
+    config.addDataSourceProperty("ipTypes", "PUBLIC,PRIVATE");
 
     // ... Specify additional connection properties here.
     // [START_EXCLUDE]

--- a/cloud-sql/sqlserver/servlet/src/main/java/com/example/cloudsql/ConnectionPoolContextListener.java
+++ b/cloud-sql/sqlserver/servlet/src/main/java/com/example/cloudsql/ConnectionPoolContextListener.java
@@ -45,6 +45,14 @@ public class ConnectionPoolContextListener implements ServletContextListener {
     // The configuration object specifies behaviors for the connection pool.
     HikariConfig config = new HikariConfig();
 
+    // The following is equivalent to setting the config options below:
+    // jdbc:sqlserver://;user=<DB_USER>;password=<DB_PASS>;databaseName=<DB_NAME>;
+    // socketFactoryClass=com.google.cloud.sql.sqlserver.SocketFactory;
+    // socketFactoryConstructorArg=<CLOUD_SQL_CONNECTION_NAME>
+    
+    // See the link below for more info on building a JDBC URL for the Cloud SQL JDBC Socket Factory
+    // https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory#creating-the-jdbc-url
+
     // Configure which instance and what database user to connect with.
     config
         .setDataSourceClassName("com.microsoft.sqlserver.jdbc.SQLServerDataSource");

--- a/cloud-sql/sqlserver/servlet/src/main/java/com/example/cloudsql/ConnectionPoolContextListener.java
+++ b/cloud-sql/sqlserver/servlet/src/main/java/com/example/cloudsql/ConnectionPoolContextListener.java
@@ -47,7 +47,7 @@ public class ConnectionPoolContextListener implements ServletContextListener {
 
     // Configure which instance and what database user to connect with.
     config
-        .setDataSourceClassName(String.format("com.microsoft.sqlserver.jdbc.SQLServerDataSource"));
+        .setDataSourceClassName("com.microsoft.sqlserver.jdbc.SQLServerDataSource");
     config.setUsername(DB_USER); // e.g. "root", "sqlserver"
     config.setPassword(DB_PASS); // e.g. "my-password"
     config.addDataSourceProperty("databaseName", DB_NAME);


### PR DESCRIPTION
- Added example connection URL to SQL Server sample
- Added instructions for forcing connection with Private IP to MySQL and Postgres samples
- Updated renovate.json to only update driver if new jre8 versions are released.
