### PR TITLE
docs: Update README.md

### DIFF
--- a/bigtable/beam/workload-generator/README.md
+++ b/bigtable/beam/workload-generator/README.md
@@ -15,7 +15,7 @@ be run as a Dataflow job.
     INSTANCE_ID=YOUR-INSTANCE-ID
     TABLE_ID=YOUR-TABLE-ID
     REGION=us-central1
-    WORKLOAD_QPS=100 # Optional
+    WORKLOAD_QPS=100 # Optional, default to 1000
     ```
 
 1. Run this command to start a job from dataflow template:
@@ -27,7 +27,7 @@ be run as a Dataflow job.
     --parameters bigtableInstanceId="$INSTANCE_ID" \
     --parameters bigtableTableId="$TABLE_ID" \
     --region "$REGION" \
-    --parameters workloadQPS=$WORKLOAD_QPS
+    --parameters workloadRate=$WORKLOAD_QPS
     ```
 
 1. Make sure to cancel the job once you are done.


### PR DESCRIPTION
Fix parameter mismatch.

Also, the command `gcloud dataflow jobs cancel $JOB_NAME` gives me error

```
Could not cancel workflow; user does not have sufficient permissions on project: autonomous-mote-782, or the job does not exist in the project. Please ensure you have permission to access the job and the `--region` flag, us-central1, matches the job's region.
```

Any thoughts?