### PR TITLE
Upgrade Spring Cloud GCP and remaining Spring Boot versions

### DIFF
--- a/pubsub/spring/pom.xml
+++ b/pubsub/spring/pom.xml
@@ -55,7 +55,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>spring-cloud-gcp-dependencies</artifactId>
-        <version>2.0.6</version>
+        <version>2.0.7</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/run/idp-sql/pom.xml
+++ b/run/idp-sql/pom.xml
@@ -38,14 +38,14 @@ limitations under the License.
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.5.5</version>
+        <version>2.5.8</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>spring-cloud-gcp-dependencies</artifactId>
-        <version>2.0.6</version>
+        <version>2.0.7</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/run/image-processing/pom.xml
+++ b/run/image-processing/pom.xml
@@ -44,7 +44,7 @@ limitations under the License.
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>spring-cloud-gcp-dependencies</artifactId>
-        <version>2.0.6</version>
+        <version>2.0.7</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/spanner/spring-data/pom.xml
+++ b/spanner/spring-data/pom.xml
@@ -41,7 +41,7 @@ limitations under the License.
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>spring-cloud-gcp-dependencies</artifactId>
-        <version>2.0.6</version>
+        <version>2.0.7</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Spring Cloud GCP 2.0.7 is released. It includes a transitive dependency on the latest Spring Boot in 2.5.x train.

I also found a couple of Spring Boot versions I missed in #6600.

- [x ] **Tests** pass:   `mvn clean verify` **required**
- [ x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ x] Please **merge** this PR for me once it is approved.
