### PR TITLE
Update Spring Boot dependencies to 2.5.8

### DIFF
--- a/eventarc/generic/pom.xml
+++ b/eventarc/generic/pom.xml
@@ -35,7 +35,7 @@ limitations under the License.
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.5.5</version>
+        <version>2.5.8</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/eventarc/pubsub/pom.xml
+++ b/eventarc/pubsub/pom.xml
@@ -35,7 +35,7 @@ limitations under the License.
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.5.5</version>
+        <version>2.5.8</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/flexible/helloworld-springboot/pom.xml
+++ b/flexible/helloworld-springboot/pom.xml
@@ -40,17 +40,17 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>2.5.5</version>
+      <version>2.5.8</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
-      <version>2.5.5</version>
+      <version>2.5.8</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
-      <version>2.5.4</version>
+      <version>2.5.8</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -66,7 +66,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>2.5.5</version>
+        <version>2.5.8</version>
         <executions>
           <execution>
             <goals>

--- a/pubsub/spring/pom.xml
+++ b/pubsub/spring/pom.xml
@@ -47,7 +47,7 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.5.7</version>
+        <version>2.5.8</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/run/helloworld/pom.xml
+++ b/run/helloworld/pom.xml
@@ -32,7 +32,7 @@ limitations under the License.
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.5.5</version>
+        <version>2.5.8</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/run/image-processing/pom.xml
+++ b/run/image-processing/pom.xml
@@ -35,7 +35,7 @@ limitations under the License.
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.5.5</version>
+        <version>2.5.8</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/run/markdown-preview/editor/pom.xml
+++ b/run/markdown-preview/editor/pom.xml
@@ -36,7 +36,7 @@
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.5.5</version>
+        <version>2.5.8</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/spanner/r2dbc/pom.xml
+++ b/spanner/r2dbc/pom.xml
@@ -45,6 +45,7 @@
   </dependencyManagement>
 
   <dependencies>
+
     <!-- [START spanner_spring_data_r2dbc_dependency] -->
     <dependency>
       <groupId>com.google.cloud</groupId>
@@ -71,6 +72,13 @@
     </dependency>
 
     <!-- Test dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>

--- a/spanner/r2dbc/pom.xml
+++ b/spanner/r2dbc/pom.xml
@@ -5,13 +5,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.example</groupId>
-  <artifactId>cloud-spanner-r2dbc</artifactId>
+  <artifactId>cloud-spanner-r2dbc-sample</artifactId>
   <version>1.0-SNAPSHOT</version>
 
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <spring-boot.version>2.5.5</spring-boot.version>
+    <spring-boot.version>2.5.8</spring-boot.version>
   </properties>
 
   <!--
@@ -33,11 +33,18 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
   <dependencies>
-
     <!-- [START spanner_spring_data_r2dbc_dependency] -->
     <dependency>
       <groupId>com.google.cloud</groupId>
@@ -61,21 +68,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-webflux</artifactId>
-      <version>${spring-boot.version}</version>
     </dependency>
 
     <!-- Test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
-      <version>${spring-boot.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/spanner/r2dbc/src/test/java/com/example/spanner/r2dbc/R2dbcSampleApplicationIT.java
+++ b/spanner/r2dbc/src/test/java/com/example/spanner/r2dbc/R2dbcSampleApplicationIT.java
@@ -16,6 +16,7 @@
 
 package com.example.spanner.r2dbc;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.google.cloud.ServiceOptions;
@@ -38,8 +39,6 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT,
     classes = {R2dbcSampleApplication.class, WebController.class})

--- a/spanner/r2dbc/src/test/java/com/example/spanner/r2dbc/R2dbcSampleApplicationIT.java
+++ b/spanner/r2dbc/src/test/java/com/example/spanner/r2dbc/R2dbcSampleApplicationIT.java
@@ -16,8 +16,8 @@
 
 package com.example.spanner.r2dbc;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.spanner.DatabaseAdminClient;
@@ -27,9 +27,10 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -37,11 +38,12 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.r2dbc.core.DatabaseClient;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
 
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT,
-    classes = {R2dbcSampleApplication.class, WebController.class})
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class R2dbcSampleApplicationIT {
 
   @DynamicPropertySource
@@ -71,7 +73,7 @@ public class R2dbcSampleApplicationIT {
   DatabaseAdminClient dbAdminClient;
 
   // setup/teardown cannot be static because then properties will not be injected yet
-  @BeforeEach
+  @Before
   public void createDatabase() {
     SpannerOptions options = SpannerOptions.newBuilder().build();
     Spanner spanner = options.getService();
@@ -79,7 +81,7 @@ public class R2dbcSampleApplicationIT {
     dbAdminClient.createDatabase(instance, this.databaseName, Collections.EMPTY_LIST);
   }
 
-  @AfterEach
+  @After
   public void dropDatabase() {
     dbAdminClient.dropDatabase(instance, this.databaseName);
   }
@@ -88,7 +90,7 @@ public class R2dbcSampleApplicationIT {
   public void testAllWebEndpoints() {
 
     // DDL takes time; extend timeout to avoid "Timeout on blocking read" exceptions.
-    webTestClient = webTestClient.mutate().responseTimeout(Duration.ofSeconds(300)).build();
+    webTestClient = webTestClient.mutate().responseTimeout(Duration.ofSeconds(30)).build();
 
     this.webTestClient.post().uri("/createTable").exchange()
         .expectBody(String.class).isEqualTo("table NAMES created successfully");
@@ -105,8 +107,8 @@ public class R2dbcSampleApplicationIT {
         .expectBody(Name[].class)
         .consumeWith(result -> {
           Name[] names = result.getResponseBody();
-          assertEquals(1, names.length, "1 row expected");
-          assertEquals("Bob", names[0].getName(), "where is Bob?");
+          assertEquals("1 row expected", 1, names.length);
+          assertEquals("where is Bob?", "Bob", names[0].getName());
           uuid.set(names[0].getUuid());
         });
 


### PR DESCRIPTION
The latest Spring Boot release was yesterday; it upgrades log4j-api to 2.17.0.

Do you know why renovate bot does not get to these dependencies?

I also had to upgrade the R2DBC test to JUnit5 -- at some point when spring-boot-test dependency got upgraded to 2.5.x, the test got silently ignored.

- [x ] **Tests** pass:   `mvn clean verify` **required**
- [x ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] Please **merge** this PR for me once it is approved.
