### PR TITLE
fix: extend timeout for flaky test

### DIFF
--- a/unittests/src/test/java/com/google/appengine/samples/DeferredTaskTest.java
+++ b/unittests/src/test/java/com/google/appengine/samples/DeferredTaskTest.java
@@ -28,9 +28,12 @@ import com.google.appengine.tools.development.testing.LocalTaskQueueTestConfig;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
-public class DeferredTaskTest extends BaseTestConfiguration {
+public class DeferredTaskTest {
+  @Rule public Timeout testTimeout = new Timeout(10, TimeUnit.MINUTES);
 
   // Unlike CountDownLatch, TaskCountDownlatch lets us reset.
   private static final LocalTaskQueueTestConfig.TaskCountDownLatch latch =


### PR DESCRIPTION
Fixes #5588 

> It's a good idea to open an issue first for discussion.

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] Please **merge** this PR for me once it is approved.
