### PR TITLE
Update common.cfg

### DIFF
--- a/.kokoro/java8/common.cfg
+++ b/.kokoro/java8/common.cfg
@@ -15,7 +15,7 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
 # Build timeout of 5 hours
-timeout_mins: 300
+timeout_mins: 360
 
 # Download secrets from Cloud Storage.
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/java-docs-samples"


### PR DESCRIPTION
Java 8 continuous builds are timing out at 5h (300m), increase to 6h

- [x] Please **merge** this PR for me once it is approved.
