### PR TITLE
test: add got to assertion message

### DIFF
--- a/spanner/changestreams/src/test/java/com/example/spanner/changestreams/ChangeStreamSampleIT.java
+++ b/spanner/changestreams/src/test/java/com/example/spanner/changestreams/ChangeStreamSampleIT.java
@@ -108,10 +108,9 @@ public class ChangeStreamSampleIT {
 
     String got = bout.toString();
     System.setOut(stdOut);
-    System.out.println("Standard output: " + got);
-    Assert.assertTrue(got.contains("Received a ChildPartitionsRecord"));
-    Assert.assertTrue(got.contains("Received a DataChangeRecord"));
-    Assert.assertTrue(got.contains("mods=[Mod{keysJson={\"SingerId\":\"1\"}, "
+    Assert.assertTrue(got, got.contains("Received a ChildPartitionsRecord"));
+    Assert.assertTrue(got, got.contains("Received a DataChangeRecord"));
+    Assert.assertTrue(got, got.contains("mods=[Mod{keysJson={\"SingerId\":\"1\"}, "
         + "oldValuesJson='', "
         + "newValuesJson="
         + "'{\"FirstName\":\"singer_1_first_name\",\"LastName\":\"singer_1_last_name\"}'}, "


### PR DESCRIPTION
Adds the actual change text that was received to the assertion message
so the log will contain a hint as to why the test seems to be flaky.

cc @Neenu1995 @haikuo-google 

Updates #7165
