### PR TITLE
fix: replace deprecated envelope encryption method in Tink sample

### DIFF
--- a/cloud-sql/mysql/client-side-encryption/src/main/java/cloudsql/tink/CloudKmsEnvelopeAead.java
+++ b/cloud-sql/mysql/client-side-encryption/src/main/java/cloudsql/tink/CloudKmsEnvelopeAead.java
@@ -19,8 +19,10 @@ package cloudsql.tink;
 // [START cloud_sql_mysql_cse_key]
 
 import com.google.crypto.tink.Aead;
+import com.google.crypto.tink.KmsClient;
 import com.google.crypto.tink.aead.AeadConfig;
 import com.google.crypto.tink.aead.AeadKeyTemplates;
+import com.google.crypto.tink.aead.KmsEnvelopeAead;
 import com.google.crypto.tink.integration.gcpkms.GcpKmsClient;
 import java.security.GeneralSecurityException;
 

--- a/cloud-sql/mysql/client-side-encryption/src/main/java/cloudsql/tink/CloudKmsEnvelopeAead.java
+++ b/cloud-sql/mysql/client-side-encryption/src/main/java/cloudsql/tink/CloudKmsEnvelopeAead.java
@@ -31,17 +31,15 @@ public class CloudKmsEnvelopeAead {
 
   public static Aead get(String kmsUri) throws GeneralSecurityException {
     AeadConfig.register();
-    // Generate a new envelope key template, then generate key material.
-    KeyTemplate kmsEnvKeyTemplate = AeadKeyTemplates
-        .createKmsEnvelopeAeadKeyTemplate(kmsUri, AeadKeyTemplates.AES128_GCM);
-    KeysetHandle keysetHandle = KeysetHandle.generateNew(kmsEnvKeyTemplate);
 
-    // Register the KMS client.
-    KmsClients.add(new GcpKmsClient()
-        .withDefaultCredentials());
+    // Create a new KMS Client
+    KmsClient client = new GcpKmsClient().withDefaultCredentials();
 
-    // Create envelope AEAD primitive from keysetHandle
-    return keysetHandle.getPrimitive(Aead.class);
+    // Create an AEAD primitive using the Cloud KMS key
+    Aead gcpAead = client.getAead(kmsUri);
+
+    // Create an envelope AEAD primitive
+    return new KmsEnvelopeAead(AeadKeyTemplates.AES128_GCM, gcpAead);
   }
 }
 // [END cloud_sql_mysql_cse_key]

--- a/cloud-sql/mysql/client-side-encryption/src/main/java/cloudsql/tink/CloudKmsEnvelopeAead.java
+++ b/cloud-sql/mysql/client-side-encryption/src/main/java/cloudsql/tink/CloudKmsEnvelopeAead.java
@@ -19,12 +19,9 @@ package cloudsql.tink;
 // [START cloud_sql_mysql_cse_key]
 
 import com.google.crypto.tink.Aead;
-import com.google.crypto.tink.KeysetHandle;
-import com.google.crypto.tink.KmsClients;
 import com.google.crypto.tink.aead.AeadConfig;
 import com.google.crypto.tink.aead.AeadKeyTemplates;
 import com.google.crypto.tink.integration.gcpkms.GcpKmsClient;
-import com.google.crypto.tink.proto.KeyTemplate;
 import java.security.GeneralSecurityException;
 
 public class CloudKmsEnvelopeAead {


### PR DESCRIPTION
@thaidn mentioned that there's a plan to deprecate the API we're using for envelope encryption in our Java sample. Updating this with the new, preferred method

> It's a good idea to open an issue first for discussion.

- [x ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [x ] `pom.xml` parent set to latest `shared-configuration`
- [x ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] Please **merge** this PR for me once it is approved.
