### PR TITLE
mqtt: use options on reconnect

### DIFF
--- a/iot/api-client/manager/src/main/java/com/example/cloud/iot/examples/MqttExample.java
+++ b/iot/api-client/manager/src/main/java/com/example/cloud/iot/examples/MqttExample.java
@@ -433,7 +433,7 @@ public class MqttExample {
               "Invalid algorithm " + options.algorithm + ". Should be one of 'RS256' or 'ES256'.");
         }
         client.disconnect();
-        client.connect();
+        client.connect(connectOptions);
         attachCallback(client, options.deviceId);
       }
       // [END iot_mqtt_jwt_refresh]


### PR DESCRIPTION
Fix for "Invalid protocol version (1)" on reconnect