### PR TITLE
dataflow: avoid importing log4j at all

### DIFF
--- a/dataflow/encryption-keys/pom.xml
+++ b/dataflow/encryption-keys/pom.xml
@@ -34,13 +34,13 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <beam.version>2.31.0</beam.version>
+    <beam.version>2.34.0</beam.version>
 
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
-    <log4j2.version>2.17.0</log4j2.version>
+    <slf4j.version>1.7.32</slf4j.version>
   </properties>
 
   <repositories>
@@ -132,14 +132,14 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>${log4j2.version}</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>${log4j2.version}</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <version>${slf4j.version}</version>
       <scope>runtime</scope>
     </dependency>
 

--- a/dataflow/flex-templates/kafka_to_bigquery/pom.xml
+++ b/dataflow/flex-templates/kafka_to_bigquery/pom.xml
@@ -34,14 +34,14 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <beam.version>2.31.0</beam.version>
+    <beam.version>2.34.0</beam.version>
     <kafka.version>7.0.0-ce</kafka.version>
 
     <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
-    <log4j2.version>2.17.0</log4j2.version>
+    <slf4j.version>1.7.32</slf4j.version>
   </properties>
 
   <repositories>
@@ -128,14 +128,14 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>${log4j2.version}</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>${log4j2.version}</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <version>${slf4j.version}</version>
       <scope>runtime</scope>
     </dependency>
 

