### PR TITLE
chore: only use release version of spring-boot-dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -92,6 +92,10 @@
       ],
       "enabled": false,
       "description": "@anguillanneuf: This package is no longer actively maintained. Best to use the version specified in https://github.com/googleapis/google-api-java-client-services/tree/master/clients/google-api-services-dataflow/v1b3"
+    },
+    {
+      "matchPackagePatterns": [ "org.springframework.boot" ],
+      "matchCurrentVersion": "/.*RELEASE/"
     }
   ],
   "labels": [


### PR DESCRIPTION
Fixes #4579

Followed [this](https://docs.renovatebot.com/configuration-options/#matchcurrentversion) example which enforces only 1.* versions will be used