### PR TITLE
restore transfer service initializer samples with proper region tags

### DIFF
--- a/storage/storage-transfer/src/main/java/com/google/cloud/storage/storagetransfer/samples/CreateTransferClient.java
+++ b/storage/storage-transfer/src/main/java/com/google/cloud/storage/storagetransfer/samples/CreateTransferClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Google Inc.
+ * Copyright 2021 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// [START all]
 
 package com.google.cloud.storage.storagetransfer.samples;
 

--- a/storage/storage-transfer/src/main/java/com/google/cloud/storage/storagetransfer/samples/CreateTransferClient.java
+++ b/storage/storage-transfer/src/main/java/com/google/cloud/storage/storagetransfer/samples/CreateTransferClient.java
@@ -16,8 +16,9 @@
 
 // [START all]
 
-package com.google.cloud.storage.storagetransfer.samples.test.util;
+package com.google.cloud.storage.storagetransfer.samples;
 
+// [START storagetransfer_create_client]
 import com.google.api.client.googleapis.util.Utils;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
@@ -30,7 +31,7 @@ import com.google.common.base.Preconditions;
 import java.io.IOException;
 
 /** Create a client to make calls to Storage Transfer API. */
-public final class TransferClientCreator {
+public final class CreateTransferClient {
 
   /**
    * Create a Storage Transfer client using application default credentials and other default
@@ -73,4 +74,4 @@ public final class TransferClientCreator {
         .build();
   }
 }
-// [END all]
+// [END storagetransfer_create_client]

--- a/storage/storage-transfer/src/main/java/com/google/cloud/storage/storagetransfer/samples/RetryHttpInitializerWrapper.java
+++ b/storage/storage-transfer/src/main/java/com/google/cloud/storage/storagetransfer/samples/RetryHttpInitializerWrapper.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage.storagetransfer.samples;
+
+// [START storagetransfer_create_retry_handler]
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.http.HttpBackOffIOExceptionHandler;
+import com.google.api.client.http.HttpBackOffUnsuccessfulResponseHandler;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpUnsuccessfulResponseHandler;
+import com.google.api.client.util.ExponentialBackOff;
+import com.google.api.client.util.Sleeper;
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.logging.Logger;
+
+/**
+ * RetryHttpInitializerWrapper will automatically retry upon RPC failures, preserving the
+ * auto-refresh behavior of the Google Credentials.
+ */
+public class RetryHttpInitializerWrapper implements HttpRequestInitializer {
+
+  private static final Logger LOG = Logger.getLogger(RetryHttpInitializerWrapper.class.getName());
+  private final Credential wrappedCredential;
+  private final Sleeper sleeper;
+  private static final int MILLIS_PER_MINUTE = 60 * 1000;
+
+  /**
+   * A constructor using the default Sleeper.
+   *
+   * @param wrappedCredential the credential used to authenticate with a Google Cloud Platform
+   *     project
+   */
+  public RetryHttpInitializerWrapper(Credential wrappedCredential) {
+    this(wrappedCredential, Sleeper.DEFAULT);
+  }
+
+  /**
+   * A constructor used only for testing.
+   *
+   * @param wrappedCredential the credential used to authenticate with a Google Cloud Platform
+   *     project
+   * @param sleeper a user-supplied Sleeper
+   */
+  RetryHttpInitializerWrapper(Credential wrappedCredential, Sleeper sleeper) {
+    this.wrappedCredential = Preconditions.checkNotNull(wrappedCredential);
+    this.sleeper = sleeper;
+  }
+
+  /**
+   * Initialize an HttpRequest.
+   *
+   * @param request an HttpRequest that should be initialized
+   */
+  public void initialize(HttpRequest request) {
+    request.setReadTimeout(2 * MILLIS_PER_MINUTE); // 2 minutes read timeout
+    final HttpUnsuccessfulResponseHandler backoffHandler =
+        new HttpBackOffUnsuccessfulResponseHandler(new ExponentialBackOff()).setSleeper(sleeper);
+    request.setInterceptor(wrappedCredential);
+    request.setUnsuccessfulResponseHandler(
+        new HttpUnsuccessfulResponseHandler() {
+          public boolean handleResponse(
+              final HttpRequest request, final HttpResponse response, final boolean supportsRetry)
+              throws IOException {
+            if (wrappedCredential.handleResponse(request, response, supportsRetry)) {
+              // If credential decides it can handle it, the return code or message indicated
+              // something specific to authentication, and no backoff is desired.
+              return true;
+            } else if (backoffHandler.handleResponse(request, response, supportsRetry)) {
+              // Otherwise, we defer to the judgement of our internal backoff handler.
+              LOG.info("Retrying " + request.getUrl().toString());
+              return true;
+            } else {
+              return false;
+            }
+          }
+        });
+    request.setIOExceptionHandler(
+        new HttpBackOffIOExceptionHandler(new ExponentialBackOff()).setSleeper(sleeper));
+  }
+}
+// [END storagetransfer_create_retry_handler]

--- a/storage/storage-transfer/src/test/java/com/google/cloud/storage/storagetransfer/samples/test/CheckLatestTransferOperationTest.java
+++ b/storage/storage-transfer/src/test/java/com/google/cloud/storage/storagetransfer/samples/test/CheckLatestTransferOperationTest.java
@@ -28,7 +28,7 @@ import com.google.api.services.storagetransfer.v1.model.TransferJob;
 import com.google.api.services.storagetransfer.v1.model.TransferOptions;
 import com.google.api.services.storagetransfer.v1.model.TransferSpec;
 import com.google.cloud.storage.storagetransfer.samples.CheckLatestTransferOperation;
-import com.google.cloud.storage.storagetransfer.samples.test.util.TransferClientCreator;
+import com.google.cloud.storage.storagetransfer.samples.CreateTransferClient;
 import com.google.cloud.storage.storagetransfer.samples.test.util.TransferJobUtils;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -60,7 +60,7 @@ public class CheckLatestTransferOperationTest {
             .setSchedule(new Schedule().setScheduleStartDate(date).setStartTimeOfDay(time))
             .setStatus("ENABLED");
 
-    Storagetransfer client = TransferClientCreator.createStorageTransferClient();
+    Storagetransfer client = CreateTransferClient.createStorageTransferClient();
     TransferJob response = client.transferJobs().create(transferJob).execute();
 
     PrintStream standardOut = System.out;

--- a/storage/storage-transfer/src/test/java/com/google/cloud/storage/storagetransfer/samples/test/CheckTransferJobTest.java
+++ b/storage/storage-transfer/src/test/java/com/google/cloud/storage/storagetransfer/samples/test/CheckTransferJobTest.java
@@ -28,7 +28,7 @@ import com.google.api.services.storagetransfer.v1.model.TransferJob;
 import com.google.api.services.storagetransfer.v1.model.TransferOptions;
 import com.google.api.services.storagetransfer.v1.model.TransferSpec;
 import com.google.cloud.storage.storagetransfer.samples.CheckTransferJob;
-import com.google.cloud.storage.storagetransfer.samples.test.util.TransferClientCreator;
+import com.google.cloud.storage.storagetransfer.samples.CreateTransferClient;
 import com.google.cloud.storage.storagetransfer.samples.test.util.TransferJobUtils;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -60,7 +60,7 @@ public class CheckTransferJobTest {
             .setSchedule(new Schedule().setScheduleStartDate(date).setStartTimeOfDay(time))
             .setStatus("ENABLED");
 
-    Storagetransfer client = TransferClientCreator.createStorageTransferClient();
+    Storagetransfer client = CreateTransferClient.createStorageTransferClient();
     TransferJob response = client.transferJobs().create(transferJob).execute();
 
     PrintStream standardOut = System.out;


### PR DESCRIPTION
Although they won't be used as a dependency for the other samples anymore, these samples are still needed on the [Creating a Client](https://cloud.google.com/storage-transfer/docs/create-client) page, so I've restored them, this time with proper region tags (i added them to the tracker). 