### PR TITLE
Fix and add logging to com.example.spanner.changestreams.ChangeStreamSampleIT: testChangeStreamSample

### DIFF
--- a/spanner/changestreams/src/main/java/com/example/spanner/changestreams/ChangeStreamSample.java
+++ b/spanner/changestreams/src/main/java/com/example/spanner/changestreams/ChangeStreamSample.java
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
  * 5. Drops the created table and change stream.
  */
 public class ChangeStreamSample {
-  private static final long TIMEOUT_MINUTES = 2;
+  private static final long TIMEOUT_MINUTES = 10;
 
   public static void run(String instanceId, String databaseId, String prefix) {
     final String tableName = prefix + "_Singers";

--- a/spanner/changestreams/src/test/java/com/example/spanner/changestreams/ChangeStreamSampleIT.java
+++ b/spanner/changestreams/src/test/java/com/example/spanner/changestreams/ChangeStreamSampleIT.java
@@ -30,6 +30,7 @@ import java.io.PrintStream;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -73,7 +74,8 @@ public class ChangeStreamSampleIT {
     dbId = DatabaseId.of(options.getProjectId(), instanceId, databaseId);
     dbClient.dropDatabase(dbId.getInstanceId().getInstance(), dbId.getDatabase());
     try {
-      dbClient.createDatabase(instanceId, databaseId, Collections.emptyList()).get();
+      dbClient.createDatabase(instanceId, databaseId, Collections.emptyList())
+          .get(10, TimeUnit.MINUTES);
     } catch (Exception e) {
       e.printStackTrace();
     }
@@ -105,6 +107,8 @@ public class ChangeStreamSampleIT {
     ChangeStreamSample.run(instanceId, databaseId, prefix);
 
     String got = bout.toString();
+    System.setOut(stdOut);
+    System.out.println("Standard output: " + got);
     Assert.assertTrue(got.contains("Received a ChildPartitionsRecord"));
     Assert.assertTrue(got.contains("Received a DataChangeRecord"));
     Assert.assertTrue(got.contains("mods=[Mod{keysJson={\"SingerId\":\"1\"}, "


### PR DESCRIPTION
Fix and add logging to com.example.spanner.changestreams.ChangeStreamSampleIT: testChangeStreamSample

In my local testing, sometimes the test failed with timeout executing DDL, so I increased the timeout from 2 minutes to 15 minutes. After the fix, I run the test 100 times locally and all of them passed.

I am not sure if this will fix the problem since the test was failed at a different place in Sponge, but I cannot repro it locally and I cannot see the logging since the standard output was hidden, so I also print the standard output and hopefully we will see some logging to debug if it fails another time.

Fixes #6831

> It's a good idea to open an issue first for discussion.

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [x] Please **merge** this PR for me once it is approved.
