### PR TITLE
docs: update eventarc docs and region tags

### DIFF
--- a/eventarc/README.md
+++ b/eventarc/README.md
@@ -1,18 +1,19 @@
-# Eventarc Java Samples
+# Eventarc Samples
 
 [![Open in Cloud Shell][shell_img]][shell_link]
 
 [shell_img]: http://gstatic.com/cloudssh/images/open-btn.png
 [shell_link]: https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=blog/README.md
 
-This directory contains samples for Eventarc.
+This directory contains samples for creating Cloud Run services that listens to events from [Eventarc](https://cloud.google.com/eventarc/docs/).
 
 ## Samples
 
 |           Sample                |        Description       |     Deploy    |
 | ------------------------------- | ------------------------ | ------------- |
-|[Eventarc - Pub/Sub](pubsub/) | Eventarc with Pub/Sub | [<img src="https://storage.googleapis.com/cloudrun/button.svg" alt="Run on Google Cloud" height="30">][run_button_events_pubsub] |
-|[Eventarc - Audit – Storage](audit-storage/) | Eventarc with Cloud Storage | [<img src="https://storage.googleapis.com/cloudrun/button.svg" alt="Run on Google Cloud" height="30">][run_button_events_audit_storage] |
+|[Eventarc - Pub/Sub](pubsub/) | Listen to Pub/Sub events | [<img src="https://storage.googleapis.com/cloudrun/button.svg" alt="Run on Google Cloud" height="30">][run_button_events_pubsub] |
+|[Eventarc - Audit – Storage](audit-storage/) | Listen to Audit Log events from Cloud Storage | [<img src="https://storage.googleapis.com/cloudrun/button.svg" alt="Run on Google Cloud" height="30">][run_button_events_audit_storage] |
+|[Eventarc - Generic](generic/) | Listen to a generic event from Eventarc | [<img src="https://storage.googleapis.com/cloudrun/button.svg" alt="Run on Google Cloud" height="30">][run_button_events_generic] |
 
 ## Setup
 
@@ -101,4 +102,5 @@ Learn more about [testing your container image locally.][testing]
 
 [run_button_events_audit_storage]: https://deploy.cloud.run/?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&dir=eventarc/audit-storage
 [run_button_events_pubsub]: https://deploy.cloud.run/?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&dir=eventarc/pubsub
+[run_button_events_generic]: https://deploy.cloud.run/?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&dir=eventarc/generic
 [testing]: https://cloud.google.com/run/docs/testing/local#running_locally_using_docker_with_access_to_services

--- a/eventarc/README.md
+++ b/eventarc/README.md
@@ -1,20 +1,18 @@
-# Cloud Eventarc Java Samples
+# Eventarc Java Samples
 
 [![Open in Cloud Shell][shell_img]][shell_link]
 
 [shell_img]: http://gstatic.com/cloudssh/images/open-btn.png
 [shell_link]: https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=blog/README.md
 
-This directory contains samples for Cloud Eventarc.
+This directory contains samples for Eventarc.
 
 ## Samples
 
 |           Sample                |        Description       |     Deploy    |
 | ------------------------------- | ------------------------ | ------------- |
-|[Eventarc - Pub/Sub](pubsub/) | Events for Cloud Run with Pub/Sub | [<img src="https://storage.googleapis.com/cloudrun/button.svg" alt="Run on Google Cloud" height="30">][run_button_events_pubsub] |
-|[Anthos Events - Pub/Sub](pubsub/anthos.md) | Events for Cloud Run on Anthos with Pub/Sub | - |
-|[Eventarc - Storage](audit-storage/) | Events for Cloud Run with Cloud Storage | [<img src="https://storage.googleapis.com/cloudrun/button.svg" alt="Run on Google Cloud" height="30">][run_button_events_audit_storage] |
-|[Anthos Events - Storage](audit-storage/anthos.md) | Events for Cloud Run on Anthos with Cloud Storage | - |
+|[Eventarc - Pub/Sub](pubsub/) | Eventarc with Pub/Sub | [<img src="https://storage.googleapis.com/cloudrun/button.svg" alt="Run on Google Cloud" height="30">][run_button_events_pubsub] |
+|[Eventarc - Audit – Storage](audit-storage/) | Eventarc with Cloud Storage | [<img src="https://storage.googleapis.com/cloudrun/button.svg" alt="Run on Google Cloud" height="30">][run_button_events_audit_storage] |
 
 ## Setup
 
@@ -103,3 +101,4 @@ Learn more about [testing your container image locally.][testing]
 
 [run_button_events_audit_storage]: https://deploy.cloud.run/?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&dir=eventarc/audit-storage
 [run_button_events_pubsub]: https://deploy.cloud.run/?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&dir=eventarc/pubsub
+[testing]: https://cloud.google.com/run/docs/testing/local#running_locally_using_docker_with_access_to_services

--- a/eventarc/audit-storage/README.md
+++ b/eventarc/audit-storage/README.md
@@ -1,14 +1,10 @@
-# Cloud Eventarc - Cloud Storage via Audit Logs tutorial
+# Eventarc - Cloud Storage Events via Audit Logs
 
 This sample shows how to create a service that processes GCS events.
 
 For more details on how to work with this sample read the [Google Cloud Run Java Samples README](https://github.com/GoogleCloudPlatform/java-docs-samples/tree/master/run).
 
 [![Run in Google Cloud][run_img]][run_link]
-
-[run_img]: https://storage.googleapis.com/cloudrun/button.svg
-[run_link]: https://deploy.cloud.run/?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&dir=run/events-storage
-
 
 ## Dependencies
 
@@ -76,3 +72,6 @@ gcloud logging read "resource.type=cloud_run_revision AND \
 resource.labels.service_name=$MY_RUN_SERVICE" --project \
 $(gcloud config get-value project) --limit 30 --format 'value(textPayload)'
 ```
+
+[run_img]: https://storage.googleapis.com/cloudrun/button.svg
+[run_link]: https://deploy.cloud.run/?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&dir=run/events-storage

--- a/eventarc/audit-storage/pom.xml
+++ b/eventarc/audit-storage/pom.xml
@@ -91,7 +91,7 @@ limitations under the License.
           </execution>
         </executions>
       </plugin>
-      <!-- [START eventarc_gcs_jib] -->
+      <!-- [START eventarc_audit_storage_jib] -->
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
@@ -102,7 +102,7 @@ limitations under the License.
           </to>
         </configuration>
       </plugin>
-      <!-- [END eventarc_gcs_jib] -->
+      <!-- [END eventarc_audit_storage_jib] -->
     </plugins>
   </build>
 </project>

--- a/eventarc/audit-storage/src/main/java/com/example/cloudrun/Application.java
+++ b/eventarc/audit-storage/src/main/java/com/example/cloudrun/Application.java
@@ -16,7 +16,7 @@
 
 package com.example.cloudrun;
 
-// [START eventarc_gcs_server]
+// [START eventarc_audit_storage_server]
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -26,4 +26,4 @@ public class Application {
     SpringApplication.run(Application.class, args);
   }
 }
-// [END eventarc_gcs_server]
+// [END eventarc_audit_storage_server]

--- a/eventarc/audit-storage/src/main/java/com/example/cloudrun/EventController.java
+++ b/eventarc/audit-storage/src/main/java/com/example/cloudrun/EventController.java
@@ -16,7 +16,7 @@
 
 package com.example.cloudrun;
 
-// [START eventarc_gcs_handler]
+// [START eventarc_audit_storage_handler]
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -57,4 +57,4 @@ public class EventController {
     return new ResponseEntity<String>(msg, HttpStatus.OK);
   }
 }
-// [END eventarc_gcs_handler]
+// [END eventarc_audit_storage_handler]

--- a/eventarc/generic/README.md
+++ b/eventarc/generic/README.md
@@ -1,14 +1,10 @@
-# Cloud Eventarc - Generic tutorial
+# Eventarc - Generic
 
 This sample shows how to create a service that processes generic [CloudEvents](https://cloudevents.io/).
 
 For more details on how to work with this sample read the [Google Cloud Run Java Samples README](https://github.com/GoogleCloudPlatform/java-docs-samples/tree/master/run).
 
 [![Run in Google Cloud][run_img]][run_link]
-
-[run_img]: https://storage.googleapis.com/cloudrun/button.svg
-[run_link]: https://deploy.cloud.run/?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&dir=run/events-generic
-
 
 ## Dependencies
 
@@ -48,3 +44,6 @@ curl -XPOST $CLOUD_RUN_URL \
 ```
 
 You may observe the Cloud Run service receiving an event in Cloud Logging.
+
+[run_img]: https://storage.googleapis.com/cloudrun/button.svg
+[run_link]: https://deploy.cloud.run/?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&dir=run/events-generic

--- a/eventarc/generic/pom.xml
+++ b/eventarc/generic/pom.xml
@@ -90,7 +90,7 @@ limitations under the License.
         <version>2.8.0</version>
         <configuration>
           <to>
-            <image>gcr.io/serverless-com-demo/eventarc-generic</image>
+            <image>gcr.io/PROJECT_ID/eventarc-generic</image>
           </to>
         </configuration>
       </plugin>

--- a/eventarc/generic/pom.xml
+++ b/eventarc/generic/pom.xml
@@ -90,7 +90,7 @@ limitations under the License.
         <version>2.8.0</version>
         <configuration>
           <to>
-            <image>gcr.io/PROJECT_ID/eventarc-generic</image>
+            <image>gcr.io/serverless-com-demo/eventarc-generic</image>
           </to>
         </configuration>
       </plugin>

--- a/eventarc/pubsub/README.md
+++ b/eventarc/pubsub/README.md
@@ -1,14 +1,10 @@
-# Cloud Eventarc - Pub/Sub tutorial
+# Eventarc - Pub/Sub
 
 This sample shows how to create a service that processes Pub/Sub messages.
 
 For more details on how to work with this sample read the [Google Cloud Run Java Samples README](https://github.com/GoogleCloudPlatform/java-docs-samples/tree/master/run).
 
 [![Run in Google Cloud][run_img]][run_link]
-
-[run_img]: https://storage.googleapis.com/cloudrun/button.svg
-[run_link]: https://deploy.cloud.run/?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&dir=run/events-pubsub
-
 
 ## Dependencies
 
@@ -41,10 +37,10 @@ gcloud run deploy cloudrun-events-pubsub \
 Create a Cloud Pub/Sub trigger:
 
 ```sh
-gcloud alpha events triggers create pubsub-trigger \
---target-service cloudrun-events-pubsub \
---type com.google.cloud.pubsub.topic.publish \
---parameters topic=my-topic
+gcloud eventarc triggers create events-pubsub-trigger \
+  --destination-run-service=cloudrun-events-pubsub \
+  --destination-run-region=us-central1 \
+  --event-filters="type=google.cloud.pubsub.topic.v1.messagePublished"
 ```
 
 ## Test
@@ -52,7 +48,12 @@ gcloud alpha events triggers create pubsub-trigger \
 Test your Cloud Run service by publishing a message to the topic: 
 
 ```sh
-gcloud pubsub topics publish my-topic --message="Hello there"
+export RUN_TOPIC=$(gcloud eventarc triggers describe events-pubsub-trigger \
+  --format='value(transport.pubsub.topic)')
+gcloud pubsub topics publish $RUN_TOPIC --message "Runner"
 ```
 
 You may observe the Run service receiving an event in Cloud Logging.
+
+[run_img]: https://storage.googleapis.com/cloudrun/button.svg
+[run_link]: https://deploy.cloud.run/?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&dir=run/events-pubsub


### PR DESCRIPTION
## docs: update eventarc docs and region tags

- Updates Eventarc naming style
- Removes leftover traces of Anthos in the `eventarc/` directory
- Updates region tags
- Updates `gcloud` commands (although these may be removed completely at some point when docs are ready)