### PR TITLE
feat: add cloud spanner change streams samples

### DIFF
--- a/spanner/changestreams/README.md
+++ b/spanner/changestreams/README.md
@@ -1,0 +1,24 @@
+# Cloud Spanner Change Stream Sample
+
+## Setup
+
+This sample requires [Java](https://www.java.com/en/download/) and [Maven](http://maven.apache.org/) to run the integration test.
+
+1.  **Follow the set-up instructions in [the documentation](https://cloud.google.com/java/docs/setup).**
+
+2.  Enable APIs for your project.
+    [Click here](https://console.cloud.google.com/flows/enableapi?apiid=spanner.googleapis.com&showconfirmation=true)
+    to visit Cloud Platform Console and enable the Google Cloud Spanner API.
+
+3.  Create a Cloud Spanner instance and database via the Cloud Plaform Console's
+    [Cloud Spanner section](http://console.cloud.google.com/spanner).
+
+4.  Enable application default credentials by running the command `gcloud auth application-default login`.
+
+## Run integration test
+
+Run the following Maven command to run integration test:
+
+```
+mvn test -Dspanner.test.instance=my-instance -Dspanner.test.database=my-db -Dtest=com.example.spanner.changestreams.ChangeStreamSampleIT
+```

--- a/spanner/changestreams/pom.xml
+++ b/spanner/changestreams/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2022 Google LLC.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+  </properties>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.2.0</version>
+  </parent>
+
+  <groupId>com.example.spanner</groupId>
+  <artifactId>changestreams</artifactId>
+  <name>Cloud Spanner Change Streams Sample</name>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>24.2.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+      <dependency>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+          <version>31.0.1-jre</version>
+      </dependency>
+      <dependency>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro</artifactId>
+          <version>1.10.1</version>
+      </dependency>
+      <dependency>
+          <groupId>com.google.cloud</groupId>
+          <artifactId>google-cloud-spanner</artifactId>
+      </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/spanner/changestreams/src/main/java/com/example/spanner/changestreams/ChangeStreamRecordMapper.java
+++ b/spanner/changestreams/src/main/java/com/example/spanner/changestreams/ChangeStreamRecordMapper.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.changestreams;
+
+import com.example.spanner.changestreams.model.ChangeStreamRecord;
+import com.example.spanner.changestreams.model.ChildPartition;
+import com.example.spanner.changestreams.model.ChildPartitionsRecord;
+import com.example.spanner.changestreams.model.ColumnType;
+import com.example.spanner.changestreams.model.DataChangeRecord;
+import com.example.spanner.changestreams.model.HeartbeatRecord;
+import com.example.spanner.changestreams.model.Mod;
+import com.example.spanner.changestreams.model.ModType;
+import com.example.spanner.changestreams.model.TypeCode;
+import com.example.spanner.changestreams.model.ValueCaptureType;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.Type;
+import com.google.common.collect.Sets;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * ChangeStreamRecordMapper converts a Struct returned from Change Streams API into a well-defined
+ * model, which could be one of DataChangeRecord, ChildPartitionsRecord or HeartbeatRecord.
+ */
+public class ChangeStreamRecordMapper {
+
+  public List<ChangeStreamRecord> toChangeStreamRecords(Struct row) {
+    return row.getStructList(0).stream()
+      .flatMap(struct -> toChangeStreamRecord(struct))
+      .collect(Collectors.toList());
+  }
+
+  private Stream<ChangeStreamRecord> toChangeStreamRecord(Struct row) {
+    final Stream<DataChangeRecord> dataChangeRecords =
+        row.getStructList("data_change_record").stream()
+        .filter(this::isNonNullDataChangeRecord)
+        .map(struct -> toDataChangeRecord(struct));
+
+    final Stream<HeartbeatRecord> heartbeatRecords =
+        row.getStructList("heartbeat_record").stream()
+        .filter(this::isNonNullHeartbeatRecord)
+        .map(struct -> toHeartbeatRecord(struct));
+
+    final Stream<ChildPartitionsRecord> childPartitionsRecords =
+        row.getStructList("child_partitions_record").stream()
+          .filter(this::isNonNullChildPartitionsRecord)
+          .map(struct -> toChildPartitionsRecord(struct));
+
+    return Stream.concat(
+      Stream.concat(dataChangeRecords, heartbeatRecords), childPartitionsRecords);
+  }
+
+  private boolean isNonNullDataChangeRecord(Struct row) {
+    return !row.isNull("commit_timestamp");
+  }
+
+  private boolean isNonNullHeartbeatRecord(Struct row) {
+    return !row.isNull("timestamp");
+  }
+
+  private boolean isNonNullChildPartitionsRecord(Struct row) {
+    return !row.isNull("start_timestamp");
+  }
+
+  private DataChangeRecord toDataChangeRecord(Struct row) {
+    final Timestamp commitTimestamp = row.getTimestamp("commit_timestamp");
+    return new DataChangeRecord(
+      commitTimestamp,
+      row.getString("server_transaction_id"),
+      row.getBoolean("is_last_record_in_transaction_in_partition"),
+      row.getString("record_sequence"),
+      row.getString("table_name"),
+      row.getStructList("column_types").stream()
+        .map(this::columnTypeFrom)
+        .collect(Collectors.toList()),
+      row.getStructList("mods").stream().map(this::modFrom).collect(Collectors.toList()),
+      ModType.valueOf(row.getString("mod_type")),
+      ValueCaptureType.valueOf(row.getString("value_capture_type")),
+      row.getLong("number_of_records_in_transaction"),
+      row.getLong("number_of_partitions_in_transaction"));
+  }
+
+  private HeartbeatRecord toHeartbeatRecord(Struct row) {
+    final Timestamp timestamp = row.getTimestamp("timestamp");
+    return new HeartbeatRecord(timestamp);
+  }
+
+  private ChildPartitionsRecord toChildPartitionsRecord(Struct row) {
+    final Timestamp startTimestamp = row.getTimestamp("start_timestamp");
+    return new ChildPartitionsRecord(
+      startTimestamp,
+      row.getString("record_sequence"),
+      row.getStructList("child_partitions").stream()
+        .map(struct -> childPartitionFrom(struct))
+        .collect(Collectors.toList()));
+  }
+
+  private ColumnType columnTypeFrom(Struct struct) {
+    // TODO: Move to type struct.getJson when backend is fully migrated
+    final String type = getJsonString(struct, "type");
+    return new ColumnType(
+      struct.getString("name"),
+        new TypeCode(type),
+      struct.getBoolean("is_primary_key"),
+      struct.getLong("ordinal_position"));
+  }
+
+  private Mod modFrom(Struct struct) {
+    // TODO: Move to keys struct.getJson when backend is fully migrated
+    final String keys = getJsonString(struct, "keys");
+    // TODO: Move to oldValues struct.getJson when backend is fully migrated
+    final String oldValues =
+        struct.isNull("old_values") ? null : getJsonString(struct, "old_values");
+    // TODO: Move to newValues struct.getJson when backend is fully migrated
+    final String newValues =
+        struct.isNull("new_values") ? null : getJsonString(struct, "new_values");
+    return new Mod(keys, oldValues, newValues);
+  }
+
+  private ChildPartition childPartitionFrom(Struct struct) {
+    final HashSet<String> parentTokens =
+        Sets.newHashSet(struct.getStringList("parent_partition_tokens"));
+    return new ChildPartition(struct.getString("token"), parentTokens);
+  }
+
+  // TODO: Remove when backend is fully migrated to JSON.
+  private String getJsonString(Struct struct, String columnName) {
+    if (struct.getColumnType(columnName).equals(Type.json())) {
+      return struct.getJson(columnName);
+    } else if (struct.getColumnType(columnName).equals(Type.string())) {
+      return struct.getString(columnName);
+    } else {
+      throw new IllegalArgumentException("Can not extract string from value " + columnName);
+    }
+  }
+}

--- a/spanner/changestreams/src/main/java/com/example/spanner/changestreams/ChangeStreamSample.java
+++ b/spanner/changestreams/src/main/java/com/example/spanner/changestreams/ChangeStreamSample.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.changestreams;
+
+// TODO(haikuo@google.com): we should remove the models and the mapper once the change stream
+//  connector code that includes these models are released into Beam repo.
+import com.example.spanner.changestreams.model.ChangeStreamRecord;
+import com.example.spanner.changestreams.model.ChildPartition;
+import com.example.spanner.changestreams.model.ChildPartitionsRecord;
+import com.example.spanner.changestreams.model.DataChangeRecord;
+import com.example.spanner.changestreams.model.HeartbeatRecord;
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.DatabaseAdminClient;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.DatabaseId;
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.SpannerOptions;
+import com.google.cloud.spanner.Statement;
+import com.google.common.collect.ImmutableList;
+import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Sample code for querying change stream, it:
+ * 1. Creates a table with simple schema and a change stream that watches the table.
+ * 2. Inserts test data into the table.
+ * 3. Executes a change stream initial query to get change stream partition tokens.
+ * 4. Executes a change stream partition query to get data change records of the inserted rows.
+ * 5. Drops the created table and change stream.
+ */
+public class ChangeStreamSample {
+  private static final long TIMEOUT_MINUTES = 2;
+
+  public static void run(String instanceId, String databaseId, String prefix) {
+    final String tableName = prefix + "_Singers";
+    final String changeStreamName = prefix + "_ChangeStreamSingers";
+    final SpannerOptions options = SpannerOptions.newBuilder().build();
+    final Spanner spanner = options.getService();
+    final DatabaseAdminClient dbAdminClient = spanner.getDatabaseAdminClient();
+    final DatabaseClient dbClient = spanner.getDatabaseClient(
+        DatabaseId.of(options.getProjectId(), instanceId, databaseId));
+
+    try {
+      createChangeStream(dbAdminClient, instanceId, databaseId, tableName, changeStreamName);
+      queryChangeStream(dbClient, tableName, changeStreamName);
+      dropChangeStream(dbAdminClient, instanceId, databaseId, tableName, changeStreamName);
+    } catch (Exception e) {
+      e.printStackTrace();
+    } finally {
+      spanner.close();
+    }
+  }
+
+  // [START spanner_change_streams_sample_create_change_streams]
+  static void createChangeStream(
+      DatabaseAdminClient dbAdminClient, String instanceId, String databaseId, String tableName,
+      String changeStreamName) throws Exception {
+    System.out.println(
+        String.format("Updating database DDL to create table %s and change stream %s.",
+          tableName, changeStreamName));
+
+    OperationFuture<Void, UpdateDatabaseDdlMetadata> op = dbAdminClient
+        .updateDatabaseDdl(
+        instanceId,
+        databaseId,
+        Arrays.asList(
+          String.format("CREATE TABLE %s ("
+            + "  SingerId   INT64 NOT NULL,"
+            + "  FirstName  STRING(1024),"
+            + "  LastName   STRING(1024)"
+            + ") PRIMARY KEY (SingerId)", tableName),
+          String.format("CREATE CHANGE STREAM %s FOR %s", changeStreamName, tableName)),
+        null
+      );
+
+    op.get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
+  }
+  // [END spanner_change_streams_sample_create_change_streams]
+
+  // [START spanner_change_streams_sample_query_change_streams]
+  public static void queryChangeStream(DatabaseClient dbClient, String tableName,
+                                       String changeStreamName) {
+    // Insert test data into the table.
+    System.out.println(
+        String.format("Inserting rows "
+          + "(1, singer_1_first_name, singer_1_last_name) and "
+          + "(2, singer_2_first_name, singer_2_last_name) "
+          + "into %s table.", tableName));
+
+    insertRows(dbClient, tableName);
+
+    final Timestamp startTimestamp = Timestamp.now();
+    // end = start + 30 seconds.
+    final Timestamp endTimestamp = Timestamp.ofTimeSecondsAndNanos(
+        startTimestamp.getSeconds() + 30, startTimestamp.getNanos());
+
+    final ChangeStreamRecordMapper changeStreamRecordMapper =
+        new ChangeStreamRecordMapper();
+
+    // Execute an initial query to get partition tokens.
+    System.out.println("Executing change stream initial query.");
+    // For initial query the partition token is null.
+    List<ChangeStreamRecord> initialQueryRecords = executeChangeStreamQueryAndPrint(
+        dbClient, changeStreamName, startTimestamp, endTimestamp, null,
+        changeStreamRecordMapper);
+
+    System.out.println("Executing change stream partition queries.");
+    for (ChangeStreamRecord record : initialQueryRecords) {
+      // Executes a partition query to print data records that we just inserted.
+      if (record instanceof ChildPartitionsRecord) {
+        ChildPartitionsRecord childPartitionsRecord = (ChildPartitionsRecord) record;
+        for (ChildPartition childPartition : childPartitionsRecord.getChildPartitions()) {
+          executeChangeStreamQueryAndPrint(
+              dbClient, changeStreamName, childPartitionsRecord.getStartTimestamp(), endTimestamp,
+              childPartition.getToken(), changeStreamRecordMapper);
+        }
+      } else if (record instanceof DataChangeRecord) {
+        throw new IllegalArgumentException("Got unexpected DataChangeRecord from Change Streams "
+          + "initial query");
+      }
+    }
+  }
+
+  // Insert two rows into Singers table.
+  static void insertRows(DatabaseClient client, String tableName) {
+    client.write(
+        ImmutableList.of(
+        Mutation.newInsertOrUpdateBuilder(tableName)
+          .set("SingerId").to(1)
+          .set("FirstName").to("singer_1_first_name")
+          .set("LastName").to("singer_1_last_name")
+          .build(),
+        Mutation.newInsertOrUpdateBuilder(tableName)
+          .set("SingerId").to(2)
+          .set("FirstName").to("singer_2_first_name")
+          .set("LastName").to("singer_2_last_name")
+          .build()
+      )
+    );
+  }
+
+  // Execute a change stream query, return and print out the result records.
+  // For initial query, partitionToken is expected to be null.
+  public static List<ChangeStreamRecord> executeChangeStreamQueryAndPrint(
+      DatabaseClient dbClient, String changeStreamName, Timestamp startTimestamp,
+      Timestamp endTimestamp, String partitionToken,
+      ChangeStreamRecordMapper changeStreamRecordMapper) {
+    System.out.println("Executing a change stream query with: "
+        + "start_timestamp => " + startTimestamp
+        + ", end_timestamp => " + endTimestamp
+        + ", partition_token => " + partitionToken
+        + ", heartbeat_milliseconds => 5000");
+
+    final String query =
+        String.format("SELECT * FROM READ_%s ("
+          + "start_timestamp => @startTimestamp,"
+          + "end_timestamp => @endTimestamp,"
+          + "partition_token => @partitionToken,"
+          + "heartbeat_milliseconds => @heartbeatMillis"
+          + ")", changeStreamName);
+
+    final ResultSet resultSet =
+        dbClient
+          .singleUse()
+          .executeQuery(
+            Statement.newBuilder(query)
+              .bind("startTimestamp").to(startTimestamp)
+              .bind("endTimestamp").to(endTimestamp)
+              .bind("partitionToken").to(partitionToken)
+              .bind("heartbeatMillis").to(5000)
+              .build());
+
+    List<ChangeStreamRecord> result = new ArrayList<>();
+    while (resultSet.next()) {
+      // Parses result set into change stream result format.
+      final List<ChangeStreamRecord> records =
+          changeStreamRecordMapper.toChangeStreamRecords(resultSet.getCurrentRowAsStruct());
+
+      // Prints out all the query results.
+      for (final ChangeStreamRecord record : records) {
+        if (record instanceof DataChangeRecord) {
+          System.out.println("Received a DataChangeRecord: " + record);
+        } else if (record instanceof HeartbeatRecord) {
+          System.out.println("Received a HeartbeatRecord: " + record);
+        } else if (record instanceof ChildPartitionsRecord) {
+          System.out.println("Received a ChildPartitionsRecord: " + record);
+        } else {
+          // We should never reach here.
+          throw new IllegalArgumentException("Unknown record type " + record.getClass());
+        }
+      }
+      result.addAll(records);
+    }
+
+    return result;
+  }
+  // [END spanner_change_streams_sample_query_change_streams]
+
+  // [START spanner_change_streams_sample_drop_change_streams]
+  public static void dropChangeStream(
+      DatabaseAdminClient dbAdminClient, String instanceId, String databaseId, String tableName,
+      String changeStreamName) throws Exception {
+    System.out.println(
+        String.format("Updating database DDL to drop table %s and change stream %s.",
+          tableName, changeStreamName));
+
+    OperationFuture<Void, UpdateDatabaseDdlMetadata> op = dbAdminClient
+        .updateDatabaseDdl(
+        instanceId,
+        databaseId,
+        Arrays.asList(
+          "DROP CHANGE STREAM " + changeStreamName,
+          "DROP TABLE " + tableName),
+        null
+      );
+
+    op.get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
+  }
+  // [END spanner_change_streams_sample_drop_change_streams]
+}

--- a/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/ChangeStreamRecord.java
+++ b/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/ChangeStreamRecord.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.changestreams.model;
+
+import java.io.Serializable;
+
+/**
+ * Represents a Spanner Change Stream Record. It can be one of: {@link DataChangeRecord}, {@link
+ * HeartbeatRecord} or {@link ChildPartitionsRecord}.
+ */
+public interface ChangeStreamRecord extends Serializable { }

--- a/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/ChildPartition.java
+++ b/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/ChildPartition.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.changestreams.model;
+
+import com.google.common.collect.Sets;
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Objects;
+
+/**
+ * A child partition represents a new partition that should be queried. Child partitions are emitted
+ * in {@link ChildPartitionsRecord}.
+ */
+public class ChildPartition implements Serializable {
+
+  private String token;
+  // This needs to be an implementation (HashSet), instead of the Set interface, otherwise
+  // we can not encode / decode this.
+  private HashSet<String> parentTokens;
+
+  /** Default constructor for serialization only. */
+  private ChildPartition() {}
+
+  /**
+   * Constructs a child partition, which will have its own token and the parents that it originated
+   * from. A child partition will have a single parent if it is originated from a partition move or
+   * split. A child partition will have multiple parents if it is originated from a partition merge.
+   *
+   * @param token the child partition token
+   * @param parentTokens the partition tokens of the parent(s) that originated the child partition
+   */
+  public ChildPartition(String token, HashSet<String> parentTokens) {
+    this.token = token;
+    this.parentTokens = parentTokens;
+  }
+
+  /**
+   * Constructs a child partition, which will have its own token and the parent that it originated
+   * from. Use this constructor for child partitions with a single parent (generated from a move or
+   * split).
+   *
+   * @param token the child partition token
+   * @param parentToken the partition tokens of the parent that originated the child partition
+   */
+  public ChildPartition(String token, String parentToken) {
+    this(token, Sets.newHashSet(parentToken));
+  }
+
+  /**
+   * Unique partition identifier, which can be used to perform a change stream query.
+   *
+   * @return the unique partition identifier
+   */
+  public String getToken() {
+    return token;
+  }
+
+  /**
+   * The unique partition identifiers of the parent partitions where this child partition originated
+   * from.
+   *
+   * @return a set of parent partition tokens
+   */
+  public HashSet<String> getParentTokens() {
+    return parentTokens;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ChildPartition)) {
+      return false;
+    }
+    ChildPartition that = (ChildPartition) o;
+    return Objects.equals(token, that.token) && Objects.equals(parentTokens, that.parentTokens);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(token, parentTokens);
+  }
+
+  @Override
+  public String toString() {
+    return "ChildPartition{"
+        + "childToken='"
+        + token
+        + '\''
+        + ", parentTokens="
+        + parentTokens
+        + '}';
+  }
+}

--- a/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/ChildPartitionsRecord.java
+++ b/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/ChildPartitionsRecord.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.changestreams.model;
+
+import com.google.cloud.Timestamp;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents a ChildPartitionsRecord. This record will be emitted in one of the following cases: a
+ * partition has been moved into a new partition, a partition has been split into multiple new child
+ * partitions or partitions have been merged into a new partition
+ *
+ * <p>When receiving this record, the caller should perform new queries using the child partition
+ * tokens received.
+ */
+public class ChildPartitionsRecord implements ChangeStreamRecord {
+
+  private Timestamp startTimestamp;
+
+  private String recordSequence;
+  private List<ChildPartition> childPartitions;
+
+  /** Default constructor for serialization only. */
+  private ChildPartitionsRecord() {}
+
+  /**
+   * Constructs a child partitions record containing one or more child partitions.
+   *
+   * @param startTimestamp the timestamp which this partition started being valid in Cloud Spanner
+   * @param recordSequence the order within a partition and a transaction in which the record was
+   *     put to the stream
+   * @param childPartitions child partition tokens emitted within this record
+   */
+  public ChildPartitionsRecord(
+      Timestamp startTimestamp,
+      String recordSequence,
+      List<ChildPartition> childPartitions) {
+    this.startTimestamp = startTimestamp;
+    this.recordSequence = recordSequence;
+    this.childPartitions = childPartitions;
+  }
+
+  /**
+   * It is the partition_start_time of the child partition token. This partition_start_time is
+   * guaranteed to be the same across all the child partitions yielded from a parent. When users
+   * start new queries with the child partition tokens, the returned records must have a timestamp
+   * >= partition_start_time.
+   *
+   * @return the start timestamp of the partition
+   */
+  public Timestamp getStartTimestamp() {
+    return startTimestamp;
+  }
+
+  /**
+   * Indicates the order in which a record was put to the stream. Is unique and increasing within a
+   * partition. It is relative to the scope of partition, commit timestamp, and
+   * server_transaction_id. It is useful for readers downstream to dedup any duplicate records that
+   * were read/recorded.
+   *
+   * @return record sequence of the record
+   */
+  public String getRecordSequence() {
+    return recordSequence;
+  }
+
+  /**
+   * List of child partitions yielded within this record.
+   *
+   * @return child partitions
+   */
+  public List<ChildPartition> getChildPartitions() {
+    return childPartitions;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ChildPartitionsRecord)) {
+      return false;
+    }
+    ChildPartitionsRecord that = (ChildPartitionsRecord) o;
+    return Objects.equals(startTimestamp, that.startTimestamp)
+        && Objects.equals(recordSequence, that.recordSequence)
+        && Objects.equals(childPartitions, that.childPartitions);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(startTimestamp, recordSequence, childPartitions);
+  }
+
+  @Override
+  public String toString() {
+    return "ChildPartitionsRecord{"
+        + "startTimestamp="
+        + startTimestamp
+        + ", recordSequence='"
+        + recordSequence
+        + '\''
+        + ", childPartitions="
+        + childPartitions
+        + '}';
+  }
+}

