### PR TITLE
deps: update bigtable to 1.21.0

### DIFF
--- a/bigtable/scheduled-backups/pom.xml
+++ b/bigtable/scheduled-backups/pom.xml
@@ -44,9 +44,14 @@ limitations under the License.
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.6</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigtable</artifactId>
-      <version>1.18.1</version>
+      <version>1.21.0</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
@@ -72,12 +77,7 @@ limitations under the License.
       <version>30.1-jre</version>
       <scope>test</scope>
     </dependency>
-        <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.8.6</version>
-      <scope>test</scope>
-    </dependency>
+
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>


### PR DESCRIPTION
The CreateBackupIT was throwing a NoClassDefFoundError on Gson's JsonReader class and therefore failing to create a backup. I need to dig more into that as this is somewhere deep in the transitive dependency tree, but for now, promote gson to an earlier dependency to avoid conflicts.

Opening in favor of #4825