### PR TITLE
Revert "chore(deps): update hbaseversion for org.apache.hbase to v2.4.9"

### DIFF
--- a/bigtable/spark/build.sbt
+++ b/bigtable/spark/build.sbt
@@ -21,9 +21,9 @@ version := "0.1"
 // Versions to match Dataproc 1.4
 // https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-release-1.4
 scalaVersion := "2.11.12"
-val sparkVersion = "2.4.9"
+val sparkVersion = "2.4.8"
 val bigtableVersion = "2.0.0"
-val hbaseVersion = "2.4.9"
+val hbaseVersion = "2.4.8"
 
 libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-sql" % sparkVersion % Provided,


### PR DESCRIPTION
Reverts GoogleCloudPlatform/java-docs-samples#6747

This sample should pin the hbase version, which I will update the renovate config to do separately. There's also a bug with renovate bot where it also updated the `sparkVersion` as part of this PR, thinking it was an hbase dependency.