### PR TITLE
docs(compute-samples): init add samples for custom hostname

### DIFF
--- a/compute/cloud-client/pom.xml
+++ b/compute/cloud-client/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2021 Google LLC
+  Copyright 2022 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
     <dependency>
       <artifactId>google-cloud-compute</artifactId>
       <groupId>com.google.cloud</groupId>
-      <version>1.6.0-beta</version>
+      <version>1.7.0</version>
     </dependency>
     <dependency>
       <artifactId>google-cloud-storage</artifactId>
@@ -32,12 +32,12 @@
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax</artifactId>
-      <version>2.7.1</version>
+      <version>2.8.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-httpjson</artifactId>
-      <version>0.92.1</version>
+      <version>0.93.1</version>
     </dependency>
 
 

--- a/compute/cloud-client/src/main/java/compute/customhostname/CreateInstanceWithCustomHostname.java
+++ b/compute/cloud-client/src/main/java/compute/customhostname/CreateInstanceWithCustomHostname.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package compute.customhostname;
+
+// [START compute_instances_create_custom_hostname]
+
+import com.google.cloud.compute.v1.AttachedDisk;
+import com.google.cloud.compute.v1.AttachedDiskInitializeParams;
+import com.google.cloud.compute.v1.InsertInstanceRequest;
+import com.google.cloud.compute.v1.Instance;
+import com.google.cloud.compute.v1.InstancesClient;
+import com.google.cloud.compute.v1.NetworkInterface;
+import com.google.cloud.compute.v1.Operation;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+public class CreateInstanceWithCustomHostname {
+
+  public static void main(String[] args)
+      throws IOException, ExecutionException, InterruptedException {
+    // TODO(developer): Replace these variables before running the sample.
+    // hostName: Custom hostname of the new VM instance.
+    // *    Custom hostnames must conform to RFC 1035 requirements for valid hostnames.
+    String project = "your-project-id";
+    String zone = "zone-name"; // eg: "us-central1-a"
+    String instanceName = "instance-name";
+    String hostName = "host.example.com";
+    createInstanceWithCustomHostname(project, zone, instanceName, hostName);
+  }
+
+  // Creates an instance with custom hostname.
+  public static void createInstanceWithCustomHostname(String projectId, String zone,
+      String instanceName, String hostName)
+      throws IOException, ExecutionException, InterruptedException {
+    //  machineType - Machine type for the VM instance specified in the following format:
+    //  *    "zones/{zone}/machineTypes/{type_name}". For example:
+    //  *    "zones/europe-west3-c/machineTypes/f1-micro"
+    //  *    You can find the list of available machine types by using this gcloud command:
+    //  *    $ gcloud compute machine-types list
+    //  sourceImage - Path of the disk image you want to use for your boot
+    //  *    disk. This image can be one of the public images
+    //  *    eg: "projects/...
+    //  *    or a private image you have access to.
+    //  *    You can check the list of available public images using:
+    //  *    $ gcloud compute images list
+    //  networkName - Name of the network you want the new instance to use.
+    //  *    For example: global/networks/default - if you want to use the default network.
+    String machineType = "n1-standard-1";
+    String sourceImage = String.format("projects/%s/global/images/family/%s", "debian-cloud",
+        "debian-11");
+    String networkName = "global/networks/default";
+
+    try (InstancesClient instancesClient = InstancesClient.create()) {
+      System.out.printf("Creating the %s instance in %s with hostname %s...", instanceName, zone,
+          hostName);
+
+      AttachedDisk disk =
+          AttachedDisk.newBuilder()
+              .setBoot(true)
+              .setAutoDelete(true)
+              .setType(AttachedDisk.Type.PERSISTENT.toString())
+              .setInitializeParams(
+                  // Describe the size and source image of the boot disk to attach to the instance.
+                  AttachedDiskInitializeParams.newBuilder()
+                      .setSourceImage(sourceImage)
+                      .setDiskSizeGb(10).build())
+              .build();
+
+      // Use the network interface provided in the networkName argument.
+      NetworkInterface networkInterface = NetworkInterface.newBuilder()
+          .setName(networkName)
+          .build();
+
+      Instance instanceResource = Instance.newBuilder()
+          // Custom hostnames are not resolved by the automatically created records
+          // provided by Compute Engine internal DNS.
+          // You must manually configure the DNS record for your custom hostname.
+          .setName(instanceName)
+          .setHostname(hostName)
+          .addDisks(disk)
+          .setMachineType(String.format("zones/%s/machineTypes/%s", zone, machineType))
+          .addNetworkInterfaces(networkInterface).build();
+
+      InsertInstanceRequest request = InsertInstanceRequest.newBuilder()
+          .setProject(projectId)
+          .setZone(zone)
+          .setInstanceResource(instanceResource).build();
+
+      // Wait for the create operation to complete.
+      Operation response = instancesClient.insertAsync(request).get();
+
+      if (response.hasError()) {
+        System.out.printf("Instance creation failed for instance: %s ; Response: %s ! ! ",
+            instanceName, response);
+        return;
+      }
+      System.out.printf("Instance created : %s", instanceName);
+      System.out.printf("Operation Status for instance %s is %s: ", instanceName,
+          response.getStatus());
+    }
+
+  }
+
+}
+// [END compute_instances_create_custom_hostname]

