### PR TITLE
test: update IT to run Pub/Sub Lite I/O sample on GCP

### DIFF
--- a/pubsublite/streaming-analytics/pom.xml
+++ b/pubsublite/streaming-analytics/pom.xml
@@ -156,6 +156,18 @@
       <version>1.1.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+      <version>1.31.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-dataflow</artifactId>
+      <version>v1b3-rev20210408-1.31.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pubsublite/streaming-analytics/src/main/java/examples/PubsubliteToGcs.java
+++ b/pubsublite/streaming-analytics/src/main/java/examples/PubsubliteToGcs.java
@@ -65,7 +65,7 @@ public class PubsubliteToGcs {
 
   private static final Logger LOG = LoggerFactory.getLogger(PubsubliteToGcs.class);
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws InterruptedException {
     // The maximum number of shards when writing output files.
     int numShards = 1;
 
@@ -114,8 +114,9 @@ public class PubsubliteToGcs {
                 .accumulatingFiredPanes())
         .apply("Write elements to GCS", new WriteOneFilePerWindow(options.getOutput(), numShards));
 
-    // Execute the pipeline.
-    pipeline.run().waitUntilFinish();
+    // Execute the pipeline with an optional timeout for your local program.
+    // This will not cancel the remote job.
+    pipeline.run().waitUntilFinish(Duration.standardMinutes(10));
   }
 }
 // [END pubsublite_to_gcs]


### PR DESCRIPTION
Fixes #5113 

This test will add another 10 minutes to the tests 😖   

The tricky bit is canceling the Dataflow job using the Discovery API (apiary client) for Dataflow, which uses a different auth method: https://github.com/googleapis/google-auth-library-java#using-credentials-with-google-http-client

#### How does the test work?
A permanent Pub/Sub Lite topic has been created for this test. This Lite topic has some messages already published to it. Every time the test runs, a new Lite subscription is created for the topic and is configured to read all the messages in the topic. The Dataflow job, when run correctly, shall window the messages based on some logic defined by the windowing function and then write three files to Cloud Storage. The test checks for those files and passes when their content match the desired output. 