### PR TITLE
Set up application to be packaged as an uber-jar via application.properties

### DIFF
--- a/appengine-java11/quarkus-helloworld/src/main/resources/application.properties
+++ b/appengine-java11/quarkus-helloworld/src/main/resources/application.properties
@@ -14,3 +14,4 @@
 
 # Set the port to the PORT environment variable
 quarkus.http.port=${PORT:8080}
+quarkus.package.type=uber-jar


### PR DESCRIPTION
I have noticed that Quarkus GAE "hello world" example doesn't work, as uber JAR is not produced. To rectify this, it is necessary to add 

```
quarkus.package.type=uber-jar
```

to ```applications.properties```, as per [documentation](https://quarkus.io/guides/deploying-to-google-cloud)