### PR TITLE
Naming fix (secrets manager -> secret manager)

### DIFF
--- a/run/idp-sql/README.md
+++ b/run/idp-sql/README.md
@@ -44,7 +44,7 @@ Uncomment variables in `application.properties` and set:
 
 * Saving credentials directly as environment variables is convenient for local testing,
   but not secure for production; therefore using `SECRET_NAME` and `VERSION`
-  in combination with the Cloud Secrets Manager is recommended.  
+  in combination with the Google Secret Manager is recommended.  
 
 ## Running Locally
 


### PR DESCRIPTION
Naming fix (secrets manager -> secret manager)

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [x] Appropriate changes to README are included in PR
- [x] API's need to be enabled to test (tell us)
- [x] Environment Variables need to be set (ask us to set them)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [x] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [x] Please **merge** this PR for me once it is approved.
