### PR TITLE
fix(storagetransfer):use AWS creds from environment variable directly in sample

### DIFF
--- a/storage-transfer/src/main/java/com/google/cloud/storage/storagetransfer/samples/TransferFromAws.java
+++ b/storage-transfer/src/main/java/com/google/cloud/storage/storagetransfer/samples/TransferFromAws.java
@@ -40,9 +40,7 @@ public class TransferFromAws {
       String jobDescription,
       String awsSourceBucket,
       String gcsSinkBucket,
-      long startDateTime,
-      String awsAccessKeyId,
-      String awsSecretAccessKey)
+      long startDateTime)
       throws IOException {
 
     // Your Google Cloud Project ID
@@ -63,10 +61,10 @@ public class TransferFromAws {
     //     new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2000-01-01 00:00:00").getTime();
 
     // The ID used to access your AWS account. Should be accessed via environment variable.
-    // String awsAccessKeyId = System.getenv("AWS_ACCESS_KEY_ID");
+    String awsAccessKeyId = System.getenv("AWS_ACCESS_KEY_ID");
 
     // The Secret Key used to access your AWS account. Should be accessed via environment variable.
-    // String awsSecretAccessKey = System.getenv("AWS_SECRET_ACCESS_KEY");
+    String awsSecretAccessKey = System.getenv("AWS_SECRET_ACCESS_KEY");
 
     // Set up source and sink
     TransferSpec transferSpec =

--- a/storage-transfer/src/main/java/com/google/cloud/storage/storagetransfer/samples/apiary/TransferFromAwsApiary.java
+++ b/storage-transfer/src/main/java/com/google/cloud/storage/storagetransfer/samples/apiary/TransferFromAwsApiary.java
@@ -42,9 +42,7 @@ public class TransferFromAwsApiary {
       String jobDescription,
       String awsSourceBucket,
       String gcsSinkBucket,
-      long startDateTime,
-      String awsAccessKeyId,
-      String awsSecretAccessKey)
+      long startDateTime)
       throws IOException {
 
     // Your Google Cloud Project ID
@@ -65,10 +63,10 @@ public class TransferFromAwsApiary {
     //     new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2000-01-01 00:00:00").getTime();
 
     // The ID used to access your AWS account. Should be accessed via environment variable.
-    // String awsAccessKeyId = System.getenv("AWS_ACCESS_KEY_ID");
+    String awsAccessKeyId = System.getenv("AWS_ACCESS_KEY_ID");
 
     // The Secret Key used to access your AWS account. Should be accessed via environment variable.
-    // String awsSecretAccessKey = System.getenv("AWS_SECRET_ACCESS_KEY");
+    String awsSecretAccessKey = System.getenv("AWS_SECRET_ACCESS_KEY");
 
     // Set up source and sink
     TransferSpec transferSpec =

--- a/storage-transfer/src/test/java/com/google/cloud/storage/storagetransfer/samples/test/ITStoragetransferSamplesTest.java
+++ b/storage-transfer/src/test/java/com/google/cloud/storage/storagetransfer/samples/test/ITStoragetransferSamplesTest.java
@@ -311,9 +311,8 @@ public class ITStoragetransferSamplesTest {
         "Sample transfer job from S3 to GCS.",
         AMAZON_BUCKET,
         SINK_GCS_BUCKET,
-        new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2000-01-01 00:00:00").getTime(),
-        System.getenv("AWS_ACCESS_KEY_ID"),
-        System.getenv("AWS_SECRET_ACCESS_KEY"));
+        new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2000-01-01 00:00:00")
+            .getTime());
 
     String sampleOutput = stdOutCaptureRule.getCapturedOutputAsUtf8String();
     assertThat(sampleOutput).contains("transferJobs/");
@@ -328,9 +327,8 @@ public class ITStoragetransferSamplesTest {
         "Sample transfer job from S3 to GCS.",
         AMAZON_BUCKET,
         SINK_GCS_BUCKET,
-        new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2000-01-01 00:00:00").getTime(),
-        System.getenv("AWS_ACCESS_KEY_ID"),
-        System.getenv("AWS_SECRET_ACCESS_KEY"));
+        new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2000-01-01 00:00:00")
+            .getTime());
 
     String sampleOutput = stdOutCaptureRule.getCapturedOutputAsUtf8String();
     assertThat(sampleOutput).contains("transferJobs/");


### PR DESCRIPTION
Use AWS creds from environment variable directly in sample instead of passing them in via program args