### PR TITLE
chore(secret-manager): add checksum-usage to snippets

### DIFF
--- a/secretmanager/pom.xml
+++ b/secretmanager/pom.xml
@@ -33,15 +33,15 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-secretmanager</artifactId>
-      <version>2.1.1</version>
+      <version>2.1.2</version>
     </dependency>
 
     <dependency>

--- a/secretmanager/src/main/java/secretmanager/AccessSecretVersion.java
+++ b/secretmanager/src/main/java/secretmanager/AccessSecretVersion.java
@@ -21,6 +21,8 @@ import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
 import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
 import com.google.cloud.secretmanager.v1.SecretVersionName;
 import java.io.IOException;
+import java.util.zip.CRC32C;
+import java.util.zip.Checksum;
 
 public class AccessSecretVersion {
 
@@ -44,6 +46,17 @@ public class AccessSecretVersion {
 
       // Access the secret version.
       AccessSecretVersionResponse response = client.accessSecretVersion(secretVersionName);
+
+      // Verify checksum. The used library is available in Java 9+.
+      // If using Java 8, you may use the following:
+      // https://cloud.google.com/appengine/docs/standard/java/javadoc/com/google/appengine/api/files/Crc32c
+      byte[] data = response.getPayload().getData().toByteArray();
+      Checksum checksum = new CRC32C();
+      checksum.update(data, 0, data.length);
+      if (response.getPayload().getDataCrc32C() != checksum.getValue()) {
+        System.out.printf("Data corruption detected.");
+        return;
+      }
 
       // Print the secret payload.
       //


### PR DESCRIPTION
Adds checksum-usage snippets to SecretManager samples.

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [x] Appropriate changes to README are included in PR
- [x] API's need to be enabled to test (tell us)
- [x] Environment Variables need to be set (ask us to set them)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [x] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [x] Please **merge** this PR for me once it is approved.
