### PR TITLE
Add a Cloud Spanner with Spring Data R2DBC sample app

### DIFF
--- a/spanner/r2dbc/README.md
+++ b/spanner/r2dbc/README.md
@@ -1,0 +1,47 @@
+# Cloud Spanner R2DBC Example
+
+This sample application demonstrates using Spring Data R2DBC with [Google Cloud Spanner](https://cloud.google.com/spanner/).
+
+## Maven
+This sample uses the [Apache Maven][maven] build system. Before getting started, be
+sure to [download][maven-download] and [install][maven-install] it. When you use
+Maven as described here, it will automatically download the needed client
+libraries.
+
+[maven]: https://maven.apache.org
+[maven-download]: https://maven.apache.org/download.cgi
+[maven-install]: https://maven.apache.org/install.html
+
+## Setup
+
+1.  Follow the set-up instructions in [the documentation](https://cloud.google.com/java/docs/setup).
+
+2.  Enable APIs for your project.
+    [Click here](https://console.cloud.google.com/flows/enableapi?apiid=spanner.googleapis.com&showconfirmation=true)
+    to visit Cloud Platform Console and enable the Google Cloud Spanner API.
+
+3.  Create a Cloud Spanner instance and database via the Cloud Plaform Console's
+    [Cloud Spanner section](http://console.cloud.google.com/spanner).
+
+4.  Enable application default credentials by running the command `gcloud auth application-default login`.
+
+## Run the Example
+
+1. Set up the following environment variables to help the application locate your database:
+
+    ````
+    export project=[PROJECT]
+    export instance=[INSTANCE]
+    export database=[DATABASE]
+    ````
+
+2. Then run the application from command line, after switching to this directory:
+
+    ````
+    mvn spring-boot:run
+    ````
+
+3. Go to http://localhost:8080/index.html and experiment with it.
+You'll be able to create and drop a simple table called `NAMES`, containing two columns: a unique identifier (`UUID`) and a single data column called `NAME`.
+
+All functionality is done through the Spring Data objects that were automatically configured by Spring Boot.

--- a/spanner/r2dbc/pom.xml
+++ b/spanner/r2dbc/pom.xml
@@ -52,6 +52,21 @@
       <version>${spring-boot.version}</version>
     </dependency>
 
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <version>${spring-boot.version}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/spanner/r2dbc/pom.xml
+++ b/spanner/r2dbc/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.example</groupId>
+  <artifactId>cloud-spanner-r2dbc</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <spring-boot.version>2.4.5</spring-boot.version>
+  </properties>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.0.22</version>
+  </parent>
+
+  <dependencies>
+
+    <!-- [START spanner_spring_data_r2dbc_dependency] -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-spanner-spring-data-r2dbc</artifactId>
+      <version>0.5.0</version>
+    </dependency>
+    <!-- [END spanner_spring_data_r2dbc_dependency] -->
+
+    <!-- The driver (cloud-spanner-r2dbc) dependency is actually redundant since the previous
+     module transitively imports it. The dependency is there for documentation. -->
+
+    <!-- [START spanner_r2dbc_dependency] -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-spanner-r2dbc</artifactId>
+      <version>0.5.0</version>
+    </dependency>
+    <!-- [END spanner_r2dbc_dependency] -->
+
+    <!-- Unrelated to R2DBC; Spring Webflux is a web application framework -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
+      <version>${spring-boot.version}</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot.version}</version>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/spanner/r2dbc/src/main/java/com/example/spanner/r2dbc/Name.java
+++ b/spanner/r2dbc/src/main/java/com/example/spanner/r2dbc/Name.java
@@ -30,6 +30,10 @@ public class Name {
   @Column("NAME")
   private String name;
 
+  public Name() {
+    // needed for deserialization
+  }
+
   public Name(String uuid, String name) {
     this.uuid = uuid;
     this.name = name;

--- a/spanner/r2dbc/src/main/java/com/example/spanner/r2dbc/Name.java
+++ b/spanner/r2dbc/src/main/java/com/example/spanner/r2dbc/Name.java
@@ -1,0 +1,29 @@
+package com.example.spanner.r2dbc;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table("NAMES")
+public class Name {
+
+  @Id
+  @Column("UUID")
+  private String uuid;
+
+  @Column("NAME")
+  private String name;
+
+  public Name(String uuid, String name) {
+    this.uuid = uuid;
+    this.name = name;
+  }
+
+  public String getUuid() {
+    return uuid;
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/spanner/r2dbc/src/main/java/com/example/spanner/r2dbc/Name.java
+++ b/spanner/r2dbc/src/main/java/com/example/spanner/r2dbc/Name.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.spanner.r2dbc;
 
 import org.springframework.data.annotation.Id;

--- a/spanner/r2dbc/src/main/java/com/example/spanner/r2dbc/R2dbcSampleApplication.java
+++ b/spanner/r2dbc/src/main/java/com/example/spanner/r2dbc/R2dbcSampleApplication.java
@@ -1,0 +1,12 @@
+package com.example.spanner.r2dbc;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class R2dbcSampleApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(R2dbcSampleApplication.class, args);
+  }
+}

--- a/spanner/r2dbc/src/main/java/com/example/spanner/r2dbc/R2dbcSampleApplication.java
+++ b/spanner/r2dbc/src/main/java/com/example/spanner/r2dbc/R2dbcSampleApplication.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.spanner.r2dbc;
 
 import org.springframework.boot.SpringApplication;

--- a/spanner/r2dbc/src/main/java/com/example/spanner/r2dbc/WebController.java
+++ b/spanner/r2dbc/src/main/java/com/example/spanner/r2dbc/WebController.java
@@ -25,7 +25,6 @@ import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;

--- a/spanner/r2dbc/src/main/java/com/example/spanner/r2dbc/WebController.java
+++ b/spanner/r2dbc/src/main/java/com/example/spanner/r2dbc/WebController.java
@@ -1,0 +1,63 @@
+package com.example.spanner.r2dbc;
+
+import static org.springframework.data.relational.core.query.Criteria.where;
+import static org.springframework.data.relational.core.query.Query.query;
+
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@RestController
+public class WebController {
+
+  @Autowired
+  R2dbcEntityTemplate r2dbcEntityTemplate;
+
+
+  @PostMapping("createTable")
+  public Mono<String> createTable() {
+    return r2dbcEntityTemplate.getDatabaseClient()
+        .sql("CREATE TABLE NAMES " +
+            "(UUID STRING(36), NAME STRING(60) NOT NULL) " +
+            "PRIMARY KEY (UUID)")
+        .fetch()
+        .rowsUpdated()
+        .map(numRows -> "table NAMES created successfully")
+        .onErrorResume(error -> Mono.just("table creation failed: " + error.getMessage()));
+  }
+
+  @PostMapping("dropTable")
+  public Mono<String> dropTable() {
+    return r2dbcEntityTemplate.getDatabaseClient().sql("DROP TABLE NAMES")
+        .fetch().rowsUpdated().map(numRows -> "table NAMES dropped successfully")
+        .onErrorResume(error -> Mono.just("table deletion failed: " + error.getMessage()));
+  }
+
+  @GetMapping("listRows")
+  public Flux<Name> listRows() {
+    return r2dbcEntityTemplate.select(Name.class)
+        .all();
+  }
+
+  @PostMapping("addRow")
+  public Mono<String> addRow(@RequestBody String newName) {
+    return r2dbcEntityTemplate.insert(new Name(UUID.randomUUID().toString(), newName))
+      .map(numRows -> "row inserted successfully")
+        .onErrorResume(error -> Mono.just("row insertion failed: " + error.getMessage()));
+  }
+
+  @PostMapping("deleteRow")
+  public Mono<String> deleteRow(@RequestBody String uuid) {
+    return r2dbcEntityTemplate.delete(Name.class).matching(query(where("uuid").is(uuid)))
+        .all()
+        .map(numDeleted -> numDeleted > 0 ? "row deleted successfully" : "row did not exist")
+        .onErrorResume(error -> Mono.just("row deletion failed: " + error.getMessage()));
+  }
+}

--- a/spanner/r2dbc/src/main/java/com/example/spanner/r2dbc/WebController.java
+++ b/spanner/r2dbc/src/main/java/com/example/spanner/r2dbc/WebController.java
@@ -35,7 +35,6 @@ public class WebController {
   @Autowired
   R2dbcEntityTemplate r2dbcEntityTemplate;
 
-
   @PostMapping("createTable")
   public Mono<String> createTable() {
     return r2dbcEntityTemplate.getDatabaseClient()

--- a/spanner/r2dbc/src/main/java/com/example/spanner/r2dbc/WebController.java
+++ b/spanner/r2dbc/src/main/java/com/example/spanner/r2dbc/WebController.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.spanner.r2dbc;
 
 import static org.springframework.data.relational.core.query.Criteria.where;
@@ -24,9 +40,9 @@ public class WebController {
   @PostMapping("createTable")
   public Mono<String> createTable() {
     return r2dbcEntityTemplate.getDatabaseClient()
-        .sql("CREATE TABLE NAMES " +
-            "(UUID STRING(36), NAME STRING(60) NOT NULL) " +
-            "PRIMARY KEY (UUID)")
+        .sql("CREATE TABLE NAMES "
+            + "(UUID STRING(36), NAME STRING(60) NOT NULL) "
+            + "PRIMARY KEY (UUID)")
         .fetch()
         .rowsUpdated()
         .map(numRows -> "table NAMES created successfully")

--- a/spanner/r2dbc/src/main/resources/application.properties
+++ b/spanner/r2dbc/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.r2dbc.url=\
+r2dbc:spanner://spanner.googleapis.com:443/projects/${project}/instances/${instance}/databases/${database}

--- a/spanner/r2dbc/src/main/resources/application.properties
+++ b/spanner/r2dbc/src/main/resources/application.properties
@@ -1,2 +1,16 @@
+#  Copyright 2021 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 spring.r2dbc.url=\
 r2dbc:spanner://spanner.googleapis.com:443/projects/${project}/instances/${instance}/databases/${database}

--- a/spanner/r2dbc/src/main/resources/static/index.html
+++ b/spanner/r2dbc/src/main/resources/static/index.html
@@ -1,0 +1,104 @@
+<html>
+  <head>
+    <title>R2DBC Sample Application</title>
+
+    <script>
+      function createTable() {
+        setStatus("WAIT...");
+        fetch('/createTable', {method: 'POST'})
+          .then(response => response.text())
+          .then(status => setStatus(status));
+        return false;
+      }
+
+      function dropTable() {
+        setStatus("WAIT...");
+        fetch('/dropTable', {method: 'POST'})
+          .then(response => response.text())
+          .then(status => setStatus(status));
+        return false;
+      }
+
+      function listRows() {
+        setStatus("WAIT...");
+        fetch('/listRows')
+          .then(response => response.json())
+          .then(listOfRows => {
+            setStatus(listOfRows.map(row => row.name + " (" + row.uuid + ")").join("<br/>"))
+          });
+        return false;
+      }
+
+      function addRow() {
+        setStatus("WAIT...");
+        const name = document.getElementById('newName').value;
+        if (!name) {
+          setStatus("Please provide a non-empty name");
+          return false;
+        }
+        fetch('/addRow', {
+            method: 'POST',
+            body: name
+          })
+          .then(response => response.text())
+          .then(status => setStatus(status));
+        return false;
+      }
+
+      function deleteRow() {
+        setStatus("WAIT...");
+        const uuid = document.getElementById('uuid').value;
+        if (!uuid) {
+          setStatus("Please provide a non-empty uuid");
+          return false;
+        }
+        fetch('/deleteRow', {
+            method: 'POST',
+            body: uuid
+          })
+          .then(response => response.text())
+          .then(status => setStatus(status));
+        return false;
+      }
+
+      function setStatus(status) {
+        document.getElementById("status").innerHTML = status;
+      }
+    </script>
+
+    <style>
+      #status {
+        margin: 2em 0;
+        border: 1px solid green;
+      }
+
+      div { margin-top: 1em; }
+    </style>
+  </head>
+
+  <body>
+
+    <h2>Table actions</h2>
+    <div>
+      <button onClick="return createTable();">Create Table</button>
+    </div>
+    <div>
+      <button onClick="return dropTable();">Drop Table</button>
+    </div>
+
+    <h2>Row actions</h2>
+    <div>
+      <button onClick="return listRows();">List Rows</button>
+    </div>
+    <div>
+      Name: <input id="newName"/> <button onClick="return addRow();">Insert Row</button>
+    </div>
+    <div>
+      UUID: <input id="uuid"/> <button onClick="return deleteRow();">Delete Row</button>
+    </div>
+
+
+    <h2>Operation status</h2>
+    <div id="status"></div>
+  </body>
+</html>

--- a/spanner/r2dbc/src/test/java/com/example/spanner/r2dbc/R2dbcSampleApplicationIT.java
+++ b/spanner/r2dbc/src/test/java/com/example/spanner/r2dbc/R2dbcSampleApplicationIT.java
@@ -25,7 +25,7 @@ import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerOptions;
 import java.time.Duration;
 import java.util.Collections;
-import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
 import org.junit.Before;
@@ -48,9 +48,10 @@ public class R2dbcSampleApplicationIT {
 
   @DynamicPropertySource
   static void registerProperties(DynamicPropertyRegistry registry) {
-    int rand = Math.abs((new Random()).nextInt());
     registry.add("project", () -> ServiceOptions.getDefaultProjectId());
-    registry.add("database", () -> "r2dbc-docs-testdb-" + rand);
+    // Spanner DB name limit is 30 characters; cannot end with "-".
+    String suffix = UUID.randomUUID().toString().substring(0, 23);
+    registry.add("database", () -> "r2dbc-" + suffix);
 
     assertNotNull("Please provide spanner.test.instance environment variable",
         System.getProperty("spanner.test.instance"));
@@ -86,7 +87,7 @@ public class R2dbcSampleApplicationIT {
   }
 
   @Test
-  public void createTable() {
+  public void testAllWebEndpoints() {
 
     // DDL takes time; extend timeout to avoid "Timeout on blocking read" exceptions.
     webTestClient = webTestClient.mutate().responseTimeout(Duration.ofSeconds(10)).build();

--- a/spanner/r2dbc/src/test/java/com/example/spanner/r2dbc/R2dbcSampleApplicationIT.java
+++ b/spanner/r2dbc/src/test/java/com/example/spanner/r2dbc/R2dbcSampleApplicationIT.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.r2dbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.spanner.DatabaseAdminClient;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.SpannerOptions;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.r2dbc.core.DatabaseClient;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class R2dbcSampleApplicationIT {
+
+  @DynamicPropertySource
+  static void registerProperties(DynamicPropertyRegistry registry) {
+    int rand = Math.abs((new Random()).nextInt());
+    registry.add("project", () -> ServiceOptions.getDefaultProjectId());
+    registry.add("database", () -> "r2dbc-docs-testdb-" + rand);
+
+    assertNotNull("Please provide spanner.test.instance environment variable",
+        System.getProperty("spanner.test.instance"));
+    registry.add("instance", () -> System.getProperty("spanner.test.instance"));
+  }
+
+  @Value("${database}")
+  String databaseName;
+
+  @Value("${instance}")
+  String instance;
+
+  @Autowired
+  private WebTestClient webTestClient;
+
+  @Autowired
+  DatabaseClient databaseClient;
+
+  DatabaseAdminClient dbAdminClient;
+
+  // setup/teardown cannot be static because then properties will not be injected yet
+  @Before
+  public void createDatabase() {
+    SpannerOptions options = SpannerOptions.newBuilder().build();
+    Spanner spanner = options.getService();
+    dbAdminClient = spanner.getDatabaseAdminClient();
+    dbAdminClient.createDatabase(instance, this.databaseName, Collections.EMPTY_LIST);
+  }
+
+  @After
+  public void dropDatabase() {
+    dbAdminClient.dropDatabase(instance, this.databaseName);
+  }
+
+  @Test
+  public void createTable() {
+
+    // DDL takes time; extend timeout to avoid "Timeout on blocking read" exceptions.
+    webTestClient = webTestClient.mutate().responseTimeout(Duration.ofSeconds(10)).build();
+
+    this.webTestClient.post().uri("/createTable").exchange()
+        .expectBody(String.class).isEqualTo("table NAMES created successfully");
+
+    // initially empty table
+    this.webTestClient.get().uri("/listRows").exchange()
+        .expectBody(String[].class).isEqualTo(new String[0]);
+
+    this.webTestClient.post().uri("/addRow").body(Mono.just("Bob"), String.class).exchange()
+        .expectBody(String.class).isEqualTo("row inserted successfully");
+
+    AtomicReference<String> uuid = new AtomicReference<>();
+    this.webTestClient.get().uri("/listRows").exchange()
+        .expectBody(Name[].class)
+        .consumeWith(result -> {
+          Name[] names = result.getResponseBody();
+          assertEquals("1 row expected", 1, names.length);
+          assertEquals("where is Bob?", "Bob", names[0].getName());
+          uuid.set(names[0].getUuid());
+        });
+
+    this.webTestClient.post().uri("/deleteRow").body(Mono.just(uuid.get()), String.class)
+        .exchange()
+        .expectBody(String.class).isEqualTo("row deleted successfully");
+
+    this.webTestClient.post().uri("/deleteRow").body(Mono.just("nonexistent"), String.class)
+        .exchange()
+        .expectBody(String.class).isEqualTo("row did not exist");
+
+    this.webTestClient.post().uri("/dropTable").exchange()
+        .expectBody(String.class).isEqualTo("table NAMES dropped successfully");
+
+  }
+
+}


### PR DESCRIPTION
This sample uses the already-enabled Cloud Spanner API. This PR does not include an integration test, but if we add one, the environment variables will also be reused from the client library/JDBC Cloud Spanner examples.

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [x] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
PMD reporting Spring Endpoints as a potential security issue. For a sample application, it is surely not.
- [x] Please **merge** this PR for me once it is approved.
