### PR TITLE
fix(pubsublite): remove processing time trigger

### DIFF
--- a/pubsublite/streaming-analytics/pom.xml
+++ b/pubsublite/streaming-analytics/pom.xml
@@ -128,6 +128,18 @@
       <version>${beam.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+      <version>1.32.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-dataflow</artifactId>
+      <version>v1b3-rev20210825-1.32.1</version>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.hamcrest</groupId>
@@ -144,18 +156,6 @@
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <version>1.1.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.api-client</groupId>
-      <artifactId>google-api-client</artifactId>
-      <version>1.32.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.apis</groupId>
-      <artifactId>google-api-services-dataflow</artifactId>
-      <version>v1b3-rev20210825-1.32.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
By default, `FixedWindows` are triggered by event time (if no trigger is specified), which is the publish timestamp of a message. 

The example was using the processing time trigger because the PubsubLiteIO at one time had a bug. 

The bug has since been fixed (b/186174854), so we no longer need to demonstrate how to use processing time triggers for the sample to work. 

The `pom.xml` changes are required for running the sample via command line - I had previously thought they were required by the test only. Without them as compile dependencies, the following error will be thrown:

```
An exception occured while executing the Java class. com/google/api/services/dataflow/Dataflow: com.google.api.services.dataflow.Dataflow
```