--- a/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/ColumnType.java
+++ b/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/ColumnType.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.changestreams.model;
+
+import com.google.common.base.Objects;
+import java.io.Serializable;
+
+/**
+ * Defines a column type from a Cloud Spanner table with the following information: column name,
+ * column type, flag indicating if column is primary key and column position in the table.
+ */
+public class ColumnType implements Serializable {
+
+  private String name;
+  private TypeCode type;
+  private boolean isPrimaryKey;
+  private long ordinalPosition;
+
+  /** Default constructor for serialization only. */
+  private ColumnType() {}
+
+  public ColumnType(String name, TypeCode type, boolean isPrimaryKey, long ordinalPosition) {
+    this.name = name;
+    this.type = type;
+    this.isPrimaryKey = isPrimaryKey;
+    this.ordinalPosition = ordinalPosition;
+  }
+
+  /** The name of the column. */
+  public String getName() {
+    return name;
+  }
+
+  /** The type of the column. */
+  public TypeCode getType() {
+    return type;
+  }
+
+  /** True if the column is part of the primary key, false otherwise. */
+  public boolean isPrimaryKey() {
+    return isPrimaryKey;
+  }
+
+  /** The position of the column in the table. */
+  public long getOrdinalPosition() {
+    return ordinalPosition;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ColumnType that = (ColumnType) o;
+    return isPrimaryKey() == that.isPrimaryKey()
+        && getOrdinalPosition() == that.getOrdinalPosition()
+        && Objects.equal(getName(), that.getName())
+        && Objects.equal(getType(), that.getType());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(getName(), getType(), isPrimaryKey(), getOrdinalPosition());
+  }
+
+  @Override
+  public String toString() {
+    return "ColumnType{"
+        + "name='"
+        + name
+        + '\''
+        + ", type="
+        + type
+        + ", isPrimaryKey="
+        + isPrimaryKey
+        + ", ordinalPosition="
+        + ordinalPosition
+        + '}';
+  }
+}

