### PR TITLE
Use spring-boot-starter-data-r2dbc and version manage as little dependencies as possible

### DIFF
--- a/cloud-sql/r2dbc/pom.xml
+++ b/cloud-sql/r2dbc/pom.xml
@@ -36,21 +36,14 @@
       <artifactId>spring-boot-starter-thymeleaf</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.data</groupId>
-      <artifactId>spring-data-r2dbc</artifactId>
-      <version>1.2.3</version>
-    </dependency>
-    <dependency>
-      <groupId>io.r2dbc</groupId>
-      <artifactId>r2dbc-pool</artifactId>
-      <version>0.8.5.RELEASE</version>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-r2dbc</artifactId>
     </dependency>
 
     <!-- MySQL dependencies start -->
     <dependency>
       <groupId>dev.miku</groupId>
       <artifactId>r2dbc-mysql</artifactId>
-      <version>0.8.2.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.sql</groupId>
@@ -63,7 +56,6 @@
     <dependency>
       <groupId>io.r2dbc</groupId>
       <artifactId>r2dbc-postgresql</artifactId>
-      <version>0.8.6.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.sql</groupId>


### PR DESCRIPTION
The PR replaces the dependencies on `spring-data-r2dbc` and `r2dbc-pool` with `spring-boot-starter-data-r2dbc` (already version managed by Spring Boot), which includes those dependencies.

This PR also removes other version numbers for dependencies which are already version managed via Spring Boot to simplify and future-proof the `pom.xml` file.