### PR TITLE
docs: add PostgreSQL read and query samples for SpannerIO

### DIFF
--- a/dataflow/spanner-io/src/main/java/com/example/dataflow/SpannerGroupWrite.java
+++ b/dataflow/spanner-io/src/main/java/com/example/dataflow/SpannerGroupWrite.java
@@ -84,16 +84,20 @@ public class SpannerGroupWrite {
     final Timestamp timestamp = Timestamp.now();
 
     if (options.getDialect() == Dialect.POSTGRESQL) {
-      pgWrite(instanceId, databaseId, p, suspiciousUserIds, timestamp);
+      postgreSqlWrite(instanceId, databaseId, p, suspiciousUserIds, timestamp);
     } else {
-      spannerWrite(instanceId, databaseId, suspiciousUserIds, timestamp);
+      googleSqlWrite(instanceId, databaseId, suspiciousUserIds, timestamp);
     }
 
     p.run().waitUntilFinish();
 
   }
 
-  static void spannerWrite(
+  /**
+   * {@link MutationGroup} depends on the dialect that is used, and will by default use {@link
+   * Dialect#GOOGLE_STANDARD_SQL}.
+   */
+  static void googleSqlWrite(
       String instanceId,
       String databaseId,
       PCollection<String> suspiciousUserIds,
@@ -147,7 +151,11 @@ public class SpannerGroupWrite {
     // [END spanner_dataflow_writegroup]
   }
 
-  static void pgWrite(
+  /**
+   * {@link MutationGroup} depends on the dialect that is used. We therefore need to set the dialect
+   * to {@link Dialect#POSTGRESQL} for PostgreSQL databases.
+   */
+  static void postgreSqlWrite(
       String instanceId,
       String databaseId,
       Pipeline pipeline,

--- a/dataflow/spanner-io/src/main/java/com/example/dataflow/SpannerRead.java
+++ b/dataflow/spanner-io/src/main/java/com/example/dataflow/SpannerRead.java
@@ -86,13 +86,13 @@ public class SpannerRead {
 
   public static void main(String[] args) {
     Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
-    Pipeline p = Pipeline.create(options);
+    Pipeline pipeline = Pipeline.create(options);
 
     String instanceId = options.getInstanceId();
     String databaseId = options.getDatabaseId();
     // [START spanner_dataflow_read]
     // Query for all the columns and rows in the specified Spanner table
-    PCollection<Struct> records = p.apply(
+    PCollection<Struct> records = pipeline.apply(
         SpannerIO.read()
             .withInstanceId(instanceId)
             .withDatabaseId(databaseId)
@@ -111,6 +111,6 @@ public class SpannerRead {
         .apply(ToString.elements())
         .apply(TextIO.write().to(options.getOutput()).withoutSharding());
 
-    p.run().waitUntilFinish();
+    pipeline.run().waitUntilFinish();
   }
 }

--- a/dataflow/spanner-io/src/main/java/com/example/dataflow/SpannerReadAll.java
+++ b/dataflow/spanner-io/src/main/java/com/example/dataflow/SpannerReadAll.java
@@ -94,27 +94,36 @@ public class SpannerReadAll {
     p.run().waitUntilFinish();
   }
 
-  static PCollection<Struct> spannerReadAll(SpannerConfig spannerConfig, Pipeline p) {
+  static PCollection<Struct> spannerReadAll(SpannerConfig spannerConfig, Pipeline pipeline) {
     // [START spanner_dataflow_readall]
-    PCollection<Struct> allRecords = p.apply(SpannerIO.read()
-        .withSpannerConfig(spannerConfig)
-        .withBatching(false)
-        .withQuery("SELECT t.table_name FROM information_schema.tables AS t WHERE t"
-            + ".table_catalog = '' AND t.table_schema = ''")).apply(
-        MapElements.into(TypeDescriptor.of(ReadOperation.class))
-            .via((SerializableFunction<Struct, ReadOperation>) input -> {
-              String tableName = input.getString(0);
-              return ReadOperation.create().withQuery("SELECT * FROM " + tableName);
-            })).apply(SpannerIO.readAll().withSpannerConfig(spannerConfig));
+    PCollection<Struct> allRecords =
+        pipeline
+            .apply(
+                SpannerIO.read()
+                    .withSpannerConfig(spannerConfig)
+                    .withBatching(false)
+                    .withQuery(
+                        "SELECT t.table_name FROM information_schema.tables AS t WHERE t"
+                            + ".table_catalog = '' AND t.table_schema = ''"))
+            .apply(
+                MapElements.into(TypeDescriptor.of(ReadOperation.class))
+                    .via(
+                        (SerializableFunction<Struct, ReadOperation>)
+                            input -> {
+                              String tableName = input.getString(0);
+                              return ReadOperation.create().withQuery("SELECT * FROM " + tableName);
+                            }))
+            .apply(SpannerIO.readAll().withSpannerConfig(spannerConfig));
     // [END spanner_dataflow_readall]
 
     return allRecords;
   }
 
-  static PCollection<Struct> pgReadAll(SpannerConfig spannerConfig, Pipeline p) {
+  static PCollection<Struct> pgReadAll(SpannerConfig spannerConfig, Pipeline pipeline) {
     // [START spanner_pg_dataflow_readall]
     PCollection<Struct> allRecords =
-        p.apply(
+        pipeline
+            .apply(
                 SpannerIO.read()
                     .withSpannerConfig(spannerConfig)
                     .withBatching(false)
@@ -141,5 +150,4 @@ public class SpannerReadAll {
 
     return allRecords;
   }
-
 }

--- a/dataflow/spanner-io/src/main/java/com/example/dataflow/SpannerReadAll.java
+++ b/dataflow/spanner-io/src/main/java/com/example/dataflow/SpannerReadAll.java
@@ -80,9 +80,9 @@ public class SpannerReadAll {
 
     PCollection<Struct> allRecords;
     if (options.getDialect() == Dialect.POSTGRESQL) {
-      allRecords = pgReadAll(spannerConfig, p);
+      allRecords = postgreSqlReadAll(spannerConfig, p);
     } else {
-      allRecords = spannerReadAll(spannerConfig, p);
+      allRecords = googleSqlReadAll(spannerConfig, p);
     }
 
     PCollection<Long> dbEstimatedSize = allRecords.apply(EstimateSize.create())
@@ -94,7 +94,8 @@ public class SpannerReadAll {
     p.run().waitUntilFinish();
   }
 
-  static PCollection<Struct> spannerReadAll(SpannerConfig spannerConfig, Pipeline pipeline) {
+  /** GoogleSQL databases use the empty string as the default catalog and schema values. */
+  static PCollection<Struct> googleSqlReadAll(SpannerConfig spannerConfig, Pipeline pipeline) {
     // [START spanner_dataflow_readall]
     PCollection<Struct> allRecords =
         pipeline
@@ -119,7 +120,11 @@ public class SpannerReadAll {
     return allRecords;
   }
 
-  static PCollection<Struct> pgReadAll(SpannerConfig spannerConfig, Pipeline pipeline) {
+  /**
+   * PostgreSQL databases use 'public' as the default schema and the unqualified database name as
+   * the default catalog name.
+   */
+  static PCollection<Struct> postgreSqlReadAll(SpannerConfig spannerConfig, Pipeline pipeline) {
     // [START spanner_pg_dataflow_readall]
     PCollection<Struct> allRecords =
         pipeline

--- a/dataflow/spanner-io/src/main/java/com/example/dataflow/SpannerReadApi.java
+++ b/dataflow/spanner-io/src/main/java/com/example/dataflow/SpannerReadApi.java
@@ -74,9 +74,9 @@ public class SpannerReadApi {
     Dialect dialect = options.getDialect();
     PCollection<Struct> records;
     if (dialect == Dialect.POSTGRESQL) {
-      records = pgRead(instanceId, databaseId, pipeline);
+      records = postgreSqlRead(instanceId, databaseId, pipeline);
     } else {
-      records = spannerRead(instanceId, databaseId, pipeline);
+      records = googleSqlRead(instanceId, databaseId, pipeline);
     }
 
     PCollection<Long> tableEstimatedSize = records
@@ -93,7 +93,12 @@ public class SpannerReadApi {
     pipeline.run().waitUntilFinish();
   }
 
-  static PCollection<Struct> spannerRead(String instanceId, String databaseId, Pipeline pipeline) {
+  /**
+   * GoogleSQL databases retain the casing of table and column names. It is therefore common to use
+   * CamelCase for identifiers.
+   */
+  static PCollection<Struct> googleSqlRead(
+      String instanceId, String databaseId, Pipeline pipeline) {
     // [START spanner_dataflow_readapi]
     // Query for all the columns and rows in the specified Spanner table
     PCollection<Struct> records = pipeline.apply(
@@ -106,7 +111,12 @@ public class SpannerReadApi {
     return records;
   }
 
-  static PCollection<Struct> pgRead(String instanceId, String databaseId, Pipeline pipeline) {
+  /**
+   * PostgreSQL databases automatically fold identifiers to lower case. It is therefore common to
+   * use all lower case identifiers with underscores to separate multiple words in an identifier.
+   */
+  static PCollection<Struct> postgreSqlRead(
+      String instanceId, String databaseId, Pipeline pipeline) {
     // [START spanner_pg_dataflow_readapi]
     // Query for all the columns and rows in the specified Spanner table
     PCollection<Struct> records = pipeline.apply(

--- a/dataflow/spanner-io/src/main/java/com/example/dataflow/SpannerWrite.java
+++ b/dataflow/spanner-io/src/main/java/com/example/dataflow/SpannerWrite.java
@@ -214,15 +214,19 @@ public class SpannerWrite {
         .apply("ParseAlbums", ParDo.of(new ParseAlbum()));
 
     if (options.getDialect() == Dialect.POSTGRESQL) {
-      pgWrite(instanceId, databaseId, p, albums);
+      postgreSqlWrite(instanceId, databaseId, p, albums);
     } else {
-      spannerWrite(instanceId, databaseId, albums);
+      googleSqlWrite(instanceId, databaseId, albums);
     }
 
     p.run().waitUntilFinish();
   }
 
-  static void spannerWrite(String instanceId, String databaseId, PCollection<Album> albums) {
+  /**
+   * Mutations depend on the dialect that is used, and will by default use {@link
+   * Dialect#GOOGLE_STANDARD_SQL}.
+   */
+  static void googleSqlWrite(String instanceId, String databaseId, PCollection<Album> albums) {
     // [START spanner_dataflow_write]
     albums
         // Spanner expects a Mutation object, so create it using the Album's data
@@ -244,7 +248,11 @@ public class SpannerWrite {
     // [END spanner_dataflow_write]
   }
 
-  static void pgWrite(
+  /**
+   * Mutations depend on the dialect that is used. We therefore need to set the dialect to {@link
+   * Dialect#POSTGRESQL} for PostgreSQL databases.
+   */
+  static void postgreSqlWrite(
       String instanceId, String databaseId, Pipeline pipeline, PCollection<Album> albums) {
     // [START spanner_pg_dataflow_write]
     PCollectionView<Dialect> dialectView =

--- a/dataflow/spanner-io/src/main/java/com/example/dataflow/TransactionalRead.java
+++ b/dataflow/spanner-io/src/main/java/com/example/dataflow/TransactionalRead.java
@@ -16,6 +16,8 @@
 
 package com.example.dataflow;
 
+import com.google.cloud.Tuple;
+import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.TimestampBound;
 import com.google.common.base.Joiner;
@@ -26,6 +28,8 @@ import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerIO;
 import org.apache.beam.sdk.io.gcp.spanner.Transaction;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Default.Enum;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -52,6 +56,13 @@ public class TransactionalRead {
     String getDatabaseId();
 
     void setDatabaseId(String value);
+
+    @Description("Dialect of the database that is used")
+    @Default
+    @Enum("GOOGLE_STANDARD_SQL")
+    Dialect getDialect();
+
+    void setDialect(Dialect dialect);
 
     @Description("Singers output filename in the format: singer_id\tfirst_name\tlast_name")
     String getSingersFilename();
@@ -101,27 +112,20 @@ public class TransactionalRead {
 
   public static void main(String[] args) {
     Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
-    Pipeline p = Pipeline.create(options);
+    Pipeline pipeline = Pipeline.create(options);
 
     String instanceId = options.getInstanceId();
     String databaseId = options.getDatabaseId();
+    Dialect dialect = options.getDialect();
 
-    // [START spanner_dataflow_txread]
-    SpannerConfig spannerConfig = SpannerConfig.create()
-        .withInstanceId(instanceId)
-        .withDatabaseId(databaseId);
-    PCollectionView<Transaction> tx = p.apply(
-        SpannerIO.createTransaction()
-            .withSpannerConfig(spannerConfig)
-            .withTimestampBound(TimestampBound.strong()));
-    PCollection<Struct> singers = p.apply(SpannerIO.read()
-        .withSpannerConfig(spannerConfig)
-        .withQuery("SELECT SingerID, FirstName, LastName FROM Singers")
-        .withTransaction(tx));
-    PCollection<Struct> albums = p.apply(SpannerIO.read().withSpannerConfig(spannerConfig)
-        .withQuery("SELECT SingerId, AlbumId, AlbumTitle FROM Albums")
-        .withTransaction(tx));
-    // [END spanner_dataflow_txread]
+    Tuple<PCollection<Struct>, PCollection<Struct>> records;
+    if (dialect == Dialect.POSTGRESQL) {
+      records = pgRead(instanceId, databaseId, pipeline);
+    } else {
+      records = spannerRead(instanceId, databaseId, pipeline);
+    }
+    PCollection<Struct> singers = records.x();
+    PCollection<Struct> albums = records.y();
 
     singers.apply(MapElements.via(new SimpleFunction<Struct, String>() {
 
@@ -139,8 +143,61 @@ public class TransactionalRead {
       }
     })).apply(TextIO.write().to(options.getAlbumsFilename()).withoutSharding());
 
-    p.run().waitUntilFinish();
+    pipeline.run().waitUntilFinish();
 
   }
 
+  static Tuple<PCollection<Struct>, PCollection<Struct>> spannerRead(
+      String instanceId, String databaseId, Pipeline pipeline) {
+    // [START spanner_dataflow_txread]
+    SpannerConfig spannerConfig =
+        SpannerConfig.create().withInstanceId(instanceId).withDatabaseId(databaseId);
+    PCollectionView<Transaction> tx =
+        pipeline.apply(
+            SpannerIO.createTransaction()
+                .withSpannerConfig(spannerConfig)
+                .withTimestampBound(TimestampBound.strong()));
+    PCollection<Struct> singers =
+        pipeline.apply(
+            SpannerIO.read()
+                .withSpannerConfig(spannerConfig)
+                .withQuery("SELECT SingerID, FirstName, LastName FROM Singers")
+                .withTransaction(tx));
+    PCollection<Struct> albums =
+        pipeline.apply(
+            SpannerIO.read()
+                .withSpannerConfig(spannerConfig)
+                .withQuery("SELECT SingerId, AlbumId, AlbumTitle FROM Albums")
+                .withTransaction(tx));
+    // [END spanner_dataflow_txread]
+
+    return Tuple.of(singers, albums);
+  }
+
+  static Tuple<PCollection<Struct>, PCollection<Struct>> pgRead(
+      String instanceId, String databaseId, Pipeline pipeline) {
+    // [START spanner_pg_dataflow_txread]
+    SpannerConfig spannerConfig =
+        SpannerConfig.create().withInstanceId(instanceId).withDatabaseId(databaseId);
+    PCollectionView<Transaction> tx =
+        pipeline.apply(
+            SpannerIO.createTransaction()
+                .withSpannerConfig(spannerConfig)
+                .withTimestampBound(TimestampBound.strong()));
+    PCollection<Struct> singers =
+        pipeline.apply(
+            SpannerIO.read()
+                .withSpannerConfig(spannerConfig)
+                .withQuery("SELECT singer_id, first_name, last_name FROM singers")
+                .withTransaction(tx));
+    PCollection<Struct> albums =
+        pipeline.apply(
+            SpannerIO.read()
+                .withSpannerConfig(spannerConfig)
+                .withQuery("SELECT singer_id, album_id, album_title FROM albums")
+                .withTransaction(tx));
+    // [END spanner_pg_dataflow_txread]
+
+    return Tuple.of(singers, albums);
+  }
 }

--- a/dataflow/spanner-io/src/main/java/com/example/dataflow/TransactionalRead.java
+++ b/dataflow/spanner-io/src/main/java/com/example/dataflow/TransactionalRead.java
@@ -120,9 +120,9 @@ public class TransactionalRead {
 
     Tuple<PCollection<Struct>, PCollection<Struct>> records;
     if (dialect == Dialect.POSTGRESQL) {
-      records = pgRead(instanceId, databaseId, pipeline);
+      records = postgreSqlRead(instanceId, databaseId, pipeline);
     } else {
-      records = spannerRead(instanceId, databaseId, pipeline);
+      records = googleSqlRead(instanceId, databaseId, pipeline);
     }
     PCollection<Struct> singers = records.x();
     PCollection<Struct> albums = records.y();
@@ -147,7 +147,11 @@ public class TransactionalRead {
 
   }
 
-  static Tuple<PCollection<Struct>, PCollection<Struct>> spannerRead(
+  /**
+   * GoogleSQL databases retain the casing of table and column names. It is therefore common to use
+   * CamelCase for identifiers.
+   */
+  static Tuple<PCollection<Struct>, PCollection<Struct>> googleSqlRead(
       String instanceId, String databaseId, Pipeline pipeline) {
     // [START spanner_dataflow_txread]
     SpannerConfig spannerConfig =
@@ -174,7 +178,11 @@ public class TransactionalRead {
     return Tuple.of(singers, albums);
   }
 
-  static Tuple<PCollection<Struct>, PCollection<Struct>> pgRead(
+  /**
+   * PostgreSQL databases automatically fold identifiers to lower case. It is therefore common to
+   * use all lower case identifiers with underscores to separate multiple words in an identifier.
+   */
+  static Tuple<PCollection<Struct>, PCollection<Struct>> postgreSqlRead(
       String instanceId, String databaseId, Pipeline pipeline) {
     // [START spanner_pg_dataflow_txread]
     SpannerConfig spannerConfig =


### PR DESCRIPTION
Adds PostgreSQL-specific samples for read and query operations using `SpannerIO`:
* Cloud Spanner GoogleSQL column names use camel case.
* Cloud Spanner PostgreSQL column names all lowercase with underscores to separate words. This because PostgreSQL automatically folds identifiers to lowercase.

All `Pipeline` variables that were named `p` are renamed to `pipeline` for better readability in the documentation that imports the code samples here: https://cloud.google.com/spanner/docs/dataflow-connector#read-without

Fixes b/232995390