### PR TITLE
chore(bigtable_spark): rollback scala update and update renovate config

### DIFF
--- a/bigtable/spark/build.sbt
+++ b/bigtable/spark/build.sbt
@@ -20,7 +20,7 @@ version := "0.1"
 
 // Versions to match Dataproc 1.4
 // https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-release-1.4
-scalaVersion := "2.13.4"
+scalaVersion := "2.11.12"
 val sparkVersion = "2.4.7"
 val bigtableVersion = "1.16.0"
 val hbaseVersion = "1.3.6"

--- a/renovate.json
+++ b/renovate.json
@@ -46,6 +46,10 @@
     {
       "packageNames": ["com.microsoft.sqlserver:mssql-jdbc"],
       "allowedVersions": "/.+jre8.?/"
+    },
+    {
+      "packagePatterns": ["^scalaVersion"],
+      "enabled": false
     }
   ],
   "labels": [


### PR DESCRIPTION
We are pinning versions to dataproc 1.4, so do not automatically update deps.

Updated config following: https://docs.renovatebot.com/configuration-options/#enabled

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] Please **merge** this PR for me once it is approved.
