### PR TITLE
feat: samples for Spanner PostgreSQL JDBC

### DIFF
--- a/spanner/jdbc/pom.xml
+++ b/spanner/jdbc/pom.xml
@@ -41,12 +41,10 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner-jdbc</artifactId>
-      <version>2.5.11</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
-      <version>6.17.3</version>
     </dependency>
     <!--CSV parsing dependencies -->
     <dependency>

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgBatchDmlSample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgBatchDmlSample.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Arrays;
+
+class PgBatchDmlSample {
+
+  static void pgBatchDml() throws SQLException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project";
+    String instanceId = "my-instance";
+    String databaseId = "my-database";
+    pgBatchDml(projectId, instanceId, databaseId);
+  }
+
+  static void pgBatchDml(String projectId, String instanceId, String databaseId)
+      throws SQLException {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s",
+                projectId, instanceId, databaseId))) {
+      // Spanner PostgreSQL supports BatchDML statements. This will batch multiple DML statements
+      // into one request, which reduces the number of round trips that is needed for multiple DML
+      // statements. Use the standard JDBC PreparedStatement batching feature to batch multiple DML
+      // statements together.
+      try (PreparedStatement statement =
+          connection.prepareStatement(
+              "INSERT INTO Singers (SingerId, FirstName, LastName) " + "VALUES (?, ?, ?)")) {
+        statement.setLong(1, 10L);
+        statement.setString(2, "Alice");
+        statement.setString(3, "Henderson");
+        statement.addBatch();
+
+        statement.setLong(1, 11L);
+        statement.setString(2, "Bruce");
+        statement.setString(3, "Allison");
+        statement.addBatch();
+
+        int[] updateCounts = statement.executeBatch();
+        int totalUpdateCount = Arrays.stream(updateCounts).sum();
+        System.out.printf("Inserted %d singers\n", totalUpdateCount);
+      }
+    }
+  }
+}

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgCaseSensitivitySample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgCaseSensitivitySample.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.jdbc.CloudSpannerJdbcConnection;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+
+class PgCaseSensitivitySample {
+
+  static void pgCaseSensitivity() throws SQLException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project";
+    String instanceId = "my-instance";
+    String databaseId = "my-database";
+    pgCaseSensitivity(projectId, instanceId, databaseId);
+  }
+
+  static void pgCaseSensitivity(String projectId, String instanceId, String databaseId)
+      throws SQLException {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s",
+                projectId, instanceId, databaseId))) {
+
+      // Spanner PostgreSQL follows the case sensitivity rules of PostgreSQL. This means that:
+      // 1. Identifiers that are not double-quoted are folded to lower case.
+      // 2. Identifiers that are double-quoted retain their case and are case-sensitive.
+      // See https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+      // for more information.
+
+      connection
+          .createStatement()
+          .execute(
+              "CREATE TABLE Singers ("
+                  // SingerId will be folded to `singerid`.
+                  + "  SingerId      bigint NOT NULL PRIMARY KEY,"
+                  // FirstName and LastName are double-quoted and will therefore retain their
+                  // mixed case and are case-sensitive. This means that any statement that
+                  // references any of these columns must use double quotes.
+                  + "  \"FirstName\" varchar(1024) NOT NULL,"
+                  + "  \"LastName\"  varchar(1024) NOT NULL"
+                  + ")");
+
+      connection
+          .unwrap(CloudSpannerJdbcConnection.class)
+          .write(
+              Collections.singleton(
+                  Mutation.newInsertBuilder("Singers")
+                      .set("singerid")
+                      .to(1L)
+                      // Column names in mutations are always case-insensitive, regardless whether
+                      // the
+                      // columns were double-quoted or not during creation.
+                      .set("firstname")
+                      .to("Bruce")
+                      .set("lastname")
+                      .to("Allison")
+                      .build()));
+
+      try (ResultSet singers = connection.createStatement().executeQuery("SELECT * FROM Singers")) {
+        while (singers.next()) {
+          System.out.printf(
+              "SingerId: %d, FirstName: %s, LastName: %s\n",
+              // SingerId is automatically folded to lower case. Accessing the column by its name in
+              // a result set must therefore use all lower-case letters.
+              singers.getLong("singerid"),
+              // FirstName and LastName were double-quoted during creation, and retain their mixed
+              // case when returned in a result set.
+              singers.getString("FirstName"),
+              singers.getString("LastName"));
+        }
+      }
+
+      // Aliases are also identifiers, and specifying an alias in double quotes will make the alias
+      // retain its case.
+      try (ResultSet singers =
+          connection
+              .createStatement()
+              .executeQuery(
+                  "SELECT "
+                      + "singerid AS \"SingerId\", "
+                      + "concat(\"FirstName\", ' '::varchar, \"LastName\") AS \"FullName\" "
+                      + "FROM Singers")) {
+        while (singers.next()) {
+          System.out.printf(
+              "SingerId: %d, FullName: %s\n",
+              // The aliases are double-quoted and therefore retains their mixed case.
+              singers.getLong("SingerId"), singers.getString("FullName"));
+        }
+      }
+
+      // DML statements must also follow the PostgreSQL case rules.
+      try (PreparedStatement statement =
+          connection.prepareStatement(
+              "INSERT INTO Singers (SingerId, \"FirstName\", \"LastName\") "
+                  + "VALUES (?, ?, ?)")) {
+        statement.setLong(1, 2L);
+        statement.setString(2, "Alice");
+        statement.setString(3, "Bruxelles");
+      }
+    }
+  }
+}

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgCastDataTypeSample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgCastDataTypeSample.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Base64;
+
+class PgCastDataTypeSample {
+
+  static void pgCastDataType() throws SQLException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project";
+    String instanceId = "my-instance";
+    String databaseId = "my-database";
+    pgCastDataType(projectId, instanceId, databaseId);
+  }
+
+  static void pgCastDataType(String projectId, String instanceId, String databaseId)
+      throws SQLException {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s",
+                projectId, instanceId, databaseId))) {
+      // The `::` cast operator can be used to cast from one data type to another.
+      try (ResultSet resultSet =
+          connection
+              .createStatement()
+              .executeQuery(
+                  "select 1::varchar as str, '2'::int as int, 3::decimal as dec,"
+                      + "'4'::bytea as bytes, 5::float as float, 'true'::bool as bool, "
+                      + "'2021-11-03T09:35:01UTC'::timestamptz as timestamp")) {
+        while (resultSet.next()) {
+          System.out.printf("String: %s\n", resultSet.getString("str"));
+          System.out.printf("Int: %d\n", resultSet.getLong("int"));
+          System.out.printf("Decimal: %s\n", resultSet.getBigDecimal("dec"));
+          System.out.printf(
+              "Bytes: %s\n", Base64.getEncoder().encodeToString(resultSet.getBytes("bytes")));
+          System.out.printf("Float: %f\n", resultSet.getDouble("float"));
+          System.out.printf("Bool: %s\n", resultSet.getBoolean("bool"));
+          System.out.printf(
+              "Timestamp: %s\n",
+              OffsetDateTime.ofInstant(
+                  Instant.ofEpochMilli(resultSet.getTimestamp("timestamp").getTime()),
+                  ZoneId.of("UTC")));
+        }
+      }
+    }
+  }
+}

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgConnectToDatabaseSample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgConnectToDatabaseSample.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+class PgConnectToDatabaseSample {
+
+  static void pgConnectToDatabase() throws SQLException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project";
+    String instanceId = "my-instance";
+    String databaseId = "my-database";
+    pgConnectToDatabase(projectId, instanceId, databaseId);
+  }
+
+  // Creates a JDBC connection to a Cloud Spanner database with the PostgreSQL dialect.
+  static void pgConnectToDatabase(String projectId, String instanceId, String databaseId)
+      throws SQLException {
+    // Connecting to a Cloud Spanner PostgreSQL database using the Spanner JDBC driver uses the same
+    // JDBC URL as for normal Spanner databases. The JDBC driver will automatically detect the
+    // dialect that is used by the underlying database.
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s",
+                projectId, instanceId, databaseId))) {
+      try (ResultSet rs = connection.createStatement().executeQuery("SELECT now()")) {
+        while (rs.next()) {
+          System.out.printf(
+              "Connected to Cloud Spanner PostgreSQL at [%s]%n", rs.getTimestamp(1).toString());
+        }
+      }
+    }
+  }
+}

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgCreateInterleavedTableSample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgCreateInterleavedTableSample.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+class PgCreateInterleavedTableSample {
+
+  static void pgCreateInterleavedTable() throws SQLException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project";
+    String instanceId = "my-instance";
+    String databaseId = "my-database";
+    pgCreateInterleavedTable(projectId, instanceId, databaseId);
+  }
+
+  static void pgCreateInterleavedTable(String projectId, String instanceId, String databaseId)
+      throws SQLException {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s",
+                projectId, instanceId, databaseId))) {
+      try (Statement statement = connection.createStatement()) {
+        // The Spanner PostgreSQL dialect extends the PostgreSQL dialect with certain Spanner
+        // specific features, such as interleaved tables.
+        // See
+        // https://cloud.google.com/spanner/docs/postgresql/data-definition-language#create_table
+        // for the full CREATE TABLE syntax. The tables are created in one batch by adding the
+        // individual DDL statements to a JDBC batch and then executed as a single batch.
+        statement.addBatch(
+            "CREATE TABLE Singers ("
+                + "  SingerId  bigint NOT NULL PRIMARY KEY,"
+                + "  FirstName varchar(1024) NOT NULL,"
+                + "  LastName  varchar(1024) NOT NULL"
+                + ")");
+        statement.addBatch(
+            "CREATE TABLE Albums ("
+                + "  SingerId bigint NOT NULL,"
+                + "  AlbumId  bigint NOT NULL,"
+                + "  Title    varchar(1024) NOT NULL,"
+                + "  PRIMARY KEY (SingerId, AlbumId)"
+                + ") INTERLEAVE IN PARENT Singers ON DELETE CASCADE");
+        statement.executeBatch();
+        System.out.println("Created Singers and Albums tables");
+      }
+    }
+  }
+}

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgDmlWithParametersSample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgDmlWithParametersSample.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+class PgDmlWithParametersSample {
+
+  static void pgDmlWithParameters() throws SQLException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project";
+    String instanceId = "my-instance";
+    String databaseId = "my-database";
+    pgDmlWithParameters(projectId, instanceId, databaseId);
+  }
+
+  static void pgDmlWithParameters(String projectId, String instanceId, String databaseId)
+      throws SQLException {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s",
+                projectId, instanceId, databaseId))) {
+      try (PreparedStatement statement =
+          connection.prepareStatement(
+              "INSERT INTO Singers (SingerId, FirstName, LastName) "
+                  + "VALUES (?, ?, ?), (?, ?, ?)")) {
+        statement.setLong(1, 10L);
+        statement.setString(2, "Alice");
+        statement.setString(3, "Henderson");
+        statement.setLong(4, 11L);
+        statement.setString(5, "Bruce");
+        statement.setString(6, "Allison");
+        int updateCount = statement.executeUpdate();
+        System.out.printf("Inserted %d singers\n", updateCount);
+      }
+    }
+  }
+}

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgFunctionsSample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgFunctionsSample.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
+class PgFunctionsSample {
+
+  static void pgFunctions() throws SQLException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project";
+    String instanceId = "my-instance";
+    String databaseId = "my-database";
+    pgFunctions(projectId, instanceId, databaseId);
+  }
+
+  static void pgFunctions(String projectId, String instanceId, String databaseId)
+      throws SQLException {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s",
+                projectId, instanceId, databaseId))) {
+      // Use the PostgreSQL `to_timestamp` function to convert a number of seconds since epoch to a
+      // timestamp. 1284352323 seconds = Monday, September 13, 2010 4:32:03 AM.
+      try (ResultSet resultSet =
+          connection.createStatement().executeQuery("SELECT to_timestamp(1284352323) AS t")) {
+        while (resultSet.next()) {
+          Timestamp timestamp = resultSet.getTimestamp("t");
+          System.out.printf(
+              "1284352323 seconds after epoch is %s\n",
+              OffsetDateTime.ofInstant(
+                  Instant.ofEpochMilli(timestamp.getTime()), ZoneId.of("UTC")));
+        }
+      }
+    }
+  }
+}

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgInformationSchemaSample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgInformationSchemaSample.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+class PgInformationSchemaSample {
+
+  static void pgInformationSchema() throws SQLException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project";
+    String instanceId = "my-instance";
+    String databaseId = "my-database";
+    pgInformationSchema(projectId, instanceId, databaseId);
+  }
+
+  static void pgInformationSchema(String projectId, String instanceId, String databaseId)
+      throws SQLException {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s",
+                projectId, instanceId, databaseId))) {
+      connection
+          .createStatement()
+          .execute(
+              "CREATE TABLE Venues ("
+                  + "  VenueId  bigint NOT NULL PRIMARY KEY,"
+                  + "  Name     varchar(1024) NOT NULL,"
+                  + "  Revenues numeric,"
+                  + "  Picture  bytea"
+                  + ")");
+
+      // The Spanner INFORMATION_SCHEMA tables can be used to query the metadata of tables and
+      // columns of PostgreSQL databases. The returned results will include additional PostgreSQL
+      // metadata columns.
+
+      // Get all the user tables in the database. PostgreSQL uses the `public` schema for user
+      // tables. The table_catalog is equal to the database name.
+      try (ResultSet tables =
+          connection
+              .createStatement()
+              .executeQuery(
+                  "SELECT table_catalog, table_schema, table_name, "
+                      // The following columns are only available for PostgreSQL databases.
+                      + "user_defined_type_catalog, "
+                      + "user_defined_type_schema, "
+                      + "user_defined_type_name "
+                      + "FROM INFORMATION_SCHEMA.tables "
+                      + "WHERE table_schema='public'")) {
+        while (tables.next()) {
+          String catalog = tables.getString("table_catalog");
+          String schema = tables.getString("table_schema");
+          String table = tables.getString("table_name");
+          String userDefinedTypeCatalog = tables.getString("user_defined_type_catalog");
+          String userDefinedTypeSchema = tables.getString("user_defined_type_schema");
+          String userDefinedTypeName = tables.getString("user_defined_type_name");
+          String userDefinedType =
+              userDefinedTypeName == null
+                  ? null
+                  : String.format(
+                      "%s.%s.%s",
+                      userDefinedTypeCatalog, userDefinedTypeSchema, userDefinedTypeName);
+          System.out.printf(
+              "Table: %s.%s.%s (User defined type: %s)\n", catalog, schema, table, userDefinedType);
+        }
+      }
+
+      // The java.sql.DatabaseMetaData of the JDBC connection can also be used to retrieve
+      // information about tables, columns, indexes etc. These methods return the metadata as if it
+      // was a normal Spanner database.
+      try (ResultSet tables =
+          connection.getMetaData().getTables(null, null, null, new String[] {"TABLE"})) {
+        while (tables.next()) {
+          // Catalog and schema are empty.
+          String catalog = tables.getString("TABLE_CAT");
+          String schema = tables.getString("TABLE_SCHEM");
+          String table = tables.getString("TABLE_NAME");
+          System.out.printf("Table in JDBC metadata: %s.%s.%s\n", catalog, schema, table);
+        }
+      }
+    }
+  }
+}

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgNumericDataTypeSample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgNumericDataTypeSample.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.Value;
+import com.google.cloud.spanner.jdbc.CloudSpannerJdbcConnection;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.Arrays;
+
+class PgNumericDataTypeSample {
+
+  static void pgNumericDataType() throws SQLException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project";
+    String instanceId = "my-instance";
+    String databaseId = "my-database";
+    pgNumericDataType(projectId, instanceId, databaseId);
+  }
+
+  static void pgNumericDataType(String projectId, String instanceId, String databaseId)
+      throws SQLException {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s",
+                projectId, instanceId, databaseId))) {
+      // Create a table that includes a column with data type NUMERIC. As the database has been
+      // created with the PostgreSQL dialect, the data type that is used will be the PostgreSQL
+      // NUMERIC / DECIMAL data type.
+      connection
+          .createStatement()
+          .execute(
+              "CREATE TABLE Venues ("
+                  + "  VenueId  bigint NOT NULL PRIMARY KEY,"
+                  + "  Name     varchar(1024) NOT NULL,"
+                  + "  Revenues numeric"
+                  + ")");
+      System.out.print("Created Venues table\n");
+
+      // Insert a Venue using DML.
+      try (PreparedStatement statement =
+          connection.prepareStatement(
+              "INSERT INTO Venues (VenueId, Name, Revenues) " + "VALUES (?, ?, ?)")) {
+        statement.setLong(1, 1L);
+        statement.setString(2, "Venue 1");
+        statement.setBigDecimal(3, new BigDecimal("3150.25"));
+        int updateCount = statement.executeUpdate();
+        System.out.printf("Inserted %d venues\n", updateCount);
+      }
+
+      // Insert a Venue with a NULL value for the Revenues column.
+      try (PreparedStatement statement =
+          connection.prepareStatement(
+              "INSERT INTO Venues (VenueId, Name, Revenues) " + "VALUES (?, ?, ?)")) {
+        statement.setLong(1, 2L);
+        statement.setString(2, "Venue 2");
+        statement.setNull(3, Types.NUMERIC);
+        int updateCount = statement.executeUpdate();
+        System.out.printf("Inserted %d venues with NULL revenues\n", updateCount);
+      }
+
+      // Insert a Venue with a NaN (Not a Number) value for the Revenues column.
+      try (PreparedStatement statement =
+          connection.prepareStatement(
+              "INSERT INTO Venues (VenueId, Name, Revenues) " + "VALUES (?, ?, ?)")) {
+        statement.setLong(1, 3L);
+        statement.setString(2, "Venue 3");
+        // Not a Number (NaN) can be set both using the Double.NaN constant or the String 'NaN'.
+        statement.setDouble(3, Double.NaN);
+        int updateCount = statement.executeUpdate();
+        System.out.printf("Inserted %d venues with NaN revenues\n", updateCount);
+      }
+
+      // Get all Venues and inspect the Revenues values.
+      try (ResultSet venues =
+          connection.createStatement().executeQuery("SELECT Name, Revenues FROM Venues")) {
+        while (venues.next()) {
+          String name = venues.getString("name");
+          // Getting a PostgreSQL NUMERIC value as a Value is always supported, regardless whether
+          // the value is a number, NULL or NaN.
+          Value revenuesAsValue = venues.getObject("revenues", Value.class);
+          System.out.printf("Revenues of %s: %s\n", name, revenuesAsValue);
+
+          // Getting a PostgreSQL NUMERIC value as a double is supported for all possible values. If
+          // the value is NULL, this method will return 0 and the wasNull() method will return true.
+          double revenuesAsDouble = venues.getDouble("revenues");
+          boolean wasNull = venues.wasNull();
+          if (wasNull) {
+            System.out.printf("\tRevenues of %s as double: null\n", name);
+          } else {
+            System.out.printf("\tRevenues of %s as double: %f\n", name, revenuesAsDouble);
+          }
+
+          // Getting a PostgreSQL NUMERIC as a BigDecimal is supported for both NULL and non-NULL
+          // values, but not for NaN, as there is no BigDecimal representation of NaN.
+          if (!Double.valueOf(revenuesAsDouble).isNaN()) {
+            BigDecimal revenuesAsBigDecimal = venues.getBigDecimal("revenues");
+            System.out.printf("\tRevenues of %s as BigDecimal: %s\n", name, revenuesAsBigDecimal);
+          }
+
+          // A PostgreSQL NUMERIC value may also be retrieved as a String.
+          String revenuesAsString = venues.getString("revenues");
+          System.out.printf("\tRevenues of %s as String: %s\n", name, revenuesAsString);
+        }
+      }
+
+      // Mutations can also be used to insert/update NUMERIC values, including NaN values.
+      // Mutations can be used with the JDBC driver by unwrapping the
+      // com.google.cloud.spanner.jdbc.CloudSpannerJdbcConnection interface from the connection.
+      CloudSpannerJdbcConnection cloudSpannerJdbcConnection =
+          connection.unwrap(CloudSpannerJdbcConnection.class);
+      cloudSpannerJdbcConnection.write(
+          Arrays.asList(
+              Mutation.newInsertBuilder("Venues")
+                  .set("VenueId")
+                  .to(4L)
+                  .set("Name")
+                  .to("Venue 4")
+                  .set("Revenues")
+                  .to(Value.pgNumeric("125.10"))
+                  .build(),
+              Mutation.newInsertBuilder("Venues")
+                  .set("VenueId")
+                  .to(5L)
+                  .set("Name")
+                  .to("Venue 5")
+                  .set("Revenues")
+                  .to(Value.pgNumeric(Value.NAN))
+                  .build()));
+      Timestamp commitTimestamp = cloudSpannerJdbcConnection.getCommitTimestamp();
+      System.out.printf("Inserted 2 Venues using mutations at %s\n", commitTimestamp);
+    }
+  }
+}

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgOrderNullsSample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgOrderNullsSample.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.jdbc.CloudSpannerJdbcConnection;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+
+class PgOrderNullsSample {
+
+  static void pgOrderNulls() throws SQLException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project";
+    String instanceId = "my-instance";
+    String databaseId = "my-database";
+    pgOrderNulls(projectId, instanceId, databaseId);
+  }
+
+  static void pgOrderNulls(String projectId, String instanceId, String databaseId)
+      throws SQLException {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s",
+                projectId, instanceId, databaseId))) {
+
+      // Spanner PostgreSQL follows the ORDER BY rules for NULL values of PostgreSQL. This means
+      // that:
+      // 1. NULL values are ordered last by default when a query result is ordered in ascending
+      //    order.
+      // 2. NULL values are ordered first by default when a query result is ordered in descending
+      //    order.
+      // 3. NULL values can be order first or last by specifying NULLS FIRST or NULLS LAST in the
+      //    ORDER BY clause.
+      connection
+          .createStatement()
+          .execute(
+              "CREATE TABLE Singers ("
+                  + "  SingerId bigint NOT NULL PRIMARY KEY,"
+                  + "  Name     varchar(1024)"
+                  + ")");
+
+      connection
+          .unwrap(CloudSpannerJdbcConnection.class)
+          .write(
+              Arrays.asList(
+                  Mutation.newInsertBuilder("Singers")
+                      .set("SingerId")
+                      .to(1L)
+                      .set("Name")
+                      .to("Alice")
+                      .build(),
+                  Mutation.newInsertBuilder("Singers")
+                      .set("SingerId")
+                      .to(2L)
+                      .set("Name")
+                      .to("Bruce")
+                      .build(),
+                  Mutation.newInsertBuilder("Singers")
+                      .set("SingerId")
+                      .to(3L)
+                      .set("Name")
+                      .to((String) null)
+                      .build()));
+
+      // This returns the singers in order Alice, Bruce, null
+      System.out.println("Singers ORDER BY Name");
+      try (ResultSet singers =
+          connection.createStatement().executeQuery("SELECT * FROM Singers ORDER BY Name")) {
+        printSingerNames(singers);
+      }
+
+      // This returns the singers in order null, Bruce, Alice
+      System.out.println("Singers ORDER BY Name DESC");
+      try (ResultSet singers =
+          connection.createStatement().executeQuery("SELECT * FROM Singers ORDER BY Name DESC")) {
+        printSingerNames(singers);
+      }
+
+      // This returns the singers in order null, Alice, Bruce
+      System.out.println("Singers ORDER BY Name NULLS FIRST");
+      try (ResultSet singers =
+          connection
+              .createStatement()
+              .executeQuery("SELECT * FROM Singers ORDER BY Name NULLS FIRST")) {
+        printSingerNames(singers);
+      }
+
+      // This returns the singers in order Bruce, Alice, null
+      System.out.println("Singers ORDER BY Name DESC NULLS LAST");
+      try (ResultSet singers =
+          connection
+              .createStatement()
+              .executeQuery("SELECT * FROM Singers ORDER BY Name DESC NULLS LAST")) {
+        printSingerNames(singers);
+      }
+    }
+  }
+
+  static void printSingerNames(ResultSet singers) throws SQLException {
+    while (singers.next()) {
+      System.out.printf(
+          "\t%s\n", singers.getString("name") == null ? "<null>" : singers.getString("name"));
+    }
+  }
+}

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgPartitionedDmlSample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgPartitionedDmlSample.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+class PgPartitionedDmlSample {
+
+  static void pgPartitionedDml() throws SQLException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project";
+    String instanceId = "my-instance";
+    String databaseId = "my-database";
+    pgPartitionedDml(projectId, instanceId, databaseId);
+  }
+
+  static void pgPartitionedDml(String projectId, String instanceId, String databaseId)
+      throws SQLException {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s",
+                projectId, instanceId, databaseId))) {
+      // Spanner PostgreSQL has the same transaction limits as normal Spanner. This includes a
+      // maximum of 20,000 mutations in a single read/write transaction. Large update operations can
+      // be executed using Partitioned DML. This is also supported on Spanner PostgreSQL.
+      // See https://cloud.google.com/spanner/docs/dml-partitioned for more information.
+
+      // Switch to Partitioned DML.
+      connection.createStatement().execute("SET AUTOCOMMIT_DML_MODE='PARTITIONED_NON_ATOMIC'");
+      // Execute the DML statement.
+      int deletedCount = connection.createStatement().executeUpdate("DELETE FROM Singers");
+      // The returned update count is the lower bound of the number of records that was deleted.
+      System.out.printf("Deleted at least %d singers\n", deletedCount);
+    }
+  }
+}

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgQueryParameterSample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgQueryParameterSample.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+class PgQueryParameterSample {
+
+  static void pgQueryParameter() throws SQLException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project";
+    String instanceId = "my-instance";
+    String databaseId = "my-database";
+    pgQueryParameter(projectId, instanceId, databaseId);
+  }
+
+  static void pgQueryParameter(String projectId, String instanceId, String databaseId)
+      throws SQLException {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s",
+                projectId, instanceId, databaseId))) {
+      try (PreparedStatement statement =
+          connection.prepareStatement(
+              "SELECT SingerId, FirstName, LastName "
+                  + "FROM Singers "
+                  + "WHERE LastName LIKE ?")) {
+        statement.setString(1, "A%");
+        System.out.print("Listing all singers with a last name that starts with 'A'\n");
+        try (ResultSet resultSet = statement.executeQuery()) {
+          while (resultSet.next()) {
+            // Note that the PostgreSQL dialect will return all column names in lower case, unless
+            // the
+            // columns have been created with case-sensitive column names. See
+            // https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+            // for more information on PostgreSQL identifiers.
+            System.out.printf(
+                "%d %s %s%n",
+                resultSet.getLong("singerid"),
+                resultSet.getString("firstname"),
+                resultSet.getString("lastname"));
+          }
+        }
+      }
+    }
+  }
+}

