### PR TITLE
chore(storage): move storage/s3-sdk into a package

### DIFF
--- a/storage/s3-sdk/src/main/java/storage/s3sdk/ListGcsBuckets.java
+++ b/storage/s3-sdk/src/main/java/storage/s3sdk/ListGcsBuckets.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package storage.s3sdk;
+
+// [START storage_s3_sdk_list_buckets]
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.Bucket;
+import java.util.List;
+
+public class ListGcsBuckets {
+  public static void listGcsBuckets(String googleAccessKeyId, String googleAccessKeySecret) {
+
+    // String googleAccessKeyId = "your-google-access-key-id";
+    // String googleAccessKeySecret = "your-google-access-key-secret";
+
+    // Create a BasicAWSCredentials using Cloud Storage HMAC credentials.
+    BasicAWSCredentials googleCreds =
+        new BasicAWSCredentials(googleAccessKeyId, googleAccessKeySecret);
+
+    // Create a new client and do the following:
+    // 1. Change the endpoint URL to use the Google Cloud Storage XML API endpoint.
+    // 2. Use Cloud Storage HMAC Credentials.
+    AmazonS3 interopClient =
+        AmazonS3ClientBuilder.standard()
+            .withEndpointConfiguration(
+                new AwsClientBuilder.EndpointConfiguration(
+                    "https://storage.googleapis.com", "auto"))
+            .withCredentials(new AWSStaticCredentialsProvider(googleCreds))
+            .build();
+
+    // Call GCS to list current buckets
+    List<Bucket> buckets = interopClient.listBuckets();
+
+    // Print bucket names
+    System.out.println("Buckets:");
+    for (Bucket bucket : buckets) {
+      System.out.println(bucket.getName());
+    }
+
+    // Explicitly clean up client resources.
+    interopClient.shutdown();
+  }
+  // [END storage_s3_sdk_list_buckets]
+}

--- a/storage/s3-sdk/src/main/java/storage/s3sdk/ListGcsObjects.java
+++ b/storage/s3-sdk/src/main/java/storage/s3sdk/ListGcsObjects.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package storage.s3sdk;
+
+// [START storage_s3_sdk_list_objects]
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+
+public class ListGcsObjects {
+  public static void listGcsObjects(
+      String googleAccessKeyId, String googleAccessKeySecret, String bucketName) {
+
+    // String googleAccessKeyId = "your-google-access-key-id";
+    // String googleAccessKeySecret = "your-google-access-key-secret";
+    // String bucketName = "bucket-name";
+
+    // Create a BasicAWSCredentials using Cloud Storage HMAC credentials.
+    BasicAWSCredentials googleCreds =
+        new BasicAWSCredentials(googleAccessKeyId, googleAccessKeySecret);
+
+    // Create a new client and do the following:
+    // 1. Change the endpoint URL to use the Google Cloud Storage XML API endpoint.
+    // 2. Use Cloud Storage HMAC Credentials.
+    AmazonS3 interopClient =
+        AmazonS3ClientBuilder.standard()
+            .withEndpointConfiguration(
+                new AwsClientBuilder.EndpointConfiguration(
+                    "https://storage.googleapis.com", "auto"))
+            .withCredentials(new AWSStaticCredentialsProvider(googleCreds))
+            .build();
+
+    // Call GCS to list current objects
+    ObjectListing objects = interopClient.listObjects(bucketName);
+
+    // Print objects names
+    System.out.println("Objects:");
+    for (S3ObjectSummary object : objects.getObjectSummaries()) {
+      System.out.println(object.getKey());
+    }
+
+    // Explicitly clean up client resources.
+    interopClient.shutdown();
+  }
+}
+// [END storage_s3_sdk_list_objects]

--- a/storage/s3-sdk/src/test/java/storage/s3sdk/ListGcsBucketsTest.java
+++ b/storage/s3-sdk/src/test/java/storage/s3sdk/ListGcsBucketsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package storage.s3sdk;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import com.amazonaws.services.s3.model.Bucket;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.List;
+import org.hamcrest.CoreMatchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ListGcsBucketsTest {
+  private static final String BUCKET = System.getenv("GOOGLE_CLOUD_PROJECT_S3_SDK");
+  private static final String KEY_ID = System.getenv("STORAGE_HMAC_ACCESS_KEY_ID");
+  private static final String SECRET_KEY = System.getenv("STORAGE_HMAC_ACCESS_SECRET_KEY");
+  private ByteArrayOutputStream bout;
+
+  private static void requireEnvVar(String varName) {
+    assertNotNull(
+        System.getenv(varName),
+        "Environment variable '%s' is required to perform these tests.".format(varName)
+    );
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT_S3_SDK");
+    requireEnvVar("STORAGE_HMAC_ACCESS_KEY_ID");
+    requireEnvVar("STORAGE_HMAC_ACCESS_SECRET_KEY");
+  }
+
+  @Before
+  public void beforeTest() {
+    bout = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(bout));
+  }
+
+  @After
+  public void tearDown() {
+    System.setOut(null);
+    bout.reset();
+  }
+
+  @Test
+  public void testListBucket() throws Exception {
+    ListGcsBuckets.listGcsBuckets(KEY_ID, SECRET_KEY);
+    String output = bout.toString();
+    assertThat(output, CoreMatchers.containsString("Buckets:"));
+  }
+}

--- a/storage/s3-sdk/src/test/java/storage/s3sdk/ListGcsObjectsTest.java
+++ b/storage/s3-sdk/src/test/java/storage/s3sdk/ListGcsObjectsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package storage.s3sdk;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import com.amazonaws.services.s3.model.Bucket;
+import com.amazonaws.services.s3.model.ObjectListing;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.List;
+import org.hamcrest.CoreMatchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+
+public class ListGcsObjectsTest {
+  private static final String BUCKET = System.getenv("GOOGLE_CLOUD_PROJECT_S3_SDK");
+  private static final String KEY_ID = System.getenv("STORAGE_HMAC_ACCESS_KEY_ID");
+  private static final String SECRET_KEY = System.getenv("STORAGE_HMAC_ACCESS_SECRET_KEY");
+  private ByteArrayOutputStream bout;
+
+  private static void requireEnvVar(String varName) {
+    assertNotNull(
+        System.getenv(varName),
+        "Environment variable '%s' is required to perform these tests.".format(varName)
+    );
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT_S3_SDK");
+    requireEnvVar("STORAGE_HMAC_ACCESS_KEY_ID");
+    requireEnvVar("STORAGE_HMAC_ACCESS_SECRET_KEY");
+  }
+
+  @Before
+  public void beforeTest() {
+    bout = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(bout));
+  }
+
+  @After
+  public void tearDown() {
+    System.setOut(null);
+    bout.reset();
+  }
+
+  @Test
+  public void testListObjects() throws Exception {
+    ListGcsObjects.listGcsObjects(KEY_ID, SECRET_KEY, BUCKET);
+    String output = bout.toString();
+    assertThat(output, CoreMatchers.containsString("Objects:"));
+  }
+}


### PR DESCRIPTION
This will allow better reporting for storage test failures. In order
to avoid breaking docs links, I'm first going to copy the files
and then delete the originals in a separate PR.


> It's a good idea to open an issue first for discussion.

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] Please **merge** this PR for me once it is approved.