--- a/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/DataChangeRecord.java
+++ b/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/DataChangeRecord.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.changestreams.model;
+
+import com.google.cloud.Timestamp;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A data change record encodes modifications to Cloud Spanner rows. A record will contain one or
+ * more modifications made in one table with the same {@link ModType}. There can be multiple data
+ * change records for a transaction and commit timestamp.
+ */
+public class DataChangeRecord implements ChangeStreamRecord {
+
+  private Timestamp commitTimestamp;
+
+  private String serverTransactionId;
+  private boolean isLastRecordInTransactionInPartition;
+  private String recordSequence;
+  private String tableName;
+  private List<ColumnType> rowType;
+  private List<Mod> mods;
+  private ModType modType;
+  private ValueCaptureType valueCaptureType;
+  private long numberOfRecordsInTransaction;
+  private long numberOfPartitionsInTransaction;
+
+  /** Default constructor for serialization only. */
+  private DataChangeRecord() {}
+
+  /**
+   * Constructs a data change record for a given partition, at a given timestamp, for a given
+   * transaction. The data change record needs to be given information about the table modified, the
+   * type of primary keys and modified columns, the modifications themselves and other metadata.
+   *
+   * @param commitTimestamp the timestamp at which the modifications within were committed in Cloud
+   *     Spanner
+   * @param serverTransactionId the unique transaction id in which the modifications occurred
+   * @param isLastRecordInTransactionInPartition indicates whether this record is the last emitted
+   *     for the given transaction in the given partition
+   * @param recordSequence indicates the order in which this record was put into the change stream
+   *     in the scope of a partition, commit timestamp and transaction tuple
+   * @param tableName the name of the table in which the modifications occurred
+   * @param rowType the type of the primary keys and modified columns
+   * @param mods the modifications occurred
+   * @param modType the operation that caused the modification to occur
+   * @param valueCaptureType the capture type of the change stream
+   * @param numberOfRecordsInTransaction the total number of records for the given transaction
+   * @param numberOfPartitionsInTransaction the total number of partitions within the given
+   *     transaction
+   */
+  public DataChangeRecord(
+      Timestamp commitTimestamp,
+      String serverTransactionId,
+      boolean isLastRecordInTransactionInPartition,
+      String recordSequence,
+      String tableName,
+      List<ColumnType> rowType,
+      List<Mod> mods,
+      ModType modType,
+      ValueCaptureType valueCaptureType,
+      long numberOfRecordsInTransaction,
+      long numberOfPartitionsInTransaction) {
+    this.commitTimestamp = commitTimestamp;
+    this.serverTransactionId = serverTransactionId;
+    this.isLastRecordInTransactionInPartition = isLastRecordInTransactionInPartition;
+    this.recordSequence = recordSequence;
+    this.tableName = tableName;
+    this.rowType = rowType;
+    this.mods = mods;
+    this.modType = modType;
+    this.valueCaptureType = valueCaptureType;
+    this.numberOfRecordsInTransaction = numberOfRecordsInTransaction;
+    this.numberOfPartitionsInTransaction = numberOfPartitionsInTransaction;
+  }
+
+  /** The timestamp at which the modifications within were committed in Cloud Spanner. */
+  public Timestamp getCommitTimestamp() {
+    return commitTimestamp;
+  }
+
+  /** The unique transaction id in which the modifications occurred. */
+  public String getServerTransactionId() {
+    return serverTransactionId;
+  }
+
+  /**
+   * Indicates whether this record is the last emitted for the given transaction in the given
+   * partition.
+   */
+  public boolean isLastRecordInTransactionInPartition() {
+    return isLastRecordInTransactionInPartition;
+  }
+
+  /**
+   * Indicates the order in which this record was put into the change stream in the scope of a
+   * partition, commit timestamp and transaction tuple.
+   */
+  public String getRecordSequence() {
+    return recordSequence;
+  }
+
+  /** The name of the table in which the modifications within this record occurred. */
+  public String getTableName() {
+    return tableName;
+  }
+
+  /** The type of the primary keys and modified columns within this record. */
+  public List<ColumnType> getRowType() {
+    return rowType;
+  }
+
+  /** The modifications within this record. */
+  public List<Mod> getMods() {
+    return mods;
+  }
+
+  /** The type of operation that caused the modifications within this record. */
+  public ModType getModType() {
+    return modType;
+  }
+
+  /** The capture type of the change stream that generated this record. */
+  public ValueCaptureType getValueCaptureType() {
+    return valueCaptureType;
+  }
+
+  /** The total number of data change records for the given transaction. */
+  public long getNumberOfRecordsInTransaction() {
+    return numberOfRecordsInTransaction;
+  }
+
+  /** The total number of partitions for the given transaction. */
+  public long getNumberOfPartitionsInTransaction() {
+    return numberOfPartitionsInTransaction;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof DataChangeRecord)) {
+      return false;
+    }
+    DataChangeRecord that = (DataChangeRecord) o;
+    return isLastRecordInTransactionInPartition == that.isLastRecordInTransactionInPartition
+        && numberOfRecordsInTransaction == that.numberOfRecordsInTransaction
+        && numberOfPartitionsInTransaction == that.numberOfPartitionsInTransaction
+        && Objects.equals(commitTimestamp, that.commitTimestamp)
+        && Objects.equals(serverTransactionId, that.serverTransactionId)
+        && Objects.equals(recordSequence, that.recordSequence)
+        && Objects.equals(tableName, that.tableName)
+        && Objects.equals(rowType, that.rowType)
+        && Objects.equals(mods, that.mods)
+        && modType == that.modType
+        && valueCaptureType == that.valueCaptureType;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        commitTimestamp,
+        serverTransactionId,
+        isLastRecordInTransactionInPartition,
+        recordSequence,
+        tableName,
+        rowType,
+        mods,
+        modType,
+        valueCaptureType,
+        numberOfRecordsInTransaction,
+        numberOfPartitionsInTransaction);
+  }
+
+  @Override
+  public String toString() {
+    return "DataChangeRecord{"
+        + "commitTimestamp="
+        + commitTimestamp
+        + ", serverTransactionId='"
+        + serverTransactionId
+        + '\''
+        + ", isLastRecordInTransactionInPartition="
+        + isLastRecordInTransactionInPartition
+        + ", recordSequence='"
+        + recordSequence
+        + '\''
+        + ", tableName='"
+        + tableName
+        + '\''
+        + ", rowType="
+        + rowType
+        + ", mods="
+        + mods
+        + ", modType="
+        + modType
+        + ", valueCaptureType="
+        + valueCaptureType
+        + ", numberOfRecordsInTransaction="
+        + numberOfRecordsInTransaction
+        + ", numberOfPartitionsInTransaction="
+        + numberOfPartitionsInTransaction
+        + '}';
+  }
+}