--- a/compute/cloud-client/src/main/java/compute/customhostname/GetInstanceHostname.java
+++ b/compute/cloud-client/src/main/java/compute/customhostname/GetInstanceHostname.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package compute.customhostname;
+
+// [START compute_instances_get_hostname]
+
+import com.google.cloud.compute.v1.Instance;
+import com.google.cloud.compute.v1.InstancesClient;
+import java.io.IOException;
+
+public class GetInstanceHostname {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String project = "your-project-id";
+    String zone = "zone-name"; // eg: "us-central1-a"
+    String instanceName = "instance-name"; // Name of the VM instance to retrieve.
+
+    getInstanceHostname(project, zone, instanceName);
+  }
+
+  // Retrieves the hostname of the Google Cloud VM instance.
+  public static void getInstanceHostname(String projectId, String zone, String instanceName)
+      throws IOException {
+    try (InstancesClient instancesClient = InstancesClient.create()) {
+
+      Instance instance = instancesClient.get(projectId, zone, instanceName);
+
+      if (instance.hasHostname()) {
+        // If a custom hostname is not set, the output for instance.getHostname() will be undefined.
+        System.out.printf("Custom Hostname for the instance %s is: %s", instanceName,
+            instance.getHostname());
+      }
+    }
+  }
+
+}
+// [END compute_instances_get_hostname]

--- a/compute/cloud-client/src/test/java/compute/customhostname/CustomHostnameInstanceIT.java
+++ b/compute/cloud-client/src/test/java/compute/customhostname/CustomHostnameInstanceIT.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package compute.customhostname;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import compute.DeleteInstance;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class CustomHostnameInstanceIT {
+
+  private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static String INSTANCE_NAME;
+  private static String ZONE;
+  private static String CUSTOM_HOSTNAME;
+
+  private ByteArrayOutputStream stdOut;
+
+  // Check if the required environment variables are set.
+  public static void requireEnvVar(String envVarName) {
+    assertWithMessage(String.format("Missing environment variable '%s' ", envVarName))
+        .that(System.getenv(envVarName)).isNotEmpty();
+  }
+
+  @BeforeClass
+  public static void setup() throws IOException, ExecutionException, InterruptedException {
+    final PrintStream out = System.out;
+    ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(stdOut));
+    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+
+    INSTANCE_NAME = "my-custom-hostname-test-instance" + UUID.randomUUID().toString().split("-")[0];
+    ZONE = "us-central1-a";
+    CUSTOM_HOSTNAME = "host.domain.com";
+
+    // Create Instance with a custom hostname.
+    CreateInstanceWithCustomHostname.createInstanceWithCustomHostname(PROJECT_ID, ZONE,
+        INSTANCE_NAME, CUSTOM_HOSTNAME);
+    assertThat(stdOut.toString()).contains("Instance created : " + INSTANCE_NAME);
+
+    stdOut.close();
+    System.setOut(out);
+  }
+
+  @AfterClass
+  public static void cleanUp() throws IOException, ExecutionException, InterruptedException {
+    final PrintStream out = System.out;
+    ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(stdOut));
+    DeleteInstance.deleteInstance(PROJECT_ID, ZONE, INSTANCE_NAME);
+    stdOut.close();
+    System.setOut(out);
+  }
+
+  @Before
+  public void beforeEach() {
+    stdOut = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(stdOut));
+  }
+
+  @After
+  public void afterEach() {
+    stdOut = null;
+    System.setOut(null);
+  }
+
+  @Test
+  public void testGetInstanceHostname() throws IOException {
+    GetInstanceHostname.getInstanceHostname(PROJECT_ID, ZONE, INSTANCE_NAME);
+    assertThat(stdOut.toString()).contains(CUSTOM_HOSTNAME);
+  }
+
+}


### PR DESCRIPTION
Added samples for instance creation with custom hostname.

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] Please **merge** this PR for me once it is approved.