--- a/dataflow/flex-templates/kafka_to_bigquery/src/main/java/org/apache/beam/samples/KafkaToBigQuery.java
+++ b/dataflow/flex-templates/kafka_to_bigquery/src/main/java/org/apache/beam/samples/KafkaToBigQuery.java
@@ -39,8 +39,8 @@ import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 
@@ -49,7 +49,7 @@ import org.joda.time.Instant;
  * writes them to a BigQuery table.
  */
 public class KafkaToBigQuery {
-  private static final Logger LOG = LogManager.getLogger(KafkaToBigQuery.class);
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaToBigQuery.class);
   private static final Gson GSON = new Gson();
 
   public interface Options extends StreamingOptions {
@@ -59,8 +59,7 @@ public class KafkaToBigQuery {
 
     void setInputTopic(String value);
 
-    @Description(
-        "BigQuery table to write to, in the form 'project:dataset.table' or 'dataset.table'.")
+    @Description("BigQuery table to write to, in the form 'project:dataset.table' or 'dataset.table'.")
     @Default.String("beam_samples.streaming_beam_sql")
     String getOutputTable();
 
@@ -76,8 +75,10 @@ public class KafkaToBigQuery {
   @DefaultCoder(AvroCoder.class)
   private static class PageRating {
     Instant processingTime;
-    @Nullable String url;
-    @Nullable String rating;
+    @Nullable
+    String url;
+    @Nullable
+    String rating;
   }
 
   public static void main(final String[] args) {

--- a/dataflow/flex-templates/kafka_to_bigquery/src/main/java/org/apache/beam/samples/KafkaToBigQuery.java
+++ b/dataflow/flex-templates/kafka_to_bigquery/src/main/java/org/apache/beam/samples/KafkaToBigQuery.java
@@ -75,10 +75,8 @@ public class KafkaToBigQuery {
   @DefaultCoder(AvroCoder.class)
   private static class PageRating {
     Instant processingTime;
-    @Nullable
-    String url;
-    @Nullable
-    String rating;
+    @Nullable String url;
+    @Nullable String rating;
   }
 
   public static void main(final String[] args) {

--- a/dataflow/flex-templates/kafka_to_bigquery/src/main/java/org/apache/beam/samples/KafkaToBigQuery.java
+++ b/dataflow/flex-templates/kafka_to_bigquery/src/main/java/org/apache/beam/samples/KafkaToBigQuery.java
@@ -39,10 +39,10 @@ import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An Apache Beam pipeline that reads JSON encoded messages from Kafka and
@@ -59,7 +59,8 @@ public class KafkaToBigQuery {
 
     void setInputTopic(String value);
 
-    @Description("BigQuery table to write to, in the form 'project:dataset.table' or 'dataset.table'.")
+    @Description("BigQuery table to write to, in the form "
+        + "'project:dataset.table' or 'dataset.table'.")
     @Default.String("beam_samples.streaming_beam_sql")
     String getOutputTable();
 

--- a/dataflow/flex-templates/streaming_beam_sql/pom.xml
+++ b/dataflow/flex-templates/streaming_beam_sql/pom.xml
@@ -34,13 +34,13 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <beam.version>2.31.0</beam.version>
+    <beam.version>2.34.0</beam.version>
 
     <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
-    <log4j2.version>2.17.0</log4j2.version>
+    <slf4j.version>1.7.32</slf4j.version>
   </properties>
 
   <repositories>
@@ -133,14 +133,14 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>${log4j2.version}</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>${log4j2.version}</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <version>${slf4j.version}</version>
       <scope>runtime</scope>
     </dependency>
 

--- a/dataflow/flex-templates/streaming_beam_sql/src/main/java/org/apache/beam/samples/StreamingBeamSql.java
+++ b/dataflow/flex-templates/streaming_beam_sql/src/main/java/org/apache/beam/samples/StreamingBeamSql.java
@@ -42,118 +42,120 @@ import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TypeDescriptor;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 
 /**
- * An Apache Beam streaming pipeline that reads JSON encoded messages fromPub/Sub,
- * uses Beam SQL to transform the message data, and writes the results to a BigQuery.
+ * An Apache Beam streaming pipeline that reads JSON encoded messages
+ * fromPub/Sub,
+ * uses Beam SQL to transform the message data, and writes the results to a
+ * BigQuery.
  */
 public class StreamingBeamSql {
-  private static final Logger LOG = LogManager.getLogger(StreamingBeamSql.class);
-  private static final Gson GSON = new Gson();
+    private static final Logger LOG = LoggerFactory.getLogger(StreamingBeamSql.class);
+    private static final Gson GSON = new Gson();
 
-  public interface Options extends StreamingOptions {
-    @Description("Pub/Sub subscription to read from.")
-    @Validation.Required
-    String getInputSubscription();
+    public interface Options extends StreamingOptions {
+        @Description("Pub/Sub subscription to read from.")
+        @Validation.Required
+        String getInputSubscription();
 
-    void setInputSubscription(String value);
+        void setInputSubscription(String value);
 
-    @Description("BigQuery table to write to, in the form "
-        + "'project:dataset.table' or 'dataset.table'.")
-    @Default.String("beam_samples.streaming_beam_sql")
-    String getOutputTable();
+        @Description("BigQuery table to write to, in the form "
+                + "'project:dataset.table' or 'dataset.table'.")
+        @Default.String("beam_samples.streaming_beam_sql")
+        String getOutputTable();
 
-    void setOutputTable(String value);
-  }
+        void setOutputTable(String value);
+    }
 
-  @DefaultCoder(AvroCoder.class)
-  private static class PageReviewMessage {
-    @Nullable
-    String url;
-    @Nullable
-    String review;
-  }
+    @DefaultCoder(AvroCoder.class)
+    private static class PageReviewMessage {
+        @Nullable
+        String url;
+        @Nullable
+        String review;
+    }
 
-  public static void main(final String[] args) {
-    Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
-    options.setStreaming(true);
+    public static void main(final String[] args) {
+        Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+        options.setStreaming(true);
 
-    var project = options.as(GcpOptions.class).getProject();
-    var subscription = ProjectSubscriptionName
-        .of(project, options.getInputSubscription()).toString();
+        var project = options.as(GcpOptions.class).getProject();
+        var subscription = ProjectSubscriptionName
+                .of(project, options.getInputSubscription()).toString();
 
-    var schema = Schema.builder()
-        .addStringField("url")
-        .addDoubleField("page_score")
-        .addDateTimeField("processing_time")
-        .build();
+        var schema = Schema.builder()
+                .addStringField("url")
+                .addDoubleField("page_score")
+                .addDateTimeField("processing_time")
+                .build();
 
-    var pipeline = Pipeline.create(options);
-    pipeline
-        // Read, parse, and validate messages from Pub/Sub.
-        .apply("Read messages from Pub/Sub", PubsubIO.readStrings().fromSubscription(subscription))
-        .apply("Parse JSON into SQL rows", MapElements.into(TypeDescriptor.of(Row.class))
-            .via(message -> {
-              // This is a good place to add error handling.
-              // The first transform should act as a validation layer to make sure
-              // that any data coming to the processing pipeline must be valid.
-              // See `MapElements.MapWithFailures` for more details.
-              LOG.info("message: {}", message);
-              var msg = GSON.fromJson(message, PageReviewMessage.class);
-              return Row.withSchema(schema).addValues(
-                  msg.url,                                    // row url
-                  msg.review.equals("positive") ? 1.0 : 0.0,  // row page_score
-                  new Instant()                               // row processing_time
-              ).build();
-            })).setRowSchema(schema) // make sure to set the row schema for the PCollection
+        var pipeline = Pipeline.create(options);
+        pipeline
+                // Read, parse, and validate messages from Pub/Sub.
+                .apply("Read messages from Pub/Sub", PubsubIO.readStrings().fromSubscription(subscription))
+                .apply("Parse JSON into SQL rows", MapElements.into(TypeDescriptor.of(Row.class))
+                        .via(message -> {
+                            // This is a good place to add error handling.
+                            // The first transform should act as a validation layer to make sure
+                            // that any data coming to the processing pipeline must be valid.
+                            // See `MapElements.MapWithFailures` for more details.
+                            LOG.info("message: {}", message);
+                            var msg = GSON.fromJson(message, PageReviewMessage.class);
+                            return Row.withSchema(schema).addValues(
+                                    msg.url, // row url
+                                    msg.review.equals("positive") ? 1.0 : 0.0, // row page_score
+                                    new Instant() // row processing_time
+                            ).build();
+                        }))
+                .setRowSchema(schema) // make sure to set the row schema for the PCollection
 
-        // Add timestamps and bundle elements into windows.
-        .apply("Add processing time", WithTimestamps
-            .of((row) -> row.getDateTime("processing_time").toInstant()))
-        .apply("Fixed-size windows", Window.into(FixedWindows.of(Duration.standardMinutes(1))))
+                // Add timestamps and bundle elements into windows.
+                .apply("Add processing time", WithTimestamps
+                        .of((row) -> row.getDateTime("processing_time").toInstant()))
+                .apply("Fixed-size windows", Window.into(FixedWindows.of(Duration.standardMinutes(1))))
 
-        // Apply a SQL query for every window of elements.
-        .apply("Run Beam SQL query", SqlTransform.query(
-            "SELECT "
-                + "  url, "
-                + "  COUNT(page_score) AS num_reviews, "
-                + "  AVG(page_score) AS score, "
-                + "  MIN(processing_time) AS first_date, "
-                + "  MAX(processing_time) AS last_date "
-                + "FROM PCOLLECTION "
-                + "GROUP BY url"
-        ))
+                // Apply a SQL query for every window of elements.
+                .apply("Run Beam SQL query", SqlTransform.query(
+                        "SELECT "
+                                + "  url, "
+                                + "  COUNT(page_score) AS num_reviews, "
+                                + "  AVG(page_score) AS score, "
+                                + "  MIN(processing_time) AS first_date, "
+                                + "  MAX(processing_time) AS last_date "
+                                + "FROM PCOLLECTION "
+                                + "GROUP BY url"))
 
-        // Convert the SQL Rows into BigQuery TableRows and write them to BigQuery.
-        .apply("Convert to BigQuery TableRow", MapElements.into(TypeDescriptor.of(TableRow.class))
-            .via(row -> {
-              LOG.info("rating summary: {} {} ({} reviews)", row.getDouble("score"),
-                  row.getString("url"), row.getInt64("num_reviews"));
-              return new TableRow()
-                  .set("url", row.getString("url"))
-                  .set("num_reviews", row.getInt64("num_reviews"))
-                  .set("score", row.getDouble("score"))
-                  .set("first_date", row.getDateTime("first_date").toInstant().toString())
-                  .set("last_date", row.getDateTime("last_date").toInstant().toString());
-            }))
-        .apply("Write to BigQuery", BigQueryIO.writeTableRows()
-            .to(options.getOutputTable())
-            .withSchema(new TableSchema().setFields(Arrays.asList(
-                // To learn more about the valid BigQuery types:
-                //   https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types
-                new TableFieldSchema().setName("url").setType("STRING"),
-                new TableFieldSchema().setName("num_reviews").setType("INTEGER"),
-                new TableFieldSchema().setName("score").setType("FLOAT64"),
-                new TableFieldSchema().setName("first_date").setType("TIMESTAMP"),
-                new TableFieldSchema().setName("last_date").setType("TIMESTAMP"))))
-            .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED)
-            .withWriteDisposition(WriteDisposition.WRITE_APPEND));
+                // Convert the SQL Rows into BigQuery TableRows and write them to BigQuery.
+                .apply("Convert to BigQuery TableRow", MapElements.into(TypeDescriptor.of(TableRow.class))
+                        .via(row -> {
+                            LOG.info("rating summary: {} {} ({} reviews)", row.getDouble("score"),
+                                    row.getString("url"), row.getInt64("num_reviews"));
+                            return new TableRow()
+                                    .set("url", row.getString("url"))
+                                    .set("num_reviews", row.getInt64("num_reviews"))
+                                    .set("score", row.getDouble("score"))
+                                    .set("first_date", row.getDateTime("first_date").toInstant().toString())
+                                    .set("last_date", row.getDateTime("last_date").toInstant().toString());
+                        }))
+                .apply("Write to BigQuery", BigQueryIO.writeTableRows()
+                        .to(options.getOutputTable())
+                        .withSchema(new TableSchema().setFields(Arrays.asList(
+                                // To learn more about the valid BigQuery types:
+                                // https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types
+                                new TableFieldSchema().setName("url").setType("STRING"),
+                                new TableFieldSchema().setName("num_reviews").setType("INTEGER"),
+                                new TableFieldSchema().setName("score").setType("FLOAT64"),
+                                new TableFieldSchema().setName("first_date").setType("TIMESTAMP"),
+                                new TableFieldSchema().setName("last_date").setType("TIMESTAMP"))))
+                        .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED)
+                        .withWriteDisposition(WriteDisposition.WRITE_APPEND));
 
-    // For a Dataflow Flex Template, do NOT waitUntilFinish().
-    pipeline.run();
-  }
+        // For a Dataflow Flex Template, do NOT waitUntilFinish().
+        pipeline.run();
+    }
 }

--- a/dataflow/flex-templates/streaming_beam_sql/src/main/java/org/apache/beam/samples/StreamingBeamSql.java
+++ b/dataflow/flex-templates/streaming_beam_sql/src/main/java/org/apache/beam/samples/StreamingBeamSql.java
@@ -42,10 +42,10 @@ import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TypeDescriptor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An Apache Beam streaming pipeline that reads JSON encoded messages fromPub/Sub,

--- a/dataflow/spanner-io/pom.xml
+++ b/dataflow/spanner-io/pom.xml
@@ -38,7 +38,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <apache_beam.version>2.34.0</apache_beam.version>
+    <apache_beam.version>2.33.0</apache_beam.version>
     <slf4j.version>1.7.32</slf4j.version>
   </properties>
 

--- a/dataflow/spanner-io/pom.xml
+++ b/dataflow/spanner-io/pom.xml
@@ -34,11 +34,11 @@
   </parent>
 
   <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>1.8</java.version>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <apache_beam.version>2.32.0</apache_beam.version>
+
+    <apache_beam.version>2.34.0</apache_beam.version>
     <slf4j.version>1.7.32</slf4j.version>
   </properties>
 

--- a/dataflow/spanner-io/pom.xml
+++ b/dataflow/spanner-io/pom.xml
@@ -38,7 +38,7 @@
     <java.version>1.8</java.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <apache_beam.version>2.34.0</apache_beam.version>
+    <apache_beam.version>2.32.0</apache_beam.version>
     <slf4j.version>1.7.32</slf4j.version>
   </properties>
 

--- a/dataflow/spanner-io/pom.xml
+++ b/dataflow/spanner-io/pom.xml
@@ -38,8 +38,8 @@
     <java.version>1.8</java.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <apache_beam.version>2.31.0</apache_beam.version>
-    <log4j2.version>2.17.0</log4j2.version>
+    <apache_beam.version>2.34.0</apache_beam.version>
+    <slf4j.version>1.7.32</slf4j.version>
   </properties>
 
   <build>
@@ -102,14 +102,14 @@
 
     <!-- Misc -->
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>${log4j2.version}</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>${log4j2.version}</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <version>${slf4j.version}</version>
       <scope>runtime</scope>
     </dependency>
 

--- a/dataflow/spanner-io/src/main/java/com/example/dataflow/SpannerWrite.java
+++ b/dataflow/spanner-io/src/main/java/com/example/dataflow/SpannerWrite.java
@@ -29,8 +29,8 @@ import org.apache.beam.sdk.options.Validation;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
-import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /*
 This sample demonstrates how to write to a Spanner table.
@@ -99,8 +99,7 @@ public class SpannerWrite {
     String firstName;
     String lastName;
 
-    Singer() {
-    }
+    Singer() {}
 
     Singer(long singerId, String firstName, String lastName) {
       this.singerId = singerId;
@@ -115,8 +114,7 @@ public class SpannerWrite {
     long albumId;
     String albumTitle;
 
-    Album() {
-    }
+    Album() {}
 
     Album(long singerId, long albumId, String albumTitle) {
       this.singerId = singerId;
@@ -126,8 +124,7 @@ public class SpannerWrite {
   }
 
   /**
-   * Parses each tab-delimited line into a Singer object. The line format is the
-   * following:
+   * Parses each tab-delimited line into a Singer object. The line format is the following:
    * singer_id\tfirstName\tlastName
    */
   static class ParseSinger extends DoFn<String, Singer> {
@@ -148,8 +145,7 @@ public class SpannerWrite {
   }
 
   /**
-   * Parses each tab-delimited line into an Album object. The line format is the
-   * following:
+   * Parses each tab-delimited line into an Album object. The line format is the following:
    * singer_id\talbumId\talbumTitle
    */
   static class ParseAlbum extends DoFn<String, Album> {

--- a/dataflow/spanner-io/src/main/java/com/example/dataflow/SpannerWrite.java
+++ b/dataflow/spanner-io/src/main/java/com/example/dataflow/SpannerWrite.java
@@ -29,8 +29,8 @@ import org.apache.beam.sdk.options.Validation;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 /*
 This sample demonstrates how to write to a Spanner table.
@@ -99,7 +99,8 @@ public class SpannerWrite {
     String firstName;
     String lastName;
 
-    Singer() {}
+    Singer() {
+    }
 
     Singer(long singerId, String firstName, String lastName) {
       this.singerId = singerId;
@@ -114,7 +115,8 @@ public class SpannerWrite {
     long albumId;
     String albumTitle;
 
-    Album() {}
+    Album() {
+    }
 
     Album(long singerId, long albumId, String albumTitle) {
       this.singerId = singerId;
@@ -124,11 +126,12 @@ public class SpannerWrite {
   }
 
   /**
-   * Parses each tab-delimited line into a Singer object. The line format is the following:
-   *   singer_id\tfirstName\tlastName
+   * Parses each tab-delimited line into a Singer object. The line format is the
+   * following:
+   * singer_id\tfirstName\tlastName
    */
   static class ParseSinger extends DoFn<String, Singer> {
-    private static final Logger LOG = LogManager.getLogger(ParseSinger.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ParseSinger.class);
 
     @ProcessElement
     public void processElement(ProcessContext c) {
@@ -145,11 +148,12 @@ public class SpannerWrite {
   }
 
   /**
-   * Parses each tab-delimited line into an Album object. The line format is the following:
-   *   singer_id\talbumId\talbumTitle
+   * Parses each tab-delimited line into an Album object. The line format is the
+   * following:
+   * singer_id\talbumId\talbumTitle
    */
   static class ParseAlbum extends DoFn<String, Album> {
-    private static final Logger LOG = LogManager.getLogger(ParseAlbum.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ParseAlbum.class);
 
     @ProcessElement
     public void processElement(ProcessContext c) {

--- a/dataflow/templates/pom.xml
+++ b/dataflow/templates/pom.xml
@@ -40,7 +40,7 @@
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
-    <log4j2.version>2.17.0</log4j2.version>
+    <slf4j.version>1.7.32</slf4j.version>
   </properties>
 
   <repositories>
@@ -132,14 +132,14 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>${log4j2.version}</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>${log4j2.version}</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <version>${slf4j.version}</version>
       <scope>runtime</scope>
     </dependency>
 


### PR DESCRIPTION
Remove any direct dependencies of log4j and use slf4j instead, as recommended by the [documentation](https://cloud.google.com/dataflow/docs/guides/logging#java_1), and update to Beam 2.34 which doesn't depend on log4j.

Confirmed with `mvn dependency:tree | grep log4j-api` that there are no direct or indirect dependency instances of log4j on any sample by doing this.

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] Please **merge** this PR for me once it is approved.
