### PR TITLE
pubsublite: rewrite test and bump versions

### DIFF
--- a/pubsublite/streaming-analytics/pom.xml
+++ b/pubsublite/streaming-analytics/pom.xml
@@ -34,7 +34,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <beam.version>2.38.0</beam.version>
+    <beam.version>2.39.0</beam.version>
 
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
@@ -66,7 +66,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.0.0</version>
+        <version>25.4.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pubsublite/streaming-analytics/src/test/java/PubsubliteToGcsIT.java
+++ b/pubsublite/streaming-analytics/src/test/java/PubsubliteToGcsIT.java
@@ -69,8 +69,8 @@ public class PubsubliteToGcsIT {
   private static final String cloudRegion = "us-east1";
   private static final char zoneId = 'b';
   private static final String suffix = UUID.randomUUID().toString().substring(0, 6);
-  private static final String topicId = "pubsublite-streaming-analytics-" + suffix;
-  private static final String subscriptionId = "pubsublite-streaming-analytics-" + suffix;
+  private static final String topicId = "pubsublite-streaming-analytics-topic-" + suffix;
+  private static final String subscriptionId = "pubsublite-streaming-analytics-sub-" + suffix;
   private static final String bucketName = "pubsublite-it";
   private static final String directoryPrefix = "samples/" + suffix;
   private static final String jobName = "pubsublite-dataflow-job-" + suffix;
@@ -136,7 +136,7 @@ public class PubsubliteToGcsIT {
     // Create a test topic and subscription.
     try (AdminClient adminClient = AdminClient.create(adminClientSettings)) {
       Topic responseTopic = adminClient.createTopic(topic).get();
-      System.out.println(responseTopic.getAllFields() + "created successfully.");
+      System.out.println(responseTopic.getAllFields() + " created successfully.");
       Subscription response = adminClient.createSubscription(subscription).get();
       System.out.println(response.getAllFields() + " created successfully.");
     }
@@ -155,7 +155,7 @@ public class PubsubliteToGcsIT {
     // Delete the output files.
     Page<Blob> blobs = storage.list(bucketName, Storage.BlobListOption.prefix(directoryPrefix));
     for (Blob blob : blobs.iterateAll()) {
-      // storage.delete(bucketName, blob.getName());
+      storage.delete(bucketName, blob.getName());
       System.out.println("Deleted a file: " + blob.getName());
     }
 

--- a/pubsublite/streaming-analytics/src/test/java/PubsubliteToGcsIT.java
+++ b/pubsublite/streaming-analytics/src/test/java/PubsubliteToGcsIT.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.TestCase.assertNotNull;
 
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
@@ -34,22 +33,30 @@ import com.google.cloud.pubsublite.SubscriptionName;
 import com.google.cloud.pubsublite.SubscriptionPath;
 import com.google.cloud.pubsublite.TopicName;
 import com.google.cloud.pubsublite.TopicPath;
+import com.google.cloud.pubsublite.cloudpubsub.Publisher;
+import com.google.cloud.pubsublite.cloudpubsub.PublisherSettings;
 import com.google.cloud.pubsublite.proto.Subscription;
 import com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig;
 import com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement;
+import com.google.cloud.pubsublite.proto.Topic;
+import com.google.cloud.pubsublite.proto.Topic.PartitionConfig;
+import com.google.cloud.pubsublite.proto.Topic.PartitionConfig.Capacity;
+import com.google.cloud.pubsublite.proto.Topic.RetentionConfig;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.util.Durations;
+import com.google.pubsub.v1.PubsubMessage;
 import examples.PubsubliteToGcs;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.apache.beam.sdk.testing.TestPipeline;
-import org.apache.beam.sdk.values.KV;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -61,8 +68,8 @@ public class PubsubliteToGcsIT {
   private static final String projectId = System.getenv("GOOGLE_CLOUD_PROJECT");
   private static final String cloudRegion = "us-east1";
   private static final char zoneId = 'b';
-  private static final String suffix = UUID.randomUUID().toString();
-  private static final String topicId = "pubsublite-streaming-analytics";
+  private static final String suffix = UUID.randomUUID().toString().substring(0, 6);
+  private static final String topicId = "pubsublite-streaming-analytics-" + suffix;
   private static final String subscriptionId = "pubsublite-streaming-analytics-" + suffix;
   private static final String bucketName = "pubsublite-it";
   private static final String directoryPrefix = "samples/" + suffix;
@@ -76,6 +83,22 @@ public class PubsubliteToGcsIT {
           .setProject(ProjectId.of(projectId))
           .setLocation(CloudZone.of(CloudRegion.of(cloudRegion), zoneId))
           .setName(TopicName.of(topicId))
+          .build();
+
+  private static final Topic topic =
+      Topic.newBuilder()
+          .setName(topicPath.toString())
+          .setPartitionConfig(
+              PartitionConfig.newBuilder()
+                  .setCount(1)
+                  .setCapacity(
+                      Capacity.newBuilder().setPublishMibPerSec(4).setSubscribeMibPerSec(4).build())
+                  .build())
+          .setRetentionConfig(
+              RetentionConfig.newBuilder()
+                  .setPeriod(Durations.fromDays(1))
+                  .setPerPartitionBytes(30 * 1024 * 1024 * 1024L)
+                  .build())
           .build();
 
   private static final SubscriptionPath subscriptionPath =
@@ -110,8 +133,10 @@ public class PubsubliteToGcsIT {
 
   @Before
   public void setUp() throws Exception {
-    // Create a subscription that reads from the entire message backlog in the topic.
+    // Create a test topic and subscription.
     try (AdminClient adminClient = AdminClient.create(adminClientSettings)) {
+      Topic responseTopic = adminClient.createTopic(topic).get();
+      System.out.println(responseTopic.getAllFields() + "created successfully.");
       Subscription response = adminClient.createSubscription(subscription).get();
       System.out.println(response.getAllFields() + " created successfully.");
     }
@@ -119,17 +144,18 @@ public class PubsubliteToGcsIT {
 
   @After
   public void tearDown() throws Exception {
-    // Delete the test subscription.
+    // Delete the test topic and subscription.
     try (AdminClient adminClient = AdminClient.create(adminClientSettings)) {
+      adminClient.deleteTopic(topicPath).get();
+      System.out.println("Deleted topic: " + topicPath);
       adminClient.deleteSubscription(subscriptionPath).get();
       System.out.println("Deleted subscription: " + subscriptionPath);
     }
 
     // Delete the output files.
     Page<Blob> blobs = storage.list(bucketName, Storage.BlobListOption.prefix(directoryPrefix));
-
     for (Blob blob : blobs.iterateAll()) {
-      storage.delete(bucketName, blob.getName());
+      // storage.delete(bucketName, blob.getName());
       System.out.println("Deleted a file: " + blob.getName());
     }
 
@@ -176,7 +202,7 @@ public class PubsubliteToGcsIT {
   }
 
   @Test
-  public void testPubsubliteToGcs() throws InterruptedException {
+  public void testPubsubliteToGcs() throws InterruptedException, ExecutionException {
     // Run the pipeline on Dataflow as instructed in the README.
     PubsubliteToGcs.main(
         new String[] {
@@ -190,30 +216,40 @@ public class PubsubliteToGcsIT {
           "--jobName=" + jobName
         });
 
-    // Wait 10 minute for the Dataflow job.
-    TimeUnit.MINUTES.sleep(10);
+    // Create a publisher client.
+    PublisherSettings publisherSettings =
+        PublisherSettings.newBuilder().setTopicPath(topicPath).build();
+    Publisher publisher = Publisher.create(publisherSettings);
+
+    // Start the publisher client.
+    publisher.startAsync().awaitRunning();
+
+    // Publish a few messages at one-minute interval.
+    for (int i = 0; i < 6; i++) {
+      String message = "message-" + i;
+      ByteString data = ByteString.copyFromUtf8(message);
+      PubsubMessage pubsubMessage = PubsubMessage.newBuilder().setData(data).build();
+      publisher.publish(pubsubMessage).get();
+      TimeUnit.MINUTES.sleep(1);
+    }
+
+    // Stop the publisher client.
+    publisher.stopAsync().awaitTerminated();
 
     // Check for output files.
     Page<Blob> blobs = storage.list(bucketName, Storage.BlobListOption.prefix(directoryPrefix));
 
-    List<KV<String, String>> desiredOutput = new ArrayList<KV<String, String>>();
+    int numFiles = 0;
+    // Check the content of the output files.
     for (Blob blob : blobs.iterateAll()) {
-      String fileName = blob.getName();
       String content = new String(blob.getContent(), StandardCharsets.UTF_8);
-      System.out.println("Found a file: " + fileName);
       System.out.println("Has content: " + content);
-
-      desiredOutput.add(KV.of(fileName, content));
+      Assert.assertTrue(content.contains("message-"));
+      // Increment the count if the file has the desired content.
+      numFiles += 1;
     }
 
-    assertThat(
-        desiredOutput.contains(
-            KV.of(directoryPrefix + "/output-17:08-17:09-0-of-1", "Hello world!\t1619197725")));
-    assertThat(
-        desiredOutput.contains(
-            KV.of(directoryPrefix + "/output-17:09-17:10-0-of-1", "Hello world!\t1619197759")));
-    assertThat(
-        desiredOutput.contains(
-            KV.of(directoryPrefix + "/output-17:10-17:11-0-of-1", "Hello world!\t1619197817")));
+    // Expect at least one file of desired output.
+    Assert.assertTrue(numFiles > 0);
   }
 }


### PR DESCRIPTION
The sample test as it was written should have failed for the last Beam version bump. 

There's a known issue with PubsubLiteIO in Beam==2.38.0: https://github.com/apache/beam/issues/21703

Need to bump Beam version to the latest and our libraries-bom together. 

TL;DR - PubsubLiteIO for Beam==2.39 [requires](https://mvnrepository.com/artifact/org.apache.beam/beam-sdks-java-io-google-cloud-platform/2.39.0) google-cloud-pubsublite==1.5.0-1.6.0. [libraries-bom==25.0.0](https://repo1.maven.org/maven2/com/google/cloud/libraries-bom/25.0.0/libraries-bom-25.0.0.pom) uses [google-cloud-bom==0.171.0](https://repo1.maven.org/maven2/com/google/cloud/google-cloud-bom/0.171.0/google-cloud-bom-0.171.0.pom), which pulls in an older version of google-cloud-pubsublite.