### PR TITLE
test: remove flaky unnecessary testCreateFirewallRule

### DIFF
--- a/compute/cloud-client/src/test/java/compute/SnippetsIT.java
+++ b/compute/cloud-client/src/test/java/compute/SnippetsIT.java
@@ -489,13 +489,6 @@ public class SnippetsIT {
   }
 
   @Test
-  public void testCreateFirewallRule() throws IOException {
-    // Assert that firewall rule has been created as part of the setup.
-    compute.GetFirewallRule.getFirewallRule(PROJECT_ID, FIREWALL_RULE_CREATE);
-    assertThat(stdOut.toString()).contains(FIREWALL_RULE_CREATE);
-  }
-
-  @Test
   public void testInstanceOperations()
       throws IOException, ExecutionException, InterruptedException {
     Assert.assertEquals(getInstanceStatus(MACHINE_NAME), Status.RUNNING.toString());


### PR DESCRIPTION
This is already tested in the test setup.
Fixes: #6828.