### PR TITLE
bigtable: migrate Quickstart example from cloud-bigtable-examples

### DIFF
--- a/bigtable/hbase/snippets/src/main/java/com/example/bigtable/Quickstart.java
+++ b/bigtable/hbase/snippets/src/main/java/com/example/bigtable/Quickstart.java
@@ -16,10 +16,9 @@
 
 // [START bigtable_quickstart_hbase]
 
-package com.example.cloud.bigtable.quickstart;
+package com.example.bigtable;
 
 import com.google.cloud.bigtable.hbase.BigtableConfiguration;
-
 import java.io.IOException;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Connection;
@@ -29,16 +28,16 @@ import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.util.Bytes;
 
 /**
- * A quickstart application that shows connecting to a Cloud Bigtable instance
- * using the native HBase API to read a row from a table.
+ * A quickstart application that shows connecting to a Cloud Bigtable instance using the native
+ * HBase API to read a row from a table.
  */
 public class Quickstart {
 
   public static void main(String... args) {
 
-    String projectId = args[0];  // my-gcp-project-id
+    String projectId = args[0]; // my-gcp-project-id
     String instanceId = args[1]; // my-bigtable-instance-id
-    String tableId = args[2];    // my-bigtable-table-id
+    String tableId = args[2]; // my-bigtable-table-id
 
     // Create a connection to the Cloud Bigtable instance.
     // Use try-with-resources to make sure the connection is closed correctly
@@ -51,8 +50,8 @@ public class Quickstart {
 
         // Read a row
         String rowKey = "r1";
-        System.out.printf("--- Reading for row-key: %s for provided table: %s ---\n",
-            rowKey, tableId);
+        System.out.printf(
+            "--- Reading for row-key: %s for provided table: %s ---\n", rowKey, tableId);
 
         // Retrieve the result
         Result result = table.get(new Get(Bytes.toBytes(rowKey)));
@@ -64,7 +63,7 @@ public class Quickstart {
 
         System.out.println(" --- Finished reading row --- ");
 
-      }  catch (IOException e) {
+      } catch (IOException e) {
         // handle exception while connecting to a table
         throw e;
       }

--- a/bigtable/hbase/snippets/src/test/java/com/example/bigtable/QuickstartTest.java
+++ b/bigtable/hbase/snippets/src/test/java/com/example/bigtable/QuickstartTest.java
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-
-package com.example.cloud.bigtable.quickstart.it;
+package com.example.bigtable;
 
 import static org.junit.Assert.assertTrue;
 
-import com.example.cloud.bigtable.quickstart.Quickstart;
 import com.google.cloud.bigtable.hbase.BigtableConfiguration;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -38,22 +36,19 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/**
- * Cloud Bigtable Quickstart integration tests
- */
+/** Cloud Bigtable Quickstart integration tests */
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
-public class QuickstartIT {
+public class QuickstartTest {
 
   // provide your project id as an env var
-  private final String projectId = System.getProperty("bigtable.test.projectID");
-  private final String instanceId = System.getProperty("bigtable.test.instanceID");
+  private final String projectId = System.getProperty("bigtable.projectID");
+  private final String instanceId = System.getProperty("bigtable.instanceID");
 
   private final String tableId = formatForTest("my-table");
   private final String columnFamilyName = "my-column-family";
   private final String columnName = "my-column";
   private final String data = "my-data";
-
 
   private String formatForTest(String name) {
     return name + "-" + UUID.randomUUID().toString().substring(0, 20);
@@ -72,8 +67,8 @@ public class QuickstartIT {
           String rowKey = "r1";
 
           Put put = new Put(Bytes.toBytes(rowKey));
-          put.addColumn(Bytes.toBytes(columnFamilyName), Bytes.toBytes(columnName),
-              Bytes.toBytes(data));
+          put.addColumn(
+              Bytes.toBytes(columnFamilyName), Bytes.toBytes(columnName), Bytes.toBytes(data));
           table.put(put);
         }
       }


### PR DESCRIPTION
Moves https://github.com/GoogleCloudPlatform/cloud-bigtable-examples/tree/main/java/quickstart

Fixes #issue

> It's a good idea to open an issue first for discussion.

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] Please **merge** this PR for me once it is approved.
