### PR TITLE
Change PubsubliteToGcs.java to create processing-time windows of elements

### DIFF
--- a/pubsublite/streaming-analytics/src/main/java/examples/PubsubliteToGcs.java
+++ b/pubsublite/streaming-analytics/src/main/java/examples/PubsubliteToGcs.java
@@ -30,7 +30,7 @@ import org.apache.beam.sdk.options.StreamingOptions;
 import org.apache.beam.sdk.options.Validation.Required;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
-import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
 import org.apache.beam.sdk.transforms.windowing.Repeatedly;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.TypeDescriptors;


### PR DESCRIPTION
Its previous windowing construct can cause confusion to users trying to write simple batches of data to GCS since it relied on the publish timestamp of the messages, and also has issues when not using runnerv2 due to an incomplete SDF implementation.
