### PR TITLE
Use latest 2.4 Spark version 2.4.8

### DIFF
--- a/bigtable/spark/build.sbt
+++ b/bigtable/spark/build.sbt
@@ -21,7 +21,7 @@ version := "0.1"
 // Versions to match Dataproc 1.4
 // https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-release-1.4
 scalaVersion := "2.11.12"
-val sparkVersion = "2.4.9"
+val sparkVersion = "2.4.8"
 val bigtableVersion = "2.0.0"
 val hbaseVersion = "2.4.9"
 


### PR DESCRIPTION
https://spark.apache.org/news/ shows 2.4.9 was not released. The robot accidentally upgraded it in https://github.com/GoogleCloudPlatform/java-docs-samples/pull/6847
