### PR TITLE
pubsub(fix): avoid default port in spring app

### DIFF
--- a/pubsub/spring/src/main/resources/application.properties
+++ b/pubsub/spring/src/main/resources/application.properties
@@ -26,3 +26,6 @@ spring.cloud.stream.bindings.receiveMessageFromTopicTwo-in-0.destination=topic-t
 # [END pubsub_spring_cloud_stream_input_binder_properties]
 
 spring.cloud.function.definition=sendMessageToTopicOne;receiveMessageFromTopicTwo
+
+# Multiple tests use the default port 8080. Avoid the default.
+server.port=8088


### PR DESCRIPTION
Fixes #7166 