### PR TITLE
dataflow: update log4j to 2.17.0

### DIFF
--- a/dataflow/encryption-keys/pom.xml
+++ b/dataflow/encryption-keys/pom.xml
@@ -40,7 +40,7 @@
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
   </properties>
 
   <repositories>

--- a/dataflow/flex-templates/kafka_to_bigquery/pom.xml
+++ b/dataflow/flex-templates/kafka_to_bigquery/pom.xml
@@ -41,7 +41,7 @@
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
   </properties>
 
   <repositories>

--- a/dataflow/flex-templates/streaming_beam_sql/pom.xml
+++ b/dataflow/flex-templates/streaming_beam_sql/pom.xml
@@ -40,7 +40,7 @@
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
   </properties>
 
   <repositories>

--- a/dataflow/spanner-io/pom.xml
+++ b/dataflow/spanner-io/pom.xml
@@ -39,7 +39,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <apache_beam.version>2.31.0</apache_beam.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
   </properties>
 
   <build>

--- a/dataflow/templates/pom.xml
+++ b/dataflow/templates/pom.xml
@@ -40,7 +40,7 @@
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Related to #6588 and #6587 
### Background:
As recently reported on [apache.org](https://logging.apache.org/log4j/2.x/security.html)

Apache Log4j2 versions 2.0-alpha1 through 2.16.0 did not protect from uncontrolled recursion from self-referential lookups. When the logging configuration uses a non-default Pattern Layout with a Context Lookup (for example, $${ctx:loginId}), attackers with control over Thread Context Map (MDC) input data can craft malicious input data that contains a recursive lookup, resulting in a StackOverflowError that will terminate the process. This is also known as a DOS (Denial of Service) attack.


