### PR TITLE
dataflow: use log4j 2.15 to patch security bug

### DIFF
--- a/dataflow/encryption-keys/pom.xml
+++ b/dataflow/encryption-keys/pom.xml
@@ -40,7 +40,7 @@
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
-    <slf4j.version>1.7.32</slf4j.version>
+    <log4j2.version>2.15.0</log4j2.version>
   </properties>
 
   <repositories>
@@ -131,16 +131,16 @@
   </build>
 
   <dependencies>
-    <!-- slf4j API frontend binding with JUL backend -->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j2.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-      <version>${slf4j.version}</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j2.version}</version>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Apache Beam

--- a/dataflow/flex-templates/kafka_to_bigquery/pom.xml
+++ b/dataflow/flex-templates/kafka_to_bigquery/pom.xml
@@ -41,7 +41,7 @@
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
-    <slf4j.version>1.7.32</slf4j.version>
+    <log4j2.version>2.15.0</log4j2.version>
   </properties>
 
   <repositories>
@@ -127,16 +127,16 @@
   </build>
 
   <dependencies>
-    <!-- slf4j API frontend binding with JUL backend -->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j2.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-      <version>${slf4j.version}</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j2.version}</version>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Apache Beam

--- a/dataflow/flex-templates/streaming_beam_sql/pom.xml
+++ b/dataflow/flex-templates/streaming_beam_sql/pom.xml
@@ -40,7 +40,7 @@
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
-    <slf4j.version>1.7.32</slf4j.version>
+    <log4j2.version>2.15.0</log4j2.version>
   </properties>
 
   <repositories>
@@ -132,16 +132,16 @@
   </build>
 
   <dependencies>
-    <!-- slf4j API frontend binding with JUL backend -->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j2.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-      <version>${slf4j.version}</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j2.version}</version>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Apache Beam

--- a/dataflow/spanner-io/pom.xml
+++ b/dataflow/spanner-io/pom.xml
@@ -39,6 +39,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <apache_beam.version>2.31.0</apache_beam.version>
+    <log4j2.version>2.15.0</log4j2.version>
   </properties>
 
   <build>
@@ -101,9 +102,15 @@
 
     <!-- Misc -->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-      <version>1.7.32</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j2.version}</version>
+      <scope>runtime</scope>
     </dependency>
 
   </dependencies>

--- a/dataflow/templates/pom.xml
+++ b/dataflow/templates/pom.xml
@@ -40,7 +40,7 @@
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
-    <slf4j.version>1.7.32</slf4j.version>
+    <log4j2.version>2.15.0</log4j2.version>
   </properties>
 
   <repositories>
@@ -131,16 +131,16 @@
   </build>
 
   <dependencies>
-    <!-- slf4j API frontend binding with JUL backend -->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j2.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-      <version>${slf4j.version}</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j2.version}</version>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Apache Beam


### PR DESCRIPTION
Fixes log4j security vulnerability

https://logging.apache.org/log4j/2.x/security.html

Uses log4j 2.15 explicitly (where the vulnerability has been fixed) instead of slf4j.

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] Please **merge** this PR for me once it is approved.
