### PR TITLE
Migrating pubsub-spring sample to 2.x version of Spring Cloud GCP 

### DIFF
--- a/pubsub/spring/pom.xml
+++ b/pubsub/spring/pom.xml
@@ -53,9 +53,9 @@
       </dependency>
       <!-- [START pubsub_spring_dependency_manager] -->
       <dependency>
-        <groupId>org.springframework.cloud</groupId>
+        <groupId>com.google.cloud</groupId>
         <artifactId>spring-cloud-gcp-dependencies</artifactId>
-        <version>1.2.8.RELEASE</version>
+        <version>2.0.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -71,7 +71,7 @@
     <!-- [START pubsub_spring_boot_starter] -->
     <!-- [START pubsub_spring_integration] -->
     <dependency>
-      <groupId>org.springframework.cloud</groupId>
+      <groupId>com.google.cloud</groupId>
       <artifactId>spring-cloud-gcp-starter-pubsub</artifactId>
     </dependency>
     <!-- [END pubsub_spring_boot_starter] -->
@@ -82,7 +82,7 @@
     <!-- [END pubsub_spring_integration] -->
     <!-- [START pubsub_spring_cloud_stream_binder] -->
     <dependency>
-      <groupId>org.springframework.cloud</groupId>
+      <groupId>com.google.cloud</groupId>
       <artifactId>spring-cloud-gcp-pubsub-stream-binder</artifactId>
     </dependency>
     <!-- [END pubsub_spring_cloud_stream_binder] -->

--- a/pubsub/spring/src/main/java/demo/PubSubApplication.java
+++ b/pubsub/spring/src/main/java/demo/PubSubApplication.java
@@ -16,6 +16,12 @@
 
 package demo;
 
+import com.google.cloud.spring.pubsub.core.PubSubTemplate;
+import com.google.cloud.spring.pubsub.integration.AckMode;
+import com.google.cloud.spring.pubsub.integration.inbound.PubSubInboundChannelAdapter;
+import com.google.cloud.spring.pubsub.integration.outbound.PubSubMessageHandler;
+import com.google.cloud.spring.pubsub.support.BasicAcknowledgeablePubsubMessage;
+import com.google.cloud.spring.pubsub.support.GcpPubSubHeaders;
 import java.util.Random;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -24,12 +30,6 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
-import org.springframework.cloud.gcp.pubsub.integration.AckMode;
-import org.springframework.cloud.gcp.pubsub.integration.inbound.PubSubInboundChannelAdapter;
-import org.springframework.cloud.gcp.pubsub.integration.outbound.PubSubMessageHandler;
-import org.springframework.cloud.gcp.pubsub.support.BasicAcknowledgeablePubsubMessage;
-import org.springframework.cloud.gcp.pubsub.support.GcpPubSubHeaders;
 import org.springframework.context.annotation.Bean;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.channel.PublishSubscribeChannel;


### PR DESCRIPTION
Spring Cloud GCP migrated from the SpringCloud organization into GoogleCloudPlatform organization with the release of v2.0, requiring chages to artifact groupId and package names.

This PR migrates PubSub spring sample to the latest version of Spring Cloud GCP.

Part of addressing #6095

I have followed Sample Format Guide
[Done] Appropriate changes to README are included in PR
[Done] Tests pass: mvn clean verify required
[Done] Lint passes: mvn -P lint checkstyle:check required
 Static Analysis: mvn -P lint clean compile pmd:cpd-check spotbugs:check advisory only
These errors are due to Entity fields not being accessed. They are used in documentation snippets to demonstrate use of different data types instead.
Please merge this PR for me once it is approved.