### PR TITLE
chore: add more pubsub and pubsublite codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,5 +12,7 @@
 /firestore/**/*.java            @GoogleCloudPlatform/cloud-native-db-dpes @GoogleCloudPlatform/java-samples-reviewers @yoshi-approver
 /iot/                           @gcseh @GoogleCloudPlatform/api-iot @GoogleCloudPlatform/java-samples-reviewers @yoshi-approver
 /logging/                       @GoogleCloudPlatform/observability-devx @GoogleCloudPlatform/java-samples-reviewers @yoshi-approver
+/pubsub/                        @GoogleCloudPlatform/api-pubsub-and-pubsublite @GoogleCloudPlatform/java-samples-reviewers @yoshi-approver
+/pubsublite/                    @GoogleCloudPlatform/api-pubsub-and-pubsublite @GoogleCloudPlatform/java-samples-reviewers @yoshi-approver
 /storage/**/*.java              @GoogleCloudPlatform/cloud-storage-dpes @GoogleCloudPlatform/java-samples-reviewers @yoshi-approver
 .github/auto-approve.yml        @googleapis/github-automation/ @sofisl @GoogleCloudPlatform/java-samples-reviewers


### PR DESCRIPTION
Include everyone in https://github.com/orgs/GoogleCloudPlatform/teams/api-pubsub-and-pubsublite/members for Pub/Sub and Pub/Sub Lite code reviews. 

Note that this group is a GitHub TeamSync Team and maps to an internal group. Ask @anguillanneuf about this internal group. 

@brijk7 You have been added and can review PRs that have `api-pubsub-and-pubsublite` assigned as Reviewers in java-docs-samples.