### PR TITLE
Add comment about authenticated push JWT token validation.

### DIFF
--- a/appengine-java8/pubsub/src/main/java/com/example/appengine/pubsub/PubSubAuthenticatedPush.java
+++ b/appengine-java8/pubsub/src/main/java/com/example/appengine/pubsub/PubSubAuthenticatedPush.java
@@ -77,8 +77,16 @@ public class PubSubAuthenticatedPush extends HttpServlet {
       // messsages have prompted a singple push server to handle them, in which
       // case they would all share the same token for a limited time window.
       GoogleIdToken idToken = verifier.verify(authorization);
+
+      GoogleIdToken.Payload payload = idToken.getPayload();
+      // IMPORTANT: you should validate claim details not covered by signature
+      // and audience verification above, including:
+      //   - Ensure that `payload.getEmail()` is equal to the expected service
+      //     account set up in the push subscription settings.
+      //   - Ensure that `payload.getEmailVerified()` is set to true.
+
       messageRepository.saveToken(authorization);
-      messageRepository.saveClaim(idToken.getPayload().toPrettyString());
+      messageRepository.saveClaim(payload.toPrettyString());
       // parse message object from "message" field in the request body json
       // decode message data from base64
       Message message = getMessage(req);


### PR DESCRIPTION
This snippet is used in the Cloud Pub/Sub docs (https://cloud.google.com/pubsub/docs/push#validating_tokens) and many users are not aware that signature verification of the token is not enough, the claim needs to be validated also.

See similar change in the nodejs repo: https://github.com/GoogleCloudPlatform/nodejs-docs-samples/pull/2222.
