### PR TITLE
feat: adds downscoping with Credential Access Boundaries samples

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -40,9 +40,14 @@ You can then run a given `ClassName` via:
 The same configuration above applies. 
 
 To run the samples for [Downscoping with Credential Access Boundaries](https://cloud.google.com/iam/docs/downscoping-short-lived-credentials)
-you must provide both a bucket name and an object name.
+you must provide both a bucket name and object name under the TODO(developer): in the main method of `DownscopingExample`. 
 
-    mvn exec:java -Dexec.mainClass=com.google.cloud.auth.samples.DownscopingExample
-        -Dexec.args="bucketName objectName"
+You can then run `DownscopingExample` via:
 
+	mvn exec:exec
 
+## Tests
+Run all tests:
+```
+   mvn clean verify
+```

--- a/auth/README.md
+++ b/auth/README.md
@@ -34,3 +34,15 @@ You can then run a given `ClassName` via:
 
     mvn exec:java -Dexec.mainClass=com.google.cloud.auth.samples.AuthExample
         -Dexec.args="compute"
+
+## Downscoping with Credential Access Boundaries
+
+The same configuration above applies. 
+
+To run the samples for [Downscoping with Credential Access Boundaries](https://cloud.google.com/iam/docs/downscoping-short-lived-credentials)
+you must provide both a bucket name and an object name.
+
+    mvn exec:java -Dexec.mainClass=com.google.cloud.auth.samples.DownscopingExample
+        -Dexec.args="bucketName objectName"
+
+

--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -60,7 +60,12 @@ limitations under the License.
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-appengine</artifactId>
-      <version>1.0.0</version>
+      <version>1.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <version>1.1.0</version>
     </dependency>
     <!-- END dependencies -->
     <dependency>

--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -77,4 +77,29 @@ limitations under the License.
     <!-- START dependencies -->
   </dependencies>
   <!-- END dependencies -->
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.6.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <executable>java</executable>
+          <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>com.google.cloud.auth.samples.DownscopingExample</argument>
+          </arguments>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/auth/src/main/java/com/google/cloud/auth/samples/DownscopingExample.java
+++ b/auth/src/main/java/com/google/cloud/auth/samples/DownscopingExample.java
@@ -32,7 +32,7 @@ public class DownscopingExample {
   /**
    * Tests the downscoping functionality.
    *
-   * <p>This will generate a downscoped token with readonly access to the specified GCS bucket,
+   * This will generate a downscoped token with readonly access to the specified GCS bucket,
    * inject them into a storage instance and then test print the contents of the specified object.
    */
   public static void main(String[] args) throws IOException {

--- a/auth/src/main/java/com/google/cloud/auth/samples/DownscopingExample.java
+++ b/auth/src/main/java/com/google/cloud/auth/samples/DownscopingExample.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.auth.samples;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.CredentialAccessBoundary;
+import com.google.auth.oauth2.DownscopedCredentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.OAuth2CredentialsWithRefresh;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import java.io.IOException;
+
+/** Demonstrates how to use Downscoping with Credential Access Boundaries.". */
+public class DownscopingExample {
+
+  /** Simulates token broker generating downscoped tokens for specified bucket. */
+  // [START auth_downscoping_token_broker]
+  public static AccessToken getTokenFromBroker(String bucketName, String objectPrefix)
+      throws IOException {
+    // Retrieve the source credentials from ADC.
+    GoogleCredentials sourceCredentials =
+        GoogleCredentials.getApplicationDefault()
+            .createScoped("https://www.googleapis.com/auth/cloud-platform");
+
+    // [START auth_downscoping_rules]
+    // Initialize the Credential Access Boundary rules.
+    String availableResource =
+        String.format("//storage.googleapis.com/projects/_/buckets/%s", bucketName);
+
+    // Downscoped credentials will have readonly access to the resource.
+    String availablePermission = "inRole:roles/storage.objectViewer";
+
+    // Only objects starting with the specified prefix string in the object name will be allowed
+    // read access.
+    String expression =
+        String.format(
+            "resource.name.startsWith('projects/_/buckets/%s/objects/%s')",
+            bucketName, objectPrefix);
+
+    // Define the single access boundary rule using the above properties.
+    CredentialAccessBoundary.AccessBoundaryRule rule =
+        CredentialAccessBoundary.AccessBoundaryRule.newBuilder()
+            .setAvailableResource(availableResource)
+            .addAvailablePermission(availablePermission)
+            .setAvailabilityCondition(
+                CredentialAccessBoundary.AccessBoundaryRule.AvailabilityCondition.newBuilder()
+                    .setExpression(expression)
+                    .build())
+            .build();
+
+    // Define the Credential Access Boundary with all the relevant rules.
+    CredentialAccessBoundary credentialAccessBoundary =
+        CredentialAccessBoundary.newBuilder().addRule(rule).build();
+    // [END auth_downscoping_rules]
+
+    // [START auth_downscoping_initialize_downscoped_cred]
+    // Create the downscoped credentials.
+    DownscopedCredentials downscopedCredentials =
+        DownscopedCredentials.newBuilder()
+            .setSourceCredential(sourceCredentials)
+            .setCredentialAccessBoundary(credentialAccessBoundary)
+            .build();
+
+    // Retrieve the token.
+    // This will need to be passed to the Token Consumer.
+    AccessToken accessToken = downscopedCredentials.refreshAccessToken();
+    // [END auth_downscoping_initialize_downscoped_cred]
+    return accessToken;
+  }
+  // [END auth_downscoping_token_broker]
+
+  /** Simulates token consumer readonly access to the specified object. */
+  // [START auth_downscoping_token_consumer]
+  public static void tokenConsumer(final String bucketName, final String objectName)
+      throws IOException {
+    // You can pass an `OAuth2RefreshHandler` to `OAuth2CredentialsWithRefresh` which will allow the
+    // library to seamlessly handle downscoped token refreshes on expiration.
+    OAuth2CredentialsWithRefresh.OAuth2RefreshHandler handler =
+        new OAuth2CredentialsWithRefresh.OAuth2RefreshHandler() {
+          @Override
+          public AccessToken refreshAccessToken() throws IOException {
+            // The common pattern of usage is to have a token broker pass the downscoped short-lived
+            // access tokens to a token consumer via some secure authenticated channel.
+            // For illustration purposes, we are generating the downscoped token locally.
+            // We want to test the ability to limit access to objects with a certain prefix string
+            // in the resource bucket. objectName.substring(0, 3) is the prefix here. This field is
+            // not required if access to all bucket resources are allowed. If access to limited
+            // resources in the bucket is needed, this mechanism can be used.
+            return getTokenFromBroker(bucketName, objectName.substring(0, 3));
+          }
+        };
+
+    // Downscoped token retrieved from token broker.
+    AccessToken downscopedToken = handler.refreshAccessToken();
+
+    // Create the OAuth2CredentialsWithRefresh from the downscoped token and pass a refresh handler
+    // which will handle token expiration.
+    // This will allow the consumer to seamlessly obtain new downscoped tokens on demand every time
+    // token expires.
+    OAuth2CredentialsWithRefresh credentials =
+        OAuth2CredentialsWithRefresh.newBuilder()
+            .setAccessToken(downscopedToken)
+            .setRefreshHandler(handler)
+            .build();
+
+    // Use the credentials with the Cloud Storage SDK.
+    StorageOptions options = StorageOptions.newBuilder().setCredentials(credentials).build();
+    Storage storage = options.getService();
+
+    // Call GCS APIs.
+    Blob blob = storage.get(bucketName, objectName);
+    System.out.println(new String(blob.getContent()));
+  }
+  // [END auth_downscoping_token_consumer]
+
+  /**
+   * Tests the downscoping functionality.
+   *
+   * <p>This will generate a downscoped token with readonly access to the specified GCS bucket,
+   * inject them into a storage instance and then test print the contents of the specified object.
+   */
+  public static void main(String[] args) throws IOException {
+    if (args.length != 2) {
+      throw new IllegalArgumentException("A GCS bucket name and object name must be provided.");
+    }
+
+    System.out.println("Testing token consumer read access...");
+    tokenConsumer(args[0], args[1]);
+    System.out.println("done");
+  }
+}

--- a/auth/src/main/java/com/google/cloud/auth/samples/DownscopingExample.java
+++ b/auth/src/main/java/com/google/cloud/auth/samples/DownscopingExample.java
@@ -29,6 +29,25 @@ import java.io.IOException;
 /** Demonstrates how to use Downscoping with Credential Access Boundaries.". */
 public class DownscopingExample {
 
+  /**
+   * Tests the downscoping functionality.
+   *
+   * <p>This will generate a downscoped token with readonly access to the specified GCS bucket,
+   * inject them into a storage instance and then test print the contents of the specified object.
+   */
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    // The Cloud Storage bucket name.
+    String bucketName = "your-gcs-bucket-name";
+    // The Cloud Storage object name that resides in the specified bucket.
+    String objectName = "your-gcs-object-name";
+
+    System.out.println("Testing token consumer read access...");
+    String content = tokenConsumer(bucketName, objectName);
+    System.out.println(content);
+    System.out.println("done");
+  }
+
   /** Simulates token broker generating downscoped tokens for specified bucket. */
   // [START auth_downscoping_token_broker]
   public static AccessToken getTokenFromBroker(String bucketName, String objectPrefix)
@@ -87,7 +106,7 @@ public class DownscopingExample {
 
   /** Simulates token consumer readonly access to the specified object. */
   // [START auth_downscoping_token_consumer]
-  public static void tokenConsumer(final String bucketName, final String objectName)
+  public static String tokenConsumer(final String bucketName, final String objectName)
       throws IOException {
     // You can pass an `OAuth2RefreshHandler` to `OAuth2CredentialsWithRefresh` which will allow the
     // library to seamlessly handle downscoped token refreshes on expiration.
@@ -123,25 +142,9 @@ public class DownscopingExample {
     StorageOptions options = StorageOptions.newBuilder().setCredentials(credentials).build();
     Storage storage = options.getService();
 
-    // Call GCS APIs.
+    // Call Cloud Storage APIs.
     Blob blob = storage.get(bucketName, objectName);
-    System.out.println(new String(blob.getContent()));
+    return new String(blob.getContent());
   }
   // [END auth_downscoping_token_consumer]
-
-  /**
-   * Tests the downscoping functionality.
-   *
-   * <p>This will generate a downscoped token with readonly access to the specified GCS bucket,
-   * inject them into a storage instance and then test print the contents of the specified object.
-   */
-  public static void main(String[] args) throws IOException {
-    if (args.length != 2) {
-      throw new IllegalArgumentException("A GCS bucket name and object name must be provided.");
-    }
-
-    System.out.println("Testing token consumer read access...");
-    tokenConsumer(args[0], args[1]);
-    System.out.println("done");
-  }
 }

--- a/auth/src/main/java/com/google/cloud/auth/samples/DownscopingExample.java
+++ b/auth/src/main/java/com/google/cloud/auth/samples/DownscopingExample.java
@@ -26,7 +26,7 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import java.io.IOException;
 
-/** Demonstrates how to use Downscoping with Credential Access Boundaries.". */
+/** Demonstrates how to use Downscoping with Credential Access Boundaries. */
 public class DownscopingExample {
 
   /**

--- a/auth/src/test/java/com/google/cloud/auth/samples/DownscopingExampleIT.java
+++ b/auth/src/test/java/com/google/cloud/auth/samples/DownscopingExampleIT.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.auth.samples;
+
+import static org.junit.Assert.assertNotNull;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+// CHECKSTYLE OFF: AbbreviationAsWordInName
+public class DownscopingExampleIT {
+  // CHECKSTYLE ON: AbbreviationAsWordInName
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private String credentials;
+  private Bucket bucket;
+  private Blob blob;
+  private String[] args;
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    System.setOut(out);
+
+    credentials = System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
+    assertNotNull(credentials);
+
+    // Create a bucket and object that are deleted once the test completes.
+    Storage storage = StorageOptions.newBuilder().build().getService();
+
+    String bucketName = String.format("bucket-downscoping-test-%s", UUID.randomUUID());
+    Bucket bucket = storage.create(BucketInfo.newBuilder(bucketName).build());
+
+    String objectName = String.format("blob-downscoping-test-%s", UUID.randomUUID());
+    BlobId blobId = BlobId.of(bucketName, objectName);
+    BlobInfo blobInfo = Blob.newBuilder(blobId).build();
+    Blob blob = storage.create(blobInfo, "test".getBytes(StandardCharsets.UTF_8));
+
+    this.bucket = bucket;
+    this.blob = blob;
+    this.args = new String[] {bucketName, objectName};
+  }
+
+  @After
+  public void cleanup() {
+    blob.delete();
+    bucket.delete();
+  }
+
+  @Test
+  public void testDownscoping() throws IOException {
+    DownscopingExample.main(args);
+  }
+}

--- a/auth/src/test/java/com/google/cloud/auth/samples/DownscopingExampleIT.java
+++ b/auth/src/test/java/com/google/cloud/auth/samples/DownscopingExampleIT.java
@@ -16,8 +16,8 @@
 
 package com.google.cloud.auth.samples;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
@@ -82,7 +82,15 @@ public class DownscopingExampleIT {
 
   @Test
   public void testDownscoping() throws IOException {
-    String content = DownscopingExample.tokenConsumer(bucket.getName(), blob.getName());
-    assertEquals(CONTENT, content);
+    DownscopingExample.tokenConsumer(bucket.getName(), blob.getName());
+    String expectedOutput =
+        "Retrieved object, "
+            + blob.getName()
+            + ", from bucket,"
+            + bucket.getName()
+            + ", with content: "
+            + CONTENT;
+    String output = bout.toString();
+    assertTrue(output.contains(expectedOutput));
   }
 }

--- a/auth/src/test/java/com/google/cloud/auth/samples/DownscopingExampleIT.java
+++ b/auth/src/test/java/com/google/cloud/auth/samples/DownscopingExampleIT.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.auth.samples;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import com.google.cloud.storage.Blob;
@@ -40,6 +41,7 @@ import org.junit.runners.JUnit4;
 // CHECKSTYLE OFF: AbbreviationAsWordInName
 public class DownscopingExampleIT {
   // CHECKSTYLE ON: AbbreviationAsWordInName
+  private static final String CONTENT = "CONTENT";
   private ByteArrayOutputStream bout;
   private PrintStream out;
   private String credentials;
@@ -65,7 +67,7 @@ public class DownscopingExampleIT {
     String objectName = String.format("blob-downscoping-test-%s", UUID.randomUUID());
     BlobId blobId = BlobId.of(bucketName, objectName);
     BlobInfo blobInfo = Blob.newBuilder(blobId).build();
-    Blob blob = storage.create(blobInfo, "test".getBytes(StandardCharsets.UTF_8));
+    Blob blob = storage.create(blobInfo, CONTENT.getBytes(StandardCharsets.UTF_8));
 
     this.bucket = bucket;
     this.blob = blob;
@@ -80,6 +82,7 @@ public class DownscopingExampleIT {
 
   @Test
   public void testDownscoping() throws IOException {
-    DownscopingExample.main(args);
+    String content = DownscopingExample.tokenConsumer(bucket.getName(), blob.getName());
+    assertEquals(CONTENT, content);
   }
 }


### PR DESCRIPTION
Adds a sample to illustrate token broker and token consumer functionality for downscoping with CAB.

This includes samples on:
- How to initialize the CAB rules.
- How to initialize the downscoped credentials.
- How to inject the downscoped credentials in the token consumer.

The samples also include a test that verifies readonly access to a temporary
object.
