### PR TITLE
deps: use libraries bom for Spanner JDBC samples

### DIFF
--- a/spanner/jdbc/pom.xml
+++ b/spanner/jdbc/pom.xml
@@ -28,7 +28,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.0.0</version>
+        <version>25.1.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -41,12 +41,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner-jdbc</artifactId>
-      <version>2.5.11</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-spanner</artifactId>
-      <version>6.17.3</version>
     </dependency>
     <!--CSV parsing dependencies -->
     <dependency>


### PR DESCRIPTION
Use the versions from the `libraries-bom` instead of specific versions for the Spanner JDBC driver samples.

Replaces #6844