--- a/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/HeartbeatRecord.java
+++ b/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/HeartbeatRecord.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.changestreams.model;
+
+import com.google.cloud.Timestamp;
+import java.util.Objects;
+
+/**
+ * A heartbeat record serves as a notification that the change stream query has returned all changes
+ * for the partition less or equal to the record timestamp.
+ */
+public class HeartbeatRecord implements ChangeStreamRecord {
+
+  private Timestamp timestamp;
+
+  /** Default constructor for serialization only. */
+  private HeartbeatRecord() {}
+
+  /**
+   * Constructs the heartbeat record with the given timestamp and metadata.
+   *
+   * @param timestamp the timestamp for which all changes in the partition have occurred
+   */
+  public HeartbeatRecord(Timestamp timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  /**
+   * Indicates the timestamp for which the change stream query has returned all changes. All records
+   * emitted after the heartbeat record will have a timestamp greater than this one.
+   *
+   * @return the timestamp for which the change stream query has returned all changes
+   */
+  public Timestamp getTimestamp() {
+    return timestamp;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof HeartbeatRecord)) {
+      return false;
+    }
+    HeartbeatRecord that = (HeartbeatRecord) o;
+    return Objects.equals(timestamp, that.timestamp);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(timestamp);
+  }
+
+  @Override
+  public String toString() {
+    return "HeartbeatRecord{" + "timestamp=" + timestamp + '}';
+  }
+}

