### PR TITLE
fix(run/markdown-preview): full width input form

### DIFF
--- a/run/markdown-preview/editor/src/main/resources/templates/index.html
+++ b/run/markdown-preview/editor/src/main/resources/templates/index.html
@@ -20,8 +20,8 @@ limitations under the License.
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Markdown Editor</title>
   <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=">
-  <link href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css" rel="stylesheet">
-  <script src="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.js"></script>
+  <link href="https://unpkg.com/material-components-web@11.0.0/dist/material-components-web.min.css" rel="stylesheet">
+  <script src="https://unpkg.com/material-components-web@11.0.0/dist/material-components-web.min.js"></script>
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 </head>
 <body class="mdc-typography">
@@ -50,7 +50,7 @@ limitations under the License.
         <h2>Markdown Text</h2>
         <section class="mdc-card mdc-card--outlined">
           <div class="text-field-container">
-            <div class="mdc-text-field mdc-text-field--fullwidth md-text-field--no-label mdc-text-field--textarea mdc-ripple-upgraded">
+            <div class="mdc-text-field md-text-field--no-label mdc-text-field--textarea mdc-ripple-upgraded" style="width: 100%">
               <textarea id="editor" class="mdc-text-field__input" style="height: 36rem;" th:text="${Default}"></textarea>
             </div>
           </div>


### PR DESCRIPTION
This is a fix propagating from https://github.com/GoogleCloudPlatform/golang-samples/pull/2149

* Pin material to v11
* Use new fullwidth guide "width: 100%"
