### PR TITLE
deps: update bigtable to 1.21.0

### DIFF
--- a/bigtable/cassandra-migration-codelab/pom.xml
+++ b/bigtable/cassandra-migration-codelab/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigtable</artifactId>
-      <version>1.20.1</version>
+      <version>1.21.0</version>
     </dependency>
 
     <dependency>

--- a/bigtable/hbase/snippets/pom.xml
+++ b/bigtable/hbase/snippets/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigtable</artifactId>
-      <version>1.20.1</version>
+      <version>1.21.0</version>
     </dependency>
 
     <dependency>

--- a/bigtable/memorystore/pom.xml
+++ b/bigtable/memorystore/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigtable</artifactId>
-      <version>1.20.1</version>
+      <version>1.21.0</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/net.spy/spymemcached -->


### PR DESCRIPTION
not sure why renovate didn't update the rest in the previous PR, updating manually
