### PR TITLE
bigtable: migrate BigtableConnect sample from cloud-bigtable-examples

### DIFF
--- a/bigtable/hbase/snippets/src/main/java/com/example/bigtable/BigtableConnect.java
+++ b/bigtable/hbase/snippets/src/main/java/com/example/bigtable/BigtableConnect.java
@@ -17,7 +17,6 @@
 package com.example.bigtable;
 
 import com.google.cloud.bigtable.hbase.BigtableConfiguration;
-import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
@@ -32,11 +31,11 @@ public class BigtableConnect {
   public static Connection connection = null;
 
   public static void main(String... args) {
-    projectId = args[0];  // my-gcp-project-id
+    projectId = args[0]; // my-gcp-project-id
     instanceId = args[1]; // my-bigtable-instance-id
 
     if (args.length > 2) {
-      appProfileId = args[2];    // my-bigtable-app-profile-id or default if not provided.
+      appProfileId = args[2]; // my-bigtable-app-profile-id or default if not provided.
     }
   }
 

--- a/bigtable/hbase/snippets/src/main/java/com/example/bigtable/BigtableConnect.java
+++ b/bigtable/hbase/snippets/src/main/java/com/example/bigtable/BigtableConnect.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.example.cloud.bigtable.connect;
+package com.example.bigtable;
 
 import com.google.cloud.bigtable.hbase.BigtableConfiguration;
 import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
@@ -60,4 +60,8 @@ public class BigtableConnect {
     connection = ConnectionFactory.createConnection(config);
   }
   // [END bigtable_connect_with_configuration]
+
+  protected void closeConnection() throws IOException {
+    connection.close();
+  }
 }

--- a/bigtable/hbase/snippets/src/test/java/com/example/bigtable/BigtableConnectTest.java
+++ b/bigtable/hbase/snippets/src/test/java/com/example/bigtable/BigtableConnectTest.java
@@ -18,13 +18,12 @@ package com.example.bigtable;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.io.IOException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.io.IOException;
 
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")

--- a/bigtable/hbase/snippets/src/test/java/com/example/bigtable/BigtableConnectTest.java
+++ b/bigtable/hbase/snippets/src/test/java/com/example/bigtable/BigtableConnectTest.java
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
-package com.example.cloud.bigtable.connect;
+package com.example.bigtable;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import java.io.IOException;
 
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
@@ -36,6 +39,11 @@ public class BigtableConnectTest {
   public void prepare() throws Exception {
     helper = new BigtableConnect();
     helper.main(projectId, instanceId);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    helper.closeConnection();
   }
 
   @Test


### PR DESCRIPTION
Moving: https://github.com/GoogleCloudPlatform/cloud-bigtable-examples/tree/main/java/connect to java-docs-samples

> It's a good idea to open an issue first for discussion.

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] Please **merge** this PR for me once it is approved.
