### PR TITLE
fix: update workflows quickstart to use env vars for config

### DIFF
--- a/workflows/cloud-client/src/main/java/com/example/workflows/WorkflowsQuickstart.java
+++ b/workflows/cloud-client/src/main/java/com/example/workflows/WorkflowsQuickstart.java
@@ -29,13 +29,17 @@ import java.util.concurrent.ExecutionException;
 
 public class WorkflowsQuickstart {
 
+  private static final String PROJECT = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static final String LOCATION = System.getenv().getOrDefault("LOCATION", "us-central1");
+  private static final String WORKFLOW = System.getenv().getOrDefault("WORKFLOW", "myFirstWorkflow");
+
   public static void main(String... args)
       throws IOException, InterruptedException, ExecutionException {
-    // TODO(developer): Replace these variables before running the sample.
-    String projectId = "your-project-id";
-    String location = "us-central1";
-    String workflow = "myFirstWorkflow";
-    workflowsQuickstart(projectId, location, workflow);
+    if (PROJECT == null) {
+      throw new IllegalArgumentException(
+        "Environment variable 'GOOGLE_CLOUD_PROJECT' is required to run this quickstart.");
+    }
+    workflowsQuickstart(PROJECT, LOCATION, WORKFLOW);
   }
 
   private static volatile boolean finished;

--- a/workflows/cloud-client/src/main/java/com/example/workflows/WorkflowsQuickstart.java
+++ b/workflows/cloud-client/src/main/java/com/example/workflows/WorkflowsQuickstart.java
@@ -31,7 +31,8 @@ public class WorkflowsQuickstart {
 
   private static final String PROJECT = System.getenv("GOOGLE_CLOUD_PROJECT");
   private static final String LOCATION = System.getenv().getOrDefault("LOCATION", "us-central1");
-  private static final String WORKFLOW = System.getenv().getOrDefault("WORKFLOW", "myFirstWorkflow");
+  private static final String WORKFLOW = System.getenv().getOrDefault("WORKFLOW",
+      "myFirstWorkflow");
 
   public static void main(String... args)
       throws IOException, InterruptedException, ExecutionException {


### PR DESCRIPTION
Workflows Quickstart: enable env vars so docs can use this format.

---

Tested locally. Examples:

```
# Project config
GOOGLE_CLOUD_PROJECT=serverless-com-demo mvn compile exec:java -Dexec.mainClass=com.example.workflows.WorkflowsQuickstart

# Full config
GOOGLE_CLOUD_PROJECT=serverless-com-demo LOCATION=us-central1 WORKFLOW=myFirstWorkflow mvn compile exec:java -Dexec.mainClass=com.example.workflows.WorkflowsQuickstart

# Test
GOOGLE_CLOUD_PROJECT=serverless-com-demo mvn clean verify
```

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [x] Appropriate changes to README are included in PR
- [x] API's need to be enabled to test (tell us)
- [x] Environment Variables need to be set (ask us to set them)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [x] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [x] Please **merge** this PR for me once it is approved.
