### PR TITLE
feat: add gradle build scripts to pubsub and pubsublite tutorials for beam

### DIFF
--- a/pubsub/streaming-analytics/README.md
+++ b/pubsub/streaming-analytics/README.md
@@ -104,12 +104,9 @@ The following example will run a streaming pipeline. It will read messages from 
 + `--runner [optional]`: specifies the runner to run the pipeline, defaults to `DirectRunner`
 + `--windowSize [optional]`: specifies the window size in minutes, defaults to 1
 
-Maven:
+Gradle:
 ```bash
-mvn compile exec:java \
-  -Dexec.mainClass=com.examples.pubsub.streaming.PubSubToGcs \
-  -Dexec.cleanupDaemonThreads=false \
-  -Dexec.args="\
+gradle execute -Dexec.args="\
     --project=$PROJECT_NAME \
     --region=$REGION \
     --inputTopic=projects/$PROJECT_NAME/topics/cron-topic \
@@ -119,9 +116,12 @@ mvn compile exec:java \
     --windowSize=2"
 ```
 
-Gradle:
+Maven:
 ```bash
-gradle execute -Dexec.args="\
+mvn compile exec:java \
+  -Dexec.mainClass=com.examples.pubsub.streaming.PubSubToGcs \
+  -Dexec.cleanupDaemonThreads=false \
+  -Dexec.args="\
     --project=$PROJECT_NAME \
     --region=$REGION \
     --inputTopic=projects/$PROJECT_NAME/topics/cron-topic \

--- a/pubsub/streaming-analytics/README.md
+++ b/pubsub/streaming-analytics/README.md
@@ -104,11 +104,24 @@ The following example will run a streaming pipeline. It will read messages from 
 + `--runner [optional]`: specifies the runner to run the pipeline, defaults to `DirectRunner`
 + `--windowSize [optional]`: specifies the window size in minutes, defaults to 1
 
+Maven:
 ```bash
 mvn compile exec:java \
   -Dexec.mainClass=com.examples.pubsub.streaming.PubSubToGcs \
   -Dexec.cleanupDaemonThreads=false \
   -Dexec.args="\
+    --project=$PROJECT_NAME \
+    --region=$REGION \
+    --inputTopic=projects/$PROJECT_NAME/topics/cron-topic \
+    --output=gs://$BUCKET_NAME/samples/output \
+    --gcpTempLocation=gs://$BUCKET_NAME/temp \
+    --runner=DataflowRunner \
+    --windowSize=2"
+```
+
+Gradle:
+```bash
+gradle execute -Dexec.args="\
     --project=$PROJECT_NAME \
     --region=$REGION \
     --inputTopic=projects/$PROJECT_NAME/topics/cron-topic \

--- a/pubsub/streaming-analytics/build.gradle
+++ b/pubsub/streaming-analytics/build.gradle
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+    maven {
+        url = uri('https://repository.apache.org/content/repositories/snapshots/')
+    }
+
+    maven {
+        url = uri('https://packages.confluent.io/maven/')
+    }
+
+    maven {
+        url = uri('https://repo.maven.apache.org/maven2/')
+    }
+}
+
+dependencies {
+    implementation 'com.github.spotbugs:spotbugs-annotations:4.5.0'
+    implementation 'org.apache.beam:beam-sdks-java-core:2.34.0'
+    implementation 'org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.34.0'
+    implementation 'org.apache.beam:beam-examples-java:2.34.0'
+    implementation 'org.slf4j:slf4j-api:1.7.32'
+    implementation 'org.slf4j:slf4j-jdk14:1.7.32'
+    implementation 'com.github.spotbugs:spotbugs-annotations:4.5.0'
+    runtimeOnly 'org.apache.beam:beam-runners-direct-java:2.34.0'
+    runtimeOnly 'org.apache.beam:beam-runners-google-cloud-dataflow-java:2.34.0'
+    testImplementation 'com.google.cloud:google-cloud-core:2.3.2'
+}
+
+group = 'com.example'
+version = '1.0.0-SNAPSHOT'
+description = 'pubsub-streaming'
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+task execute (type:JavaExec) {
+    mainClass = 'com.examples.pubsub.streaming.PubSubToGcs'
+    description('Run the Beam pipeline with gradle execute -Dexec.args=...')
+    classpath = sourceSets.main.runtimeClasspath
+    systemProperties System.getProperties()
+    args System.getProperty("exec.args", "").split()
+}

--- a/pubsub/streaming-analytics/build.gradle
+++ b/pubsub/streaming-analytics/build.gradle
@@ -33,23 +33,23 @@ repositories {
     }
 }
 
