### PR TITLE
fix(deps): manual update dependency com.google.cloud:google-cloud-pubsub to v1.120.3

### DIFF
--- a/flexible/pubsub/pom.xml
+++ b/flexible/pubsub/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsub</artifactId>
-      <version>1.117.0</version>
+      <version>1.120.3</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>

--- a/iot/api-client/codelab/manager/pom.xml
+++ b/iot/api-client/codelab/manager/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsub</artifactId>
-      <version>1.117.0</version>
+      <version>1.120.3</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>

--- a/iot/api-client/end-to-end-example/pom.xml
+++ b/iot/api-client/end-to-end-example/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsub</artifactId>
-      <version>1.117.0</version>
+      <version>1.120.3</version>
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>


### PR DESCRIPTION
#7231 is failing due to 1 of the 4 updates. Pulling 3 of the 4 updates into a seperate PR. 