### PR TITLE
feat: add client-side encryption samples for Postgres and SQL Server

### DIFF
--- a/cloud-sql/mysql/client-side-encryption/example.envrc
+++ b/cloud-sql/mysql/client-side-encryption/example.envrc
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 GOOGLE_APPLICATION_CREDENTIALS='path/to/service-account-key.json'
 DB_USER='your-database-username'
 DB_PASS='your-database-password'

--- a/cloud-sql/mysql/client-side-encryption/pom.xml
+++ b/cloud-sql/mysql/client-side-encryption/pom.xml
@@ -84,6 +84,7 @@
       <artifactId>HikariCP</artifactId>
       <version>4.0.2</version>
     </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/cloud-sql/mysql/client-side-encryption/src/main/java/cloudsql/tink/CloudKmsEnvelopeAead.java
+++ b/cloud-sql/mysql/client-side-encryption/src/main/java/cloudsql/tink/CloudKmsEnvelopeAead.java
@@ -37,7 +37,9 @@ public class CloudKmsEnvelopeAead {
     // Create an AEAD primitive using the Cloud KMS key
     Aead gcpAead = client.getAead(kmsUri);
 
-    // Create an envelope AEAD primitive
+    // Create an envelope AEAD primitive.
+    // This key should only be used for client-side encryption to ensure authenticity and integrity
+    // of data.
     return new KmsEnvelopeAead(AeadKeyTemplates.AES128_GCM, gcpAead);
   }
 }

