### PR TITLE
feat: add instructions for flex templates

### DIFF
--- a/pubsublite/streaming-analytics/metadata.json
+++ b/pubsublite/streaming-analytics/metadata.json
@@ -1,27 +1,27 @@
 {
   "name": "Pub/Sub Lite to Clous Storage",
-  "description": "An Apache Beam streaming pipeline that reads messages from Pub/Sub Lite, applies fixed windowing on the messages, and writes the results to files on Cloud Storage",
+  "description": "An Apache Beam streaming pipeline that reads messages from Pub/Sub Lite, applies fixed windowing on the messages, and writes the results to files on Cloud Storage.",
   "parameters": [
     {
       "name": "subscription",
-      "label": "Pub/Sub Lite subscription.",
-      "helpText": "Pub/Sub subscription to read from."
+      "label": "Pub/Sub Lite subscription",
+      "helpText": "Pub/Sub subscription to read from, e.g. projects/my-project/locations/us-central1-b/subscriptions/my-subscription."
     },
     {
       "name": "windowSize",
       "label": "Window size in minutes",
-      "helpText": "Window size of output files in minutes, default to 1.",
+      "helpText": "Window size of output files in minutes.",
       "regexes": [
-        "^[1-9][0-9]*"
+        "^[1-9][0-9]+$"
       ]
     },
     {
       "name": "output",
-      "label": "Filename prefix of output files, e.g. gs://my-bucket/my-filename",
-      "helpText": "Filename prefix of output files including the filepath.",
+      "label": "Filename prefix of output files including the file path",
+      "helpText": "Filename prefix of output files including the file path, e.g. gs://my-bucket/my-filename-prefix.",
       "isOptional": true,
       "regexes": [
-        "^gs:\/(\/[a-zA-Z0-9-]+){2,}"
+        "^gs:\\/\\/.*$"
       ]
     }
   ]

--- a/pubsublite/streaming-analytics/metadata.json
+++ b/pubsublite/streaming-analytics/metadata.json
@@ -1,0 +1,28 @@
+{
+  "name": "Pub/Sub Lite to Clous Storage",
+  "description": "An Apache Beam streaming pipeline that reads messages from Pub/Sub Lite, applies fixed windowing on the messages, and writes the results to files on Cloud Storage",
+  "parameters": [
+    {
+      "name": "subscription",
+      "label": "Pub/Sub Lite subscription.",
+      "helpText": "Pub/Sub subscription to read from."
+    },
+    {
+      "name": "windowSize",
+      "label": "Window size in minutes",
+      "helpText": "Window size of output files in minutes, default to 1.",
+      "regexes": [
+        "^[1-9][0-9]*"
+      ]
+    },
+    {
+      "name": "output",
+      "label": "Filename prefix of output files, e.g. gs://my-bucket/my-filename",
+      "helpText": "Filename prefix of output files including the filepath.",
+      "isOptional": true,
+      "regexes": [
+        "^gs:\/(\/[a-zA-Z0-9-]+){2,}"
+      ]
+    }
+  ]
+}

--- a/pubsublite/streaming-analytics/pom.xml
+++ b/pubsublite/streaming-analytics/pom.xml
@@ -160,13 +160,13 @@
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
       <version>1.31.2</version>
-      <scope>test</scope>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-dataflow</artifactId>
       <version>v1b3-rev20210408-1.31.0</version>
-      <scope>test</scope>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
 

--- a/pubsublite/streaming-analytics/src/main/java/examples/PubsubliteToGcs.java
+++ b/pubsublite/streaming-analytics/src/main/java/examples/PubsubliteToGcs.java
@@ -114,9 +114,8 @@ public class PubsubliteToGcs {
                 .accumulatingFiredPanes())
         .apply("Write elements to GCS", new WriteOneFilePerWindow(options.getOutput(), numShards));
 
-    // Execute the pipeline with an optional timeout for your local program.
-    // This will not cancel the remote job.
-    pipeline.run().waitUntilFinish(Duration.standardMinutes(10));
+    // Execute the pipeline.
+    pipeline.run();
   }
 }
 // [END pubsublite_to_gcs]

--- a/pubsublite/streaming-analytics/src/main/java/examples/PubsubliteToGcs.java
+++ b/pubsublite/streaming-analytics/src/main/java/examples/PubsubliteToGcs.java
@@ -107,14 +107,14 @@ public class PubsubliteToGcs {
                             .plusDelayOf(Duration.standardSeconds(30))))
                 // Ignore late elements.
                 .withAllowedLateness(Duration.ZERO)
-                // Accumulate elements in fired panes. This will make sure that when writing the
-                // elements to files later, the elements collected in an earlier pane by an earlier
-                // trigger will not be overwritten by those arriving later due to a later trigger
-                // fired within the boundaries of the same window.
+                // Accumulate elements in fired panes. This will make sure that elements collected
+                // in an earlier pane by an earlier trigger will not be overwritten by those
+                // arriving later due to a later trigger fired in the same window.
                 .accumulatingFiredPanes())
         .apply("Write elements to GCS", new WriteOneFilePerWindow(options.getOutput(), numShards));
 
-    // Execute the pipeline.
+    // Execute the pipeline. You may add `.waitUntilFinish()` to observe logs in your console, but
+    // `waitUntilFinish()` will not work in Dataflow Flex Templates.
     pipeline.run();
   }
 }

--- a/pubsublite/streaming-analytics/src/test/java/PubsubliteToGcsIT.java
+++ b/pubsublite/streaming-analytics/src/test/java/PubsubliteToGcsIT.java
@@ -47,6 +47,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.values.KV;
 import org.junit.After;
@@ -190,6 +191,9 @@ public class PubsubliteToGcsIT {
           "--tempLocation=gs://" + bucketName + "/temp",
           "--jobName=" + jobName
         });
+
+    // Wait 10 minute for the Dataflow job.
+    TimeUnit.MINUTES.sleep(10);
 
     // Check for output files.
     Page<Blob> blobs = storage.list(bucketName, Storage.BlobListOption.prefix(directoryPrefix));


### PR DESCRIPTION
Add instructions for turning a Dataflow pipeline into a [Dataflow flex template](https://cloud.google.com/dataflow/docs/guides/templates/using-flex-templates), which can be run with different input parameters via gcloud as well as in Cloud Console.

- updated README to include instructions.
- `metadata.json` is a required file for creating a flex template.
- the Dataflow Discovery API dependencies have to be given the scope `runtime` for flex templates.
- Flex templates don't allow `pipeline.run().waitUntilFinish()`. Removed `waitUntilFisnish()` from sample.
- used a blocking call to wait 10 minutes in test instead. 