+def beamVersion = '2.34.0'
+def slf4jVersion = '1.7.32'
 dependencies {
     implementation 'com.github.spotbugs:spotbugs-annotations:4.5.0'
-    implementation 'org.apache.beam:beam-sdks-java-core:2.34.0'
-    implementation 'org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.34.0'
-    implementation 'org.apache.beam:beam-examples-java:2.34.0'
-    implementation 'org.slf4j:slf4j-api:1.7.32'
-    implementation 'org.slf4j:slf4j-jdk14:1.7.32'
-    implementation 'com.github.spotbugs:spotbugs-annotations:4.5.0'
-    runtimeOnly 'org.apache.beam:beam-runners-direct-java:2.34.0'
-    runtimeOnly 'org.apache.beam:beam-runners-google-cloud-dataflow-java:2.34.0'
+    implementation "org.apache.beam:beam-sdks-java-core:${beamVersion}"
+    implementation "org.apache.beam:beam-sdks-java-io-google-cloud-platform:${beamVersion}"
+    implementation "org.apache.beam:beam-examples-java:${beamVersion}"
+    implementation "org.slf4j:slf4j-api:${slf4jVersion}"
+    implementation "org.slf4j:slf4j-jdk14:${slf4jVersion}"
+    runtimeOnly "org.apache.beam:beam-runners-direct-java:${beamVersion}"
+    runtimeOnly "org.apache.beam:beam-runners-google-cloud-dataflow-java:${beamVersion}"
     testImplementation 'com.google.cloud:google-cloud-core:2.3.2'
 }
 
 group = 'com.example'
 version = '1.0.0-SNAPSHOT'
 description = 'pubsub-streaming'
-java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 task execute (type:JavaExec) {
     mainClass = 'com.examples.pubsub.streaming.PubSubToGcs'

--- a/pubsub/streaming-analytics/pom.xml
+++ b/pubsub/streaming-analytics/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>com.example</groupId>
   <artifactId>pubsub-streaming</artifactId>
-  <version>1.0</version>
+  <version>1.0.0-SNAPSHOT</version>
 
   <parent>
     <groupId>com.google.cloud.samples</groupId>

--- a/pubsublite/streaming-analytics/README.md
+++ b/pubsublite/streaming-analytics/README.md
@@ -73,11 +73,9 @@ The following example runs a streaming pipeline. Choose `DirectRunner` to test i
 + `--region [optional]`: the Dataflow region, optional if using `DirectRunner`
 + `--tempLocation`: a Cloud Storage location for temporary files, optional if using `DirectRunner`
 
-Maven: 
+Gradle:
 ```sh
-mvn compile exec:java \
-  -Dexec.mainClass=examples.PubsubliteToGcs \
-  -Dexec.args="\
+gradle execute -Dexec.args="\
     --subscription=projects/$PROJECT_ID/locations/$LITE_LOCATION/subscriptions/$SUBSCRIPTION \
     --output=gs://$BUCKET/samples/output \
     --windowSize=1 \
@@ -87,9 +85,11 @@ mvn compile exec:java \
     --tempLocation=gs://$BUCKET/temp"
 ```
 
-Gradle:
+Maven: 
 ```sh
-gradle execute -Dexec.args="\
+mvn compile exec:java \
+  -Dexec.mainClass=examples.PubsubliteToGcs \
+  -Dexec.args="\
     --subscription=projects/$PROJECT_ID/locations/$LITE_LOCATION/subscriptions/$SUBSCRIPTION \
     --output=gs://$BUCKET/samples/output \
     --windowSize=1 \

--- a/pubsublite/streaming-analytics/README.md
+++ b/pubsublite/streaming-analytics/README.md
@@ -73,10 +73,23 @@ The following example runs a streaming pipeline. Choose `DirectRunner` to test i
 + `--region [optional]`: the Dataflow region, optional if using `DirectRunner`
 + `--tempLocation`: a Cloud Storage location for temporary files, optional if using `DirectRunner`
 
+Maven: 
 ```sh
 mvn compile exec:java \
   -Dexec.mainClass=examples.PubsubliteToGcs \
   -Dexec.args="\
+    --subscription=projects/$PROJECT_ID/locations/$LITE_LOCATION/subscriptions/$SUBSCRIPTION \
+    --output=gs://$BUCKET/samples/output \
+    --windowSize=1 \
+    --runner=DataflowRunner \
+    --project=$PROJECT_ID \
+    --region=$DATAFLOW_REGION \
+    --tempLocation=gs://$BUCKET/temp"
+```
+
+Gradle:
+```sh
+gradle execute -Dexec.args="\
     --subscription=projects/$PROJECT_ID/locations/$LITE_LOCATION/subscriptions/$SUBSCRIPTION \
     --output=gs://$BUCKET/samples/output \
     --windowSize=1 \

--- a/pubsublite/streaming-analytics/build.gradle
+++ b/pubsublite/streaming-analytics/build.gradle
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'java'
+}
+
+repositories {
+    mavenLocal()
+    maven {
+        url = uri('https://repository.apache.org/content/repositories/snapshots/')
+    }
+
+    maven {
+        url = uri('https://packages.confluent.io/maven/')
+    }
+
+    maven {
+        url = uri('https://repo.maven.apache.org/maven2/')
+    }
+}
+
+dependencies {
+    implementation 'com.github.spotbugs:spotbugs-annotations:4.5.0'
+    implementation 'org.slf4j:slf4j-api:1.7.32'
+    implementation 'org.slf4j:slf4j-jdk14:1.7.32'
+    implementation 'org.apache.beam:beam-sdks-java-core:2.34.0'
+    implementation 'org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.34.0'
+    implementation 'org.apache.beam:beam-examples-java:2.34.0'
+    implementation 'com.github.spotbugs:spotbugs-annotations:4.5.0'
+    runtimeOnly 'org.apache.beam:beam-runners-direct-java:2.34.0'
+    runtimeOnly 'org.apache.beam:beam-runners-google-cloud-dataflow-java:2.34.0'
+    testImplementation 'com.google.api-client:google-api-client:1.32.2'
+    testImplementation 'com.google.apis:google-api-services-dataflow:v1b3-rev20210825-1.32.1'
+    testImplementation 'com.google.cloud:google-cloud-core:2.3.2'
+    testImplementation 'org.hamcrest:hamcrest-all:1.3'
+    testImplementation 'com.google.cloud:google-cloud-storage:2.1.9'
+    testImplementation 'com.google.truth:truth:1.1.3'
+    testImplementation 'com.google.cloud:google-cloud-core:2.3.2'
+}
+
+group = 'com.example'
+version = '1.0.0-SNAPSHOT'
+description = 'pubsublite-streaming'
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+task execute (type:JavaExec) {
+    mainClass = 'examples.PubsubliteToGcs'
+    description('Run the Beam pipeline with gradle execute -Dexec.args=...')
+    classpath = sourceSets.main.runtimeClasspath
+    systemProperties System.getProperties()
+    args System.getProperty("exec.args", "").split()
+}