--- a/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/Mod.java
+++ b/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/Mod.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.changestreams.model;
+
+import java.io.Serializable;
+import java.util.Objects;
+import org.apache.avro.reflect.Nullable;
+
+/**
+ * Represents a modification in a table emitted within a {@link DataChangeRecord}. Each mod contains
+ * keys, new values and old values returned as JSON strings.
+ */
+public class Mod implements Serializable {
+
+  private static final long serialVersionUID = 7362322548913179939L;
+
+  private String keysJson;
+
+  @Nullable private String oldValuesJson;
+
+  @Nullable private String newValuesJson;
+
+  /** Default constructor for serialization only. */
+  private Mod() {}
+
+  /**
+   * Constructs a mod from the primary key values, the old state of the row and the new state of the
+   * row.
+   *
+   * @param keysJson JSON object as String, where the keys are the primary key column names and the
+   *     values are the primary key column values
+   * @param oldValuesJson JSON object as String, displaying the old state of the columns modified.
+   *     This JSON object can be null in the case of an INSERT
+   * @param newValuesJson JSON object as String, displaying the new state of the columns modified.
+   *     This JSON object can be null in the case of a DELETE
+   */
+  public Mod(String keysJson, String oldValuesJson, String newValuesJson) {
+    this.keysJson = keysJson;
+    this.oldValuesJson = oldValuesJson;
+    this.newValuesJson = newValuesJson;
+  }
+
+  /**
+   * The old column values before the modification was applied. This can be null when the
+   * modification was emitted for an INSERT operation. The values are returned as a JSON object
+   * (stringified), where the keys are the column names and the values are the column values.
+   *
+   * @return JSON object as String representing the old column values before the row was modified
+   */
+  public String getOldValuesJson() {
+    return oldValuesJson;
+  }
+
+  /**
+   * The new column values after the modification was applied. This can be null when the
+   * modification was emitted for a DELETE operation. The values are returned as a JSON object
+   * (stringified), where the keys are the column names and the values are the column values.
+   *
+   * @return JSON object as String representing the new column values after the row was modified
+   */
+  public String getNewValuesJson() {
+    return newValuesJson;
+  }
+
+  /**
+   * The primary keys of this specific modification. This is always present and can not be null. The
+   * keys are returned as a JSON object (stringified), where the keys are the column names and the
+   * values are the column values.
+   *
+   * @return JSON object as String representing the primary key state for the row modified
+   */
+  public String getKeysJson() {
+    return keysJson;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Mod)) {
+      return false;
+    }
+    Mod mod = (Mod) o;
+    return Objects.equals(keysJson, mod.keysJson)
+        && Objects.equals(oldValuesJson, mod.oldValuesJson)
+        && Objects.equals(newValuesJson, mod.newValuesJson);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(keysJson, oldValuesJson, newValuesJson);
+  }
+
+  @Override
+  public String toString() {
+    return "Mod{"
+        + "keysJson="
+        + keysJson
+        + ", oldValuesJson='"
+        + oldValuesJson
+        + '\''
+        + ", newValuesJson='"
+        + newValuesJson
+        + '\''
+        + '}';
+  }
+}

