### PR TITLE
chore(ci): bump btlr version

### DIFF
--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -35,7 +35,7 @@ fi
 
 # If on kokoro, add btlr to the path and cd into repo root
 if [ -n "$KOKORO_GFILE_DIR" ]; then
-  bltr_dir="$KOKORO_GFILE_DIR/v0.0.2/"
+  bltr_dir="$KOKORO_GFILE_DIR/v0.0.3/"
   chmod +x "${bltr_dir}"btlr
   export PATH="$PATH:$bltr_dir"
   cd github/java-docs-samples || exit


### PR DESCRIPTION
Bumps btlr to the newest version. The new version prints logs as each command is completed. 

