### PR TITLE
chore(renovate): add required match section to package rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,7 @@
       "groupName": "AppEngine packages"
     },
     {
+      "matchPackagePrefixes": [ "com.google" ],
       "allowedVersions": "!/.+-sp\\.[0-9]+$/"
     },
     {


### PR DESCRIPTION
Fixes #1727

Looks like a match rule is required. Docs for change: https://docs.renovatebot.com/configuration-options/#matchpackageprefixes
