### PR TITLE
chore(deps): update beam to 2.34.0 for pub/sub and dataflow

### DIFF
--- a/dataflow/templates/pom.xml
+++ b/dataflow/templates/pom.xml
@@ -34,7 +34,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <beam.version>2.31.0</beam.version>
+    <beam.version>2.34.0</beam.version>
 
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>

--- a/pubsub/streaming-analytics/pom.xml
+++ b/pubsub/streaming-analytics/pom.xml
@@ -34,7 +34,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <beam.version>2.31.0</beam.version>
+    <beam.version>2.34.0</beam.version>
 
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>

--- a/pubsublite/streaming-analytics/pom.xml
+++ b/pubsublite/streaming-analytics/pom.xml
@@ -34,7 +34,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <beam.version>2.32.0</beam.version>
+    <beam.version>2.34.0</beam.version>
 
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>


### PR DESCRIPTION
Beam 2.34.0 doesn't depend on log4j-api but 2.31.0 does.

Go into each project and do with 2.31.0 vs. 2.34.0.

`mvn dependency:tree | grep log4j`