### PR TITLE
chore(functions): use correct Gradle argument names

### DIFF
--- a/functions/helloworld/helloworld-gradle/build.gradle
+++ b/functions/helloworld/helloworld-gradle/build.gradle
@@ -52,8 +52,8 @@ tasks.register("runFunction", JavaExec) {
   classpath(configurations.invoker)
   inputs.files(configurations.runtimeClasspath, sourceSets.main.output)
   args(
-    '--target', project.findProperty('runFunction.target') ?: '',
-    '--port', project.findProperty('runFunction.port') ?: 8080
+    '--target', project.findProperty('run.functionTarget') ?: '',
+    '--port', project.findProperty('run.port') ?: 8080
   )
   doFirst {
     args('--classpath', files(configurations.runtimeClasspath, sourceSets.main.output).asPath)


### PR DESCRIPTION
The current ones don't match the commands in the docs; this fixes that.

This fixes **b/177219806**.