### PR TITLE
fix: update renovate spring boot version matcher

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -95,7 +95,7 @@
     },
     {
       "matchPackagePatterns": [ "org.springframework.boot" ],
-      "matchCurrentVersion": "/.*RELEASE/"
+      "matchCurrentVersion": "!/.*[SNAPSHOT | M]/"
     }
   ],
   "labels": [


### PR DESCRIPTION
Fixes #6955 

Spring boot does not use RELEASE to signify GA releases on Maven Central. Therefore this update rejects SNAPSHOTs and M releases that are not GA.

> It's a good idea to open an issue first for discussion.

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] Please **merge** this PR for me once it is approved.
