### PR TITLE
Update versions to latest Spring Boot and Spring Cloud GCP

### DIFF
--- a/appengine-java11/springboot-helloworld/pom.xml
+++ b/appengine-java11/springboot-helloworld/pom.xml
@@ -39,7 +39,7 @@
               <!-- Import dependency management from Spring Boot -->
               <groupId>org.springframework.boot</groupId>
               <artifactId>spring-boot-dependencies</artifactId>
-              <version>2.5.5</version>
+              <version>2.6.6</version>
               <type>pom</type>
               <scope>import</scope>
           </dependency>
@@ -70,7 +70,7 @@
     <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-jetty</artifactId>
-        <version>2.5.5</version>
+        <version>2.6.6</version>
     </dependency>
   </dependencies>
 
@@ -79,7 +79,7 @@
       <plugin>
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>
-          <version>2.5.5</version>
+          <version>2.6.6</version>
           <executions>
               <execution>
                   <goals>

--- a/appengine-java11/tasks-handler/pom.xml
+++ b/appengine-java11/tasks-handler/pom.xml
@@ -42,7 +42,7 @@ limitations under the License.
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.5.5</version>
+        <version>2.6.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -62,7 +62,7 @@ limitations under the License.
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>2.5.5</version>
+      <version>2.6.6</version>
       <exclusions>
         <!-- Exclude the Tomcat dependency -->
         <exclusion>
@@ -74,7 +74,7 @@ limitations under the License.
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-jetty</artifactId>
-      <version>2.5.5</version>
+      <version>2.6.6</version>
     </dependency>
 
   </dependencies>
@@ -84,7 +84,7 @@ limitations under the License.
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>2.5.5</version>
+        <version>2.6.6</version>
         <executions>
           <execution>
             <goals>

--- a/appengine-java8/springboot-helloworld/pom.xml
+++ b/appengine-java8/springboot-helloworld/pom.xml
@@ -20,7 +20,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <spring.boot.version>2.5.5</spring.boot.version> <!-- DO NOT UPDATE w/o MANUAL TESTING -->
+    <spring.boot.version>2.6.6</spring.boot.version> <!-- DO NOT UPDATE w/o MANUAL TESTING -->
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
   </properties>

--- a/cloud-sql/r2dbc/pom.xml
+++ b/cloud-sql/r2dbc/pom.xml
@@ -99,7 +99,7 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.5</version>
+        <version>2.6.6</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/eventarc/audit-storage/pom.xml
+++ b/eventarc/audit-storage/pom.xml
@@ -35,7 +35,7 @@ limitations under the License.
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.5.5</version>
+        <version>2.6.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/eventarc/generic/pom.xml
+++ b/eventarc/generic/pom.xml
@@ -35,7 +35,7 @@ limitations under the License.
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.5.8</version>
+        <version>2.6.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/eventarc/pubsub/pom.xml
+++ b/eventarc/pubsub/pom.xml
@@ -35,7 +35,7 @@ limitations under the License.
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.5.8</version>
+        <version>2.6.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/flexible/helloworld-springboot/pom.xml
+++ b/flexible/helloworld-springboot/pom.xml
@@ -40,17 +40,17 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>2.5.8</version>
+      <version>2.6.6</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
-      <version>2.5.8</version>
+      <version>2.6.6</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
-      <version>2.5.8</version>
+      <version>2.6.6</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -66,7 +66,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>2.5.8</version>
+        <version>2.6.6</version>
         <executions>
           <execution>
             <goals>

--- a/pubsub/spring/pom.xml
+++ b/pubsub/spring/pom.xml
@@ -47,7 +47,7 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.5.8</version>
+        <version>2.6.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -55,7 +55,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>spring-cloud-gcp-dependencies</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -110,7 +110,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>2.5.5</version>
+        <version>2.6.6</version>
         <configuration>
           <mainClass>demo.PubSubApplication</mainClass>
         </configuration>

--- a/run/endpoints-v2-backend/pom.xml
+++ b/run/endpoints-v2-backend/pom.xml
@@ -43,7 +43,7 @@ limitations under the License.
           <!-- Import dependency management from Spring Boot -->
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-dependencies</artifactId>
-          <version>2.5.5</version>
+          <version>2.6.6</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/run/filesystem/pom.xml
+++ b/run/filesystem/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.5.4</version>
+        <version>2.6.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/run/helloworld/pom.xml
+++ b/run/helloworld/pom.xml
@@ -32,7 +32,7 @@ limitations under the License.
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.5.8</version>
+        <version>2.6.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/run/idp-sql/pom.xml
+++ b/run/idp-sql/pom.xml
@@ -38,14 +38,14 @@ limitations under the License.
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.5.8</version>
+        <version>2.6.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>spring-cloud-gcp-dependencies</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/run/image-processing/pom.xml
+++ b/run/image-processing/pom.xml
@@ -35,7 +35,7 @@ limitations under the License.
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.5.8</version>
+        <version>2.6.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -44,7 +44,7 @@ limitations under the License.
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>spring-cloud-gcp-dependencies</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/run/markdown-preview/editor/pom.xml
+++ b/run/markdown-preview/editor/pom.xml
@@ -36,7 +36,7 @@
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.5.8</version>
+        <version>2.6.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/run/markdown-preview/renderer/pom.xml
+++ b/run/markdown-preview/renderer/pom.xml
@@ -36,7 +36,7 @@
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.5.5</version>
+        <version>2.6.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/run/pubsub/pom.xml
+++ b/run/pubsub/pom.xml
@@ -35,7 +35,7 @@ limitations under the License.
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.5.5</version>
+        <version>2.6.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/spanner/r2dbc/pom.xml
+++ b/spanner/r2dbc/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <spring-boot.version>2.5.8</spring-boot.version>
+    <spring-boot.version>2.6.6</spring-boot.version>
   </properties>
 
   <!--

--- a/spanner/spring-data/pom.xml
+++ b/spanner/spring-data/pom.xml
@@ -41,7 +41,7 @@ limitations under the License.
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>spring-cloud-gcp-dependencies</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -61,7 +61,7 @@ limitations under the License.
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>2.5.5</version>
+        <version>2.6.6</version>
         <configuration>
           <mainClass>com.example.spanner.QuickStartSample</mainClass>
         </configuration>


### PR DESCRIPTION
Addresses [CVE-2022-22965](https://tanzu.vmware.com/security/cve-2022-22965).
See [blog post](https://spring.io/blog/2022/03/31/spring-boot-2-6-6-available-now) for details.

I manually tested `appengine-java8/springboot-helloworld`, as the pom file requested.