--- a/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/ModType.java
+++ b/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/ModType.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.changestreams.model;
+
+/**
+ * Represents the type of modification applied in the {@link DataChangeRecord}. It can be one of the
+ * following: INSERT, UPDATE, INSERT_OR_UPDATE or DELETE.
+ */
+public enum ModType {
+  INSERT,
+  UPDATE,
+  INSERT_OR_UPDATE,
+  DELETE
+}

--- a/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/TypeCode.java
+++ b/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/TypeCode.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.changestreams.model;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Represents a type of a column within Cloud Spanner. The type itself is encoded in a String code.
+ */
+public class TypeCode implements Serializable {
+
+  private static final long serialVersionUID = -1935648338090036611L;
+
+  private String code;
+
+  /** Default constructor for serialization only. */
+  private TypeCode() {}
+
+  /**
+   * Constructs a type code from the given String code.
+   *
+   * @param code the code of the column type
+   */
+  public TypeCode(String code) {
+    this.code = code;
+  }
+
+  /**
+   * Returns the type code of the column.
+   *
+   * @return the type code of the column
+   */
+  public String getCode() {
+    return code;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TypeCode typeCode = (TypeCode) o;
+    return Objects.equals(code, typeCode.code);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(code);
+  }
+
+  @Override
+  public String toString() {
+    return "TypeCode{" + "code='" + code + '\'' + '}';
+  }
+}