--- a/pubsublite/streaming-analytics/build.gradle
+++ b/pubsublite/streaming-analytics/build.gradle
@@ -33,29 +33,28 @@ repositories {
     }
 }
 
+def beamVersion = '2.34.0'
+def slf4jVersion = '1.7.32'
 dependencies {
     implementation 'com.github.spotbugs:spotbugs-annotations:4.5.0'
-    implementation 'org.slf4j:slf4j-api:1.7.32'
-    implementation 'org.slf4j:slf4j-jdk14:1.7.32'
-    implementation 'org.apache.beam:beam-sdks-java-core:2.34.0'
-    implementation 'org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.34.0'
-    implementation 'org.apache.beam:beam-examples-java:2.34.0'
-    implementation 'com.github.spotbugs:spotbugs-annotations:4.5.0'
-    runtimeOnly 'org.apache.beam:beam-runners-direct-java:2.34.0'
-    runtimeOnly 'org.apache.beam:beam-runners-google-cloud-dataflow-java:2.34.0'
+    implementation "org.slf4j:slf4j-api:${slf4jVersion}"
+    implementation "org.slf4j:slf4j-jdk14:${slf4jVersion}"
+    implementation "org.apache.beam:beam-sdks-java-core:${beamVersion}"
+    implementation "org.apache.beam:beam-sdks-java-io-google-cloud-platform:${beamVersion}"
+    implementation "org.apache.beam:beam-examples-java:${beamVersion}"
+    runtimeOnly "org.apache.beam:beam-runners-direct-java:${beamVersion}"
+    runtimeOnly "org.apache.beam:beam-runners-google-cloud-dataflow-java:${beamVersion}"
     testImplementation 'com.google.api-client:google-api-client:1.32.2'
     testImplementation 'com.google.apis:google-api-services-dataflow:v1b3-rev20210825-1.32.1'
     testImplementation 'com.google.cloud:google-cloud-core:2.3.2'
-    testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'com.google.cloud:google-cloud-storage:2.1.9'
     testImplementation 'com.google.truth:truth:1.1.3'
-    testImplementation 'com.google.cloud:google-cloud-core:2.3.2'
+    testImplementation 'org.hamcrest:hamcrest-all:1.3'
 }
 
 group = 'com.example'
 version = '1.0.0-SNAPSHOT'
 description = 'pubsublite-streaming'
-java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 task execute (type:JavaExec) {
     mainClass = 'examples.PubsubliteToGcs'

--- a/pubsublite/streaming-analytics/pom.xml
+++ b/pubsublite/streaming-analytics/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>com.example</groupId>
   <artifactId>pubsublite-streaming</artifactId>
-  <version>1.0</version>
+  <version>1.0.0-SNAPSHOT</version>
 
   <parent>
     <groupId>com.google.cloud.samples</groupId>
@@ -150,13 +150,13 @@
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
       <version>1.32.2</version>
-      <scope>runtime</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-dataflow</artifactId>
-      <version>v1b3-rev20210408-1.31.0</version>
-      <scope>runtime</scope>
+      <version>v1b3-rev20210825-1.32.1</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Beam has moved on from Maven to Gradle as its [default build](https://beam.apache.org/get-started/quickstart-java/). Add gradle build scripts to all the Pub/Sub and Pub/Sub Lite Dataflow tutorials.

And other nits.

I didn't add the following Gradle files because one can build them from `build.gradle` with `gradle build`. 

- gradle/
- gradlew
- gradlew.bat
- settings.gradle