### PR TITLE
add(samples): add samples and tests for HC API v1 FHIR profiles

### DIFF
--- a/healthcare/v1/pom.xml
+++ b/healthcare/v1/pom.xml
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-healthcare</artifactId>
-      <version>v1-rev20211105-1.32.1</version>
+      <version>v1-rev20220818-2.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.api-client</groupId>

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/FhirStoreCreate.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/FhirStoreCreate.java
@@ -49,7 +49,7 @@ public class FhirStoreCreate {
     Map<String, String> labels = new HashMap<String, String>();
     labels.put("key1", "value1");
     labels.put("key2", "value2");
-    String version = "STU3";
+    String version = "R4";
     FhirStore content = new FhirStore().setLabels(labels).setVersion(version);
 
     // Create request and configure any parameters.

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirCreateImplementationGuide.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirCreateImplementationGuide.java
@@ -22,15 +22,16 @@ import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.healthcare.v1.CloudHealthcare;
-import com.google.api.services.healthcare.v1.CloudHealthcare.Projects.Locations.Datasets.FhirStores;
 import com.google.api.services.healthcare.v1.CloudHealthcareScopes;
-import com.google.api.services.healthcare.v1.model.FhirStore;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -40,29 +41,14 @@ import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClients;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.List;
-import com.google.api.client.json.GenericJson;
-import java.io.InputStream;
-import java.net.URISyntaxException;
-import java.io.FileInputStream;
-import com.google.api.client.json.JsonObjectParser;
-import java.io.File;
 
 public class FhirCreateImplementationGuide {
-    private static final String FHIR_NAME = "projects/%s/locations/%s/datasets/%s/fhirStores/%s";
-    private static final JsonFactory JSON_FACTORY = new JacksonFactory();
-    private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
+  private static final String FHIR_NAME = "projects/%s/locations/%s/datasets/%s/fhirStores/%s";
+  private static final JsonFactory JSON_FACTORY = new JacksonFactory();
+  private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
 
-    /**
-     * @param fhirStoreName
-     * @param filePath
-     * @throws IOException
-     * @throws URISyntaxException
-     */
-    public static void fhirCreateImplementationGuide(String fhirStoreName, String filePath) throws IOException, URISyntaxException {
+  public static void fhirCreateImplementationGuide(String fhirStoreName, String filePath)
+      throws IOException, URISyntaxException {
     // String fhirStoreName =
     //    String.format(
     //        FHIR_NAME, "project-id", "location", "dataset-id", "fhir-store-id");
@@ -72,7 +58,8 @@ public class FhirCreateImplementationGuide {
     CloudHealthcare client = createClient();
 
     HttpClient httpClient = HttpClients.createDefault();
-    String uri = String.format("%sv1/%s/fhir/ImplementationGuide", client.getRootUrl(), fhirStoreName);
+    String uri =
+        String.format("%sv1/%s/fhir/ImplementationGuide", client.getRootUrl(), fhirStoreName);
     URIBuilder uriBuilder = new URIBuilder(uri).setParameter("access_token", getAccessToken());
 
     // Load the data from JSON file containing the ImplementationGuide resource.
@@ -94,7 +81,8 @@ public class FhirCreateImplementationGuide {
     if (response.getStatusLine().getStatusCode() != HttpStatus.SC_CREATED) {
       System.err.print(
           String.format(
-              "Exception creating FHIR ImplementationGuide resource: %s\n", response.getStatusLine().toString()));
+              "Exception creating FHIR ImplementationGuide resource: %s\n",
+              response.getStatusLine().toString()));
       responseEntity.writeTo(System.err);
       throw new RuntimeException();
     }
@@ -127,7 +115,7 @@ public class FhirCreateImplementationGuide {
     GoogleCredentials credential =
         GoogleCredentials.getApplicationDefault()
             .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
-    
+
     return credential.refreshAccessToken().getTokenValue();
   }
 }

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirCreateImplementationGuide.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirCreateImplementationGuide.java
@@ -119,3 +119,4 @@ public class FhirCreateImplementationGuide {
     return credential.refreshAccessToken().getTokenValue();
   }
 }
+// [END healthcare_create_implementation_guide]

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirCreateStructureDefinition.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirCreateStructureDefinition.java
@@ -16,6 +16,15 @@
 
 package snippets.healthcare.fhir.resources;
 
+// [START healthcare_create_structure_definition]
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.healthcare.v1.CloudHealthcare;
+import com.google.api.services.healthcare.v1.CloudHealthcareScopes;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
@@ -33,95 +42,84 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClients;
 
-// [START healthcare_create_structure_definition]
-import com.google.api.client.http.HttpRequestInitializer;
-import com.google.api.client.http.javanet.NetHttpTransport;
-import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
-import com.google.api.services.healthcare.v1.CloudHealthcare;
-import com.google.api.services.healthcare.v1.CloudHealthcareScopes;
-import com.google.auth.http.HttpCredentialsAdapter;
-import com.google.auth.oauth2.GoogleCredentials;
-
 public class FhirCreateStructureDefinition {
-    private static final String FHIR_NAME = "projects/%s/locations/%s/datasets/%s/fhirStores/%s";
-    private static final JsonFactory JSON_FACTORY = new JacksonFactory();
-    private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
+  private static final String FHIR_NAME = "projects/%s/locations/%s/datasets/%s/fhirStores/%s";
+  private static final JsonFactory JSON_FACTORY = new JacksonFactory();
+  private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
 
-    /**
-     * @param fhirStoreName
-     * @param filePath
-     * @throws IOException
-     * @throws URISyntaxException
-     */
-    public static void fhirCreateStructureDefinition(String fhirStoreName, String filePath)
-            throws IOException, URISyntaxException {
-        // String fhirStoreName =
-        // String.format(
-        // FHIR_NAME, "project-id", "location", "dataset-id", "fhir-store-id");
-        // String filePath = "StructureDefinition.json";
+  public static void fhirCreateStructureDefinition(String fhirStoreName, String filePath)
+      throws IOException, URISyntaxException {
+    // String fhirStoreName =
+    // String.format(
+    // FHIR_NAME, "project-id", "location", "dataset-id", "fhir-store-id");
+    // String filePath = "StructureDefinition.json";
 
-        // Initialize the client, which will be used to interact with the service.
-        CloudHealthcare client = createClient();
+    // Initialize the client, which will be used to interact with the service.
+    CloudHealthcare client = createClient();
 
-        HttpClient httpClient = HttpClients.createDefault();
-        String uri = String.format("%sv1/%s/fhir/StructureDefinition", client.getRootUrl(), fhirStoreName);
-        URIBuilder uriBuilder = new URIBuilder(uri).setParameter("access_token", getAccessToken());
+    HttpClient httpClient = HttpClients.createDefault();
+    String uri =
+        String.format("%sv1/%s/fhir/StructureDefinition", client.getRootUrl(), fhirStoreName);
+    URIBuilder uriBuilder = new URIBuilder(uri).setParameter("access_token", getAccessToken());
 
-        // Load the data from JSON file containing the StructureDefinition resource.
-        List<String> lines = Files.readAllLines(Paths.get(filePath), Charset.defaultCharset());
-        String data = String.join("\n", lines);
-        StringEntity requestEntity = new StringEntity(data);
+    // Load the data from JSON file containing the StructureDefinition resource.
+    List<String> lines = Files.readAllLines(Paths.get(filePath), Charset.defaultCharset());
+    String data = String.join("\n", lines);
+    StringEntity requestEntity = new StringEntity(data);
 
-        HttpUriRequest request = RequestBuilder.post()
-                .setUri(uriBuilder.build())
-                .setEntity(requestEntity)
-                .addHeader("Content-Type", "application/fhir+json")
-                .addHeader("Accept-Charset", "utf-8")
-                .build();
+    HttpUriRequest request =
+        RequestBuilder.post()
+            .setUri(uriBuilder.build())
+            .setEntity(requestEntity)
+            .addHeader("Content-Type", "application/fhir+json")
+            .addHeader("Accept-Charset", "utf-8")
+            .build();
 
-        // Execute the request and process the results.
-        HttpResponse response = httpClient.execute(request);
-        HttpEntity responseEntity = response.getEntity();
-        if (response.getStatusLine().getStatusCode() != HttpStatus.SC_CREATED) {
-            System.err.print(
-                    String.format(
-                            "Exception creating FHIR StructureDefinition resource: %s\n",
-                            response.getStatusLine().toString()));
-            responseEntity.writeTo(System.err);
-            throw new RuntimeException();
-        }
-        System.out.print("FHIR StructureDefinition resource created: ");
-        responseEntity.writeTo(System.out);
+    // Execute the request and process the results.
+    HttpResponse response = httpClient.execute(request);
+    HttpEntity responseEntity = response.getEntity();
+    if (response.getStatusLine().getStatusCode() != HttpStatus.SC_CREATED) {
+      System.err.print(
+          String.format(
+              "Exception creating FHIR StructureDefinition resource: %s\n",
+              response.getStatusLine().toString()));
+      responseEntity.writeTo(System.err);
+      throw new RuntimeException();
     }
+    System.out.print("FHIR StructureDefinition resource created: ");
+    responseEntity.writeTo(System.out);
+  }
 
-    private static CloudHealthcare createClient() throws IOException {
-        // Use Application Default Credentials (ADC) to authenticate the requests
-        // For more information see
-        // https://cloud.google.com/docs/authentication/production
-        GoogleCredentials credential = GoogleCredentials.getApplicationDefault()
-                .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
+  private static CloudHealthcare createClient() throws IOException {
+    // Use Application Default Credentials (ADC) to authenticate the requests
+    // For more information see
+    // https://cloud.google.com/docs/authentication/production
+    GoogleCredentials credential =
+        GoogleCredentials.getApplicationDefault()
+            .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
 
-        // Create a HttpRequestInitializer, which will provide a baseline configuration
-        // to all requests.
-        HttpRequestInitializer requestInitializer = request -> {
-            new HttpCredentialsAdapter(credential).initialize(request);
-            request.setConnectTimeout(60000); // 1 minute connect timeout
-            request.setReadTimeout(60000); // 1 minute read timeout
+    // Create a HttpRequestInitializer, which will provide a baseline configuration
+    // to all requests.
+    HttpRequestInitializer requestInitializer =
+        request -> {
+          new HttpCredentialsAdapter(credential).initialize(request);
+          request.setConnectTimeout(60000); // 1 minute connect timeout
+          request.setReadTimeout(60000); // 1 minute read timeout
         };
 
-        // Build the client for interacting with the service.
-        return new CloudHealthcare.Builder(HTTP_TRANSPORT, JSON_FACTORY, requestInitializer)
-                .setApplicationName("your-application-name")
-                .build();
-    }
+    // Build the client for interacting with the service.
+    return new CloudHealthcare.Builder(HTTP_TRANSPORT, JSON_FACTORY, requestInitializer)
+        .setApplicationName("your-application-name")
+        .build();
+  }
 
-    private static String getAccessToken() throws IOException {
-        GoogleCredentials credential = GoogleCredentials.getApplicationDefault()
-                .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
+  private static String getAccessToken() throws IOException {
+    GoogleCredentials credential =
+        GoogleCredentials.getApplicationDefault()
+            .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
 
-        return credential.refreshAccessToken().getTokenValue();
-    }
+    return credential.refreshAccessToken().getTokenValue();
+  }
 }
 
 // [END healthcare_create_structure_definition]

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirCreateStructureDefinition.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirCreateStructureDefinition.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package snippets.healthcare.fhir.resources;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.HttpClients;
+
+// [START healthcare_create_structure_definition]
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.healthcare.v1.CloudHealthcare;
+import com.google.api.services.healthcare.v1.CloudHealthcareScopes;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+
+public class FhirCreateStructureDefinition {
+    private static final String FHIR_NAME = "projects/%s/locations/%s/datasets/%s/fhirStores/%s";
+    private static final JsonFactory JSON_FACTORY = new JacksonFactory();
+    private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
+
+    /**
+     * @param fhirStoreName
+     * @param filePath
+     * @throws IOException
+     * @throws URISyntaxException
+     */
+    public static void fhirCreateStructureDefinition(String fhirStoreName, String filePath)
+            throws IOException, URISyntaxException {
+        // String fhirStoreName =
+        // String.format(
+        // FHIR_NAME, "project-id", "location", "dataset-id", "fhir-store-id");
+        // String filePath = "StructureDefinition.json";
+
+        // Initialize the client, which will be used to interact with the service.
+        CloudHealthcare client = createClient();
+
+        HttpClient httpClient = HttpClients.createDefault();
+        String uri = String.format("%sv1/%s/fhir/StructureDefinition", client.getRootUrl(), fhirStoreName);
+        URIBuilder uriBuilder = new URIBuilder(uri).setParameter("access_token", getAccessToken());
+
+        // Load the data from JSON file containing the StructureDefinition resource.
+        List<String> lines = Files.readAllLines(Paths.get(filePath), Charset.defaultCharset());
+        String data = String.join("\n", lines);
+        StringEntity requestEntity = new StringEntity(data);
+
+        HttpUriRequest request = RequestBuilder.post()
+                .setUri(uriBuilder.build())
+                .setEntity(requestEntity)
+                .addHeader("Content-Type", "application/fhir+json")
+                .addHeader("Accept-Charset", "utf-8")
+                .build();
+
+        // Execute the request and process the results.
+        HttpResponse response = httpClient.execute(request);
+        HttpEntity responseEntity = response.getEntity();
+        if (response.getStatusLine().getStatusCode() != HttpStatus.SC_CREATED) {
+            System.err.print(
+                    String.format(
+                            "Exception creating FHIR StructureDefinition resource: %s\n",
+                            response.getStatusLine().toString()));
+            responseEntity.writeTo(System.err);
+            throw new RuntimeException();
+        }
+        System.out.print("FHIR StructureDefinition resource created: ");
+        responseEntity.writeTo(System.out);
+    }
+
+    private static CloudHealthcare createClient() throws IOException {
+        // Use Application Default Credentials (ADC) to authenticate the requests
+        // For more information see
+        // https://cloud.google.com/docs/authentication/production
+        GoogleCredentials credential = GoogleCredentials.getApplicationDefault()
+                .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
+
+        // Create a HttpRequestInitializer, which will provide a baseline configuration
+        // to all requests.
+        HttpRequestInitializer requestInitializer = request -> {
+            new HttpCredentialsAdapter(credential).initialize(request);
+            request.setConnectTimeout(60000); // 1 minute connect timeout
+            request.setReadTimeout(60000); // 1 minute read timeout
+        };
+
+        // Build the client for interacting with the service.
+        return new CloudHealthcare.Builder(HTTP_TRANSPORT, JSON_FACTORY, requestInitializer)
+                .setApplicationName("your-application-name")
+                .build();
+    }
+
+    private static String getAccessToken() throws IOException {
+        GoogleCredentials credential = GoogleCredentials.getApplicationDefault()
+                .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
+
+        return credential.refreshAccessToken().getTokenValue();
+    }
+}
+
+// [END healthcare_create_structure_definition]

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirEnableImplementationGuide.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirEnableImplementationGuide.java
@@ -38,16 +38,13 @@ public class FhirEnableImplementationGuide {
   private static final JsonFactory JSON_FACTORY = new JacksonFactory();
   private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
 
-  /**
- * @param fhirStoreName
- * @param implementationGuideUrl
- * @throws IOException
- */
-public static void fhirEnableImplementationGuide(String fhirStoreName, String implementationGuideUrl) throws IOException {
+  public static void fhirEnableImplementationGuide(
+      String fhirStoreName, String implementationGuideUrl) throws IOException {
     // String fhirStoreName =
     //    String.format(
     //        FHIR_NAME, "project-id", "location", "dataset-id", "fhir-store-id");
-    // String implementationGuideUrl = "http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core";
+    // String implementationGuideUrl =
+    // "http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core";
 
     // Initialize the client, which will be used to interact with the service.
     CloudHealthcare client = createClient();

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceCreate.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceCreate.java
@@ -56,7 +56,12 @@ public class FhirResourceCreate {
     String uri = String.format("%sv1/%s/fhir/%s", client.getRootUrl(), fhirStoreName, resourceType);
     URIBuilder uriBuilder = new URIBuilder(uri).setParameter("access_token", getAccessToken());
     StringEntity requestEntity =
-        new StringEntity("{\"resourceType\": \"" + resourceType + "\", \"language\": \"en\", \"gender\": \"female\", \"birthDate\": \"1970-01-01\", \"name\": [{\"use\": \"official\", \"family\": \"Smith\", \"given\": [\"Darcy\"]}]}");
+        new StringEntity(
+            "{\"resourceType\": \""
+                + resourceType
+                + "\", \"language\": \"en\", \"gender\": \"female\", \"birthDate\": \"1970-01-01\","
+                + " \"name\": [{\"use\": \"official\", \"family\": \"Smith\", \"given\":"
+                + " [\"Darcy\"]}]}");
 
     HttpUriRequest request =
         RequestBuilder.post()
@@ -106,7 +111,7 @@ public class FhirResourceCreate {
     GoogleCredentials credential =
         GoogleCredentials.getApplicationDefault()
             .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
-    
+
     return credential.refreshAccessToken().getTokenValue();
   }
 }

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceDelete.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceDelete.java
@@ -109,7 +109,7 @@ public class FhirResourceDelete {
     GoogleCredentials credential =
         GoogleCredentials.getApplicationDefault()
             .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
-    
+
     return credential.refreshAccessToken().getTokenValue();
   }
 }

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceGet.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceGet.java
@@ -97,7 +97,7 @@ public class FhirResourceGet {
     GoogleCredentials credential =
         GoogleCredentials.getApplicationDefault()
             .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
-    
+
     return credential.refreshAccessToken().getTokenValue();
   }
 }

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceGetHistory.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceGetHistory.java
@@ -105,7 +105,7 @@ public class FhirResourceGetHistory {
     GoogleCredentials credential =
         GoogleCredentials.getApplicationDefault()
             .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
-    
+
     return credential.refreshAccessToken().getTokenValue();
   }
 }

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceGetPatientEverything.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceGetPatientEverything.java
@@ -103,7 +103,7 @@ public class FhirResourceGetPatientEverything {
     GoogleCredentials credential =
         GoogleCredentials.getApplicationDefault()
             .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
-    
+
     return credential.refreshAccessToken().getTokenValue();
   }
 }

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceListHistory.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceListHistory.java
@@ -105,7 +105,7 @@ public class FhirResourceListHistory {
     GoogleCredentials credential =
         GoogleCredentials.getApplicationDefault()
             .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
-    
+
     return credential.refreshAccessToken().getTokenValue();
   }
 }

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourcePatch.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourcePatch.java
@@ -110,7 +110,7 @@ public class FhirResourcePatch {
     GoogleCredentials credential =
         GoogleCredentials.getApplicationDefault()
             .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
-    
+
     return credential.refreshAccessToken().getTokenValue();
   }
 }

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchGet.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceSearchGet.java
@@ -35,7 +35,6 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClients;
 
 public class FhirResourceSearchGet {
@@ -61,10 +60,7 @@ public class FhirResourceSearchGet {
     // example, to search for a Patient with the family name "Smith", specify the following:
     // uriBuilder.setParameter("family:exact", "Smith");
 
-    HttpUriRequest request =
-        RequestBuilder.get()
-            .setUri(uriBuilder.build())
-            .build();
+    HttpUriRequest request = RequestBuilder.get().setUri(uriBuilder.build()).build();
 
     // Execute the request and process the results.
     HttpResponse response = httpClient.execute(request);

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceUpdate.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceUpdate.java
@@ -111,7 +111,7 @@ public class FhirResourceUpdate {
     GoogleCredentials credential =
         GoogleCredentials.getApplicationDefault()
             .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
-    
+
     return credential.refreshAccessToken().getTokenValue();
   }
 }

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceValidate.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceValidate.java
@@ -40,19 +40,13 @@ import org.apache.http.impl.client.HttpClients;
 // [START healthcare_resource_validate]
 
 public class FhirResourceValidate {
-    private static final String FHIR_NAME =
-    "projects/%s/locations/%s/datasets/%s/fhirStores/%s/fhir/%s";
-    private static final JsonFactory JSON_FACTORY = new JacksonFactory();
-    private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();    
+  private static final String FHIR_NAME =
+      "projects/%s/locations/%s/datasets/%s/fhirStores/%s/fhir/%s";
+  private static final JsonFactory JSON_FACTORY = new JacksonFactory();
+  private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
 
-    /**
-     * @param fhirStoreName
-     * @param resourceType
-     * @throws IOException
-     * @throws URISyntaxException
-     */
-    public static void fhirResourceValidate(String resourceName, String resourceType)
-    throws IOException, URISyntaxException {
+  public static void fhirResourceValidate(String resourceName, String resourceType)
+      throws IOException, URISyntaxException {
     // String resourceName =
     //    String.format(
     //        FHIR_NAME, "project-id", "region-id", "dataset-id", "store-id", resourceType);
@@ -71,12 +65,11 @@ public class FhirResourceValidate {
     // are validating.
     StringEntity requestEntity =
         new StringEntity(
-            "{\"resourceType\": \"" + resourceType + "\"," +
-            "\"language\": \"en\"," +
-            "\"name\": [{\"use\": \"official\", \"family\": \"Smith\", \"given\": [\"Darcy\"]}]," +
-            "\"gender\": \"female\"," +
-            "\"birthDate\": \"1970-01-01\"}"
-            );
+            "{\"resourceType\": \""
+                + resourceType
+                + "\",\"language\": \"en\",\"name\": [{\"use\": \"official\", \"family\":"
+                + " \"Smith\", \"given\": [\"Darcy\"]}],\"gender\": \"female\",\"birthDate\":"
+                + " \"1970-01-01\"}");
 
     HttpUriRequest request =
         RequestBuilder.post()
@@ -126,7 +119,7 @@ public class FhirResourceValidate {
     GoogleCredentials credential =
         GoogleCredentials.getApplicationDefault()
             .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
-    
+
     return credential.refreshAccessToken().getTokenValue();
   }
 }

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceValidate.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceValidate.java
@@ -16,6 +16,7 @@
 
 package snippets.healthcare.fhir.resources;
 
+// [START healthcare_resource_validate]
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -36,8 +37,6 @@ import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClients;
-
-// [START healthcare_resource_validate]
 
 public class FhirResourceValidate {
   private static final String FHIR_NAME =

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceValidateProfileUrl.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceValidateProfileUrl.java
@@ -16,6 +16,7 @@
 
 package snippets.healthcare.fhir.resources;
 
+// [START healthcare_resource_validate_profile_url]
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -36,8 +37,6 @@ import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClients;
-
-// [START healthcare_resource_validate_profile_url]
 
 public class FhirResourceValidateProfileUrl {
   private static final String FHIR_NAME =

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceValidateProfileUrl.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceValidateProfileUrl.java
@@ -40,19 +40,14 @@ import org.apache.http.impl.client.HttpClients;
 // [START healthcare_resource_validate_profile_url]
 
 public class FhirResourceValidateProfileUrl {
-    private static final String FHIR_NAME =
-    "projects/%s/locations/%s/datasets/%s/fhirStores/%s/fhir/%s";
-    private static final JsonFactory JSON_FACTORY = new JacksonFactory();
-    private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();    
+  private static final String FHIR_NAME =
+      "projects/%s/locations/%s/datasets/%s/fhirStores/%s/fhir/%s";
+  private static final JsonFactory JSON_FACTORY = new JacksonFactory();
+  private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
 
-    /**
-     * @param fhirStoreName
-     * @param resourceType
-     * @throws IOException
-     * @throws URISyntaxException
-     */
-    public static void fhirResourceValidateProfileUrl(String resourceName, String resourceType, String profileUrl)
-    throws IOException, URISyntaxException {
+  public static void fhirResourceValidateProfileUrl(
+      String resourceName, String resourceType, String profileUrl)
+      throws IOException, URISyntaxException {
     // String resourceName =
     //    String.format(
     //        FHIR_NAME, "project-id", "region-id", "dataset-id", "store-id", resourceType);
@@ -73,7 +68,10 @@ public class FhirResourceValidateProfileUrl {
     // supply a new body with data that corresponds to the resource you
     // are validating.
     StringEntity requestEntity =
-    new StringEntity("{\"name\": [{\"use\": \"official\",\"family\": \"Smith\",\"given\": [\"Darcy\"]}],\"gender\": \"female\",\"birthDate\": \"1970-01-01\",\"resourceType\": \"Patient\"}");
+        new StringEntity(
+            "{\"name\": [{\"use\": \"official\",\"family\": \"Smith\",\"given\":"
+                + " [\"Darcy\"]}],\"gender\": \"female\",\"birthDate\":"
+                + " \"1970-01-01\",\"resourceType\": \"Patient\"}");
 
     HttpUriRequest request =
         RequestBuilder.post()
@@ -123,7 +121,7 @@ public class FhirResourceValidateProfileUrl {
     GoogleCredentials credential =
         GoogleCredentials.getApplicationDefault()
             .createScoped(Collections.singleton(CloudHealthcareScopes.CLOUD_PLATFORM));
-    
+
     return credential.refreshAccessToken().getTokenValue();
   }
 }

--- a/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceValidateProfileUrl.java
+++ b/healthcare/v1/src/main/java/snippets/healthcare/fhir/resources/FhirResourceValidateProfileUrl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package snippets.healthcare.fhir.resources;
 
-// [START healthcare_create_resource]
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -38,25 +37,43 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClients;
 
-public class FhirResourceCreate {
-  private static final String FHIR_NAME = "projects/%s/locations/%s/datasets/%s/fhirStores/%s";
-  private static final JsonFactory JSON_FACTORY = new JacksonFactory();
-  private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();
+// [START healthcare_resource_validate_profile_url]
 
-  public static void fhirResourceCreate(String fhirStoreName, String resourceType)
-      throws IOException, URISyntaxException {
-    // String fhirStoreName =
+public class FhirResourceValidateProfileUrl {
+    private static final String FHIR_NAME =
+    "projects/%s/locations/%s/datasets/%s/fhirStores/%s/fhir/%s";
+    private static final JsonFactory JSON_FACTORY = new JacksonFactory();
+    private static final NetHttpTransport HTTP_TRANSPORT = new NetHttpTransport();    
+
+    /**
+     * @param fhirStoreName
+     * @param resourceType
+     * @throws IOException
+     * @throws URISyntaxException
+     */
+    public static void fhirResourceValidateProfileUrl(String resourceName, String resourceType, String profileUrl)
+    throws IOException, URISyntaxException {
+    // String resourceName =
     //    String.format(
-    //        FHIR_NAME, "your-project-id", "your-region-id", "your-dataset-id", "your-fhir-id");
+    //        FHIR_NAME, "project-id", "region-id", "dataset-id", "store-id", resourceType);
     // String resourceType = "Patient";
+    // String profileUrl = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient";
 
     // Initialize the client, which will be used to interact with the service.
     CloudHealthcare client = createClient();
+
     HttpClient httpClient = HttpClients.createDefault();
-    String uri = String.format("%sv1/%s/fhir/%s", client.getRootUrl(), fhirStoreName, resourceType);
+    String uri = String.format("%s/v1/%s/$validate", client.getRootUrl(), resourceName);
     URIBuilder uriBuilder = new URIBuilder(uri).setParameter("access_token", getAccessToken());
+    // Pass the profile URL as a query parameter.
+    uriBuilder.setParameter("profile", profileUrl);
+
+    // The body shown works with a Patient resource and is not guaranteed
+    // to work with other types of FHIR resources. If necessary,
+    // supply a new body with data that corresponds to the resource you
+    // are validating.
     StringEntity requestEntity =
-        new StringEntity("{\"resourceType\": \"" + resourceType + "\", \"language\": \"en\", \"gender\": \"female\", \"birthDate\": \"1970-01-01\", \"name\": [{\"use\": \"official\", \"family\": \"Smith\", \"given\": [\"Darcy\"]}]}");
+    new StringEntity("{\"name\": [{\"use\": \"official\",\"family\": \"Smith\",\"given\": [\"Darcy\"]}],\"gender\": \"female\",\"birthDate\": \"1970-01-01\",\"resourceType\": \"Patient\"}");
 
     HttpUriRequest request =
         RequestBuilder.post()
@@ -64,20 +81,20 @@ public class FhirResourceCreate {
             .setEntity(requestEntity)
             .addHeader("Content-Type", "application/fhir+json")
             .addHeader("Accept-Charset", "utf-8")
-            .addHeader("Accept", "application/fhir+json; charset=utf-8")
             .build();
 
+    System.out.print("request is " + request);
     // Execute the request and process the results.
     HttpResponse response = httpClient.execute(request);
     HttpEntity responseEntity = response.getEntity();
-    if (response.getStatusLine().getStatusCode() != HttpStatus.SC_CREATED) {
+    if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
       System.err.print(
           String.format(
-              "Exception creating FHIR resource: %s\n", response.getStatusLine().toString()));
+              "Exception validating FHIR resource: %s\n", response.getStatusLine().toString()));
       responseEntity.writeTo(System.err);
       throw new RuntimeException();
     }
-    System.out.print("FHIR resource created: ");
+    System.out.print("FHIR resource with profile URL validated: ");
     responseEntity.writeTo(System.out);
   }
 
@@ -110,4 +127,4 @@ public class FhirResourceCreate {
     return credential.refreshAccessToken().getTokenValue();
   }
 }
-// [END healthcare_create_resource]
+// [END healthcare_resource_validate_profile_url]

--- a/healthcare/v1/src/test/java/snippets/healthcare/FhirResourceTests.java
+++ b/healthcare/v1/src/test/java/snippets/healthcare/FhirResourceTests.java
@@ -21,6 +21,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -28,7 +31,6 @@ import java.net.URISyntaxException;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -36,11 +38,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
-
 import snippets.healthcare.datasets.DatasetCreate;
 import snippets.healthcare.datasets.DatasetDelete;
 import snippets.healthcare.fhir.FhirStoreCreate;
@@ -75,12 +72,16 @@ public class FhirResourceTests {
   private static String resourcePath;
   private static String resourceType = "Patient";
 
-  private static String implementationGuideFilePath = "src/test/resources/ImplementationGuideExample.json";
-  private static String implementationGuideUrl = "http://example.com/ImplementationGuide/example.implementation.guide";
-  private static String structureDefinitionFilePath = "src/test/resources/StructureDefinitionExample.json";
-  private static String structureDefinitionProfileUrlFilePath = "src/test/resources/StructureDefinitionProfileUrlExample.json";
-  private static String profileUrl = "http://example.com/StructureDefinition/example-patient-profile-url";
-  
+  private static String implementationGuideFilePath =
+      "src/test/resources/ImplementationGuideExample.json";
+  private static String implementationGuideUrl =
+      "http://example.com/ImplementationGuide/example.implementation.guide";
+  private static String structureDefinitionFilePath =
+      "src/test/resources/StructureDefinitionExample.json";
+  private static String structureDefinitionProfileUrlFilePath =
+      "src/test/resources/StructureDefinitionProfileUrlExample.json";
+  private static String profileUrl =
+      "http://example.com/StructureDefinition/example-patient-profile-url";
 
   private final PrintStream originalOut = System.out;
   private ByteArrayOutputStream bout;
@@ -100,11 +101,8 @@ public class FhirResourceTests {
   @BeforeClass
   public static void setUp() throws IOException {
     String datasetId = "dataset-" + UUID.randomUUID().toString().replaceAll("-", "_");
-    datasetName = String.format(
-        "projects/%s/locations/%s/datasets/%s",
-        PROJECT_ID,
-        REGION_ID,
-        datasetId);
+    datasetName =
+        String.format("projects/%s/locations/%s/datasets/%s", PROJECT_ID, REGION_ID, datasetId);
     DatasetCreate.datasetCreate(PROJECT_ID, REGION_ID, datasetId);
 
     String fhirStoreId = "fhir-" + UUID.randomUUID().toString().replaceAll("-", "_");
@@ -113,7 +111,7 @@ public class FhirResourceTests {
     FhirStoreCreate.fhirStoreCreate(datasetName, fhirStoreId);
   }
 
-   @AfterClass
+  @AfterClass
   public static void deleteTempItems() throws IOException {
     DatasetDelete.datasetDelete(datasetName);
   }
@@ -128,11 +126,8 @@ public class FhirResourceTests {
     Matcher idMatcher = Pattern.compile("\"id\": \"([^\"]*)\",").matcher(bout.toString());
     if (idMatcher.find()) {
       fhirResourceId = idMatcher.group(1);
-      fhirResourceName = String.format(
-          "%s/fhir/%s/%s",
-          fhirStoreName,
-          resourceType,
-          fhirResourceId);
+      fhirResourceName =
+          String.format("%s/fhir/%s/%s", fhirStoreName, resourceType, fhirResourceId);
     }
 
     bout = new ByteArrayOutputStream();
@@ -145,7 +140,6 @@ public class FhirResourceTests {
     bout.reset();
   }
 
-
   @Test
   public void test_FhirResourceCreate() throws Exception {
     FhirResourceCreate.fhirResourceCreate(fhirStoreName, resourceType);
@@ -154,7 +148,7 @@ public class FhirResourceTests {
     assertThat(output, containsString("FHIR resource created:"));
   }
 
-   @Test
+  @Test
   public void test_FhirResourceValidate() throws Exception {
     FhirResourceValidate.fhirResourceValidate(resourcePath, resourceType);
 
@@ -278,8 +272,10 @@ public class FhirResourceTests {
     // Create a StructureDefinition resource that only exists in the FHIR store
     // to ensure that the fhirResourceValidateProfileUrl method fails, because the
     // validation does not adhere to the constraints in the StructureDefinition.
-    FhirCreateStructureDefinition.fhirCreateStructureDefinition(fhirStoreName, structureDefinitionProfileUrlFilePath);
-    FhirResourceValidateProfileUrl.fhirResourceValidateProfileUrl(resourcePath, resourceType, profileUrl);
+    FhirCreateStructureDefinition.fhirCreateStructureDefinition(
+        fhirStoreName, structureDefinitionProfileUrlFilePath);
+    FhirResourceValidateProfileUrl.fhirResourceValidateProfileUrl(
+        resourcePath, resourceType, profileUrl);
 
     String output = bout.toString();
     // Should fail because the FHIR resource we are validating does not
@@ -288,25 +284,28 @@ public class FhirResourceTests {
     assertThat(output, containsString("\"severity\": \"error\""));
   }
 
-   @Test
+  @Test
   public void test_FhirCreateStructureDefinition() throws Exception {
-    FhirCreateStructureDefinition.fhirCreateStructureDefinition(fhirStoreName, structureDefinitionFilePath);
+    FhirCreateStructureDefinition.fhirCreateStructureDefinition(
+        fhirStoreName, structureDefinitionFilePath);
 
     String output = bout.toString();
     assertThat(output, containsString("FHIR StructureDefinition resource created:"));
   }
 
-   @Test
+  @Test
   public void test_FhirCreateImplementationGuide() throws Exception {
-    FhirCreateImplementationGuide.fhirCreateImplementationGuide(fhirStoreName, implementationGuideFilePath);
+    FhirCreateImplementationGuide.fhirCreateImplementationGuide(
+        fhirStoreName, implementationGuideFilePath);
 
     String output = bout.toString();
     assertThat(output, containsString("FHIR ImplementationGuide resource created:"));
   }
 
-   @Test
+  @Test
   public void test_FhirEnableImplementationGuide() throws Exception {
-    FhirEnableImplementationGuide.fhirEnableImplementationGuide(fhirStoreName, implementationGuideUrl);
+    FhirEnableImplementationGuide.fhirEnableImplementationGuide(
+        fhirStoreName, implementationGuideUrl);
 
     String output = bout.toString();
     assertThat(output, containsString("ImplementationGuide enabled:"));

--- a/healthcare/v1/src/test/resources/CodeSystemExample.json
+++ b/healthcare/v1/src/test/resources/CodeSystemExample.json
@@ -1,0 +1,1 @@
+{"resourceType": "CodeSystem","id": "example-category","url": "http://example.com/CodeSystem/example-category","version": "5.0.1","name": "Example Category","status": "draft","content": "example","description": "Example set of codes."}

--- a/healthcare/v1/src/test/resources/CodeSystemExample.json
+++ b/healthcare/v1/src/test/resources/CodeSystemExample.json
@@ -1,1 +1,0 @@
-{"resourceType": "CodeSystem","id": "example-category","url": "http://example.com/CodeSystem/example-category","version": "5.0.1","name": "Example Category","status": "draft","content": "example","description": "Example set of codes."}

--- a/healthcare/v1/src/test/resources/ImplementationGuideExample.json
+++ b/healthcare/v1/src/test/resources/ImplementationGuideExample.json
@@ -1,0 +1,33 @@
+{
+    "resourceType" : "ImplementationGuide",
+    "name" : "TestImplementationGuide",
+    "url" : "http://example.com/ImplementationGuide/example.implementation.guide",
+    "packageId": "test-implementation-guide",
+    "date" : "2020-01-01",
+    "fhirVersion" : ["4.0.1"],
+    "status": "draft",
+    "license" : "CC-BY-1.0",
+    "global" : [{
+      "type" : "Patient",
+      "profile" : "http://example.com/StructureDefinition/example-patient"
+    }],
+    "definition" : {
+      "grouping" : [{
+        "name" : "test",
+        "description" : "Description"
+      }],
+      "resource": [
+        {
+          "extension": [
+            {
+              "url": "http://example.com/CodeSystem/example-category",
+              "valueString": "CodeSystem"
+            }
+          ],
+          "reference": {
+            "reference": "http://example.com/CodeSystem/example-category"
+          }
+        }
+      ]
+    }
+  }

--- a/healthcare/v1/src/test/resources/StructureDefinitionExample.json
+++ b/healthcare/v1/src/test/resources/StructureDefinitionExample.json
@@ -1,0 +1,82 @@
+{
+    "resourceType": "StructureDefinition",
+    "id": "example-patient",
+    "url": "http://example.com/StructureDefinition/example-patient",
+    "version": "1.0.0",
+    "name": "Example",
+    "title": "Example",
+    "status": "active",
+    "date": "2020-01-01",
+    "description": "This is an example.",
+    "fhirVersion": "4.0.1",
+    "kind": "complex-type",
+    "abstract": false,
+    "context": [
+      {
+        "type": "element",
+        "expression": "Patient"
+      }
+    ],
+    "type": "Patient",
+    "baseDefinition": "http://example.com/StructureDefinition/example-patient",
+    "derivation": "constraint",
+    "snapshot": {
+      "element": [
+        {
+          "id": "Patient",
+          "path": "Patient",
+          "short": "Patient",
+          "definition": "A Patient",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Patient",
+            "min": 0,
+            "max": "*"
+          }
+        },
+        {
+          "id": "Patient.name",
+          "path": "Patient.name",
+          "short": "Patient name",
+          "definition": "Patient name",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Patient.name",
+            "min": 0,
+            "max": "1"
+          }
+        },
+        {
+          "id": "Patient.gender",
+          "path": "Patient.gender",
+          "short": "Patient gender",
+          "definition": "Patient gender",
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "Patient.gender",
+            "min": 1,
+            "max": "1"
+          }
+        }
+      ]
+    },
+    "differential": {
+      "element": [
+        {
+          "id": "Patient",
+          "path": "Patient"
+        },
+        {
+          "id": "Patient.name",
+          "path": "Patient.name"
+        },
+        {
+          "id": "Patient.gender",
+          "path": "Patient.gender"
+        }
+      ]
+    }
+  }  

--- a/healthcare/v1/src/test/resources/StructureDefinitionProfileUrlExample.json
+++ b/healthcare/v1/src/test/resources/StructureDefinitionProfileUrlExample.json
@@ -1,0 +1,93 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "example-patient",
+  "url": "http://example.com/StructureDefinition/example-patient-profile-url",
+  "version": "1.0.0",
+  "name": "Example",
+  "title": "Example",
+  "status": "active",
+  "date": "2020-01-01",
+  "description": "This is an example.",
+  "fhirVersion": "4.0.1",
+  "kind": "complex-type",
+  "abstract": false,
+  "context": [
+    {
+      "type": "element",
+      "expression": "Patient"
+    }
+  ],
+  "type": "Patient",
+  "baseDefinition": "http://example.com/StructureDefinition/example-patient-profile-url",
+  "derivation": "constraint",
+  "snapshot": {
+    "element": [
+      {
+        "id": "Patient",
+        "path": "Patient",
+        "short": "Patient",
+        "definition": "A Patient",
+        "min": 0,
+        "max": "1",
+        "base": {
+          "path": "Patient",
+          "min": 0,
+          "max": "*"
+        }
+      },
+      {
+        "id": "Patient.name",
+        "path": "Patient.name",
+        "short": "Patient name",
+        "definition": "Patient name",
+        "min": 0,
+        "max": "1",
+        "base": {
+          "path": "Patient.name",
+          "min": 0,
+          "max": "1"
+        }
+      },
+      {
+        "id": "Patient.gender",
+        "path": "Patient.gender",
+        "short": "Patient gender",
+        "definition": "Patient gender",
+        "min": 1,
+        "max": "1",
+        "base": {
+          "path": "Patient.gender",
+          "min": 1,
+          "max": "1"
+        },
+        "type": [
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                "valueUrl": "uri"
+              }
+            ],
+            "code": "http://hl7.org/fhirpath/System.String"
+          }
+        ]
+      }
+    ]
+  },
+  "differential": {
+    "element": [
+      {
+        "id": "Patient",
+        "path": "Patient"
+      },
+      {
+        "id": "Patient.name",
+        "path": "Patient.name"
+      },
+      {
+        "id": "Patient.gender",
+        "path": "Patient.gender"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Part of fix for b/240609370.

- Add samples and tests for FHIR profiles.
- Update FHIR store version to R4.
- Linter picked up and made a lot of changes.

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [X] `pom.xml` parent set to latest `shared-configuration`
- [X] **Tests** pass:   `mvn clean verify` **required**
- [X] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [X] Please **merge** this PR for me once it is approved.
