### PR TITLE
fix: region tag open and close

### DIFF
--- a/pubsub/spring/pom.xml
+++ b/pubsub/spring/pom.xml
@@ -42,8 +42,8 @@
   <!-- The Spring Cloud GCP BOM will manage spring-cloud-gcp version numbers for you. -->
   <!-- [START pubsub_spring_dependency_manager] -->
   <dependencyManagement>
-  <!-- [END pubsub_spring_dependency_manager] -->
     <dependencies>
+    <!-- [END pubsub_spring_dependency_manager] -->
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
See https://cloud.google.com/pubsub/docs/spring#install-spring-integration-channel-adapters-for-pubsub. 

We are missing an opening `<dependencies>`.

Fixing internal b/178796972