### PR TITLE
chore(deps): update spring boot to v2.3.8.RELEASE

### DIFF
--- a/pubsub/spring/pom.xml
+++ b/pubsub/spring/pom.xml
@@ -47,7 +47,7 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.4.2</version>
+        <version>2.3.8.RELEASE</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
The dependency bot is not pulling in the .RELEASE version for the samples in `pubsub/spring`. This PR temporarily fixes the dependency until the bot is updated. 

https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies