### PR TITLE
Fix minor typo

### DIFF
--- a/endpoints/getting-started/clients/src/main/java/com/example/app/GoogleJwtClient.java
+++ b/endpoints/getting-started/clients/src/main/java/com/example/app/GoogleJwtClient.java
@@ -54,7 +54,7 @@ public class GoogleJwtClient {
     // Build the JWT payload
     JWTCreator.Builder token = JWT.create()
         .withIssuedAt(now)
-        // Expires after 'expiraryLength' seconds
+        // Expires after 'expiryLength' seconds
         .withExpiresAt(expTime)
         // Must match 'issuer' in the security configuration in your
         // swagger spec (e.g. service account email)


### PR DESCRIPTION
Only removes two characters in a comment, from `expirary` to `expiry`.