### PR TITLE
Use Cloud Client library for Troubleshooter

### DIFF
--- a/iam/api-client/pom.xml
+++ b/iam/api-client/pom.xml
@@ -69,9 +69,9 @@
 <!-- [END iamcredentials_java_dependency]-->
 <!-- [START troubleshooter_java_dependency]-->
     <dependency>
-      <groupId>com.google.apis</groupId>
-      <artifactId>google-api-services-policytroubleshooter</artifactId>
-      <version>v1-rev20211008-1.32.1</version>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-policy-troubleshooter</artifactId>
+      <version>1.0.2</version>
     </dependency>
 <!-- [END troubleshooter_java_dependency]-->
     <dependency>


### PR DESCRIPTION
Editing the dependency for the Troubleshooter API to use the Cloud Client library instead of the Google API client library.

Cloud Client libraries are generally preferred. I'll use this sample on 

> It's a good idea to open an issue first for discussion.

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [x] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [X] Please **merge** this PR for me once it is approved.
