### PR TITLE
fix(samples): Clean up stale Video Stitcher slates

### DIFF
--- a/media/stitcher/pom.xml
+++ b/media/stitcher/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-video-stitcher</artifactId>
-      <version>0.1.2</version>
+      <version>0.3.4</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>

--- a/media/stitcher/src/test/java/com/example/stitcher/CreateLiveSessionTest.java
+++ b/media/stitcher/src/test/java/com/example/stitcher/CreateLiveSessionTest.java
@@ -24,7 +24,6 @@ import com.google.api.gax.rpc.NotFoundException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -42,8 +41,7 @@ public class CreateLiveSessionTest {
   // (https://developers.google.com/interactive-media-ads/docs/sdks/html5/client-side/tags)
   private static final String LIVE_AD_TAG_URI =
       "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&sz=640x480&cust_params=sample_ct%3Dlinear&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=";
-  private static final String SLATE_ID =
-      "my-slate-" + UUID.randomUUID().toString().substring(0, 25);
+  private static final String SLATE_ID = TestUtils.getSlateId();
   private static final String SLATE_URI =
       "https://storage.googleapis.com/cloud-samples-data/media/ForBiggerEscapes.mp4";
   private static String PROJECT_ID;
@@ -66,6 +64,7 @@ public class CreateLiveSessionTest {
 
   @Before
   public void beforeTest() throws IOException {
+    TestUtils.cleanStaleSlates(PROJECT_ID, LOCATION);
     originalOut = System.out;
     bout = new ByteArrayOutputStream();
     System.setOut(new PrintStream(bout));

--- a/media/stitcher/src/test/java/com/example/stitcher/CreateSlateTest.java
+++ b/media/stitcher/src/test/java/com/example/stitcher/CreateSlateTest.java
@@ -24,7 +24,6 @@ import com.google.api.gax.rpc.NotFoundException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -36,8 +35,7 @@ import org.junit.runners.JUnit4;
 public class CreateSlateTest {
 
   private static final String LOCATION = "us-central1";
-  private static final String SLATE_ID =
-      "my-slate-" + UUID.randomUUID().toString().substring(0, 25);
+  private static final String SLATE_ID = TestUtils.getSlateId();
   private static final String SLATE_URI =
       "https://storage.googleapis.com/cloud-samples-data/media/ForBiggerEscapes.mp4";
   private static String PROJECT_ID;
@@ -60,6 +58,7 @@ public class CreateSlateTest {
 
   @Before
   public void beforeTest() throws IOException {
+    TestUtils.cleanStaleSlates(PROJECT_ID, LOCATION);
     originalOut = System.out;
     bout = new ByteArrayOutputStream();
     System.setOut(new PrintStream(bout));

--- a/media/stitcher/src/test/java/com/example/stitcher/DeleteSlateTest.java
+++ b/media/stitcher/src/test/java/com/example/stitcher/DeleteSlateTest.java
@@ -24,7 +24,6 @@ import com.google.api.gax.rpc.NotFoundException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -36,8 +35,7 @@ import org.junit.runners.JUnit4;
 public class DeleteSlateTest {
 
   private static final String LOCATION = "us-central1";
-  private static final String SLATE_ID =
-      "my-slate-" + UUID.randomUUID().toString().substring(0, 25);
+  private static final String SLATE_ID = TestUtils.getSlateId();
   private static final String SLATE_URI =
       "https://storage.googleapis.com/cloud-samples-data/media/ForBiggerEscapes.mp4";
   private static String PROJECT_ID;
@@ -60,6 +58,7 @@ public class DeleteSlateTest {
 
   @Before
   public void beforeTest() throws IOException {
+    TestUtils.cleanStaleSlates(PROJECT_ID, LOCATION);
     originalOut = System.out;
     bout = new ByteArrayOutputStream();
     System.setOut(new PrintStream(bout));

--- a/media/stitcher/src/test/java/com/example/stitcher/GetLiveAdTagDetailTest.java
+++ b/media/stitcher/src/test/java/com/example/stitcher/GetLiveAdTagDetailTest.java
@@ -24,7 +24,6 @@ import com.google.api.gax.rpc.NotFoundException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.After;
@@ -44,8 +43,7 @@ public class GetLiveAdTagDetailTest {
   // (https://developers.google.com/interactive-media-ads/docs/sdks/html5/client-side/tags)
   private static final String LIVE_AD_TAG_URI =
       "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&sz=640x480&cust_params=sample_ct%3Dlinear&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=";
-  private static final String SLATE_ID =
-      "my-slate-" + UUID.randomUUID().toString().substring(0, 25);
+  private static final String SLATE_ID = TestUtils.getSlateId();
   private static final String SLATE_URI =
       "https://storage.googleapis.com/cloud-samples-data/media/ForBiggerEscapes.mp4";
   private static String PROJECT_ID;
@@ -70,6 +68,7 @@ public class GetLiveAdTagDetailTest {
 
   @Before
   public void beforeTest() throws IOException {
+    TestUtils.cleanStaleSlates(PROJECT_ID, LOCATION);
     originalOut = System.out;
     bout = new ByteArrayOutputStream();
     System.setOut(new PrintStream(bout));

--- a/media/stitcher/src/test/java/com/example/stitcher/GetLiveSessionTest.java
+++ b/media/stitcher/src/test/java/com/example/stitcher/GetLiveSessionTest.java
@@ -24,7 +24,6 @@ import com.google.api.gax.rpc.NotFoundException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.After;
@@ -44,8 +43,7 @@ public class GetLiveSessionTest {
   // (https://developers.google.com/interactive-media-ads/docs/sdks/html5/client-side/tags)
   private static final String LIVE_AD_TAG_URI =
       "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&sz=640x480&cust_params=sample_ct%3Dlinear&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=";
-  private static final String SLATE_ID =
-      "my-slate-" + UUID.randomUUID().toString().substring(0, 25);
+  private static final String SLATE_ID = TestUtils.getSlateId();
   private static final String SLATE_URI =
       "https://storage.googleapis.com/cloud-samples-data/media/ForBiggerEscapes.mp4";
   private static String PROJECT_ID;
@@ -69,6 +67,7 @@ public class GetLiveSessionTest {
 
   @Before
   public void beforeTest() throws IOException {
+    TestUtils.cleanStaleSlates(PROJECT_ID, LOCATION);
     originalOut = System.out;
     bout = new ByteArrayOutputStream();
     System.setOut(new PrintStream(bout));

--- a/media/stitcher/src/test/java/com/example/stitcher/GetSlateTest.java
+++ b/media/stitcher/src/test/java/com/example/stitcher/GetSlateTest.java
@@ -24,7 +24,6 @@ import com.google.api.gax.rpc.NotFoundException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -36,8 +35,7 @@ import org.junit.runners.JUnit4;
 public class GetSlateTest {
 
   private static final String LOCATION = "us-central1";
-  private static final String SLATE_ID =
-      "my-slate-" + UUID.randomUUID().toString().substring(0, 25);
+  private static final String SLATE_ID = TestUtils.getSlateId();
   private static final String SLATE_URI =
       "https://storage.googleapis.com/cloud-samples-data/media/ForBiggerEscapes.mp4";
   private static String PROJECT_ID;
@@ -60,6 +58,7 @@ public class GetSlateTest {
 
   @Before
   public void beforeTest() throws IOException {
+    TestUtils.cleanStaleSlates(PROJECT_ID, LOCATION);
     originalOut = System.out;
     bout = new ByteArrayOutputStream();
     System.setOut(new PrintStream(bout));

--- a/media/stitcher/src/test/java/com/example/stitcher/ListLiveAdTagDetailsTest.java
+++ b/media/stitcher/src/test/java/com/example/stitcher/ListLiveAdTagDetailsTest.java
@@ -24,7 +24,6 @@ import com.google.api.gax.rpc.NotFoundException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.After;
@@ -44,8 +43,7 @@ public class ListLiveAdTagDetailsTest {
   // (https://developers.google.com/interactive-media-ads/docs/sdks/html5/client-side/tags)
   private static final String LIVE_AD_TAG_URI =
       "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&sz=640x480&cust_params=sample_ct%3Dlinear&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=";
-  private static final String SLATE_ID =
-      "my-slate-" + UUID.randomUUID().toString().substring(0, 25);
+  private static final String SLATE_ID = TestUtils.getSlateId();
   private static final String SLATE_URI =
       "https://storage.googleapis.com/cloud-samples-data/media/ForBiggerEscapes.mp4";
   private static String PROJECT_ID;
@@ -69,6 +67,7 @@ public class ListLiveAdTagDetailsTest {
 
   @Before
   public void beforeTest() throws IOException {
+    TestUtils.cleanStaleSlates(PROJECT_ID, LOCATION);
     originalOut = System.out;
     bout = new ByteArrayOutputStream();
     System.setOut(new PrintStream(bout));

--- a/media/stitcher/src/test/java/com/example/stitcher/ListSlatesTest.java
+++ b/media/stitcher/src/test/java/com/example/stitcher/ListSlatesTest.java
@@ -24,7 +24,6 @@ import com.google.api.gax.rpc.NotFoundException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -36,8 +35,7 @@ import org.junit.runners.JUnit4;
 public class ListSlatesTest {
 
   private static final String LOCATION = "us-central1";
-  private static final String SLATE_ID =
-      "my-slate-" + UUID.randomUUID().toString().substring(0, 25);
+  private static final String SLATE_ID = TestUtils.getSlateId();
   private static final String SLATE_URI =
       "https://storage.googleapis.com/cloud-samples-data/media/ForBiggerEscapes.mp4";
   private static String PROJECT_ID;
@@ -60,6 +58,7 @@ public class ListSlatesTest {
 
   @Before
   public void beforeTest() throws IOException {
+    TestUtils.cleanStaleSlates(PROJECT_ID, LOCATION);
     originalOut = System.out;
     bout = new ByteArrayOutputStream();
     System.setOut(new PrintStream(bout));

--- a/media/stitcher/src/test/java/com/example/stitcher/TestUtils.java
+++ b/media/stitcher/src/test/java/com/example/stitcher/TestUtils.java
@@ -16,15 +16,51 @@
 
 package com.example.stitcher;
 
+import com.google.api.gax.rpc.NotFoundException;
+import com.google.cloud.video.stitcher.v1.ListSlatesRequest;
+import com.google.cloud.video.stitcher.v1.LocationName;
+import com.google.cloud.video.stitcher.v1.Slate;
+import com.google.cloud.video.stitcher.v1.VideoStitcherServiceClient;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.time.Instant;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class TestUtils {
+
+  public static final String SLATE_ID_PREFIX = "my-slate-";
+  private static final int DELETION_THRESHOLD_TIME_HOURS_IN_SECONDS = 10800; // 3 hours
+
+  public static void cleanStaleSlates(String projectId, String location) throws IOException {
+    try (VideoStitcherServiceClient videoStitcherServiceClient =
+        VideoStitcherServiceClient.create()) {
+      ListSlatesRequest listSlatesRequest =
+          ListSlatesRequest.newBuilder()
+              .setParent(LocationName.of(projectId, location).toString())
+              .build();
+
+      VideoStitcherServiceClient.ListSlatesPagedResponse response =
+          videoStitcherServiceClient.listSlates(listSlatesRequest);
+
+      for (Slate slate : response.iterateAll()) {
+        // Matcher matcher = Pattern.compile(SLATE_ID_PREFIX).matcher(slate.getName());
+        // if (matcher.find()) {
+        //   String createTime = slate.getName().substring(matcher.end()).trim();
+        //   long createEpochSec = Long.parseLong(createTime);
+        //   if (createEpochSec
+        //       < Instant.now().getEpochSecond() - DELETION_THRESHOLD_TIME_HOURS_IN_SECONDS) {
+        videoStitcherServiceClient.deleteSlate(slate.getName());
+        //   }
+        // }
+      }
+    } catch (IOException | NotFoundException e) {
+      e.printStackTrace();
+    }
+  }
 
   // Finds the play URI in the given output.
   public static String getPlayUri(String output) {
@@ -61,5 +97,10 @@ public class TestUtils {
     connection.setRequestMethod("GET");
     connection.connect();
     connection.getInputStream();
+  }
+
+  // Get a slate ID that includes a creation timestamp.
+  public static String getSlateId() {
+    return SLATE_ID_PREFIX + Instant.now().getEpochSecond();
   }
 }

--- a/media/stitcher/src/test/java/com/example/stitcher/TestUtils.java
+++ b/media/stitcher/src/test/java/com/example/stitcher/TestUtils.java
@@ -35,7 +35,7 @@ public class TestUtils {
   public static final String SLATE_ID_PREFIX = "my-slate-";
   private static final int DELETION_THRESHOLD_TIME_HOURS_IN_SECONDS = 10800; // 3 hours
 
-  // Clean up old test slates that are no longer used.
+  // Clean up old test slates.
   public static void cleanStaleSlates(String projectId, String location) throws IOException {
     try (VideoStitcherServiceClient videoStitcherServiceClient =
         VideoStitcherServiceClient.create()) {

--- a/media/stitcher/src/test/java/com/example/stitcher/TestUtils.java
+++ b/media/stitcher/src/test/java/com/example/stitcher/TestUtils.java
@@ -35,7 +35,7 @@ public class TestUtils {
   public static final String SLATE_ID_PREFIX = "my-slate-";
   private static final int DELETION_THRESHOLD_TIME_HOURS_IN_SECONDS = 10800; // 3 hours
 
-  // Clean up old slates that are no longer used.
+  // Clean up old test slates that are no longer used.
   public static void cleanStaleSlates(String projectId, String location) throws IOException {
     try (VideoStitcherServiceClient videoStitcherServiceClient =
         VideoStitcherServiceClient.create()) {

--- a/media/stitcher/src/test/java/com/example/stitcher/TestUtils.java
+++ b/media/stitcher/src/test/java/com/example/stitcher/TestUtils.java
@@ -35,6 +35,7 @@ public class TestUtils {
   public static final String SLATE_ID_PREFIX = "my-slate-";
   private static final int DELETION_THRESHOLD_TIME_HOURS_IN_SECONDS = 10800; // 3 hours
 
+  // Clean up old slates that are no longer used.
   public static void cleanStaleSlates(String projectId, String location) throws IOException {
     try (VideoStitcherServiceClient videoStitcherServiceClient =
         VideoStitcherServiceClient.create()) {

--- a/media/stitcher/src/test/java/com/example/stitcher/TestUtils.java
+++ b/media/stitcher/src/test/java/com/example/stitcher/TestUtils.java
@@ -48,15 +48,15 @@ public class TestUtils {
           videoStitcherServiceClient.listSlates(listSlatesRequest);
 
       for (Slate slate : response.iterateAll()) {
-        // Matcher matcher = Pattern.compile(SLATE_ID_PREFIX).matcher(slate.getName());
-        // if (matcher.find()) {
-        //   String createTime = slate.getName().substring(matcher.end()).trim();
-        //   long createEpochSec = Long.parseLong(createTime);
-        //   if (createEpochSec
-        //       < Instant.now().getEpochSecond() - DELETION_THRESHOLD_TIME_HOURS_IN_SECONDS) {
-        videoStitcherServiceClient.deleteSlate(slate.getName());
-        //   }
-        // }
+        Matcher matcher = Pattern.compile(SLATE_ID_PREFIX).matcher(slate.getName());
+        if (matcher.find()) {
+          String createTime = slate.getName().substring(matcher.end()).trim();
+          long createEpochSec = Long.parseLong(createTime);
+          if (createEpochSec
+              < Instant.now().getEpochSecond() - DELETION_THRESHOLD_TIME_HOURS_IN_SECONDS) {
+            videoStitcherServiceClient.deleteSlate(slate.getName());
+          }
+        }
       }
     } catch (IOException | NotFoundException e) {
       e.printStackTrace();

--- a/media/stitcher/src/test/java/com/example/stitcher/UpdateSlateTest.java
+++ b/media/stitcher/src/test/java/com/example/stitcher/UpdateSlateTest.java
@@ -24,7 +24,6 @@ import com.google.api.gax.rpc.NotFoundException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -36,8 +35,7 @@ import org.junit.runners.JUnit4;
 public class UpdateSlateTest {
 
   private static final String LOCATION = "us-central1";
-  private static final String SLATE_ID =
-      "my-slate-" + UUID.randomUUID().toString().substring(0, 25);
+  private static final String SLATE_ID = TestUtils.getSlateId();
   private static final String SLATE_URI =
       "https://storage.googleapis.com/cloud-samples-data/media/ForBiggerEscapes.mp4";
   private static final String UPDATED_SLATE_URI =
@@ -62,6 +60,7 @@ public class UpdateSlateTest {
 
   @Before
   public void beforeTest() throws IOException {
+    TestUtils.cleanStaleSlates(PROJECT_ID, LOCATION);
     originalOut = System.out;
     bout = new ByteArrayOutputStream();
     System.setOut(new PrintStream(bout));


### PR DESCRIPTION
The project has run out of quota on slates (3), most likely due to b:246797639. This PR adds a mechanism to name test slates with a creation timestamp since the API does not reveal creation time.  Before applicable test runs, test slates more than 3 hours old are deleted.

This first commit deletes **all** old test slates, even those that have not been named with a creation timestamp. A subsequent commit will enable the timestamp naming and selective deletion.

- [X] Please **merge** this PR for me once it is approved.
