### PR TITLE
feat: add gradle build script to pubsub/spring tutorial

### DIFF
--- a/pubsub/spring/README.md
+++ b/pubsub/spring/README.md
@@ -16,21 +16,27 @@ When the application starts, it will do the following every ten seconds:
 
 This sample requires [Java](https://www.java.com/en/download/) and [Maven](http://maven.apache.org/) for building the application.
 
-1.  **Follow the Java development environment set-up instructions in [the documentation](https://cloud.google.com/java/docs/setup).**
+1. **Follow the Java development environment set-up instructions in [the documentation](https://cloud.google.com/java/docs/setup).**
 
-1.  Enable APIs for your project.
+2. Enable APIs for your project.
     [Click here](https://console.cloud.google.com/flows/enableapi?apiid=pubsub.googleapis.com&showconfirmation=true)
     to visit Cloud Platform Console and enable the Google Cloud Pub/Sub API.
 
-1.  Create a new topic `topic-one` and attach a subscription `sub-one` to it, then do the same for `topic-two` and `sub-two`, via the Cloud Platform Console's
+3. Create a new topic `topic-one` and attach a subscription `sub-one` to it, then do the same for `topic-two` and `sub-two`, via the Cloud Platform Console's
     [Cloud Pub/Sub section](http://console.cloud.google.com/pubsub).
 
-1.  Enable application default credentials by running the command `gcloud auth application-default login`.
+4. Enable application default credentials by running the command `gcloud auth application-default login`.
 
-1.  Run the following Maven command to run `PubSubApplication`:
+5. Run the following Maven or Gradle commands to run `PubSubApplication`:
+
     ```
     mvn clean spring-boot:run
     ```
+   
+    ```
+    gradle booRun
+    ```
+    
     You should observe an incoming message getting sent to `topic-one`, received from `sub-one`, sent to `topic-two`, and received from `topic-two` in the logged messages:
     ```
     2020-08-10 17:29:18.807  INFO 27310 --- [           main] demo.PubSubApplication                   : Started PubSubApplication in 6.063 seconds (JVM running for 6.393)

--- a/pubsub/spring/README.md
+++ b/pubsub/spring/README.md
@@ -34,7 +34,7 @@ This sample requires [Java](https://www.java.com/en/download/) and [Maven](http:
     ```
    
     ```
-    gradle booRun
+    gradle bootRun
     ```
     
     You should observe an incoming message getting sent to `topic-one`, received from `sub-one`, sent to `topic-two`, and received from `topic-two` in the logged messages:

--- a/pubsub/spring/build.gradle
+++ b/pubsub/spring/build.gradle
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'application'
+    id 'java'
+    id 'org.springframework.boot' version '2.5.7'
+}
+
+repositories {
+    mavenCentral()
+}
+
+bootRun {
+    mainClass = 'demo.PubSubApplication'
+}
+
+group = 'demo'
+version = '1.0.0-SNAPSHOT'
+description = 'Spring Cloud GCP Pub/Sub Code Sample'
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+dependencies {
+    implementation 'com.github.spotbugs:spotbugs-annotations:4.5.0'
+    implementation 'org.springframework.boot:spring-boot-starter-web:2.5.7'
+    implementation 'com.google.cloud:spring-cloud-gcp-starter-pubsub:2.0.6'
+    implementation 'org.springframework.integration:spring-integration-core:5.5.6'
+    implementation 'com.google.cloud:spring-cloud-gcp-pubsub-stream-binder:2.0.6'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'com.google.truth:truth:1.1.3'
+    testImplementation 'org.springframework.boot:spring-boot-test:2.5.7'
+}
+
+
+
+

--- a/pubsub/spring/build.gradle
+++ b/pubsub/spring/build.gradle
@@ -43,7 +43,3 @@ dependencies {
     testImplementation 'com.google.truth:truth:1.1.3'
     testImplementation 'org.springframework.boot:spring-boot-test:2.5.7'
 }
-
-
-
-

--- a/pubsub/spring/build.gradle
+++ b/pubsub/spring/build.gradle
@@ -25,7 +25,7 @@ repositories {
 }
 
 bootRun {
-    mainClass = 'demo.PubSubApplication'
+    mainClassName = 'demo.PubSubApplication'
 }
 
 group = 'demo'

--- a/pubsub/spring/pom.xml
+++ b/pubsub/spring/pom.xml
@@ -47,7 +47,7 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.5.5</version>
+        <version>2.5.7</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -97,12 +97,6 @@
       <artifactId>truth</artifactId>
       <version>1.1.3</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-core</artifactId>
-      <version>2.3.3</version>
-      <classifier>tests</classifier>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
User request to add gradle build script to the Spring project.

I didn't add the following Gradle files because one can build them from `build.gradle` with `gradle build`. 

- gradle/
- gradlew
- gradlew.bat
- settings.gradle

Remind ourselves to update to Spring v2.5.8 when Dec 23 comes around.