### PR TITLE
Update AccessSecretVersion.java

### DIFF
--- a/secretmanager/src/main/java/secretmanager/AccessSecretVersion.java
+++ b/secretmanager/src/main/java/secretmanager/AccessSecretVersion.java
@@ -49,7 +49,7 @@ public class AccessSecretVersion {
 
       // Verify checksum. The used library is available in Java 9+.
       // If using Java 8, you may use the following:
-      // https://cloud.google.com/appengine/docs/standard/java/javadoc/com/google/appengine/api/files/Crc32c
+      // https://github.com/google/guava/blob/e62d6a0456420d295089a9c319b7593a3eae4a83/guava/src/com/google/common/hash/Hashing.java#L395
       byte[] data = response.getPayload().getData().toByteArray();
       Checksum checksum = new CRC32C();
       checksum.update(data, 0, data.length);


### PR DESCRIPTION
The previously linked library is deprecated, the guice implementation is favored now.

Fixes #issue

> It's a good idea to open an issue first for discussion.

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [x] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [x] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [x] Please **merge** this PR for me once it is approved.
