### PR TITLE
Add sample for Pub/Sub Lite I/O Connector for Beam

### DIFF
--- a/pubsublite/streaming-analytics/README.md
+++ b/pubsublite/streaming-analytics/README.md
@@ -21,11 +21,11 @@ Resources needed for this example:
 
 1. [Enable the APIs](https://console.cloud.google.com/flows/enableapi?apiid=dataflow,compute_component,logging,storage_api,pubsublite.googleapis.com): Cloud Dataflow, Compute Engine, Cloud Logging, Cloud Storage, Pub/Sub Lite.
 
-1. Create a Cloud Storage bucket.
+1. Create a Cloud Storage bucket. Your bucket name needs to be globally unique.
 
    ```bash
-   PROJECT=$(gcloud config get-value project)
-   BUCKET=your-gcs-bucket
+   export PROJECT_ID=$(gcloud config get-value project)
+   export BUCKET=your-gcs-bucket
    
    gsutil mb gs://$BUCKET
    ```
@@ -33,9 +33,9 @@ Resources needed for this example:
  1. Create a Pub/Sub Lite topic and subscription. Set `LITE_LOCATION` to a [Pub/Sub Lite location].
  
     ```bash
-    TOPIC=your-lite-topic
-    SUBSCRIPTION=your-lite-subscription
-    LITE_LOCATION=your-lite-location
+    export TOPIC=your-lite-topic
+    export SUBSCRIPTION=your-lite-subscription
+    export LITE_LOCATION=your-lite-location
     
     gcloud pubsub lite-topics create $TOPIC --zone=$LITE_LOCATION --partitions=1 \
         --per-partition-bytes=30GiB
@@ -45,7 +45,7 @@ Resources needed for this example:
 1. Set `DATAFLOW_REGION` to a [Dataflow region] close to your Pub/Sub Lite location.
 
    ```
-   DATAFLOW_REGION=your-dateflow-region
+   export DATAFLOW_REGION=your-dateflow-region
    ```
    
 ### Running the example
@@ -66,11 +66,11 @@ The following example runs a streaming pipeline. Choose `DirectRunner` to test i
 mvn compile exec:java \
   -Dexec.mainClass=examples.PubsubliteToGcs \
   -Dexec.args="\
-    --subscription=projects/$PROJECT/locations/$LITE_LOCATION/subscriptions/$SUBSCRIPTION \
+    --subscription=projects/$PROJECT_ID/locations/$LITE_LOCATION/subscriptions/$SUBSCRIPTION \
     --output=gs://$BUCKET/samples/output \
     --windowSize=1 \
     --runner=DataflowRunner \
-    --project=$PROJECT \
+    --project=$PROJECT_ID \
     --region=$DATAFLOW_REGION \
     --tempLocation=gs://$BUCKET/temp"
 ```
@@ -83,20 +83,19 @@ gsutil ls gs://$BUCKET/samples/output*
 
 ## Cleaning up
 
-1. Stop the pipeline. If you use `DirectRunner`, `Ctrl+C` to cancel. If you use `DataflowRunner`, cancel the job.
+1. Stop the pipeline. If you use `DirectRunner`, `Ctrl+C` to cancel. If you use `DataflowRunner`, [click](https://console.cloud.google.com/dataflow/jobs) on the job you want to stop, then choose "Cancel".
 
-1. Delete the Lite topic and subscription. 
-   ```bash
-   gcloud pubsub lite-topics delete $TOPIC
-   gcloud pubsub lite-subscription delete $SUBSCRIPTION
-   ```
+1. Delete the Lite topic and subscription.
+```bash
+gcloud pubsub lite-topics delete $TOPIC
+gcloud pubsub lite-subscription delete $SUBSCRIPTION
+```
    
 1. Delete the Cloud Storage objects:
-
-    ```bash
-    gsutil -m rm -rf "gs://$BUCKET/samples/output*"
-    gsutil rb gs://$BUCKET
-    ```
+```bash
+gsutil -m rm -rf "gs://$BUCKET/samples/output*"
+gsutil rb gs://$BUCKET
+```
 
 [Apache Beam]: https://beam.apache.org/
 [Pub/Sub Lite]: https://cloud.google.com/pubsub/lite/docs/

--- a/pubsublite/streaming-analytics/README.md
+++ b/pubsublite/streaming-analytics/README.md
@@ -1,4 +1,4 @@
-# Stream Cloud Pub/Sub with Cloud Dataflow
+# Stream Pub/Sub Lite with Dataflow
 
 Sample(s) showing how to use [Google Cloud Pub/Sub] with [Google Cloud Dataflow].
 
@@ -108,11 +108,14 @@ mvn compile exec:java \
   -Dexec.mainClass=com.examples.pubsub.examples.PubSubToGCS \
   -Dexec.cleanupDaemonThreads=false \
   -Dexec.args="\
-    --project=$PROJECT_NAME \
+    --liteSubscriptionId=projects/$PROJECT_ID/topics/cron-topic \
+    --liteLocation=us-east1-b \
+    --outputFilename=gs://$BUCKET_NAME/samples/output \
+    --windowSizeInMinutes=1 \
+    --project=$PROJECT_ID \
     --region=$REGION \
-    --inputTopic=projects/$PROJECT_NAME/topics/cron-topic \
-    --output=gs://$BUCKET_NAME/samples/output \
     --runner=DataflowRunner \
+    --tempLocation= \
     --windowSize=2"
 ```
 

--- a/pubsublite/streaming-analytics/README.md
+++ b/pubsublite/streaming-analytics/README.md
@@ -85,7 +85,7 @@ The following instructions will help you prepare your development environment.
 1. Navigate to the sample code directory.
 
    ```bash
-   cd java-docs-samples/pubsub/streaming-analytics
+   cd java-docs-samples/pubsub/examples-analytics
    ```
 
 ## Streaming Analytics
@@ -94,7 +94,7 @@ The following instructions will help you prepare your development environment.
 
 * [PubSubToGCS.java](src/main/java/PubsubliteToGcs.java)
 
-The following example will run a streaming pipeline. It will read messages from a Pub/Sub topic, then window them into fixed-sized intervals, and write one file per window into a GCS location.
+The following example will run a examples pipeline. It will read messages from a Pub/Sub topic, then window them into fixed-sized intervals, and write one file per window into a GCS location.
 
 + `--project`: sets the Google Cloud project ID to run the pipeline on
 + `--region`: sets the Dataflow regional endpoint
@@ -105,7 +105,7 @@ The following example will run a streaming pipeline. It will read messages from 
 
 ```bash
 mvn compile exec:java \
-  -Dexec.mainClass=com.examples.pubsub.streaming.PubSubToGCS \
+  -Dexec.mainClass=com.examples.pubsub.examples.PubSubToGCS \
   -Dexec.cleanupDaemonThreads=false \
   -Dexec.args="\
     --project=$PROJECT_NAME \
@@ -135,7 +135,7 @@ gsutil ls gs://$BUCKET_NAME/samples/
 
 1. Stop the Dataflow job in [GCP Console Dataflow page]. Cancel the job instead of draining it. This may take some minutes.
 
-1. Delete the topic. [Google Cloud Dataflow] will automatically delete the subscription associated with the streaming pipeline when the job is canceled.
+1. Delete the topic. [Google Cloud Dataflow] will automatically delete the subscription associated with the examples pipeline when the job is canceled.
    ```bash
    gcloud pubsub topics delete cron-topic
    ```

--- a/pubsublite/streaming-analytics/README.md
+++ b/pubsublite/streaming-analytics/README.md
@@ -1,0 +1,176 @@
+# Stream Cloud Pub/Sub with Cloud Dataflow
+
+Sample(s) showing how to use [Google Cloud Pub/Sub] with [Google Cloud Dataflow].
+
+## Before you begin
+
+1. Install the [Cloud SDK].
+
+1. [Create a new project].
+
+1. [Enable billing].
+
+1. [Enable the APIs](https://console.cloud.google.com/flows/enableapi?apiid=dataflow,compute_component,logging,storage_component,storage_api,pubsub,cloudresourcemanager.googleapis.com,cloudscheduler.googleapis.com,appengine.googleapis.com): Dataflow, Compute Engine, Stackdriver Logging, Cloud Storage, Cloud Storage JSON, Pub/Sub, Cloud Scheduler, Cloud Resource Manager, and App Engine.
+
+1. Setup the Cloud SDK to your GCP project.
+
+   ```bash
+   gcloud init
+   ```
+
+1. [Create a service account key] as a JSON file.
+   For more information, see [Creating and managing service accounts].
+
+   * From the **Service account** list, select **New service account**.
+   * In the **Service account name** field, enter a name.
+   * From the **Role** list, select **Project > Owner**.
+
+     > **Note**: The **Role** field authorizes your service account to access resources.
+     > You can view and change this field later by using the [GCP Console IAM page].
+     > If you are developing a production app, specify more granular permissions than **Project > Owner**.
+     > For more information, see [Granting roles to service accounts].
+
+   * Click **Create**. A JSON file that contains your key downloads to your computer.
+
+1. Set your `GOOGLE_APPLICATION_CREDENTIALS` environment variable to point to your service account key file.
+
+   ```bash
+   export GOOGLE_APPLICATION_CREDENTIALS=path/to/your/credentials.json
+   ```
+
+1. Create a Cloud Storage bucket.
+
+   ```bash
+   BUCKET_NAME=your-gcs-bucket
+   PROJECT_NAME=$(gcloud config get-value project)
+   
+   gsutil mb gs://$BUCKET_NAME
+   ```
+   
+ 1. Start a [Google Cloud Scheduler] job that publishes one message to a [Google Cloud Pub/Sub] topic every minute. This will create an [App Engine] app if one has never been created on the project. 
+ 
+    ```bash
+    # Create a Pub/Sub topic.
+    gcloud pubsub topics create cron-topic
+    
+    # Create a Cloud Scheduler job
+    gcloud scheduler jobs create pubsub publisher-job --schedule="* * * * *" \
+      --topic=cron-topic --message-body="Hello!"
+    
+    # Run the job. 
+    gcloud scheduler jobs run publisher-job
+    ```
+
+1. Set `REGION` to a Dataflow [regional endpoint].
+
+   ```
+   export REGION=your-cloud-region
+   ```
+
+## Setup
+
+The following instructions will help you prepare your development environment.
+
+1. Download and install the [Java Development Kit (JDK)].
+   Verify that the [JAVA_HOME] environment variable is set and points to your JDK installation.
+
+1. Download and install [Apache Maven] by following the [Maven installation guide] for your specific operating system.
+
+1. Clone the `java-docs-samples` repository.
+
+    ```bash
+    git clone https://github.com/GoogleCloudPlatform/java-docs-samples.git
+    ```
+
+1. Navigate to the sample code directory.
+
+   ```bash
+   cd java-docs-samples/pubsub/streaming-analytics
+   ```
+
+## Streaming Analytics
+
+### Google Cloud Pub/Sub to Google Cloud Storage
+
+* [PubSubToGCS.java](src/main/java/PubsubliteToGcs.java)
+
+The following example will run a streaming pipeline. It will read messages from a Pub/Sub topic, then window them into fixed-sized intervals, and write one file per window into a GCS location.
+
++ `--project`: sets the Google Cloud project ID to run the pipeline on
++ `--region`: sets the Dataflow regional endpoint
++ `--inputTopic`: sets the input Pub/Sub topic to read messages from
++ `--output`: sets the output GCS path prefix to write files to
++ `--runner [optional]`: specifies the runner to run the pipeline, defaults to `DirectRunner`
++ `--windowSize [optional]`: specifies the window size in minutes, defaults to 1
+
+```bash
+mvn compile exec:java \
+  -Dexec.mainClass=com.examples.pubsub.streaming.PubSubToGCS \
+  -Dexec.cleanupDaemonThreads=false \
+  -Dexec.args="\
+    --project=$PROJECT_NAME \
+    --region=$REGION \
+    --inputTopic=projects/$PROJECT_NAME/topics/cron-topic \
+    --output=gs://$BUCKET_NAME/samples/output \
+    --runner=DataflowRunner \
+    --windowSize=2"
+```
+
+After the job has been submitted, you can check its status in the [GCP Console Dataflow page]. 
+
+You can also check the output to your GCS bucket using the command line below or in the [GCP Console Storage page]. You may need to wait a few minutes for the files to appear.
+
+```bash
+gsutil ls gs://$BUCKET_NAME/samples/
+```
+
+## Cleanup
+
+1. Delete the [Google Cloud Scheduler] job. 
+    ```bash
+    gcloud scheduler jobs delete publisher-job
+    ```
+
+1. `Ctrl+C` to stop the program in your terminal. Note that this does not actually stop the job if you use `DataflowRunner`. Skip 3 if you use the `DirectRunner`.
+
+1. Stop the Dataflow job in [GCP Console Dataflow page]. Cancel the job instead of draining it. This may take some minutes.
+
+1. Delete the topic. [Google Cloud Dataflow] will automatically delete the subscription associated with the streaming pipeline when the job is canceled.
+   ```bash
+   gcloud pubsub topics delete cron-topic
+   ```
+
+1. Lastly, to avoid incurring charges to your GCP account for the resources created in this tutorial:
+
+    ```bash
+    # Delete only the files created by this sample.
+    gsutil -m rm -rf "gs://$BUCKET_NAME/samples/output*"
+    
+    # [optional] Remove the Cloud Storage bucket.
+    gsutil rb gs://$BUCKET_NAME
+    ```
+
+[Apache Beam]: https://beam.apache.org/
+[Google Cloud Pub/Sub]: https://cloud.google.com/pubsub/docs/
+[Google Cloud Dataflow]: https://cloud.google.com/dataflow/docs/
+[Google Cloud Scheduler]: https://cloud.google.com/scheduler/docs/
+[App Engine]: https://cloud.google.com/appengine/docs/
+
+[Cloud SDK]: https://cloud.google.com/sdk/docs/
+[Create a new project]: https://console.cloud.google.com/projectcreate
+[Enable billing]: https://cloud.google.com/billing/docs/how-to/modify-project
+[Create a service account key]: https://console.cloud.google.com/apis/credentials/serviceaccountkey
+[Creating and managing service accounts]: https://cloud.google.com/iam/docs/creating-managing-service-accounts
+[GCP Console IAM page]: https://console.cloud.google.com/iam-admin/iam
+[Granting roles to service accounts]: https://cloud.google.com/iam/docs/granting-roles-to-service-accounts
+
+[Java Development Kit (JDK)]: https://www.oracle.com/technetwork/java/javase/downloads/index.html
+[JAVA_HOME]: https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/envvars001.html
+[Apache Maven]: http://maven.apache.org/download.cgi
+[Maven installation guide]: http://maven.apache.org/install.html
+
+[GCP Console create Dataflow job page]: https://console.cloud.google.com/dataflow/createjob
+[GCP Console Dataflow page]: https://console.cloud.google.com/dataflow
+[GCP Console Storage page]: https://console.cloud.google.com/storage
+
+[regional endpoint]: https://cloud.google.com/dataflow/docs/concepts/regional-endpoints

--- a/pubsublite/streaming-analytics/README.md
+++ b/pubsublite/streaming-analytics/README.md
@@ -6,7 +6,7 @@ Samples showing how to use [Pub/Sub Lite] with [Cloud Dataflow].
 
 ## Pub/Sub Lite to Cloud Storage sample
 
-[PubsubliteToGcs.java](examples/PubsubliteToGcs.java)
+[PubsubliteToGcs.java](src/main/java/examples/PubsubliteToGcs.java)
 
 This sample shows how to create an [Apache Beam] streaming pipeline that reads
 messages from [Pub/Sub Lite], group the messages using a fixed-sized windowing
@@ -20,37 +20,48 @@ Resources needed for this example:
 ### Setting up
 
 1. [Enable the APIs](https://console.cloud.google.com/flows/enableapi?apiid=dataflow,compute_component,logging,storage_api,pubsublite.googleapis.com): Cloud Dataflow, Compute Engine, Cloud Logging, Cloud Storage, Pub/Sub Lite.
+  > _When you enable Cloud Dataflow, which uses Compute Engine, a default Compute Engine service account with the Editor role (`roles/editor`) is created._
+2. You can skip this step if you are trying this example in a Google Cloud environment like Cloud Shell.
 
-1. Create a Cloud Storage bucket. Your bucket name needs to be globally unique.
+   Otherwise, [create](https://cloud.google.com/iam/docs/creating-managing-service-accounts#iam-service-accounts-create-gcloud) a user-managed service account and grant it the following roles on your project:
+   - `roles/dataflow.admin`
+   - `roles/pubsublite.viewer`
+   - `roles/pubsublite.subscriber`
+   - `roles/logging.viewer`
 
-   ```bash
-   export PROJECT_ID=$(gcloud config get-value project)
-   export BUCKET=your-gcs-bucket
-   
-   gsutil mb gs://$BUCKET
-   ```
-   
- 1. Create a Pub/Sub Lite topic and subscription. Set `LITE_LOCATION` to a [Pub/Sub Lite location].
- 
-    ```bash
-    export TOPIC=your-lite-topic
-    export SUBSCRIPTION=your-lite-subscription
-    export LITE_LOCATION=your-lite-location
-    
-    gcloud pubsub lite-topics create $TOPIC --zone=$LITE_LOCATION --partitions=1 \
-        --per-partition-bytes=30GiB
-    gcloud pubsub lite-subscriptions create $SUBSCRIPTION --zone=$LITE_LOCATION --topic=$TOPIC
-    ```
+   Then [create](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#iam-service-account-keys-create-gcloud) a service account key and point  `GOOGLE_APPLICATION_CREDNETIALS` to your downloaded key file.
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=path/to/your/key/file
+```
+3. Create a Cloud Storage bucket. Your bucket name needs to be globally unique.
+```bash
+export PROJECT_ID=$(gcloud config get-value project)
+export BUCKET=your-gcs-bucket
 
-1. Set `DATAFLOW_REGION` to a [Dataflow region] close to your Pub/Sub Lite location.
+gsutil mb gs://$BUCKET
+``` 
+4. Create a Pub/Sub Lite topic and subscription. Set `LITE_LOCATION` to a [Pub/Sub Lite location].
+```bash
+export TOPIC=your-lite-topic
+export SUBSCRIPTION=your-lite-subscription
+export LITE_LOCATION=your-lite-location
 
-   ```
-   export DATAFLOW_REGION=your-dateflow-region
-   ```
+gcloud pubsub lite-topics create $TOPIC \
+    --zone=$LITE_LOCATION \
+    --partitions=1 \
+    --per-partition-bytes=30GiB
+gcloud pubsub lite-subscriptions create $SUBSCRIPTION \
+    --zone=$LITE_LOCATION \
+    --topic=$TOPIC
+```
+5. Set `DATAFLOW_REGION` to a [Dataflow region] close to your Pub/Sub Lite location.
+```
+export DATAFLOW_REGION=your-dateflow-region
+```
    
 ### Running the example
 
-[PubsubliteToGcs.java](examples/PubsubliteToGcs.java)
+[PubsubliteToGcs.java](src/main/java/examples/PubsubliteToGcs.java)
 
 The following example runs a streaming pipeline. Choose `DirectRunner` to test it locally or `DataflowRunner` to run it on Dataflow.
 
@@ -60,7 +71,7 @@ The following example runs a streaming pipeline. Choose `DirectRunner` to test i
 + `--runner [optional]`: `DataflowRunner` or `DirectRunner`
 + `--project [optional]`: your project ID, optional if using `DirectRunner`
 + `--region [optional]`: the Dataflow region, optional if using `DirectRunner`
-+ `--tempLocation`: the temporary location of Dataflow files, optional if using `DirectRunner`
++ `--tempLocation`: a Cloud Storage location for temporary files, optional if using `DirectRunner`
 
 ```bash
 mvn compile exec:java \
@@ -78,7 +89,7 @@ mvn compile exec:java \
 [Publish] some messages to your Lite topic. Then check for files in your Cloud Storage bucket.
 
 ```bash
-gsutil ls gs://$BUCKET/samples/output*
+gsutil ls "gs://$BUCKET/samples/output*"
 ```
 
 ## Cleaning up

--- a/pubsublite/streaming-analytics/pom.xml
+++ b/pubsublite/streaming-analytics/pom.xml
@@ -78,7 +78,7 @@
             <manifest>
               <addClasspath>true</addClasspath>
               <classpathPrefix>lib/</classpathPrefix>
-              <mainClass>com.examples.pubsub.examples.PubSubToGCS</mainClass>
+              <mainClass>examples.PubsubliteToGcs</mainClass>
             </manifest>
           </archive>
         </configuration>
@@ -187,12 +187,14 @@
       <scope>runtime</scope>
     </dependency>
 
+    <!-- TODO: Remove when the next release of the I/O includes it as a dependency -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>30.1-jre</version>
     </dependency>
 
+    <!-- TODO: Replace when this I/O Connector published with Apache Beam is stable -->
     <!-- Pub/Sub Lite I/O Connector for Beam -->
     <dependency>
       <groupId>com.google.cloud</groupId>

--- a/pubsublite/streaming-analytics/pom.xml
+++ b/pubsublite/streaming-analytics/pom.xml
@@ -20,13 +20,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.example</groupId>
-  <artifactId>pubsub-streaming</artifactId>
+  <artifactId>pubsublite-streaming</artifactId>
   <version>1.0</version>
 
   <parent>
     <groupId>com.google.cloud.samples</groupId>
     <artifactId>shared-configuration</artifactId>
-    <version>1.0.21</version>
+    <version>1.0.22</version>
   </parent>
 
   <properties>
@@ -34,7 +34,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <beam.version>2.27.0</beam.version>
+    <beam.version>2.28.0</beam.version>
 
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
@@ -54,6 +54,10 @@
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
+    </repository>
+    <repository>
+      <id>confluent</id>
+      <url>https://packages.confluent.io/maven/</url>
     </repository>
   </repositories>
 
@@ -130,58 +134,19 @@
     </pluginManagement>
   </build>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>20.1.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
-    <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>beam-sdks-java-core</artifactId>
-      <version>${beam.version}</version>
-    </dependency>
-
-    <!--
-      By default, the starter project has a dependency on the Beam DirectRunner
-      to enable development and testing of pipelines. To run on another of the
-      Beam runners, add its module to this pom.xml according to the
-      runner-specific setup instructions on the Beam website:
-        http://beam.apache.org/documentation/#runners
-    -->
-    <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>beam-runners-direct-java</artifactId>
-      <version>${beam.version}</version>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
-      <version>${beam.version}</version>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>beam-sdks-java-io-google-cloud-platform</artifactId>
-      <version>${beam.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>beam-sdks-java-maven-archetypes-examples</artifactId>
-      <version>${beam.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>pubsublite-beam-io</artifactId>
-      <version>0.12.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-pubsublite</artifactId>
-      <version>0.12.0</version>
-    </dependency>
-
     <!-- slf4j API frontend binding with JUL backend -->
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -193,6 +158,53 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
       <version>${slf4j.version}</version>
+    </dependency>
+
+    <!-- Apache Beam
+      To run on another of the Beam runners, add its module to this pom.xml
+      according to the runner-specific setup instructions on the Beam website:
+        http://beam.apache.org/documentation/#runners
+    -->
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-core</artifactId>
+      <version>${beam.version}</version>
+    </dependency>
+
+    <!-- Direct Runner -->
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-runners-direct-java</artifactId>
+      <version>${beam.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <!-- Dataflow Runner -->
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
+      <version>${beam.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>30.1-jre</version>
+    </dependency>
+
+    <!-- Pub/Sub Lite I/O Connector for Beam -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>pubsublite-beam-io</artifactId>
+      <version>0.13.2</version>
+    </dependency>
+
+    <!-- Beam examples -->
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-maven-archetypes-examples</artifactId>
+      <version>${beam.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/pubsublite/streaming-analytics/pom.xml
+++ b/pubsublite/streaming-analytics/pom.xml
@@ -61,79 +61,6 @@
     </repository>
   </repositories>
 
-  <build>
-   <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven-compiler-plugin.version}</version>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>${maven-jar-plugin.version}</version>
-        <configuration>
-          <archive>
-            <manifest>
-              <addClasspath>true</addClasspath>
-              <classpathPrefix>lib/</classpathPrefix>
-              <mainClass>examples.PubsubliteToGcs</mainClass>
-            </manifest>
-          </archive>
-        </configuration>
-      </plugin>
-
-      <!--
-        Configures `mvn package` to produce a bundled jar ("fat jar") for runners
-        that require this for job submission to a cluster.
-      -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>${maven-shade-plugin.version}</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <finalName>${project.artifactId}-bundled-${project.version}</finalName>
-              <filters>
-                <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/LICENSE</exclude>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
-                  </excludes>
-                </filter>
-              </filters>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-              </transformers>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>exec-maven-plugin</artifactId>
-          <version>${maven-exec-plugin.version}</version>
-          <configuration>
-            <cleanupDaemonThreads>false</cleanupDaemonThreads>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -209,4 +136,77 @@
       <version>${beam.version}</version>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${maven-jar-plugin.version}</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+              <classpathPrefix>lib/</classpathPrefix>
+              <mainClass>examples.PubsubliteToGcs</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+
+      <!--
+        Configures `mvn package` to produce a bundled jar ("fat jar") for runners
+        that require this for job submission to a cluster.
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${maven-shade-plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>${project.artifactId}-bundled-${project.version}</finalName>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/LICENSE</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>${maven-exec-plugin.version}</version>
+          <configuration>
+            <cleanupDaemonThreads>false</cleanupDaemonThreads>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/pubsublite/streaming-analytics/pom.xml
+++ b/pubsublite/streaming-analytics/pom.xml
@@ -30,8 +30,8 @@
   </parent>
 
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <beam.version>2.28.0</beam.version>

--- a/pubsublite/streaming-analytics/pom.xml
+++ b/pubsublite/streaming-analytics/pom.xml
@@ -114,14 +114,16 @@
       <scope>runtime</scope>
     </dependency>
 
-    <!-- TODO: Remove when the next release of the I/O includes it as a dependency -->
+    <!-- TODO: Remove when the next release of the I/O includes it -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>30.1-jre</version>
     </dependency>
 
-    <!-- TODO: Replace when this I/O Connector published with Apache Beam is stable -->
+    <!-- TODO: Replace when this I/O Connector published with Apache Beam is stable
+     https://issues.apache.org/jira/browse/BEAM-10114
+     -->
     <!-- Pub/Sub Lite I/O Connector for Beam -->
     <dependency>
       <groupId>com.google.cloud</groupId>
@@ -134,6 +136,25 @@
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-maven-archetypes-examples</artifactId>
       <version>${beam.version}</version>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-storage</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.1.2</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/pubsublite/streaming-analytics/pom.xml
+++ b/pubsublite/streaming-analytics/pom.xml
@@ -74,7 +74,7 @@
             <manifest>
               <addClasspath>true</addClasspath>
               <classpathPrefix>lib/</classpathPrefix>
-              <mainClass>com.examples.pubsub.streaming.PubSubToGCS</mainClass>
+              <mainClass>com.examples.pubsub.examples.PubSubToGCS</mainClass>
             </manifest>
           </archive>
         </configuration>
@@ -168,6 +168,18 @@
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-maven-archetypes-examples</artifactId>
       <version>${beam.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>pubsublite-beam-io</artifactId>
+      <version>0.12.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-pubsublite</artifactId>
+      <version>0.12.0</version>
     </dependency>
 
     <!-- slf4j API frontend binding with JUL backend -->

--- a/pubsublite/streaming-analytics/pom.xml
+++ b/pubsublite/streaming-analytics/pom.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2021 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example</groupId>
+  <artifactId>pubsub-streaming</artifactId>
+  <version>1.0</version>
+
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.0.21</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <beam.version>2.27.0</beam.version>
+
+    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+    <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
+    <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
+    <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
+    <slf4j.version>1.7.30</slf4j.version>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>apache.snapshots</id>
+      <name>Apache Development Snapshot Repository</name>
+      <url>https://repository.apache.org/content/repositories/snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <build>
+   <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${maven-jar-plugin.version}</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+              <classpathPrefix>lib/</classpathPrefix>
+              <mainClass>com.examples.pubsub.streaming.PubSubToGCS</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+
+      <!--
+        Configures `mvn package` to produce a bundled jar ("fat jar") for runners
+        that require this for job submission to a cluster.
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${maven-shade-plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>${project.artifactId}-bundled-${project.version}</finalName>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/LICENSE</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>${maven-exec-plugin.version}</version>
+          <configuration>
+            <cleanupDaemonThreads>false</cleanupDaemonThreads>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-core</artifactId>
+      <version>${beam.version}</version>
+    </dependency>
+
+    <!--
+      By default, the starter project has a dependency on the Beam DirectRunner
+      to enable development and testing of pipelines. To run on another of the
+      Beam runners, add its module to this pom.xml according to the
+      runner-specific setup instructions on the Beam website:
+        http://beam.apache.org/documentation/#runners
+    -->
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-runners-direct-java</artifactId>
+      <version>${beam.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
+      <version>${beam.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-io-google-cloud-platform</artifactId>
+      <version>${beam.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-maven-archetypes-examples</artifactId>
+      <version>${beam.version}</version>
+    </dependency>
+
+    <!-- slf4j API frontend binding with JUL backend -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/pubsublite/streaming-analytics/src/main/java/PubsubliteToGcs.java
+++ b/pubsublite/streaming-analytics/src/main/java/PubsubliteToGcs.java
@@ -1,0 +1,81 @@
+// Copyright 2021 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.examples.pubsub.streaming;
+
+// [START pubsublite_to_gcs]
+
+import java.io.IOException;
+import org.apache.beam.examples.common.WriteOneFilePerWindow;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.StreamingOptions;
+import org.apache.beam.sdk.options.Validation.Required;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.joda.time.Duration;
+
+public class PubSubToGcs {
+  /*
+   * Define your own configuration options. Add your own arguments to be processed
+   * by the command-line parser, and specify default values for them.
+   */
+  public interface PubSubToGcsOptions extends PipelineOptions, StreamingOptions {
+    @Description("The Cloud Pub/Sub topic to read from.")
+    @Required
+    String getInputTopic();
+
+    void setInputTopic(String value);
+
+    @Description("Output file's window size in number of minutes.")
+    @Default.Integer(1)
+    Integer getWindowSize();
+
+    void setWindowSize(Integer value);
+
+    @Description("Path of the output file including its filename prefix.")
+    @Required
+    String getOutput();
+
+    void setOutput(String value);
+  }
+
+  public static void main(String[] args) throws IOException {
+    // The maximum number of shards when writing output.
+    int numShards = 1;
+
+    PubSubToGcsOptions options =
+        PipelineOptionsFactory.fromArgs(args).withValidation().as(PubSubToGcsOptions.class);
+
+    options.setStreaming(true);
+
+    Pipeline pipeline = Pipeline.create(options);
+
+    pipeline
+        // 1) Read string messages from a Pub/Sub topic.
+        .apply("Read PubSub Messages", PubsubIO.readStrings().fromTopic(options.getInputTopic()))
+        // 2) Group the messages into fixed-sized minute intervals.
+        .apply(Window.into(FixedWindows.of(Duration.standardMinutes(options.getWindowSize()))))
+        // 3) Write one file to GCS for every window of messages.
+        .apply("Write Files to GCS", new WriteOneFilePerWindow(options.getOutput(), numShards));
+
+    // Execute the pipeline and wait until it finishes running.
+    pipeline.run().waitUntilFinish();
+  }
+}
+// [END pubsublite_to_gcs]

--- a/pubsublite/streaming-analytics/src/test/java/PubsubliteToGcsIT.java
+++ b/pubsublite/streaming-analytics/src/test/java/PubsubliteToGcsIT.java
@@ -1,0 +1,91 @@
+// Copyright 2021 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.apache.beam.examples.common.WriteOneFilePerWindow;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.TestStream;
+import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.Repeatedly;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TimestampedValue;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class PubsubliteToGcsIT {
+  @Rule public final TestPipeline p = TestPipeline.create();
+
+  private Instant baseTime = new Instant(0);
+
+  @Test
+  public void testPubsubliteToGcs() {
+    // Create a test stream.
+    TestStream<String> teststream =
+        TestStream.create(StringUtf8Coder.of())
+            .advanceWatermarkTo(baseTime)
+            .addElements(
+                TimestampedValue.of("Hello", baseTime.plus(Duration.standardSeconds(10L))),
+                TimestampedValue.of("Hello again", baseTime.plus(Duration.standardSeconds(50L))))
+            .advanceProcessingTime(Duration.standardSeconds(60))
+            .addElements(
+                TimestampedValue.of(
+                    "Hello last time", baseTime.plus(Duration.standardSeconds(90L))))
+            .advanceWatermarkToInfinity();
+
+    // Create an input PCollection.
+    PCollection<String> input = p.apply("Create elements", teststream);
+
+    // Apply the same windowing function as in the sample with a fixed time interval of 1 minute.
+    PCollection<String> output =
+        input.apply(
+            "Apply windowing function",
+            Window.<String>into(FixedWindows.of(Duration.standardMinutes(1L)))
+                .triggering(
+                    Repeatedly.forever(
+                        AfterProcessingTime.pastFirstElementInPane()
+                            .plusDelayOf(Duration.standardSeconds(30))))
+                .withAllowedLateness(Duration.ZERO)
+                .accumulatingFiredPanes());
+
+    IntervalWindow firstWindow = new IntervalWindow(baseTime, Duration.standardMinutes(1));
+    IntervalWindow secondWindow =
+        new IntervalWindow(baseTime.plus(Duration.standardMinutes(1)), Duration.standardMinutes(1));
+
+    // Assert that the first window has produced two elements.
+    PAssert.that(output).inWindow(firstWindow).containsInAnyOrder("Hello", "Hello again");
+
+    // Assert that the second window has produced one element.
+    PAssert.that(output).inWindow(secondWindow).containsInAnyOrder("Hello last time");
+
+    // Test writing the windowed elements to files locally instead of on Cloud Storage.
+    output.apply("Write elements to files", new WriteOneFilePerWindow("output", 1));
+
+    // Assert that the pipeline has created two files.
+    assertThat(Files.exists(Paths.get("output-00:00-00:01-0-of-1")));
+    assertThat(Files.exists(Paths.get("output-00:01-00:02-0-of-1")));
+
+    // Run the pipeline.
+    p.run().waitUntilFinish();
+  }
+}

--- a/pubsublite/streaming-analytics/src/test/java/PubsubliteToGcsIT.java
+++ b/pubsublite/streaming-analytics/src/test/java/PubsubliteToGcsIT.java
@@ -34,7 +34,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class PubsubliteToGcsIT {
-  @Rule public final TestPipeline p = TestPipeline.create();
+  @Rule public final TestPipeline testPipeline = TestPipeline.create();
 
   private Instant baseTime = new Instant(0);
 
@@ -54,7 +54,7 @@ public class PubsubliteToGcsIT {
             .advanceWatermarkToInfinity();
 
     // Create an input PCollection.
-    PCollection<String> input = p.apply("Create elements", teststream);
+    PCollection<String> input = testPipeline.apply("Create elements", teststream);
 
     // Apply the same windowing function as in the sample with a fixed time interval of 1 minute.
     PCollection<String> output =
@@ -86,6 +86,6 @@ public class PubsubliteToGcsIT {
     assertThat(Files.exists(Paths.get("output-00:01-00:02-0-of-1")));
 
     // Run the pipeline.
-    p.run().waitUntilFinish();
+    testPipeline.run().waitUntilFinish();
   }
 }


### PR DESCRIPTION
This is a planned sample (See internal b/186049986), to be published as an official quickstart as well. It uses PubsubLiteIO+Dataflow to read from Pub/Sub Lite (a streaming source), group messages by fixed windows, and write them to  Cloud Storage. 

### Known issues:
1. When run on Dataflow, this I/O connector will generate a lot of `java.lang.RuntimeException: ManagedChannel allocation site` errors due to improper channel shutdown, but this doesn't seem to negatively affect performance. Also tracked in https://github.com/googleapis/java-pubsublite/issues/548 and see the maintainer's [comment](https://github.com/googleapis/java-pubsublite/issues/548#issuecomment-801437469).

 > ![Screen Shot 2021-04-21 at 4 32 22 PM](https://user-images.githubusercontent.com/9518298/115634813-35ccce80-a2bf-11eb-96cf-89bf240fce3b.png)

2. When stopping the pipeline, the "Drain" option is unsupported. See the note in the I/O's [README](https://github.com/googleapis/java-pubsublite/blob/master/pubsublite-beam-io/README.md).

> ![Screen Shot 2021-04-21 at 4 35 11 PM](https://user-images.githubusercontent.com/9518298/115635032-a07e0a00-a2bf-11eb-96ff-411473ef6ad9.png)

3. This sample is written using the I/O connector released with the Java client library for Pub/Sub Lite. When its official version, i.e. the I/O released with Apache Beam, becomes stable (~May/June), this sample will need an update.
> Note the difference between:
> ```java
> import org.apache.beam.sdk.io.gcp.pubsublite.PubsubLiteIO;
> ``` 
> vs.
> ```java
> import com.google.cloud.pubsublite.beam.PubsubLiteIO
> ```