--- a/spanner/jdbc/src/test/java/com/example/spanner/jdbc/BaseJdbcPgExamplesIT.java
+++ b/spanner/jdbc/src/test/java/com/example/spanner/jdbc/BaseJdbcPgExamplesIT.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.spanner.Database;
+import com.google.cloud.spanner.DatabaseAdminClient;
+import com.google.cloud.spanner.DatabaseId;
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.Instance;
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.SpannerOptions;
+import com.google.cloud.spanner.connection.ConnectionOptions;
+import com.google.cloud.spanner.jdbc.CloudSpannerJdbcConnection;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Integration tests for Cloud Spanner PostgreSQL JDBC examples. */
+@RunWith(JUnit4.class)
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+public abstract class BaseJdbcPgExamplesIT {
+  // The instance needs to exist for tests to pass.
+  protected static String instanceId = System.getProperty("spanner.test.instance");
+  protected static final String databaseId =
+      formatForTest(System.getProperty("spanner.sample.pgdatabase", "mypgsample"));
+  protected static DatabaseId dbId;
+  private static DatabaseAdminClient dbClient;
+  private boolean testTableCreated;
+
+  protected interface JdbcRunnable {
+    void run() throws Exception;
+  }
+
+  protected String runExample(JdbcRunnable example) {
+    PrintStream stdOut = System.out;
+    ByteArrayOutputStream bout = new ByteArrayOutputStream();
+    PrintStream out = new PrintStream(bout);
+    System.setOut(out);
+    try {
+      example.run();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    System.setOut(stdOut);
+    return bout.toString();
+  }
+
+  @BeforeClass
+  public static void createTestDatabase() throws Exception {
+    SpannerOptions options = SpannerOptions.newBuilder().build();
+    Spanner spanner = options.getService();
+    dbClient = spanner.getDatabaseAdminClient();
+    if (instanceId == null) {
+      Iterator<Instance> iterator =
+          spanner.getInstanceAdminClient().listInstances().iterateAll().iterator();
+      if (iterator.hasNext()) {
+        instanceId = iterator.next().getId().getInstance();
+      }
+    }
+    dbId = DatabaseId.of(options.getProjectId(), instanceId, databaseId);
+    dbClient.dropDatabase(dbId.getInstanceId().getInstance(), dbId.getDatabase());
+    Database database = dbClient.newDatabaseBuilder(dbId).setDialect(Dialect.POSTGRESQL).build();
+    dbClient.createDatabase(database, Collections.emptyList()).get();
+  }
+
+  @AfterClass
+  public static void dropTestDatabase() {
+    ConnectionOptions.closeSpanner();
+    dbClient.dropDatabase(dbId.getInstanceId().getInstance(), dbId.getDatabase());
+  }
+
+  static class Singer {
+    final long singerId;
+    final String firstName;
+    final String lastName;
+    final BigDecimal revenues;
+
+    Singer(long singerId, String firstName, String lastName, BigDecimal revenues) {
+      this.singerId = singerId;
+      this.firstName = firstName;
+      this.lastName = lastName;
+      this.revenues = revenues;
+    }
+  }
+
+  static final List<Singer> TEST_SINGERS =
+      Arrays.asList(
+          new Singer(1, "Marc", "Richards", new BigDecimal("104100.00")),
+          new Singer(2, "Catalina", "Smith", new BigDecimal("9880.99")),
+          new Singer(3, "Alice", "Trentor", new BigDecimal("300183")),
+          new Singer(4, "Lea", "Martin", new BigDecimal("20118.12")),
+          new Singer(5, "David", "Lomond", new BigDecimal("311399.26")),
+          new Singer(6, "Bruce", "Allison", null),
+          new Singer(7, "Alice", "Bruxelles", null));
+
+  protected boolean createTestTable() {
+    return false;
+  }
+
+  @Before
+  public void insertTestData() throws SQLException {
+    if (createTestTable()) {
+      String connectionUrl =
+          String.format(
+              "jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s",
+              ServiceOptions.getDefaultProjectId(), instanceId, databaseId);
+      try (Connection connection = DriverManager.getConnection(connectionUrl)) {
+        if (!testTableCreated) {
+          connection
+              .createStatement()
+              .execute(
+                  "CREATE TABLE Singers (\n"
+                      + "  SingerId   BIGINT NOT NULL PRIMARY KEY,\n"
+                      + "  FirstName  VARCHAR(1024),\n"
+                      + "  LastName   VARCHAR(1024),\n"
+                      + "  SingerInfo BYTEA,\n"
+                      + "  Revenues   NUMERIC\n"
+                      + ")\n");
+          testTableCreated = true;
+        }
+        CloudSpannerJdbcConnection spannerConnection =
+            connection.unwrap(CloudSpannerJdbcConnection.class);
+        spannerConnection.setAutoCommit(false);
+        for (Singer singer : TEST_SINGERS) {
+          spannerConnection.bufferedWrite(
+              Mutation.newInsertBuilder("Singers")
+                  .set("SingerId")
+                  .to(singer.singerId)
+                  .set("FirstName")
+                  .to(singer.firstName)
+                  .set("LastName")
+                  .to(singer.lastName)
+                  .set("Revenues")
+                  .to(singer.revenues)
+                  .build());
+        }
+        connection.commit();
+      }
+    }
+  }
+
+  @After
+  public void removeTestData() throws SQLException {
+    if (createTestTable()) {
+      String connectionUrl =
+          String.format(
+              "jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s",
+              ServiceOptions.getDefaultProjectId(), instanceId, databaseId);
+      try (Connection connection = DriverManager.getConnection(connectionUrl);
+          Statement statement = connection.createStatement()) {
+        statement.execute("DELETE FROM Singers WHERE 1=1");
+      }
+    }
+  }
+
+  static String formatForTest(String name) {
+    return name + "-" + UUID.randomUUID().toString().substring(0, 18);
+  }
+}

--- a/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgBatchDmlSampleIT.java
+++ b/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgBatchDmlSampleIT.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.ServiceOptions;
+import org.junit.Test;
+
+public class PgBatchDmlSampleIT extends BaseJdbcPgExamplesIT {
+
+  @Override
+  protected boolean createTestTable() {
+    return true;
+  }
+
+  @Test
+  public void testPgBatchDml() {
+    String out =
+        runExample(
+            () ->
+                PgBatchDmlSample.pgBatchDml(
+                    ServiceOptions.getDefaultProjectId(), instanceId, databaseId));
+    assertTrue(out.contains("Inserted 2 singers"));
+  }
+}

--- a/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgCaseInsensitivitySampleIT.java
+++ b/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgCaseInsensitivitySampleIT.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.ServiceOptions;
+import org.junit.Test;
+
+public class PgCaseInsensitivitySampleIT extends BaseJdbcPgExamplesIT {
+
+  @Test
+  public void testCaseInsensitivity() {
+    String out =
+        runExample(
+            () ->
+                PgCaseSensitivitySample.pgCaseSensitivity(
+                    ServiceOptions.getDefaultProjectId(), instanceId, databaseId));
+    assertTrue(out, out.contains("SingerId: 1, FirstName: Bruce, LastName: Allison"));
+    assertTrue(out, out.contains("SingerId: 1, FullName: Bruce Allison"));
+  }
+}

--- a/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgCastDataTypeSampleIT.java
+++ b/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgCastDataTypeSampleIT.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.ServiceOptions;
+import org.junit.Test;
+
+public class PgCastDataTypeSampleIT extends BaseJdbcPgExamplesIT {
+
+  @Test
+  public void testPgCastDataType() {
+    String out =
+        runExample(
+            () ->
+                PgCastDataTypeSample.pgCastDataType(
+                    ServiceOptions.getDefaultProjectId(), instanceId, databaseId));
+    assertTrue(out, out.contains("String: 1"));
+    assertTrue(out, out.contains("Int: 2"));
+    assertTrue(out, out.contains("Decimal: 3"));
+    assertTrue(out, out.contains("Bytes: NA=="));
+    assertTrue(out, out.contains("Float: 5.000000"));
+    assertTrue(out, out.contains("Bool: true"));
+    assertTrue(out, out.contains("Timestamp: 2021-11-03T09:35:01Z"));
+  }
+}

--- a/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgConnectToDatabaseSampleIT.java
+++ b/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgConnectToDatabaseSampleIT.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.ServiceOptions;
+import org.junit.Test;
+
+public class PgConnectToDatabaseSampleIT extends BaseJdbcPgExamplesIT {
+
+  @Test
+  public void testPgConnectToDatabase() {
+    String out =
+        runExample(
+            () ->
+                PgConnectToDatabaseSample.pgConnectToDatabase(
+                    ServiceOptions.getDefaultProjectId(), instanceId, databaseId));
+    assertTrue(out.contains("Connected to Cloud Spanner PostgreSQL at ["));
+  }
+}

--- a/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgCreateInterleavedTableSampleIT.java
+++ b/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgCreateInterleavedTableSampleIT.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.ServiceOptions;
+import org.junit.Test;
+
+public class PgCreateInterleavedTableSampleIT extends BaseJdbcPgExamplesIT {
+
+  @Test
+  public void testCreateInterleavedTable() {
+    String out =
+        runExample(
+            () ->
+                PgCreateInterleavedTableSample.pgCreateInterleavedTable(
+                    ServiceOptions.getDefaultProjectId(), instanceId, databaseId));
+    assertTrue(out.contains("Created Singers and Albums tables"));
+  }
+}

--- a/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgDmlWithParametersSampleIT.java
+++ b/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgDmlWithParametersSampleIT.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.ServiceOptions;
+import org.junit.Test;
+
+public class PgDmlWithParametersSampleIT extends BaseJdbcPgExamplesIT {
+
+  @Override
+  protected boolean createTestTable() {
+    return true;
+  }
+
+  @Test
+  public void testPgDmlWithParameters() {
+    String out =
+        runExample(
+            () ->
+                PgDmlWithParametersSample.pgDmlWithParameters(
+                    ServiceOptions.getDefaultProjectId(), instanceId, databaseId));
+    assertTrue(out.contains("Inserted 2 singers"));
+  }
+}

--- a/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgFunctionsSampleIT.java
+++ b/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgFunctionsSampleIT.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.ServiceOptions;
+import org.junit.Test;
+
+public class PgFunctionsSampleIT extends BaseJdbcPgExamplesIT {
+
+  @Test
+  public void testPgFunctions() {
+    String out =
+        runExample(
+            () ->
+                PgFunctionsSample.pgFunctions(
+                    ServiceOptions.getDefaultProjectId(), instanceId, databaseId));
+    assertTrue(out, out.contains("1284352323 seconds after epoch is 2010-09-13T04:32:03Z"));
+  }
+}

--- a/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgInformationSchemaSampleIT.java
+++ b/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgInformationSchemaSampleIT.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.ServiceOptions;
+import org.junit.Test;
+
+public class PgInformationSchemaSampleIT extends BaseJdbcPgExamplesIT {
+
+  @Test
+  public void testPgInformationSchema() {
+    String out =
+        runExample(
+            () ->
+                PgInformationSchemaSample.pgInformationSchema(
+                    ServiceOptions.getDefaultProjectId(), instanceId, databaseId));
+    assertTrue(
+        out,
+        out.contains(
+            String.format("Table: %s.public.venues (User defined type: null)", databaseId)));
+    assertTrue(out, out.contains("Table in JDBC metadata: ..venues"));
+  }
+}

--- a/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgNumericDataTypeSampleIT.java
+++ b/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgNumericDataTypeSampleIT.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.ServiceOptions;
+import org.junit.Test;
+
+public class PgNumericDataTypeSampleIT extends BaseJdbcPgExamplesIT {
+
+  @Test
+  public void testNumericDataType() {
+    String out =
+        runExample(
+            () ->
+                PgNumericDataTypeSample.pgNumericDataType(
+                    ServiceOptions.getDefaultProjectId(), instanceId, databaseId));
+
+    assertTrue(out, out.contains("Revenues of Venue 1: 3150.25"));
+    assertTrue(out, out.contains("Revenues of Venue 1 as double: 3150.25"));
+    assertTrue(out, out.contains("Revenues of Venue 1 as BigDecimal: 3150.25"));
+    assertTrue(out, out.contains("Revenues of Venue 1 as String: 3150.25"));
+
+    assertTrue(out, out.contains("Revenues of Venue 2: null"));
+    assertTrue(out, out.contains("Revenues of Venue 2 as double: null"));
+    assertTrue(out, out.contains("Revenues of Venue 2 as BigDecimal: null"));
+    assertTrue(out, out.contains("Revenues of Venue 2 as String: null"));
+
+    assertTrue(out, out.contains("Revenues of Venue 3: NaN"));
+    assertTrue(out, out.contains("Revenues of Venue 3 as double: NaN"));
+    assertFalse(out, out.contains("Revenues of Venue 3 as BigDecimal:"));
+    assertTrue(out, out.contains("Revenues of Venue 3 as String: NaN"));
+
+    assertTrue(out, out.contains("Inserted 2 Venues using mutations"));
+  }
+}

--- a/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgOrderNullsSampleIT.java
+++ b/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgOrderNullsSampleIT.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.ServiceOptions;
+import org.junit.Test;
+
+public class PgOrderNullsSampleIT extends BaseJdbcPgExamplesIT {
+
+  @Test
+  public void testOrderNulls() {
+    String out =
+        runExample(
+            () ->
+                PgOrderNullsSample.pgOrderNulls(
+                    ServiceOptions.getDefaultProjectId(), instanceId, databaseId));
+    assertTrue(out, out.contains("Singers ORDER BY Name\n\tAlice\n\tBruce\n\t<null>"));
+    assertTrue(out, out.contains("Singers ORDER BY Name DESC\n\t<null>\n\tBruce\n\tAlice"));
+    assertTrue(out, out.contains("Singers ORDER BY Name NULLS FIRST\n\t<null>\n\tAlice\n\tBruce"));
+    assertTrue(
+        out, out.contains("Singers ORDER BY Name DESC NULLS LAST\n\tBruce\n\tAlice\n\t<null>"));
+  }
+}

--- a/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgPartitionedDmlSampleIT.java
+++ b/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgPartitionedDmlSampleIT.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.ServiceOptions;
+import org.junit.Test;
+
+public class PgPartitionedDmlSampleIT extends BaseJdbcPgExamplesIT {
+
+  @Override
+  protected boolean createTestTable() {
+    return true;
+  }
+
+  @Test
+  public void testPgPartitionedDml() {
+    String out =
+        runExample(
+            () ->
+                PgPartitionedDmlSample.pgPartitionedDml(
+                    ServiceOptions.getDefaultProjectId(), instanceId, databaseId));
+    assertTrue(out.contains("Deleted at least 7 singers"));
+  }
+}

--- a/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgQueryParameterSampleIT.java
+++ b/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgQueryParameterSampleIT.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.ServiceOptions;
+import org.junit.Test;
+
+public class PgQueryParameterSampleIT extends BaseJdbcPgExamplesIT {
+
+  @Override
+  protected boolean createTestTable() {
+    return true;
+  }
+
+  @Test
+  public void testPgQueryParameter() {
+    String out =
+        runExample(
+            () ->
+                PgQueryParameterSample.pgQueryParameter(
+                    ServiceOptions.getDefaultProjectId(), instanceId, databaseId));
+    assertTrue(out.contains("6 Bruce Allison"));
+    assertFalse(out.contains("7 Alice Bruxelles"));
+  }
+}


### PR DESCRIPTION
Adds samples for using the Cloud Spanner JDBC driver with databases in the PostgreSQL dialect.