--- a/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/ValueCaptureType.java
+++ b/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/ValueCaptureType.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.changestreams.model;
+
+/**
+ * Represents the capture type of a change stream. The only supported value at the moment is
+ * OLD_AND_NEW_VALUES, meaning that {@link Mod}s will include the column values before and after the
+ * database operations were applied.
+ */
+public enum ValueCaptureType {
+  OLD_AND_NEW_VALUES,
+}

--- a/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/package-info.java
+++ b/spanner/changestreams/src/main/java/com/example/spanner/changestreams/model/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** User model for the Spanner change stream API. */
+package com.example.spanner.changestreams.model;

--- a/spanner/changestreams/src/test/java/com/example/spanner/changestreams/ChangeStreamSampleIT.java
+++ b/spanner/changestreams/src/test/java/com/example/spanner/changestreams/ChangeStreamSampleIT.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.changestreams;
+
+import static org.junit.Assert.assertNotNull;
+
+import com.google.cloud.spanner.DatabaseAdminClient;
+import com.google.cloud.spanner.DatabaseId;
+import com.google.cloud.spanner.Instance;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.SpannerOptions;
+import com.google.cloud.spanner.connection.ConnectionOptions;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for ChangeStreamSample.
+ */
+@RunWith(JUnit4.class)
+@SuppressWarnings("checkstyle:abbreviationaswordinname")
+public class ChangeStreamSampleIT {
+  private static String instanceId = System.getProperty("spanner.test.instance");
+  private static final String databaseId =
+      formatForTest(System.getProperty("spanner.sample.database", "cssample"));
+  private static final String prefix = "prefix";
+  private static DatabaseId dbId;
+  private static DatabaseAdminClient dbClient;
+
+  private ByteArrayOutputStream bout;
+  private final PrintStream stdOut = System.out;
+  private PrintStream out;
+
+  static String formatForTest(String name) {
+    return name + "-" + UUID.randomUUID().toString().substring(0, 20);
+  }
+
+  @Before
+  public void setUp() {
+    SpannerOptions options = SpannerOptions.newBuilder().build();
+    Spanner spanner = options.getService();
+    dbClient = spanner.getDatabaseAdminClient();
+    if (instanceId == null) {
+      Iterator<Instance> iterator =
+          spanner.getInstanceAdminClient().listInstances().iterateAll().iterator();
+      if (iterator.hasNext()) {
+        instanceId = iterator.next().getId().getInstance();
+      }
+    }
+    dbId = DatabaseId.of(options.getProjectId(), instanceId, databaseId);
+    dbClient.dropDatabase(dbId.getInstanceId().getInstance(), dbId.getDatabase());
+    try {
+      dbClient.createDatabase(instanceId, databaseId, Collections.emptyList()).get();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    ConnectionOptions.closeSpanner();
+    dbClient.dropDatabase(dbId.getInstanceId().getInstance(), dbId.getDatabase());
+
+    try {
+      bout.close();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    System.setOut(stdOut);
+  }
+
+  @Test
+  public void testChangeStreamSample() {
+    assertNotNull(instanceId);
+    assertNotNull(databaseId);
+    assertNotNull(prefix);
+    ChangeStreamSample.run(instanceId, databaseId, prefix);
+
+    String got = bout.toString();
+    Assert.assertTrue(got.contains("Received a ChildPartitionsRecord"));
+    Assert.assertTrue(got.contains("Received a DataChangeRecord"));
+    Assert.assertTrue(got.contains("mods=[Mod{keysJson={\"SingerId\":\"1\"}, "
+        + "oldValuesJson='', "
+        + "newValuesJson="
+        + "'{\"FirstName\":\"singer_1_first_name\",\"LastName\":\"singer_1_last_name\"}'}, "
+        + "Mod{keysJson={\"SingerId\":\"2\"}, "
+        + "oldValuesJson='', "
+        + "newValuesJson="
+        + "'{\"FirstName\":\"singer_2_first_name\",\"LastName\":\"singer_2_last_name\"}'}]"));
+  }
+}


### PR DESCRIPTION
The followings are included:
* Sample code for creating change stream.
* Sample code for querying change stream, basically it does an change stream initial query to get a list of partition tokens, and then use the partition tokens to query the data change records for each partition.
* Sample code for dropping change stream.
* ChangeStreamRecordMapper and models, these are the files that help change stream users understand how to model change stream records after receiving them from API, they are copied from org.apache.beam.sdk.io.gcp.spanner.changestreams.* with unused code being removed.
* README for how to run the sample code and tests.

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [x] Appropriate changes to README are included in PR
- [x] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [x] Please **merge** this PR for me once it is approved.