--- a/cloud-sql/mysql/client-side-encryption/src/main/java/cloudsql/tink/EncryptAndInsertData.java
+++ b/cloud-sql/mysql/client-side-encryption/src/main/java/cloudsql/tink/EncryptAndInsertData.java
@@ -38,6 +38,9 @@ public class EncryptAndInsertData {
     String cloudSqlConnectionName =
         System.getenv("CLOUD_SQL_CONNECTION_NAME"); // e.g. "project-name:region:instance-name"
     String kmsUri = System.getenv("CLOUD_KMS_URI"); // e.g. "gcp-kms://projects/...path/to/key
+    // Tink uses the "gcp-kms://" prefix for paths to keys stored in Google Cloud KMS. For more
+    // info on creating a KMS key and getting its path, see
+    // https://cloud.google.com/kms/docs/quickstart
 
     String team = "TABS";
     String tableName = "votes";
@@ -68,7 +71,9 @@ public class EncryptAndInsertData {
         voteStmt.setTimestamp(2, new Timestamp(new Date().getTime()));
 
         // Use the envelope AEAD primitive to encrypt the email, using the team name as
-        // associated data
+        // associated data. Encryption with associated data ensures authenticity
+        // (who the sender is) and integrity (the data has not been tampered with) of that
+        // data, but not its secrecy. (see RFC 5116 for more info)
         byte[] encryptedEmail = envAead.encrypt(email.getBytes(), team.getBytes());
         voteStmt.setBytes(3, encryptedEmail);
 

--- a/cloud-sql/mysql/client-side-encryption/src/main/java/cloudsql/tink/QueryAndDecryptData.java
+++ b/cloud-sql/mysql/client-side-encryption/src/main/java/cloudsql/tink/QueryAndDecryptData.java
@@ -38,6 +38,9 @@ public class QueryAndDecryptData {
     String cloudSqlConnectionName =
         System.getenv("CLOUD_SQL_CONNECTION_NAME"); // e.g. "project-name:region:instance-name"
     String kmsUri = System.getenv("CLOUD_KMS_URI"); // e.g. "gcp-kms://projects/...path/to/key
+    // Tink uses the "gcp-kms://" prefix for paths to keys stored in Google Cloud KMS. For more
+    // info on creating a KMS key and getting its path, see
+    // https://cloud.google.com/kms/docs/quickstart
 
     String tableName = "votes123";
 
@@ -74,7 +77,9 @@ public class QueryAndDecryptData {
           Timestamp timeCast = voteResults.getTimestamp(2);
 
           // Use the envelope AEAD primitive to decrypt the email, using the team name as
-          // associated data
+          // associated data. Encryption with associated data ensures authenticity
+          // (who the sender is) and integrity (the data has not been tampered with) of that
+          // data, but not its secrecy. (see RFC 5116 for more info)
           String email = new String(envAead.decrypt(voteResults.getBytes(3), team.getBytes()));
 
           System.out.println(String.format("%s\t%s\t%s", team, timeCast, email));

--- a/cloud-sql/postgres/client-side-encryption/README.md
+++ b/cloud-sql/postgres/client-side-encryption/README.md
@@ -1,0 +1,40 @@
+# Encrypting fields in Cloud SQL - Postgres with Tink
+
+## Before you begin
+
+1. If you haven't already, set up a Java Development Environment (including google-cloud-sdk and
+maven utilities) by following the [java setup guide](https://cloud.google.com/java/docs/setup) and
+[create a project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#creating_a_project).
+
+1. Create a 2nd Gen Cloud SQL Instance by following these 
+[instructions](https://cloud.google.com/sql/docs/postgres/create-instance). Note the connection string,
+database user, and database password that you create.
+
+1. Create a database for your application by following these 
+[instructions](https://cloud.google.com/sql/docs/postgres/create-manage-databases). Note the database
+name.
+
+1. Create a KMS key for your application by following these
+[instructions](https://cloud.google.com/kms/docs/creating-keys). Copy the resource name of your
+created key.
+
+1. Create a service account with the 'Cloud SQL Client' permissions by following these 
+[instructions](https://cloud.google.com/sql/docs/postgres/connect-external-app#4_if_required_by_your_authentication_method_create_a_service_account).
+Then, add the 'Cloud KMS CryptoKey Encrypter/Decrypter' permission for the key to your service account 
+by following these [instructions](https://cloud.google.com/kms/docs/iam).
+
+## Running Locally
+
+Before running, copy the `example.envrc` file to `.envrc` and replace the values for 
+`GOOGLE_APPLICATION_CREDENTIALS`, `DB_USER`, `DB_PASS`, `DB_NAME`, `CLOUD_SQL_CONNECTION_NAME`,
+and `CLOUD_KMS_URI` with the values from your project. Then run `source .envrc` or optionally use 
+[direnv](https://direnv.net/).
+
+Once the environment variables have been set, run:
+```
+mvn exec:java -Dexec.mainClass=cloudsql.tink.EncryptAndInsertData
+```
+and 
+```
+mvn exec:java -Dexec.mainClass=cloudsql.tink.QueryAndDecryptData
+```

--- a/cloud-sql/postgres/client-side-encryption/example.envrc
+++ b/cloud-sql/postgres/client-side-encryption/example.envrc
@@ -1,0 +1,6 @@
+GOOGLE_APPLICATION_CREDENTIALS='path/to/service-account-key.json'
+DB_USER='your-database-username'
+DB_PASS='your-database-password'
+DB_NAME='your_database_name'
+CLOUD_SQL_CONNECTION_NAME='project:region:instance-name'
+CLOUD_KMS_URI='gcp-kms://your-kms-uri`

--- a/cloud-sql/postgres/client-side-encryption/example.envrc
+++ b/cloud-sql/postgres/client-side-encryption/example.envrc
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 GOOGLE_APPLICATION_CREDENTIALS='path/to/service-account-key.json'
 DB_USER='your-database-username'
 DB_PASS='your-database-password'

--- a/cloud-sql/postgres/client-side-encryption/pom.xml
+++ b/cloud-sql/postgres/client-side-encryption/pom.xml
@@ -84,6 +84,7 @@
       <artifactId>HikariCP</artifactId>
       <version>4.0.2</version>
     </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/cloud-sql/postgres/client-side-encryption/pom.xml
+++ b/cloud-sql/postgres/client-side-encryption/pom.xml
@@ -1,0 +1,101 @@
+<!--
+  Copyright 2021 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>cloud-sql-tink-postgres</artifactId>
+  <name>Cloud SQL Client Side Encryption Samples</name>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.0.21</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+        <dependency>
+          <groupId>com.google.cloud</groupId>
+          <artifactId>libraries-bom</artifactId>
+          <version>18.0.0</version>
+          <type>pom</type>
+          <scope>import</scope>
+        </dependency>
+      <dependency>
+        <groupId>com.google.api-client</groupId>
+        <artifactId>google-api-client</artifactId>
+        <version>1.31.3</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson2</artifactId>
+      <version>1.39.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud.sql</groupId>
+      <artifactId>postgres-socket-factory</artifactId>
+      <version>1.2.1</version>
+    </dependency>
+        <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.2.19</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.crypto.tink</groupId>
+      <artifactId>tink</artifactId>
+      <version>1.5.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.crypto.tink</groupId>
+      <artifactId>tink-gcpkms</artifactId>
+      <version>1.5.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
+      <version>4.0.2</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.1.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/cloud-sql/postgres/client-side-encryption/src/main/java/cloudsql/tink/CloudKmsEnvelopeAead.java
+++ b/cloud-sql/postgres/client-side-encryption/src/main/java/cloudsql/tink/CloudKmsEnvelopeAead.java
@@ -37,7 +37,9 @@ public class CloudKmsEnvelopeAead {
     // Create an AEAD primitive using the Cloud KMS key
     Aead gcpAead = client.getAead(kmsUri);
 
-    // Create an envelope AEAD primitive
+    // Create an envelope AEAD primitive.
+    // This key should only be used for client-side encryption to ensure authenticity and integrity
+    // of data.
     return new KmsEnvelopeAead(AeadKeyTemplates.AES128_GCM, gcpAead);
   }
 }

--- a/cloud-sql/postgres/client-side-encryption/src/main/java/cloudsql/tink/CloudKmsEnvelopeAead.java
+++ b/cloud-sql/postgres/client-side-encryption/src/main/java/cloudsql/tink/CloudKmsEnvelopeAead.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudsql.tink;
+
+// [START cloud_sql_postgres_cse_key]
+
+import com.google.crypto.tink.Aead;
+import com.google.crypto.tink.KmsClient;
+import com.google.crypto.tink.aead.AeadConfig;
+import com.google.crypto.tink.aead.AeadKeyTemplates;
+import com.google.crypto.tink.aead.KmsEnvelopeAead;
+import com.google.crypto.tink.integration.gcpkms.GcpKmsClient;
+import java.security.GeneralSecurityException;
+
+public class CloudKmsEnvelopeAead {
+
+  public static Aead get(String kmsUri) throws GeneralSecurityException {
+    AeadConfig.register();
+
+    // Create a new KMS Client
+    KmsClient client = new GcpKmsClient().withDefaultCredentials();
+
+    // Create an AEAD primitive using the Cloud KMS key
+    Aead gcpAead = client.getAead(kmsUri);
+
+    // Create an envelope AEAD primitive
+    return new KmsEnvelopeAead(AeadKeyTemplates.AES128_GCM, gcpAead);
+  }
+}
+// [END cloud_sql_postgres_cse_key]

--- a/cloud-sql/postgres/client-side-encryption/src/main/java/cloudsql/tink/CloudSqlConnectionPool.java
+++ b/cloud-sql/postgres/client-side-encryption/src/main/java/cloudsql/tink/CloudSqlConnectionPool.java
@@ -44,8 +44,8 @@ public class CloudSqlConnectionPool {
     // Safely attempt to create the table schema.
     try (Connection conn = pool.getConnection()) {
       String stmt = String.format("CREATE TABLE IF NOT EXISTS %s ( "
-          + "vote_id SERIAL NOT NULL, time_cast timestamp NOT NULL, candidate CHAR(6) NOT NULL,"
-          + "voter_email VARBINARY(255), PRIMARY KEY (vote_id) );", tableName);
+          + "vote_id SERIAL NOT NULL, time_cast timestamp NOT NULL, team CHAR(6) NOT NULL,"
+          + "voter_email BYTEA, PRIMARY KEY (vote_id) );", tableName);
       try (PreparedStatement createTableStatement = conn.prepareStatement(stmt);) {
         createTableStatement.execute();
       }

--- a/cloud-sql/postgres/client-side-encryption/src/main/java/cloudsql/tink/CloudSqlConnectionPool.java
+++ b/cloud-sql/postgres/client-side-encryption/src/main/java/cloudsql/tink/CloudSqlConnectionPool.java
@@ -16,10 +16,11 @@
 
 package cloudsql.tink;
 
-// [START cloud_sql_mysql_cse_db]
+// [START cloud_sql_postgres_cse_db]
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import java.security.GeneralSecurityException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -28,12 +29,12 @@ import javax.sql.DataSource;
 public class CloudSqlConnectionPool {
 
   public static DataSource createConnectionPool(String dbUser, String dbPass, String dbName,
-      String cloudSqlConnectionName) {
+      String cloudSqlConnectionName) throws GeneralSecurityException {
     HikariConfig config = new HikariConfig();
-    config.setJdbcUrl(String.format("jdbc:mysql:///%s", dbName));
-    config.setUsername(dbUser);
-    config.setPassword(dbPass);
-    config.addDataSourceProperty("socketFactory", "com.google.cloud.sql.mysql.SocketFactory");
+    config.setJdbcUrl(String.format("jdbc:postgresql:///%s", dbName));
+    config.setUsername(dbUser); // e.g. "root", "postgres"
+    config.setPassword(dbPass); // e.g. "my-password"
+    config.addDataSourceProperty("socketFactory", "com.google.cloud.sql.postgres.SocketFactory");
     config.addDataSourceProperty("cloudSqlInstance", cloudSqlConnectionName);
     DataSource pool = new HikariDataSource(config);
     return pool;
@@ -43,7 +44,7 @@ public class CloudSqlConnectionPool {
     // Safely attempt to create the table schema.
     try (Connection conn = pool.getConnection()) {
       String stmt = String.format("CREATE TABLE IF NOT EXISTS %s ( "
-          + "vote_id SERIAL NOT NULL, time_cast timestamp NOT NULL, team CHAR(6) NOT NULL,"
+          + "vote_id SERIAL NOT NULL, time_cast timestamp NOT NULL, candidate CHAR(6) NOT NULL,"
           + "voter_email VARBINARY(255), PRIMARY KEY (vote_id) );", tableName);
       try (PreparedStatement createTableStatement = conn.prepareStatement(stmt);) {
         createTableStatement.execute();
@@ -51,4 +52,4 @@ public class CloudSqlConnectionPool {
     }
   }
 }
-// [END cloud_sql_mysql_cse_db]
+// [END cloud_sql_postgres_cse_db]

--- a/cloud-sql/postgres/client-side-encryption/src/main/java/cloudsql/tink/EncryptAndInsertData.java
+++ b/cloud-sql/postgres/client-side-encryption/src/main/java/cloudsql/tink/EncryptAndInsertData.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudsql.tink;
+
+// [START cloud_sql_postgres_cse_insert]
+
+import com.google.crypto.tink.Aead;
+import java.security.GeneralSecurityException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.Date;
+import javax.sql.DataSource;
+
+public class EncryptAndInsertData {
+
+  public static void main(String[] args) throws GeneralSecurityException, SQLException {
+    // Saving credentials in environment variables is convenient, but not secure - consider a more
+    // secure solution such as Cloud Secret Manager to help keep secrets safe.
+    String dbUser = System.getenv("DB_USER"); // e.g. "root", "postgres"
+    String dbPass = System.getenv("DB_PASS"); // e.g. "mysupersecretpassword"
+    String dbName = System.getenv("DB_NAME"); // e.g. "votes_db"
+    String cloudSqlConnectionName =
+        System.getenv("CLOUD_SQL_CONNECTION_NAME"); // e.g. "project-name:region:instance-name"
+    String kmsUri = System.getenv("CLOUD_KMS_URI"); // e.g. "gcp-kms://projects/...path/to/key
+
+    String team = "TABS";
+    String tableName = "votes";
+    String email = "hello@example.com";
+
+    // Initialize database connection pool and create table if it does not exist
+    // See CloudSqlConnectionPool.java for setup details
+    DataSource pool = CloudSqlConnectionPool
+        .createConnectionPool(dbUser, dbPass, dbName, cloudSqlConnectionName);
+    CloudSqlConnectionPool.createTable(pool, tableName);
+
+    // Initialize envelope AEAD
+    // See CloudKmsEnvelopeAead.java for setup details
+    Aead envAead = CloudKmsEnvelopeAead.get(kmsUri);
+
+    encryptAndInsertData(pool, envAead, tableName, team, email);
+  }
+
+  public static void encryptAndInsertData(DataSource pool, Aead envAead, String tableName,
+      String team, String email)
+      throws GeneralSecurityException, SQLException {
+
+    try (Connection conn = pool.getConnection()) {
+      String stmt = String.format(
+          "INSERT INTO %s (team, time_cast, voter_email) VALUES (?, ?, ?);", tableName);
+      try (PreparedStatement voteStmt = conn.prepareStatement(stmt);) {
+        voteStmt.setString(1, team);
+        voteStmt.setTimestamp(2, new Timestamp(new Date().getTime()));
+
+        // Use the envelope AEAD primitive to encrypt the email, using the team name as
+        // associated data
+        byte[] encryptedEmail = envAead.encrypt(email.getBytes(), team.getBytes());
+        voteStmt.setBytes(3, encryptedEmail);
+
+        // Finally, execute the statement. If it fails, an error will be thrown.
+        voteStmt.execute();
+        System.out.println(String.format("Successfully inserted row into table %s", tableName));
+      }
+    }
+  }
+}
+// [END cloud_sql_postgres_cse_insert]

--- a/cloud-sql/postgres/client-side-encryption/src/main/java/cloudsql/tink/EncryptAndInsertData.java
+++ b/cloud-sql/postgres/client-side-encryption/src/main/java/cloudsql/tink/EncryptAndInsertData.java
@@ -38,6 +38,9 @@ public class EncryptAndInsertData {
     String cloudSqlConnectionName =
         System.getenv("CLOUD_SQL_CONNECTION_NAME"); // e.g. "project-name:region:instance-name"
     String kmsUri = System.getenv("CLOUD_KMS_URI"); // e.g. "gcp-kms://projects/...path/to/key
+    // Tink uses the "gcp-kms://" prefix for paths to keys stored in Google Cloud KMS. For more
+    // info on creating a KMS key and getting its path, see
+    // https://cloud.google.com/kms/docs/quickstart
 
     String team = "TABS";
     String tableName = "votes";
@@ -68,7 +71,9 @@ public class EncryptAndInsertData {
         voteStmt.setTimestamp(2, new Timestamp(new Date().getTime()));
 
         // Use the envelope AEAD primitive to encrypt the email, using the team name as
-        // associated data
+        // associated data. Encryption with associated data ensures authenticity
+        // (who the sender is) and integrity (the data has not been tampered with) of that
+        // data, but not its secrecy. (see RFC 5116 for more info)
         byte[] encryptedEmail = envAead.encrypt(email.getBytes(), team.getBytes());
         voteStmt.setBytes(3, encryptedEmail);
 

--- a/cloud-sql/postgres/client-side-encryption/src/main/java/cloudsql/tink/QueryAndDecryptData.java
+++ b/cloud-sql/postgres/client-side-encryption/src/main/java/cloudsql/tink/QueryAndDecryptData.java
@@ -38,6 +38,9 @@ public class QueryAndDecryptData {
     String cloudSqlConnectionName =
         System.getenv("CLOUD_SQL_CONNECTION_NAME"); // e.g. "project-name:region:instance-name"
     String kmsUri = System.getenv("CLOUD_KMS_URI"); // e.g. "gcp-kms://projects/...path/to/key
+    // Tink uses the "gcp-kms://" prefix for paths to keys stored in Google Cloud KMS. For more
+    // info on creating a KMS key and getting its path, see
+    // https://cloud.google.com/kms/docs/quickstart
 
     String tableName = "votes123";
 
@@ -78,7 +81,9 @@ public class QueryAndDecryptData {
           String aad = voteResults.getString(1).trim();
 
           // Use the envelope AEAD primitive to decrypt the email, using the team name as
-          // associated data
+          // associated data. Encryption with associated data ensures authenticity
+          // (who the sender is) and integrity (the data has not been tampered with) of that
+          // data, but not its secrecy. (see RFC 5116 for more info)
           String email = new String(envAead.decrypt(voteResults.getBytes(3), aad.getBytes()));
 
           System.out.println(String.format("%s\t%s\t%s", team, timeCast, email));

--- a/cloud-sql/postgres/client-side-encryption/src/main/java/cloudsql/tink/QueryAndDecryptData.java
+++ b/cloud-sql/postgres/client-side-encryption/src/main/java/cloudsql/tink/QueryAndDecryptData.java
@@ -73,9 +73,13 @@ public class QueryAndDecryptData {
           String team = voteResults.getString(1);
           Timestamp timeCast = voteResults.getTimestamp(2);
 
+          // Postgres pads char VARCHAR fields with spaces. These will need to be removed before
+          // decrypting.
+          String aad = voteResults.getString(1).trim();
+
           // Use the envelope AEAD primitive to decrypt the email, using the team name as
           // associated data
-          String email = new String(envAead.decrypt(voteResults.getBytes(3), team.getBytes()));
+          String email = new String(envAead.decrypt(voteResults.getBytes(3), aad.getBytes()));
 
           System.out.println(String.format("%s\t%s\t%s", team, timeCast, email));
         }

--- a/cloud-sql/postgres/client-side-encryption/src/main/java/cloudsql/tink/QueryAndDecryptData.java
+++ b/cloud-sql/postgres/client-side-encryption/src/main/java/cloudsql/tink/QueryAndDecryptData.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudsql.tink;
+
+// [START cloud_sql_postgres_cse_query]
+
+import com.google.crypto.tink.Aead;
+import java.security.GeneralSecurityException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import javax.sql.DataSource;
+
+public class QueryAndDecryptData {
+
+  public static void main(String[] args) throws GeneralSecurityException, SQLException {
+    // Saving credentials in environment variables is convenient, but not secure - consider a more
+    // secure solution such as Cloud Secret Manager to help keep secrets safe.
+    String dbUser = System.getenv("DB_USER"); // e.g. "root", "postgres"
+    String dbPass = System.getenv("DB_PASS"); // e.g. "mysupersecretpassword"
+    String dbName = System.getenv("DB_NAME"); // e.g. "votes_db"
+    String cloudSqlConnectionName =
+        System.getenv("CLOUD_SQL_CONNECTION_NAME"); // e.g. "project-name:region:instance-name"
+    String kmsUri = System.getenv("CLOUD_KMS_URI"); // e.g. "gcp-kms://projects/...path/to/key
+
+    String tableName = "votes123";
+
+    // Initialize database connection pool and create table if it does not exist
+    // See CloudSqlConnectionPool.java for setup details
+    DataSource pool = CloudSqlConnectionPool
+        .createConnectionPool(dbUser, dbPass, dbName, cloudSqlConnectionName);
+    CloudSqlConnectionPool.createTable(pool, tableName);
+
+    // Initialize envelope AEAD
+    // See CloudKmsEnvelopeAead.java for setup details
+    Aead envAead = CloudKmsEnvelopeAead.get(kmsUri);
+
+    // Insert row into table to test
+    // See EncryptAndInsert.java for setup details
+    EncryptAndInsertData
+        .encryptAndInsertData(pool, envAead, tableName, "SPACES", "hello@example.com");
+
+    queryAndDecryptData(pool, envAead, tableName);
+  }
+
+  public static void queryAndDecryptData(DataSource pool, Aead envAead, String tableName)
+      throws GeneralSecurityException, SQLException {
+
+    try (Connection conn = pool.getConnection()) {
+      String stmt = String.format(
+          "SELECT team, time_cast, voter_email FROM %s ORDER BY time_cast DESC LIMIT 5", tableName);
+      try (PreparedStatement voteStmt = conn.prepareStatement(stmt);) {
+        ResultSet voteResults = voteStmt.executeQuery();
+
+        System.out.println("Team\tTime Cast\tEmail");
+        while (voteResults.next()) {
+          String team = voteResults.getString(1);
+          Timestamp timeCast = voteResults.getTimestamp(2);
+
+          // Use the envelope AEAD primitive to decrypt the email, using the team name as
+          // associated data
+          String email = new String(envAead.decrypt(voteResults.getBytes(3), team.getBytes()));
+
+          System.out.println(String.format("%s\t%s\t%s", team, timeCast, email));
+        }
+      }
+    }
+  }
+}
+// [END cloud_sql_postgres_cse_query]

--- a/cloud-sql/postgres/client-side-encryption/src/test/java/cloudsql/tink/EncryptInsertDataIT.java
+++ b/cloud-sql/postgres/client-side-encryption/src/test/java/cloudsql/tink/EncryptInsertDataIT.java
@@ -113,8 +113,11 @@ public class EncryptInsertDataIT {
       try (PreparedStatement voteStmt = conn.prepareStatement(stmt);) {
         ResultSet voteResults = voteStmt.executeQuery();
         while (voteResults.next()) {
+          // Postgres pads char VARCHAR fields with spaces. These will need to be removed before
+          // decrypting.
+          String aad = voteResults.getString(1).trim();
           byte[] decryptedEmail = envAead
-              .decrypt(voteResults.getBytes(3), voteResults.getString(1).getBytes());
+              .decrypt(voteResults.getBytes(3), aad.getBytes());
           decryptedEmails.add(new String(decryptedEmail));
         }
       }

--- a/cloud-sql/postgres/client-side-encryption/src/test/java/cloudsql/tink/EncryptInsertDataIT.java
+++ b/cloud-sql/postgres/client-side-encryption/src/test/java/cloudsql/tink/EncryptInsertDataIT.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudsql.tink;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.google.crypto.tink.Aead;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.security.GeneralSecurityException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class EncryptInsertDataIT {
+
+  private static final String CLOUD_KMS_URI = System.getenv("CLOUD_KMS_URI");
+  private static final String PG_USER = System.getenv("PG_USER");
+  private static final String PG_PASS = System.getenv("PG_PASS");
+  private static final String PG_DB = System.getenv("PG_DB");
+  private static final String PG_CONNECTION_NAME = System.getenv("PG_CONNECTION_NAME");
+  private static List<String> requiredEnvVars =
+      Arrays
+          .asList("PG_USER", "PG_PASS", "PG_DB", "PG_CONNECTION_NAME",
+              "CLOUD_KMS_URI");
+  private static DataSource pool;
+  private static String tableName;
+  private static Aead envAead;
+  private ByteArrayOutputStream bout;
+  private PrintStream originalOut = System.out;
+
+
+  public static void checkEnvVars() {
+    // Check that required env vars are set
+    requiredEnvVars.forEach((varName) -> {
+      assertWithMessage(
+          String.format("Environment variable '%s' must be set to perform these tests.", varName))
+          .that(System.getenv(varName)).isNotEmpty();
+    });
+  }
+
+  @BeforeClass
+  public static void setUp() throws GeneralSecurityException, SQLException {
+    checkEnvVars();
+    tableName = String.format("votes_%s", UUID.randomUUID().toString().replace("-", ""));
+    pool = CloudSqlConnectionPool
+        .createConnectionPool(PG_USER, PG_PASS, PG_DB, PG_CONNECTION_NAME);
+    CloudSqlConnectionPool.createTable(pool, tableName);
+    envAead = CloudKmsEnvelopeAead.get(CLOUD_KMS_URI);
+  }
+
+  @AfterClass
+  public static void tearDown() throws SQLException {
+    if (pool != null) {
+      try (Connection conn = pool.getConnection()) {
+        String stmt = String.format("DROP TABLE %s;", tableName);
+        try (PreparedStatement createTableStatement = conn.prepareStatement(stmt);) {
+          createTableStatement.execute();
+        }
+      }
+    }
+  }
+
+  @Before
+  public void captureOutput() {
+    bout = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(bout));
+  }
+
+  @After
+  public void resetOutput() {
+    System.setOut(originalOut);
+    bout.reset();
+  }
+
+  @Test
+  public void testEncryptAndInsertData() throws GeneralSecurityException, SQLException {
+    EncryptAndInsertData
+        .encryptAndInsertData(pool, envAead, tableName, "TABS", "hello@example.com");
+    String output = bout.toString();
+    assertThat(output).contains("Successfully inserted row into table");
+
+    List<String> decryptedEmails = new ArrayList<>();
+    try (Connection conn = pool.getConnection()) {
+      String stmt = String.format(
+          "SELECT team, time_cast, voter_email FROM %s ORDER BY time_cast DESC LIMIT 5", tableName);
+      try (PreparedStatement voteStmt = conn.prepareStatement(stmt);) {
+        ResultSet voteResults = voteStmt.executeQuery();
+        while (voteResults.next()) {
+          byte[] decryptedEmail = envAead
+              .decrypt(voteResults.getBytes(3), voteResults.getString(1).getBytes());
+          decryptedEmails.add(new String(decryptedEmail));
+        }
+      }
+    }
+    assertThat(decryptedEmails).contains("hello@example.com");
+  }
+
+}

--- a/cloud-sql/postgres/client-side-encryption/src/test/java/cloudsql/tink/QueryDecryptDataIT.java
+++ b/cloud-sql/postgres/client-side-encryption/src/test/java/cloudsql/tink/QueryDecryptDataIT.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudsql.tink;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.google.crypto.tink.Aead;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.security.GeneralSecurityException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class QueryDecryptDataIT {
+
+  private static final String CLOUD_KMS_URI = System.getenv("CLOUD_KMS_URI");
+  private static final String PG_USER = System.getenv("PG_USER");
+  private static final String PG_PASS = System.getenv("PG_PASS");
+  private static final String PG_DB = System.getenv("PG_DB");
+  private static final String PG_CONNECTION_NAME = System.getenv("PG_CONNECTION_NAME");
+  private static List<String> requiredEnvVars =
+      Arrays
+          .asList("PG_USER", "PG_PASS", "PG_DB", "PG_CONNECTION_NAME", "CLOUD_KMS_URI");
+  private static DataSource pool;
+  private static String tableName;
+  private static Aead envAead;
+  private ByteArrayOutputStream bout;
+  private PrintStream originalOut = System.out;
+
+  public static void checkEnvVars() {
+    // Check that required env vars are set
+    requiredEnvVars.forEach((varName) -> {
+      assertWithMessage(
+          String.format("Environment variable '%s' must be set to perform these tests.", varName))
+          .that(System.getenv(varName)).isNotEmpty();
+    });
+  }
+
+  @BeforeClass
+  public static void setUp() throws GeneralSecurityException, SQLException {
+    checkEnvVars();
+    tableName = String.format("votes_%s", UUID.randomUUID().toString().replace("-", ""));
+
+    pool = CloudSqlConnectionPool
+        .createConnectionPool(PG_USER, PG_PASS, PG_DB, PG_CONNECTION_NAME);
+    CloudSqlConnectionPool.createTable(pool, tableName);
+
+    envAead = CloudKmsEnvelopeAead.get(CLOUD_KMS_URI);
+    EncryptAndInsertData
+        .encryptAndInsertData(pool, envAead, tableName, "TABS", "hello@example.com");
+  }
+
+  @AfterClass
+  public static void tearDown() throws SQLException {
+    if (pool != null) {
+      try (Connection conn = pool.getConnection()) {
+        String stmt = String.format("DROP TABLE %s;", tableName);
+        try (PreparedStatement createTableStatement = conn.prepareStatement(stmt);) {
+          createTableStatement.execute();
+        }
+      }
+    }
+  }
+
+  @Before
+  public void captureOutput() {
+    bout = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(bout));
+  }
+
+  @After
+  public void resetOutput() {
+    System.setOut(originalOut);
+    bout.reset();
+  }
+
+  @Test
+  public void testQueryAndDecryptData() throws GeneralSecurityException, SQLException {
+    QueryAndDecryptData.queryAndDecryptData(pool, envAead, tableName);
+    String output = bout.toString();
+    assertThat(output).contains("Team\tTime Cast\tEmail");
+    assertThat(output).contains("hello@example.com");
+  }
+
+}

--- a/cloud-sql/postgres/servlet/pom.xml
+++ b/cloud-sql/postgres/servlet/pom.xml
@@ -70,7 +70,6 @@
       <version>3.8.0</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/cloud-sql/postgres/servlet/pom.xml
+++ b/cloud-sql/postgres/servlet/pom.xml
@@ -70,6 +70,7 @@
       <version>3.8.0</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/cloud-sql/sqlserver/client-side-encryption/README.md
+++ b/cloud-sql/sqlserver/client-side-encryption/README.md
@@ -1,0 +1,40 @@
+# Encrypting fields in Cloud SQL - SQL Server with Tink
+
+## Before you begin
+
+1. If you haven't already, set up a Java Development Environment (including google-cloud-sdk and
+maven utilities) by following the [java setup guide](https://cloud.google.com/java/docs/setup) and
+[create a project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#creating_a_project).
+
+1. Create a 2nd Gen Cloud SQL Instance by following these 
+[instructions](https://cloud.google.com/sql/docs/sqlserver/create-instance). Note the connection string,
+database user, and database password that you create.
+
+1. Create a database for your application by following these 
+[instructions](https://cloud.google.com/sql/docs/sqlserver/create-manage-databases). Note the database
+name.
+
+1. Create a KMS key for your application by following these
+[instructions](https://cloud.google.com/kms/docs/creating-keys). Copy the resource name of your
+created key.
+
+1. Create a service account with the 'Cloud SQL Client' permissions by following these 
+[instructions](https://cloud.google.com/sql/docs/sqlserver/connect-external-app#4_if_required_by_your_authentication_method_create_a_service_account).
+Then, add the 'Cloud KMS CryptoKey Encrypter/Decrypter' permission for the key to your service account 
+by following these [instructions](https://cloud.google.com/kms/docs/iam).
+
+## Running Locally
+
+Before running, copy the `example.envrc` file to `.envrc` and replace the values for 
+`GOOGLE_APPLICATION_CREDENTIALS`, `DB_USER`, `DB_PASS`, `DB_NAME`, `CLOUD_SQL_CONNECTION_NAME`,
+and `CLOUD_KMS_URI` with the values from your project. Then run `source .envrc` or optionally use 
+[direnv](https://direnv.net/).
+
+Once the environment variables have been set, run:
+```
+mvn exec:java -Dexec.mainClass=cloudsql.tink.EncryptAndInsertData
+```
+and 
+```
+mvn exec:java -Dexec.mainClass=cloudsql.tink.QueryAndDecryptData
+```

--- a/cloud-sql/sqlserver/client-side-encryption/example.envrc
+++ b/cloud-sql/sqlserver/client-side-encryption/example.envrc
@@ -1,0 +1,6 @@
+GOOGLE_APPLICATION_CREDENTIALS='path/to/service-account-key.json'
+DB_USER='your-database-username'
+DB_PASS='your-database-password'
+DB_NAME='your_database_name'
+CLOUD_SQL_CONNECTION_NAME='project:region:instance-name'
+CLOUD_KMS_URI='gcp-kms://your-kms-uri`

--- a/cloud-sql/sqlserver/client-side-encryption/example.envrc
+++ b/cloud-sql/sqlserver/client-side-encryption/example.envrc
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
 GOOGLE_APPLICATION_CREDENTIALS='path/to/service-account-key.json'
 DB_USER='your-database-username'
 DB_PASS='your-database-password'

--- a/cloud-sql/sqlserver/client-side-encryption/pom.xml
+++ b/cloud-sql/sqlserver/client-side-encryption/pom.xml
@@ -84,6 +84,7 @@
       <artifactId>HikariCP</artifactId>
       <version>4.0.2</version>
     </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/cloud-sql/sqlserver/client-side-encryption/pom.xml
+++ b/cloud-sql/sqlserver/client-side-encryption/pom.xml
@@ -1,0 +1,101 @@
+<!--
+  Copyright 2021 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>cloud-sql-tink-sqlserver</artifactId>
+  <name>Cloud SQL Client Side Encryption Samples</name>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.0.21</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+        <dependency>
+          <groupId>com.google.cloud</groupId>
+          <artifactId>libraries-bom</artifactId>
+          <version>18.0.0</version>
+          <type>pom</type>
+          <scope>import</scope>
+        </dependency>
+      <dependency>
+        <groupId>com.google.api-client</groupId>
+        <artifactId>google-api-client</artifactId>
+        <version>1.31.3</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson2</artifactId>
+      <version>1.39.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud.sql</groupId>
+      <artifactId>cloud-sql-connector-jdbc-sqlserver</artifactId>
+      <version>1.2.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.sqlserver</groupId>
+      <artifactId>mssql-jdbc</artifactId>
+      <version>9.2.1.jre8</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.crypto.tink</groupId>
+      <artifactId>tink</artifactId>
+      <version>1.5.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.crypto.tink</groupId>
+      <artifactId>tink-gcpkms</artifactId>
+      <version>1.5.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
+      <version>4.0.2</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.1.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/cloud-sql/sqlserver/client-side-encryption/src/main/java/cloudsql/tink/CloudKmsEnvelopeAead.java
+++ b/cloud-sql/sqlserver/client-side-encryption/src/main/java/cloudsql/tink/CloudKmsEnvelopeAead.java
@@ -37,7 +37,9 @@ public class CloudKmsEnvelopeAead {
     // Create an AEAD primitive using the Cloud KMS key
     Aead gcpAead = client.getAead(kmsUri);
 
-    // Create an envelope AEAD primitive
+    // Create an envelope AEAD primitive.
+    // This key should only be used for client-side encryption to ensure authenticity and integrity
+    // of data.
     return new KmsEnvelopeAead(AeadKeyTemplates.AES128_GCM, gcpAead);
   }
 }

--- a/cloud-sql/sqlserver/client-side-encryption/src/main/java/cloudsql/tink/CloudKmsEnvelopeAead.java
+++ b/cloud-sql/sqlserver/client-side-encryption/src/main/java/cloudsql/tink/CloudKmsEnvelopeAead.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudsql.tink;
+
+// [START cloud_sql_sqlserver_cse_key]
+
+import com.google.crypto.tink.Aead;
+import com.google.crypto.tink.KmsClient;
+import com.google.crypto.tink.aead.AeadConfig;
+import com.google.crypto.tink.aead.AeadKeyTemplates;
+import com.google.crypto.tink.aead.KmsEnvelopeAead;
+import com.google.crypto.tink.integration.gcpkms.GcpKmsClient;
+import java.security.GeneralSecurityException;
+
+public class CloudKmsEnvelopeAead {
+
+  public static Aead get(String kmsUri) throws GeneralSecurityException {
+    AeadConfig.register();
+
+    // Create a new KMS Client
+    KmsClient client = new GcpKmsClient().withDefaultCredentials();
+
+    // Create an AEAD primitive using the Cloud KMS key
+    Aead gcpAead = client.getAead(kmsUri);
+
+    // Create an envelope AEAD primitive
+    return new KmsEnvelopeAead(AeadKeyTemplates.AES128_GCM, gcpAead);
+  }
+}
+// [END cloud_sql_sqlserver_cse_key]

--- a/cloud-sql/sqlserver/client-side-encryption/src/main/java/cloudsql/tink/EncryptAndInsertData.java
+++ b/cloud-sql/sqlserver/client-side-encryption/src/main/java/cloudsql/tink/EncryptAndInsertData.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudsql.tink;
+
+// [START cloud_sql_sqlserver_cse_insert]
+
+import com.google.crypto.tink.Aead;
+import java.security.GeneralSecurityException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.Date;
+import javax.sql.DataSource;
+
+public class EncryptAndInsertData {
+
+  public static void main(String[] args) throws GeneralSecurityException, SQLException {
+    // Saving credentials in environment variables is convenient, but not secure - consider a more
+    // secure solution such as Cloud Secret Manager to help keep secrets safe.
+    String dbUser = System.getenv("DB_USER"); // e.g. "root", "mysql"
+    String dbPass = System.getenv("DB_PASS"); // e.g. "mysupersecretpassword"
+    String dbName = System.getenv("DB_NAME"); // e.g. "votes_db"
+    String cloudSqlConnectionName =
+        System.getenv("CLOUD_SQL_CONNECTION_NAME"); // e.g. "project-name:region:instance-name"
+    String kmsUri = System.getenv("CLOUD_KMS_URI"); // e.g. "gcp-kms://projects/...path/to/key
+
+    String team = "TABS";
+    String tableName = "votes";
+    String email = "hello@example.com";
+
+    // Initialize database connection pool and create table if it does not exist
+    // See CloudSqlConnectionPool.java for setup details
+    DataSource pool = CloudSqlConnectionPool
+        .createConnectionPool(dbUser, dbPass, dbName, cloudSqlConnectionName);
+    CloudSqlConnectionPool.createTable(pool, tableName);
+
+    // Initialize envelope AEAD
+    // See CloudKmsEnvelopeAead.java for setup details
+    Aead envAead = CloudKmsEnvelopeAead.get(kmsUri);
+
+    encryptAndInsertData(pool, envAead, tableName, team, email);
+  }
+
+  public static void encryptAndInsertData(DataSource pool, Aead envAead, String tableName,
+      String team, String email)
+      throws GeneralSecurityException, SQLException {
+
+    try (Connection conn = pool.getConnection()) {
+      String stmt = String.format(
+          "INSERT INTO %s (team, time_cast, voter_email) VALUES (?, ?, ?);", tableName);
+      try (PreparedStatement voteStmt = conn.prepareStatement(stmt);) {
+        voteStmt.setString(1, team);
+        voteStmt.setTimestamp(2, new Timestamp(new Date().getTime()));
+
+        // Use the envelope AEAD primitive to encrypt the email, using the team name as
+        // associated data
+        byte[] encryptedEmail = envAead.encrypt(email.getBytes(), team.getBytes());
+        voteStmt.setBytes(3, encryptedEmail);
+
+        // Finally, execute the statement. If it fails, an error will be thrown.
+        voteStmt.execute();
+        System.out.println(String.format("Successfully inserted row into table %s", tableName));
+      }
+    }
+  }
+}
+// [END cloud_sql_sqlserver_cse_insert]

--- a/cloud-sql/sqlserver/client-side-encryption/src/main/java/cloudsql/tink/EncryptAndInsertData.java
+++ b/cloud-sql/sqlserver/client-side-encryption/src/main/java/cloudsql/tink/EncryptAndInsertData.java
@@ -38,6 +38,9 @@ public class EncryptAndInsertData {
     String cloudSqlConnectionName =
         System.getenv("CLOUD_SQL_CONNECTION_NAME"); // e.g. "project-name:region:instance-name"
     String kmsUri = System.getenv("CLOUD_KMS_URI"); // e.g. "gcp-kms://projects/...path/to/key
+    // Tink uses the "gcp-kms://" prefix for paths to keys stored in Google Cloud KMS. For more
+    // info on creating a KMS key and getting its path, see
+    // https://cloud.google.com/kms/docs/quickstart
 
     String team = "TABS";
     String tableName = "votes";
@@ -68,7 +71,9 @@ public class EncryptAndInsertData {
         voteStmt.setTimestamp(2, new Timestamp(new Date().getTime()));
 
         // Use the envelope AEAD primitive to encrypt the email, using the team name as
-        // associated data
+        // associated data. Encryption with associated data ensures authenticity
+        // (who the sender is) and integrity (the data has not been tampered with) of that
+        // data, but not its secrecy. (see RFC 5116 for more info)
         byte[] encryptedEmail = envAead.encrypt(email.getBytes(), team.getBytes());
         voteStmt.setBytes(3, encryptedEmail);
 

--- a/cloud-sql/sqlserver/client-side-encryption/src/main/java/cloudsql/tink/QueryAndDecryptData.java
+++ b/cloud-sql/sqlserver/client-side-encryption/src/main/java/cloudsql/tink/QueryAndDecryptData.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudsql.tink;
+
+// [START cloud_sql_sqlserver_cse_query]
+
+import com.google.crypto.tink.Aead;
+import java.security.GeneralSecurityException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import javax.sql.DataSource;
+
+public class QueryAndDecryptData {
+
+  public static void main(String[] args) throws GeneralSecurityException, SQLException {
+    // Saving credentials in environment variables is convenient, but not secure - consider a more
+    // secure solution such as Cloud Secret Manager to help keep secrets safe.
+    String dbUser = System.getenv("DB_USER"); // e.g. "root", "mysql"
+    String dbPass = System.getenv("DB_PASS"); // e.g. "mysupersecretpassword"
+    String dbName = System.getenv("DB_NAME"); // e.g. "votes_db"
+    String cloudSqlConnectionName =
+        System.getenv("CLOUD_SQL_CONNECTION_NAME"); // e.g. "project-name:region:instance-name"
+    String kmsUri = System.getenv("CLOUD_KMS_URI"); // e.g. "gcp-kms://projects/...path/to/key
+
+    String tableName = "votes123";
+
+    // Initialize database connection pool and create table if it does not exist
+    // See CloudSqlConnectionPool.java for setup details
+    DataSource pool = CloudSqlConnectionPool
+        .createConnectionPool(dbUser, dbPass, dbName, cloudSqlConnectionName);
+    CloudSqlConnectionPool.createTable(pool, tableName);
+
+    // Initialize envelope AEAD
+    // See CloudKmsEnvelopeAead.java for setup details
+    Aead envAead = CloudKmsEnvelopeAead.get(kmsUri);
+
+    // Insert row into table to test
+    // See EncryptAndInsert.java for setup details
+    EncryptAndInsertData
+        .encryptAndInsertData(pool, envAead, tableName, "SPACES", "hello@example.com");
+
+    queryAndDecryptData(pool, envAead, tableName);
+  }
+
+  public static void queryAndDecryptData(DataSource pool, Aead envAead, String tableName)
+      throws GeneralSecurityException, SQLException {
+
+    try (Connection conn = pool.getConnection()) {
+      String stmt = String.format(
+          "SELECT TOP(5) team, time_cast, voter_email FROM %s ORDER BY time_cast DESC;",
+          tableName);
+      try (PreparedStatement voteStmt = conn.prepareStatement(stmt);) {
+        ResultSet voteResults = voteStmt.executeQuery();
+
+        System.out.println("Team\tTime Cast\tEmail");
+        while (voteResults.next()) {
+          String team = voteResults.getString(1);
+          Timestamp timeCast = voteResults.getTimestamp(2);
+
+          // Use the envelope AEAD primitive to decrypt the email, using the team name as
+          // associated data
+          String email = new String(envAead.decrypt(voteResults.getBytes(3), team.getBytes()));
+
+          System.out.println(String.format("%s\t%s\t%s", team, timeCast, email));
+        }
+      }
+    }
+  }
+}
+// [END cloud_sql_sqlserver_cse_query]

--- a/cloud-sql/sqlserver/client-side-encryption/src/main/java/cloudsql/tink/QueryAndDecryptData.java
+++ b/cloud-sql/sqlserver/client-side-encryption/src/main/java/cloudsql/tink/QueryAndDecryptData.java
@@ -38,6 +38,9 @@ public class QueryAndDecryptData {
     String cloudSqlConnectionName =
         System.getenv("CLOUD_SQL_CONNECTION_NAME"); // e.g. "project-name:region:instance-name"
     String kmsUri = System.getenv("CLOUD_KMS_URI"); // e.g. "gcp-kms://projects/...path/to/key
+    // Tink uses the "gcp-kms://" prefix for paths to keys stored in Google Cloud KMS. For more
+    // info on creating a KMS key and getting its path, see
+    // https://cloud.google.com/kms/docs/quickstart
 
     String tableName = "votes123";
 
@@ -75,7 +78,9 @@ public class QueryAndDecryptData {
           Timestamp timeCast = voteResults.getTimestamp(2);
 
           // Use the envelope AEAD primitive to decrypt the email, using the team name as
-          // associated data
+          // associated data. Encryption with associated data ensures authenticity
+          // (who the sender is) and integrity (the data has not been tampered with) of that
+          // data, but not its secrecy. (see RFC 5116 for more info)
           String email = new String(envAead.decrypt(voteResults.getBytes(3), team.getBytes()));
 
           System.out.println(String.format("%s\t%s\t%s", team, timeCast, email));

--- a/cloud-sql/sqlserver/client-side-encryption/src/test/java/cloudsql/tink/EncryptInsertDataIT.java
+++ b/cloud-sql/sqlserver/client-side-encryption/src/test/java/cloudsql/tink/EncryptInsertDataIT.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudsql.tink;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.google.crypto.tink.Aead;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.security.GeneralSecurityException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class EncryptInsertDataIT {
+
+  private static final String CLOUD_KMS_URI = System.getenv("CLOUD_KMS_URI");
+  private static final String SQLSERVER_USER = System.getenv("SQLSERVER_USER");
+  private static final String SQLSERVER_PASS = System.getenv("SQLSERVER_PASS");
+  private static final String SQLSERVER_DB = System.getenv("SQLSERVER_DB");
+  private static final String SQLSERVER_CONNECTION_NAME = System
+      .getenv("SQLSERVER_CONNECTION_NAME");
+  private static List<String> requiredEnvVars =
+      Arrays
+          .asList("SQLSERVER_USER", "SQLSERVER_PASS", "SQLSERVER_DB", "SQLSERVER_CONNECTION_NAME",
+              "CLOUD_KMS_URI");
+  private static DataSource pool;
+  private static String tableName;
+  private static Aead envAead;
+  private ByteArrayOutputStream bout;
+  private PrintStream originalOut = System.out;
+
+
+  public static void checkEnvVars() {
+    // Check that required env vars are set
+    requiredEnvVars.forEach((varName) -> {
+      assertWithMessage(
+          String.format("Environment variable '%s' must be set to perform these tests.", varName))
+          .that(System.getenv(varName)).isNotEmpty();
+    });
+  }
+
+  @BeforeClass
+  public static void setUp() throws GeneralSecurityException, SQLException {
+    checkEnvVars();
+    tableName = String.format("votes_%s", UUID.randomUUID().toString().replace("-", ""));
+    pool = CloudSqlConnectionPool
+        .createConnectionPool(SQLSERVER_USER, SQLSERVER_PASS, SQLSERVER_DB,
+            SQLSERVER_CONNECTION_NAME);
+    CloudSqlConnectionPool.createTable(pool, tableName);
+    envAead = CloudKmsEnvelopeAead.get(CLOUD_KMS_URI);
+  }
+
+  @AfterClass
+  public static void tearDown() throws SQLException {
+    if (pool != null) {
+      try (Connection conn = pool.getConnection()) {
+        String stmt = String.format("DROP TABLE %s;", tableName);
+        try (PreparedStatement createTableStatement = conn.prepareStatement(stmt);) {
+          createTableStatement.execute();
+        }
+      }
+    }
+  }
+
+  @Before
+  public void captureOutput() {
+    bout = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(bout));
+  }
+
+  @After
+  public void resetOutput() {
+    System.setOut(originalOut);
+    bout.reset();
+  }
+
+  @Test
+  public void testEncryptAndInsertData() throws GeneralSecurityException, SQLException {
+    EncryptAndInsertData
+        .encryptAndInsertData(pool, envAead, tableName, "TABS", "hello@example.com");
+    String output = bout.toString();
+    assertThat(output).contains("Successfully inserted row into table");
+
+    List<String> decryptedEmails = new ArrayList<>();
+    try (Connection conn = pool.getConnection()) {
+      String stmt = String.format(
+          "SELECT TOP(5) team, time_cast, voter_email FROM %s ORDER BY time_cast DESC;",
+          tableName);
+      try (PreparedStatement voteStmt = conn.prepareStatement(stmt);) {
+        ResultSet voteResults = voteStmt.executeQuery();
+        while (voteResults.next()) {
+          byte[] decryptedEmail = envAead
+              .decrypt(voteResults.getBytes(3), voteResults.getString(1).getBytes());
+          decryptedEmails.add(new String(decryptedEmail));
+        }
+      }
+    }
+    assertThat(decryptedEmails).contains("hello@example.com");
+  }
+
+}

--- a/cloud-sql/sqlserver/client-side-encryption/src/test/java/cloudsql/tink/QueryDecryptDataIT.java
+++ b/cloud-sql/sqlserver/client-side-encryption/src/test/java/cloudsql/tink/QueryDecryptDataIT.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudsql.tink;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.google.crypto.tink.Aead;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.security.GeneralSecurityException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class QueryDecryptDataIT {
+
+  private static final String CLOUD_KMS_URI = System.getenv("CLOUD_KMS_URI");
+  private static final String SQLSERVER_USER = System.getenv("SQLSERVER_USER");
+  private static final String SQLSERVER_PASS = System.getenv("SQLSERVER_PASS");
+  private static final String SQLSERVER_DB = System.getenv("SQLSERVER_DB");
+  private static final String SQLSERVER_CONNECTION_NAME = System
+      .getenv("SQLSERVER_CONNECTION_NAME");
+  private static List<String> requiredEnvVars =
+      Arrays
+          .asList("SQLSERVER_USER", "SQLSERVER_PASS", "SQLSERVER_DB", "SQLSERVER_CONNECTION_NAME",
+              "CLOUD_KMS_URI");
+  private static DataSource pool;
+  private static String tableName;
+  private static Aead envAead;
+  private ByteArrayOutputStream bout;
+  private PrintStream originalOut = System.out;
+
+  public static void checkEnvVars() {
+    // Check that required env vars are set
+    requiredEnvVars.forEach((varName) -> {
+      assertWithMessage(
+          String.format("Environment variable '%s' must be set to perform these tests.", varName))
+          .that(System.getenv(varName)).isNotEmpty();
+    });
+  }
+
+  @BeforeClass
+  public static void setUp() throws GeneralSecurityException, SQLException {
+    checkEnvVars();
+    tableName = String.format("votes_%s", UUID.randomUUID().toString().replace("-", ""));
+
+    pool = CloudSqlConnectionPool
+        .createConnectionPool(SQLSERVER_USER, SQLSERVER_PASS, SQLSERVER_DB,
+            SQLSERVER_CONNECTION_NAME);
+    CloudSqlConnectionPool.createTable(pool, tableName);
+
+    envAead = CloudKmsEnvelopeAead.get(CLOUD_KMS_URI);
+    EncryptAndInsertData
+        .encryptAndInsertData(pool, envAead, tableName, "TABS", "hello@example.com");
+  }
+
+  @AfterClass
+  public static void tearDown() throws SQLException {
+    if (pool != null) {
+      try (Connection conn = pool.getConnection()) {
+        String stmt = String.format("DROP TABLE %s;", tableName);
+        try (PreparedStatement createTableStatement = conn.prepareStatement(stmt);) {
+          createTableStatement.execute();
+        }
+      }
+    }
+  }
+
+  @Before
+  public void captureOutput() {
+    bout = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(bout));
+  }
+
+  @After
+  public void resetOutput() {
+    System.setOut(originalOut);
+    bout.reset();
+  }
+
+  @Test
+  public void testQueryAndDecryptData() throws GeneralSecurityException, SQLException {
+    QueryAndDecryptData.queryAndDecryptData(pool, envAead, tableName);
+    String output = bout.toString();
+    assertThat(output).contains("Team\tTime Cast\tEmail");
+    assertThat(output).contains("hello@example.com");
+  }
+
+}


### PR DESCRIPTION
These are mostly copied from the MySQL samples, but with the SQL statements changed to work with the other DB engines. 

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [x] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [x] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [x] Please **merge** this PR for me once it is approved.
