### PR TITLE
test(storage): fix S3 SDK tests

### DIFF
--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -63,8 +63,6 @@ if [[ "$SCRIPT_DEBUG" != "true" ]]; then
     export DATALABELING_ENDPOINT="test-datalabeling.sandbox.googleapis.com:443"
     # shellcheck source=src/aws-secrets.sh
     source "${KOKORO_GFILE_DIR}/aws-secrets.sh"
-    # shellcheck source=src/storage-hmac-credentials.sh
-    source "${KOKORO_GFILE_DIR}/storage-hmac-credentials.sh"
     # shellcheck source=src/dlp_secrets.txt
     source "${KOKORO_GFILE_DIR}/dlp_secrets.txt"
     # shellcheck source=src/bigtable_secrets.txt

--- a/storage/s3-sdk/README.md
+++ b/storage/s3-sdk/README.md
@@ -32,11 +32,13 @@ Install [Maven](http://maven.apache.org/).
 
 ## Test Sample
 
+1. Provide a service account which can be used to generate HMAC Key for the scope of the tests
+   
+   * GOOGLE_APPLICATION_CREDENTIALS=[PATH_TO_SERVICE_ACCOUNT_JSON]
+
 1. Set the following environment variable with the default project for Interoperable Storage Access Keys.
 
    * GOOGLE_CLOUD_PROJECT_S3_SDK=[GOOGLE_PROJECT_ID]
-   * STORAGE_HMAC_ACCESS_KEY_ID=[ACCESS_KEY_ID]
-   * STORAGE_HMAC_ACCESS_SECRET_KEY=[ACCESS_SECRET_KEY]
 
 1. Run test using the following Maven command:
 

--- a/storage/s3-sdk/README.md
+++ b/storage/s3-sdk/README.md
@@ -38,7 +38,7 @@ Install [Maven](http://maven.apache.org/).
 
 1. Set the following environment variable with the default project for Interoperable Storage Access Keys.
 
-   * GOOGLE_CLOUD_PROJECT_S3_SDK=[GOOGLE_PROJECT_ID]
+   * GOOGLE_CLOUD_PROJECT_S3_SDK_BUCKET_NAME=[GOOGLE_PROJECT_ID]
 
 1. Run test using the following Maven command:
 

--- a/storage/s3-sdk/pom.xml
+++ b/storage/s3-sdk/pom.xml
@@ -53,5 +53,11 @@
       <version>1.1.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-storage</artifactId>
+      <version>1.115.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/storage/s3-sdk/src/test/java/storage/s3sdk/ListGcsBucketsTest.java
+++ b/storage/s3-sdk/src/test/java/storage/s3sdk/ListGcsBucketsTest.java
@@ -16,55 +16,31 @@
 
 package storage.s3sdk;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
-import com.amazonaws.services.s3.model.Bucket;
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.util.List;
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
+import com.google.cloud.testing.junit4.StdOutCaptureRule;
 import org.hamcrest.CoreMatchers;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class ListGcsBucketsTest {
-  private static final String BUCKET = System.getenv("GOOGLE_CLOUD_PROJECT_S3_SDK");
-  private static final String KEY_ID = System.getenv("STORAGE_HMAC_ACCESS_KEY_ID");
-  private static final String SECRET_KEY = System.getenv("STORAGE_HMAC_ACCESS_SECRET_KEY");
-  private ByteArrayOutputStream bout;
 
-  private static void requireEnvVar(String varName) {
-    assertNotNull(
-        System.getenv(varName),
-        "Environment variable '%s' is required to perform these tests.".format(varName)
-    );
-  }
+  @ClassRule public static final TestHmacKeyRule hmacKey = new TestHmacKeyRule();
 
-  @BeforeClass
-  public static void checkRequirements() {
-    requireEnvVar("GOOGLE_CLOUD_PROJECT_S3_SDK");
-    requireEnvVar("STORAGE_HMAC_ACCESS_KEY_ID");
-    requireEnvVar("STORAGE_HMAC_ACCESS_SECRET_KEY");
-  }
+  /**
+   * Hmac Keys can take a little bit of time to propagate. Run our test multiple times with some
+   * backoff to try and allow for the propagation.
+   */
+  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3, 5_000);
 
-  @Before
-  public void beforeTest() {
-    bout = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(bout));
-  }
-
-  @After
-  public void tearDown() {
-    System.setOut(null);
-    bout.reset();
-  }
+  @Rule public final StdOutCaptureRule stdOut = new StdOutCaptureRule();
 
   @Test
-  public void testListBucket() throws Exception {
-    ListGcsBuckets.listGcsBuckets(KEY_ID, SECRET_KEY);
-    String output = bout.toString();
+  public void testListBucket() {
+    ListGcsBuckets.listGcsBuckets(hmacKey.getAccessKeyId(), hmacKey.getAccessSecretKey());
+    String output = stdOut.getCapturedOutputAsUtf8String();
     assertThat(output, CoreMatchers.containsString("Buckets:"));
   }
 }

--- a/storage/s3-sdk/src/test/java/storage/s3sdk/ListGcsObjectsTest.java
+++ b/storage/s3-sdk/src/test/java/storage/s3sdk/ListGcsObjectsTest.java
@@ -19,54 +19,40 @@ package storage.s3sdk;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
-import com.amazonaws.services.s3.model.Bucket;
-import com.amazonaws.services.s3.model.ObjectListing;
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.util.List;
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
+import com.google.cloud.testing.junit4.StdOutCaptureRule;
 import org.hamcrest.CoreMatchers;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
-
 
 public class ListGcsObjectsTest {
   private static final String BUCKET = System.getenv("GOOGLE_CLOUD_PROJECT_S3_SDK");
-  private static final String KEY_ID = System.getenv("STORAGE_HMAC_ACCESS_KEY_ID");
-  private static final String SECRET_KEY = System.getenv("STORAGE_HMAC_ACCESS_SECRET_KEY");
-  private ByteArrayOutputStream bout;
 
-  private static void requireEnvVar(String varName) {
-    assertNotNull(
-        System.getenv(varName),
-        "Environment variable '%s' is required to perform these tests.".format(varName)
-    );
-  }
+  @ClassRule public static final TestHmacKeyRule hmacKey = new TestHmacKeyRule();
+
+  /**
+   * Hmac Keys can take a little bit of time to propagate. Run our test multiple times with some
+   * backoff to try and allow for the propagation.
+   */
+  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3, 5_000);
+
+  @Rule public final StdOutCaptureRule stdOut = new StdOutCaptureRule();
 
   @BeforeClass
   public static void checkRequirements() {
-    requireEnvVar("GOOGLE_CLOUD_PROJECT_S3_SDK");
-    requireEnvVar("STORAGE_HMAC_ACCESS_KEY_ID");
-    requireEnvVar("STORAGE_HMAC_ACCESS_SECRET_KEY");
-  }
-
-  @Before
-  public void beforeTest() {
-    bout = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(bout));
-  }
-
-  @After
-  public void tearDown() {
-    System.setOut(null);
-    bout.reset();
+    assertNotNull(
+        System.getenv("GOOGLE_CLOUD_PROJECT_S3_SDK"),
+        String.format(
+            "Environment variable '%s' is required to perform these tests.",
+            "GOOGLE_CLOUD_PROJECT_S3_SDK"));
   }
 
   @Test
