### PR TITLE
chore: escape the escape character in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
       "groupName": "AppEngine packages"
     },
     {
-      "allowedVersions": "!/.+-sp\.[0-9]+$/"
+      "allowedVersions": "!/.+-sp\\.[0-9]+$/"
     },
     {
       "packagePatterns": [


### PR DESCRIPTION
Fixes #1727

JSON requires the backslash itself to be escaped, so that it can be a single backslash-escape in the regex. 