### PR TITLE
Added "union" to accepted types in the avro schema

### DIFF
--- a/dataflow/transforms/src/main/java/com/example/AvroToCsv.java
+++ b/dataflow/transforms/src/main/java/com/example/AvroToCsv.java
@@ -38,7 +38,7 @@ public class AvroToCsv {
 
   private static final Logger LOG = LoggerFactory.getLogger(AvroToCsv.class);
   private static final List<String> acceptedTypes = Arrays.asList(
-      new String[]{"string", "boolean", "int", "long", "float", "double"});
+      new String[]{"string", "boolean", "int", "long", "float", "double", "union"});
 
   private static String getSchema(String schemaPath) throws IOException {
     ReadableByteChannel channel = FileSystems.open(FileSystems.matchNewResource(


### PR DESCRIPTION
I opened an issue on this topic #5560 and finally found the solution myself. I wanted to share this because it allows the user to read avro files with nulls in them. This change worked for me and the pipeline returns the intended csv.

Fixes #5560

> It's a good idea to open an issue first for discussion.

- [ x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [ x] `pom.xml` parent set to latest `shared-configuration`
- [ x] Appropriate changes to README are included in PR
- [ x] API's need to be enabled to test (tell us)
- [ x] Environment Variables need to be set (ask us to set them)
- [ x] **Tests** pass:   `mvn clean verify` **required**
- [ x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [x ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [x ] Please **merge** this PR for me once it is approved.