-  public void testListObjects() throws Exception {
-    ListGcsObjects.listGcsObjects(KEY_ID, SECRET_KEY, BUCKET);
-    String output = bout.toString();
+  public void testListObjects() {
+    ListGcsObjects.listGcsObjects(hmacKey.getAccessKeyId(), hmacKey.getAccessSecretKey(), BUCKET);
+    String output = stdOut.getCapturedOutputAsUtf8String();
     assertThat(output, CoreMatchers.containsString("Objects:"));
   }
 }

--- a/storage/s3-sdk/src/test/java/storage/s3sdk/TestHmacKeyRule.java
+++ b/storage/s3-sdk/src/test/java/storage/s3sdk/TestHmacKeyRule.java
@@ -59,7 +59,9 @@ public final class TestHmacKeyRule implements TestRule {
           HmacKey hmacKey = storage.createHmacKey(serviceAccount);
           HmacKeyMetadata metadata = hmacKey.getMetadata();
           accessKeyId = metadata.getAccessId();
+          assertNotNull("metadata.getAccessId() was null", accessKeyId);
           accessSecretKey = hmacKey.getSecretKey();
+          assertNotNull("hmacKey.getSecretKey() was null", accessSecretKey);
           try {
             base.evaluate();
           } finally {

--- a/storage/s3-sdk/src/test/java/storage/s3sdk/TestHmacKeyRule.java
+++ b/storage/s3-sdk/src/test/java/storage/s3sdk/TestHmacKeyRule.java
@@ -38,6 +38,7 @@ public final class TestHmacKeyRule implements TestRule {
 
   private String accessKeyId;
   private String accessSecretKey;
+  private String projectId;
 
   @Override
   public Statement apply(Statement base, Description description) {
@@ -59,9 +60,8 @@ public final class TestHmacKeyRule implements TestRule {
           HmacKey hmacKey = storage.createHmacKey(serviceAccount);
           HmacKeyMetadata metadata = hmacKey.getMetadata();
           accessKeyId = metadata.getAccessId();
-          assertNotNull("metadata.getAccessId() was null", accessKeyId);
           accessSecretKey = hmacKey.getSecretKey();
-          assertNotNull("hmacKey.getSecretKey() was null", accessSecretKey);
+          projectId = metadata.getProjectId();
           try {
             base.evaluate();
           } finally {
@@ -79,5 +79,9 @@ public final class TestHmacKeyRule implements TestRule {
 
   public String getAccessSecretKey() {
     return accessSecretKey;
+  }
+
+  public String getProjectId() {
+    return projectId;
   }
 }

--- a/storage/s3-sdk/src/test/java/storage/s3sdk/TestHmacKeyRule.java
+++ b/storage/s3-sdk/src/test/java/storage/s3sdk/TestHmacKeyRule.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package storage.s3sdk;
+
+import static org.junit.Assert.assertNotNull;
+
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.storage.HmacKey;
+import com.google.cloud.storage.HmacKey.HmacKeyMetadata;
+import com.google.cloud.storage.HmacKey.HmacKeyState;
+import com.google.cloud.storage.ServiceAccount;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * A {@link org.junit.ClassRule} which will create and cleanup an HMAC Key for use during the scope
+ * of a test.
+ */
+public final class TestHmacKeyRule implements TestRule {
+
+  private String accessKeyId;
+  private String accessSecretKey;
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        assertNotNull(
+            "GOOGLE_APPLICATION_CREDENTIALS is not set",
+            System.getenv("GOOGLE_APPLICATION_CREDENTIALS"));
+        StorageOptions options = StorageOptions.getDefaultInstance();
+        Storage storage = options.getService();
+        Credentials credentials = options.getCredentials();
+        if (credentials instanceof ServiceAccountCredentials) {
+          ServiceAccountCredentials serviceAccountCredentials =
+              (ServiceAccountCredentials) credentials;
+
+          ServiceAccount serviceAccount =
+              ServiceAccount.of(serviceAccountCredentials.getClientEmail());
+          HmacKey hmacKey = storage.createHmacKey(serviceAccount);
+          HmacKeyMetadata metadata = hmacKey.getMetadata();
+          accessKeyId = metadata.getAccessId();
+          accessSecretKey = hmacKey.getSecretKey();
+          try {
+            base.evaluate();
+          } finally {
+            storage.updateHmacKeyState(metadata, HmacKeyState.INACTIVE);
+            storage.deleteHmacKey(metadata);
+          }
+        }
+      }
+    };
+  }
+
+  public String getAccessKeyId() {
+    return accessKeyId;
+  }
+
+  public String getAccessSecretKey() {
+    return accessSecretKey;
+  }
+}


### PR DESCRIPTION
Update S3 SDK Tests to create and use HMAC credentials in the test rather than depending on external credentials.

Test has been updated to rely on a Service Account to generate the necessary HMAC credentials.

Fixes #5374
Fixes #5375

port of https://github.com/GoogleCloudPlatform/python-docs-samples/pull/6074

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [x] Appropriate changes to README are included in PR
- [x] API's need to be enabled to test (tell us) (storage, already enabled)
- [x] Environment Variables need to be set (ask us to set them) (`GOOGLE_APPLICATION_CREDENTIALS`)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [x] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [x] Please **merge** this PR for me once it is approved.
