### PR TITLE
healthcare API: do not use client library for FHIR search requests

### DIFF
--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchGet.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchGet.java
@@ -42,7 +42,7 @@ public class FhirResourceSearchGet {
   private static final String FHIR_NAME =
       "projects/%s/locations/%s/datasets/%s/fhirStores/%s/fhir/%s";
   // The endpoint URL for the Healthcare API. Required for HttpClient.
-  private static final String ROOT_URL = "https://healthcare.googleapis.com";
+  private static final String API_ENDPOINT = "https://healthcare.googleapis.com";
   private static final JsonFactory JSON_FACTORY = new JacksonFactory();
   private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
 

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchGet.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchGet.java
@@ -22,15 +22,21 @@ import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.healthcare.v1.CloudHealthcare;
-import com.google.api.services.healthcare.v1.CloudHealthcare.Projects.Locations.Datasets.FhirStores.Fhir.Search;
 import com.google.api.services.healthcare.v1.CloudHealthcareScopes;
-import com.google.api.services.healthcare.v1.model.HttpBody;
-import com.google.api.services.healthcare.v1.model.SearchResourcesRequest;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collections;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.HttpClients;
 
 public class FhirResourceSearchGet {
   private static final String FHIR_NAME =
@@ -38,26 +44,41 @@ public class FhirResourceSearchGet {
   private static final JsonFactory JSON_FACTORY = new JacksonFactory();
   private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
 
-  public static void fhirResourceSearchGet(String fhirStoreName, String resourceType)
+  public static void fhirResourceSearchGet(String resourceName)
       throws IOException, URISyntaxException {
-    // String fhirStoreName =
+    // String resourceName =
     //    String.format(
     //        FHIR_NAME, "project-id", "region-id", "dataset-id", "fhir-store-id");
     // String resourceType = "Patient";
 
-    // Initialize the client, which will be used to interact with the service.
-    CloudHealthcare client = createClient();
+    // The endpoint URL for the Healthcare API. Required for HttpClient.
+    String rootUrl = "https://healthcare.googleapis.com";
 
-    // Create the SearchResourcesRequest and configure any parameters.
-    SearchResourcesRequest request = new SearchResourcesRequest().setResourceType(resourceType);
+    // Instantiate the client, which will be used to interact with the service.
+    HttpClient httpClient = HttpClients.createDefault();
+    String uri = String.format("%s/v1/%s", rootUrl, resourceName);
+    URIBuilder uriBuilder = new URIBuilder(uri).setParameter("access_token", getAccessToken());
+    // To set additional parameters for search filtering, add them to the URIBuilder. For
+    // example, to search for a Patient with the family name "Smith", specify the following:
+    // uriBuilder.setParameter("family:exact", "Smith");
 
-    // Create request and configure any parameters.
-    Search search =
-        client.projects().locations().datasets().fhirStores().fhir().search(fhirStoreName, request);
+    HttpUriRequest request =
+        RequestBuilder.get()
+            .setUri(uriBuilder.build())
+            .build();
 
     // Execute the request and process the results.
-    HttpBody response = search.execute();
-    System.out.println("FHIR resource search results: " + response.toPrettyString());
+    HttpResponse response = httpClient.execute(request);
+    HttpEntity responseEntity = response.getEntity();
+    if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+      System.err.print(
+          String.format(
+              "Exception searching GET FHIR resources: %s\n", response.getStatusLine().toString()));
+      responseEntity.writeTo(System.err);
+      throw new RuntimeException();
+    }
+    System.out.println("FHIR resource GET search results: ");
+    responseEntity.writeTo(System.out);
   }
 
   private static CloudHealthcare createClient() throws IOException {
@@ -66,7 +87,6 @@ public class FhirResourceSearchGet {
     GoogleCredentials credential =
         GoogleCredentials.getApplicationDefault()
             .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
-
     // Create a HttpRequestInitializer, which will provide a baseline configuration to all requests.
     HttpRequestInitializer requestInitializer =
         request -> {
@@ -74,11 +94,18 @@ public class FhirResourceSearchGet {
           request.setConnectTimeout(60000); // 1 minute connect timeout
           request.setReadTimeout(60000); // 1 minute read timeout
         };
-
     // Build the client for interacting with the service.
     return new CloudHealthcare.Builder(HTTP_TRANSPORT, JSON_FACTORY, requestInitializer)
         .setApplicationName("your-application-name")
         .build();
+  }
+
+  private static String getAccessToken() throws IOException {
+    GoogleCredentials credential =
+        GoogleCredentials.getApplicationDefault()
+            .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
+
+    return credential.refreshAccessToken().getTokenValue();
   }
 }
 // [END healthcare_search_resources_get]

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchGet.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchGet.java
@@ -41,6 +41,8 @@ import org.apache.http.impl.client.HttpClients;
 public class FhirResourceSearchGet {
   private static final String FHIR_NAME =
       "projects/%s/locations/%s/datasets/%s/fhirStores/%s/fhir/%s";
+  // The endpoint URL for the Healthcare API. Required for HttpClient.
+  private static final String ROOT_URL = "https://healthcare.googleapis.com";
   private static final JsonFactory JSON_FACTORY = new JacksonFactory();
   private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
 
@@ -51,12 +53,9 @@ public class FhirResourceSearchGet {
     //        FHIR_NAME, "project-id", "region-id", "dataset-id", "fhir-store-id");
     // String resourceType = "Patient";
 
-    // The endpoint URL for the Healthcare API. Required for HttpClient.
-    String rootUrl = "https://healthcare.googleapis.com";
-
     // Instantiate the client, which will be used to interact with the service.
     HttpClient httpClient = HttpClients.createDefault();
-    String uri = String.format("%s/v1/%s", rootUrl, resourceName);
+    String uri = String.format("%s/v1/%s", ROOT_URL, resourceName);
     URIBuilder uriBuilder = new URIBuilder(uri).setParameter("access_token", getAccessToken());
     // To set additional parameters for search filtering, add them to the URIBuilder. For
     // example, to search for a Patient with the family name "Smith", specify the following:

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchGet.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchGet.java
@@ -55,7 +55,7 @@ public class FhirResourceSearchGet {
 
     // Instantiate the client, which will be used to interact with the service.
     HttpClient httpClient = HttpClients.createDefault();
-    String uri = String.format("%s/v1/%s", ROOT_URL, resourceName);
+    String uri = String.format("%s/v1/%s", API_ENDPOINT, resourceName);
     URIBuilder uriBuilder = new URIBuilder(uri).setParameter("access_token", getAccessToken());
     // To set additional parameters for search filtering, add them to the URIBuilder. For
     // example, to search for a Patient with the family name "Smith", specify the following:

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchPost.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchPost.java
@@ -50,12 +50,18 @@ public class FhirResourceSearchPost {
     //    String.format(
     //        FHIR_NAME, "project-id", "region-id", "dataset-id", "store-id", "resource-type");
 
-    // Initialize the client, which will be used to interact with the service.
-    CloudHealthcare client = createClient();
+    // The endpoint URL for the Healthcare API. Required for HttpClient.
+    String rootUrl = "https://healthcare.googleapis.com";
 
+    // Instantiate the client, which will be used to interact with the service.
     HttpClient httpClient = HttpClients.createDefault();
-    String uri = String.format("%sv1/%s/_search", client.getRootUrl(), resourceName);
+    String uri = String.format("%s/v1/%s/_search", rootUrl, resourceName);
     URIBuilder uriBuilder = new URIBuilder(uri).setParameter("access_token", getAccessToken());
+    // To set additional parameters for search filtering, add them to the URIBuilder. For
+    // example, to search for a Patient with the family name "Smith", specify the following:
+    // uriBuilder.setParameter("family:exact", "Smith");
+
+    // Set a body otherwise HttpClient complains there is no Content-Length set.
     StringEntity requestEntity = new StringEntity("");
 
     HttpUriRequest request =
@@ -67,6 +73,7 @@ public class FhirResourceSearchPost {
             .addHeader("Accept", "application/fhir+json; charset=utf-8")
             .build();
 
+    System.out.println(request);
     // Execute the request and process the results.
     HttpResponse response = httpClient.execute(request);
     HttpEntity responseEntity = response.getEntity();
@@ -78,7 +85,7 @@ public class FhirResourceSearchPost {
       responseEntity.writeTo(System.err);
       throw new RuntimeException();
     }
-    System.out.println("FHIR resource search results: ");
+    System.out.println("FHIR resource POST search result: ");
     responseEntity.writeTo(System.out);
   }
 
@@ -107,7 +114,7 @@ public class FhirResourceSearchPost {
     GoogleCredentials credential =
         GoogleCredentials.getApplicationDefault()
             .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
-    
+
     return credential.refreshAccessToken().getTokenValue();
   }
 }

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchPost.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchPost.java
@@ -41,6 +41,8 @@ import org.apache.http.impl.client.HttpClients;
 public class FhirResourceSearchPost {
   private static final String FHIR_NAME =
       "projects/%s/locations/%s/datasets/%s/fhirStores/%s/fhir/%s";
+  // The endpoint URL for the Healthcare API. Required for HttpClient.
+  private static final String ROOT_URL = "https://healthcare.googleapis.com";
   private static final JsonFactory JSON_FACTORY = new JacksonFactory();
   private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
 
@@ -50,12 +52,9 @@ public class FhirResourceSearchPost {
     //    String.format(
     //        FHIR_NAME, "project-id", "region-id", "dataset-id", "store-id", "resource-type");
 
-    // The endpoint URL for the Healthcare API. Required for HttpClient.
-    String rootUrl = "https://healthcare.googleapis.com";
-
     // Instantiate the client, which will be used to interact with the service.
     HttpClient httpClient = HttpClients.createDefault();
-    String uri = String.format("%s/v1/%s/_search", rootUrl, resourceName);
+    String uri = String.format("%s/v1/%s/_search", ROOT_URL, resourceName);
     URIBuilder uriBuilder = new URIBuilder(uri).setParameter("access_token", getAccessToken());
     // To set additional parameters for search filtering, add them to the URIBuilder. For
     // example, to search for a Patient with the family name "Smith", specify the following:

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchPost.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchPost.java
@@ -54,7 +54,7 @@ public class FhirResourceSearchPost {
 
     // Instantiate the client, which will be used to interact with the service.
     HttpClient httpClient = HttpClients.createDefault();
-    String uri = String.format("%s/v1/%s/_search", ROOT_URL, resourceName);
+    String uri = String.format("%s/v1/%s/_search", API_ENDPOINT, resourceName);
     URIBuilder uriBuilder = new URIBuilder(uri).setParameter("access_token", getAccessToken());
     // To set additional parameters for search filtering, add them to the URIBuilder. For
     // example, to search for a Patient with the family name "Smith", specify the following:

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchPost.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchPost.java
@@ -73,7 +73,6 @@ public class FhirResourceSearchPost {
             .addHeader("Accept", "application/fhir+json; charset=utf-8")
             .build();
 
-    System.out.println(request);
     // Execute the request and process the results.
     HttpResponse response = httpClient.execute(request);
     HttpEntity responseEntity = response.getEntity();

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchPost.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchPost.java
@@ -42,7 +42,7 @@ public class FhirResourceSearchPost {
   private static final String FHIR_NAME =
       "projects/%s/locations/%s/datasets/%s/fhirStores/%s/fhir/%s";
   // The endpoint URL for the Healthcare API. Required for HttpClient.
-  private static final String ROOT_URL = "https://healthcare.googleapis.com";
+  private static final String API_ENDPOINT = "https://healthcare.googleapis.com";
   private static final JsonFactory JSON_FACTORY = new JacksonFactory();
   private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
 

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchPost.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchPost.java
@@ -85,7 +85,7 @@ public class FhirResourceSearchPost {
       responseEntity.writeTo(System.err);
       throw new RuntimeException();
     }
-    System.out.println("FHIR resource POST search result: ");
+    System.out.println("FHIR resource POST search results: ");
     responseEntity.writeTo(System.out);
   }
 

--- a/healthcare/v1/src/test/java/snippets/healthcare/FhirResourceTests.java
+++ b/healthcare/v1/src/test/java/snippets/healthcare/FhirResourceTests.java
@@ -143,10 +143,10 @@ public class FhirResourceTests {
 
   @Test
   public void test_FhirResourceSearchGet() throws Exception {
-    FhirResourceSearchGet.fhirResourceSearchGet(fhirStoreName, resourceType);
+    FhirResourceSearchGet.fhirResourceSearchGet(resourcePath);
 
     String output = bout.toString();
-    assertThat(output, containsString("FHIR resource search results:"));
+    assertThat(output, containsString("FHIR resource GET search results:"));
   }
 
   @Test
@@ -154,7 +154,7 @@ public class FhirResourceTests {
     FhirResourceSearchPost.fhirResourceSearchPost(resourcePath);
 
     String output = bout.toString();
-    assertThat(output, containsString("FHIR resource search results:"));
+    assertThat(output, containsString("FHIR resource POST search results:"));
   }
 
   @Test


### PR DESCRIPTION
Part of fix for b/221324824. Our client libraries do not allow for FHIR GET/POST search requests to be set in the HTTP request path, which is required by the FHIR specification. Due to a bug, you can send search requests by specifying a resource type in the request body, but this is an anti-pattern. Until we fix the issue with the client library, we need to use the Apache HTTP client to explicitly make GET/POST requests and not use the client library.

> It's a good idea to open an issue first for discussion.

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [X] **Tests** pass:   `mvn clean verify` **required**
- [X] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [X] Please **merge** this PR for me once it is approved. 
