### PR TITLE
test: Address IOT flaky tests

### DIFF
--- a/iot/api-client/manager/src/test/java/com/example/cloud/iot/examples/ManagerIT.java
+++ b/iot/api-client/manager/src/test/java/com/example/cloud/iot/examples/ManagerIT.java
@@ -1,17 +1,17 @@
 /*
  * Copyright 2017 Google Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package com.example.cloud.iot.examples;
@@ -20,6 +20,7 @@ import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.gax.rpc.AlreadyExistsException;
 import com.google.api.services.cloudiot.v1.CloudIot;
 import com.google.api.services.cloudiot.v1.CloudIotScopes;
 import com.google.api.services.cloudiot.v1.model.DeviceRegistry;
@@ -49,15 +50,12 @@ public class ManagerIT {
   private static final String CLOUD_REGION = "us-central1";
   private static final String ES_PATH = "resources/ec_public.pem";
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
-  private static final String REGISTRY_ID =
-      "java-reg-"
-              + UUID.randomUUID().toString().substring(0, 10) + "-"
-          + System.currentTimeMillis();
+  private static final String REGISTRY_ID = "java-reg-"
+      + UUID.randomUUID().toString().substring(0, 10) + "-" + System.currentTimeMillis();
   private static final String RSA_PATH = "resources/rsa_cert.pem";
   private static final String PKCS_PATH = "resources/rsa_private_pkcs8";
-  private static final String TOPIC_ID =
-      "java-pst-"
-          + UUID.randomUUID().toString().substring(0, 10) + "-" + System.currentTimeMillis();
+  private static final String TOPIC_ID = "java-pst-" + UUID.randomUUID().toString().substring(0, 10)
+      + "-" + System.currentTimeMillis();
   private static final String MEMBER = "group:dpebot@google.com";
   private static final String ROLE = "roles/viewer";
   private static Topic topic;
@@ -89,19 +87,12 @@ public class ManagerIT {
     HttpRequestInitializer init = new HttpCredentialsAdapter(credential);
     final CloudIot service =
         new CloudIot.Builder(GoogleNetHttpTransport.newTrustedTransport(), jsonFactory, init)
-            .setApplicationName("TEST")
-            .build();
+            .setApplicationName("TEST").build();
 
     final String projectPath = "projects/" + PROJECT_ID + "/locations/" + CLOUD_REGION;
 
-    List<DeviceRegistry> registries =
-        service
-            .projects()
-            .locations()
-            .registries()
-            .list(projectPath)
-            .execute()
-            .getDeviceRegistries();
+    List<DeviceRegistry> registries = service.projects().locations().registries().list(projectPath)
+        .execute().getDeviceRegistries();
 
     if (registries != null) {
       for (DeviceRegistry r : registries) {
@@ -140,25 +131,19 @@ public class ManagerIT {
 
     try {
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-      DeviceRegistryExample.createDeviceWithNoAuth(
-          deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-      DeviceRegistryExample.patchRsa256ForAuth(
-          deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.createDeviceWithNoAuth(deviceName, PROJECT_ID, CLOUD_REGION,
+          REGISTRY_ID);
+      DeviceRegistryExample.patchRsa256ForAuth(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
+          REGISTRY_ID);
 
       String got = bout.toString(StandardCharsets.UTF_8.name());
       Assert.assertTrue(got.contains("Created device: {"));
+
     } finally {
       DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
-
-    try {
-      TopicAdminClient topicAdminClient = TopicAdminClient.create();
-    } catch (ApiException e) {
-      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
-        throw e;
-      }
-    } finally {
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -170,25 +155,19 @@ public class ManagerIT {
 
     try {
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-      DeviceRegistryExample.createDeviceWithNoAuth(
-          deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-      DeviceRegistryExample.patchEs256ForAuth(
-          deviceName, ES_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.createDeviceWithNoAuth(deviceName, PROJECT_ID, CLOUD_REGION,
+          REGISTRY_ID);
+      DeviceRegistryExample.patchEs256ForAuth(deviceName, ES_PATH, PROJECT_ID, CLOUD_REGION,
+          REGISTRY_ID);
 
       String got = bout.toString(StandardCharsets.UTF_8.name());
       Assert.assertTrue(got.contains("Created device: {"));
+
     } finally {
       DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
-
-    try {
-      TopicAdminClient topicAdminClient = TopicAdminClient.create();
-    } catch (ApiException e) {
-      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
-        throw e;
-      }
-    } finally {
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -198,21 +177,19 @@ public class ManagerIT {
     final String deviceName = "noauth-device";
     topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
 
-    DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-    DeviceRegistryExample.createDeviceWithNoAuth(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-
-    String got = bout.toString(StandardCharsets.UTF_8.name());
-    Assert.assertTrue(got.contains("Created device: {"));
-
-    DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     try {
-      TopicAdminClient topicAdminClient = TopicAdminClient.create();
-    } catch (ApiException e) {
-      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
-        throw e;
-      }
+      DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
+      DeviceRegistryExample.createDeviceWithNoAuth(deviceName, PROJECT_ID, CLOUD_REGION,
+          REGISTRY_ID);
+
+      String got = bout.toString(StandardCharsets.UTF_8.name());
+      Assert.assertTrue(got.contains("Created device: {"));
+
     } finally {
+      DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
+    }
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -220,24 +197,21 @@ public class ManagerIT {
   @Test
   public void testCreateDeleteEsDevice() throws Exception {
     final String deviceName = "es-device";
-    topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
-    DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-    DeviceRegistryExample.createDeviceWithEs256(
-        deviceName, ES_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.getDeviceStates(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-
-    String got = bout.toString(StandardCharsets.UTF_8.name());
-    Assert.assertTrue(got.contains("Created device: {"));
-
-    DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     try {
-      TopicAdminClient topicAdminClient = TopicAdminClient.create();
-    } catch (ApiException e) {
-      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
-        throw e;
-      }
+      topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
+      DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
+      DeviceRegistryExample.createDeviceWithEs256(deviceName, ES_PATH, PROJECT_ID, CLOUD_REGION,
+          REGISTRY_ID);
+      DeviceRegistryExample.getDeviceStates(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+
+      String got = bout.toString(StandardCharsets.UTF_8.name());
+      Assert.assertTrue(got.contains("Created device: {"));
+
     } finally {
+      DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
+    }
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -245,50 +219,45 @@ public class ManagerIT {
   @Test
   public void testCreateDeleteRsaDevice() throws Exception {
     final String deviceName = "rsa-device";
-    topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
-    DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-    DeviceRegistryExample.createDeviceWithRs256(
-        deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.getDeviceStates(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-
-    String got = bout.toString(StandardCharsets.UTF_8.name());
-    Assert.assertTrue(got.contains("Created device: {"));
-
-    DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     try {
-      TopicAdminClient topicAdminClient = TopicAdminClient.create();
-    } catch (ApiException e) {
-      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
-        throw e;
-      }
+      topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
+      DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
+      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
+          REGISTRY_ID);
+
+      DeviceRegistryExample.getDeviceStates(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+
+      String got = bout.toString(StandardCharsets.UTF_8.name());
+      Assert.assertTrue(got.contains("Created device: {"));
+
     } finally {
+      DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
+    }
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
-    }    
+    }
   }
 
   @Test
   public void testCreateGetDevice() throws Exception {
     final String deviceName = "rsa-device";
-    topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
-    DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-    DeviceRegistryExample.createDeviceWithRs256(
-        deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.getDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-
-    String got = bout.toString(StandardCharsets.UTF_8.name());
-    Assert.assertTrue(got.contains("Created device: {"));
-    Assert.assertTrue(got.contains("Retrieving device"));
-
-    DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     try {
-      TopicAdminClient topicAdminClient = TopicAdminClient.create();
-    } catch (ApiException e) {
-      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
-        throw e;
-      }
+      topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
+      DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
+      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
+          REGISTRY_ID);
+      DeviceRegistryExample.getDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+
+      String got = bout.toString(StandardCharsets.UTF_8.name());
+      Assert.assertTrue(got.contains("Created device: {"));
+      Assert.assertTrue(got.contains("Retrieving device"));
+
     } finally {
+      DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
+    }
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -296,25 +265,22 @@ public class ManagerIT {
   @Test
   public void testCreateConfigureDevice() throws Exception {
     final String deviceName = "rsa-device-config";
-    topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
-    DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-    DeviceRegistryExample.createDeviceWithRs256(
-        deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.setDeviceConfiguration(
-        deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID, "some-test-data", 0L);
-
-    String got = bout.toString(StandardCharsets.UTF_8.name());
-    Assert.assertTrue(got.contains("Updated: 2"));
-
-    DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     try {
-      TopicAdminClient topicAdminClient = TopicAdminClient.create();
-    } catch (ApiException e) {
-      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
-        throw e;
-      }
+      topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
+      DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
+      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
+          REGISTRY_ID);
+      DeviceRegistryExample.setDeviceConfiguration(deviceName, PROJECT_ID, CLOUD_REGION,
+          REGISTRY_ID, "some-test-data", 0L);
+
+      String got = bout.toString(StandardCharsets.UTF_8.name());
+      Assert.assertTrue(got.contains("Updated: 2"));
+
     } finally {
+      DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
+    }
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -322,89 +288,77 @@ public class ManagerIT {
   @Test
   public void testCreateListDevices() throws Exception {
     final String deviceName = "rsa-device";
-    topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
-    DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-    DeviceRegistryExample.createDeviceWithRs256(
-        deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.listDevices(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-
-    String got = bout.toString(StandardCharsets.UTF_8.name());
-    Assert.assertTrue(got.contains("Created device: {"));
-    Assert.assertTrue(got.contains("Found"));
-
-    DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     try {
-      TopicAdminClient topicAdminClient = TopicAdminClient.create();
-    } catch (ApiException e) {
-      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
-        throw e;
-      }
+      topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
+      DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
+      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
+          REGISTRY_ID);
+      DeviceRegistryExample.listDevices(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+
+      String got = bout.toString(StandardCharsets.UTF_8.name());
+      Assert.assertTrue(got.contains("Created device: {"));
+      Assert.assertTrue(got.contains("Found"));
+
     } finally {
+      DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
+    }
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
 
   @Test
   public void testCreateGetRegistry() throws Exception {
-    topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
-    DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-    DeviceRegistryExample.getRegistry(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-
-    String got = bout.toString(StandardCharsets.UTF_8.name());
-    Assert.assertFalse(got.contains("eventNotificationConfigs"));
-
-    DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     try {
-      TopicAdminClient topicAdminClient = TopicAdminClient.create();
-    } catch (ApiException e) {
-      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
-        throw e;
-      }
+      topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
+      DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
+      DeviceRegistryExample.getRegistry(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+
+      String got = bout.toString(StandardCharsets.UTF_8.name());
+      Assert.assertFalse(got.contains("eventNotificationConfigs"));
+
     } finally {
+      DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
+    }
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
 
   @Test
   public void testGetIam() throws Exception {
-    topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
-    DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-    DeviceRegistryExample.getIamPermissions(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-
-    String got = bout.toString(StandardCharsets.UTF_8.name());
-    Assert.assertTrue(got.contains("ETAG"));
-
-    DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     try {
-      TopicAdminClient topicAdminClient = TopicAdminClient.create();
-    } catch (ApiException e) {
-      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
-        throw e;
-      }
+      topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
+      DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
+      DeviceRegistryExample.getIamPermissions(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+
+      String got = bout.toString(StandardCharsets.UTF_8.name());
+      Assert.assertTrue(got.contains("ETAG"));
+
     } finally {
+      DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
+    }
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
 
   @Test
   public void testSetIam() throws Exception {
-    topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
-    DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-    DeviceRegistryExample.setIamPermissions(PROJECT_ID, CLOUD_REGION, REGISTRY_ID, MEMBER, ROLE);
-    DeviceRegistryExample.getIamPermissions(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-
-    String got = bout.toString(StandardCharsets.UTF_8.name());
-    Assert.assertTrue(got.contains("ETAG"));
-
-    DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     try {
-      TopicAdminClient topicAdminClient = TopicAdminClient.create();
-    } catch (ApiException e) {
-      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
-        throw e;
-      }
+      topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
+      DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
+      DeviceRegistryExample.setIamPermissions(PROJECT_ID, CLOUD_REGION, REGISTRY_ID, MEMBER, ROLE);
+      DeviceRegistryExample.getIamPermissions(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+
+      String got = bout.toString(StandardCharsets.UTF_8.name());
+      Assert.assertTrue(got.contains("ETAG"));
+
     } finally {
+      DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
+    }
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -414,40 +368,31 @@ public class ManagerIT {
   @Test
   public void testHttpDeviceEvent() throws Exception {
     final String deviceName = "rsa-device-http-event";
-    topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
-    DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-    DeviceRegistryExample.createDeviceWithRs256(
-        deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.listDevices(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-
-    // Device bootstrapped, time to connect and run.
-    String[] testArgs = {
-      "-project_id=" + PROJECT_ID,
-      "-registry_id=" + REGISTRY_ID,
-      "-device_id=" + deviceName,
-      "-private_key_file=" + PKCS_PATH,
-      "-num_messages=1",
-      "-message_type=event",
-      "-algorithm=RS256"
-    };
-    com.example.cloud.iot.examples.HttpExample.main(testArgs);
-    // End device test.
-
-    // Assertions
-    String got = bout.toString(StandardCharsets.UTF_8.name());
-    Assert.assertTrue(got.contains("200"));
-    Assert.assertTrue(got.contains("OK"));
-
-    // Clean up
-    DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     try {
-      TopicAdminClient topicAdminClient = TopicAdminClient.create();
-    } catch (ApiException e) {
-      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
-        throw e;
-      }
+      topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
+      DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
+      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
+          REGISTRY_ID);
+      DeviceRegistryExample.listDevices(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+
+      // Device bootstrapped, time to connect and run.
+      String[] testArgs = {"-project_id=" + PROJECT_ID, "-registry_id=" + REGISTRY_ID,
+          "-device_id=" + deviceName, "-private_key_file=" + PKCS_PATH, "-num_messages=1",
+          "-message_type=event", "-algorithm=RS256"};
+      com.example.cloud.iot.examples.HttpExample.main(testArgs);
+      // End device test.
+
+      // Assertions
+      String got = bout.toString(StandardCharsets.UTF_8.name());
+      Assert.assertTrue(got.contains("200"));
+      Assert.assertTrue(got.contains("OK"));
+
     } finally {
+      // Clean up
+      DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
+    }
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -455,40 +400,31 @@ public class ManagerIT {
   @Test
   public void testHttpDeviceState() throws Exception {
     final String deviceName = "rsa-device-http-state";
-    topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
-    DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-    DeviceRegistryExample.createDeviceWithRs256(
-        deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.listDevices(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-
-    // Device bootstrapped, time to connect and run.
-    String[] testArgs = {
-      "-project_id=" + PROJECT_ID,
-      "-registry_id=" + REGISTRY_ID,
-      "-device_id=" + deviceName,
-      "-private_key_file=" + PKCS_PATH,
-      "-num_messages=1",
-      "-message_type=state",
-      "-algorithm=RS256"
-    };
-    com.example.cloud.iot.examples.HttpExample.main(testArgs);
-    // End device test.
-
-    // Assertions
-    String got = bout.toString(StandardCharsets.UTF_8.name());
-    Assert.assertTrue(got.contains("200"));
-    Assert.assertTrue(got.contains("OK"));
-
-    // Clean up
-    DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     try {
-      TopicAdminClient topicAdminClient = TopicAdminClient.create();
-    } catch (ApiException e) {
-      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
-        throw e;
-      }
+      topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
+      DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
+      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
+          REGISTRY_ID);
+      DeviceRegistryExample.listDevices(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+
+      // Device bootstrapped, time to connect and run.
+      String[] testArgs = {"-project_id=" + PROJECT_ID, "-registry_id=" + REGISTRY_ID,
+          "-device_id=" + deviceName, "-private_key_file=" + PKCS_PATH, "-num_messages=1",
+          "-message_type=state", "-algorithm=RS256"};
+      com.example.cloud.iot.examples.HttpExample.main(testArgs);
+      // End device test.
+
+      // Assertions
+      String got = bout.toString(StandardCharsets.UTF_8.name());
+      Assert.assertTrue(got.contains("200"));
+      Assert.assertTrue(got.contains("OK"));
+
     } finally {
+      // Clean up
+      DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
+    }
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -496,41 +432,32 @@ public class ManagerIT {
   @Test
   public void testHttpDeviceConfig() throws Exception {
     final String deviceName = "rsa-device-http-state";
-    topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
-    DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-    DeviceRegistryExample.createDeviceWithRs256(
-        deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.listDevices(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-
-    // Device bootstrapped, time to connect and run.
-    String[] testArgs = {
-      "-project_id=" + PROJECT_ID,
-      "-registry_id=" + REGISTRY_ID,
-      "-device_id=" + deviceName,
-      "-private_key_file=" + PKCS_PATH,
-      "-num_messages=1",
-      "-message_type=event",
-      "-algorithm=RS256"
-    };
-    com.example.cloud.iot.examples.HttpExample.main(testArgs);
-    // End device test.
-
-    // Assertions
-    String got = bout.toString(StandardCharsets.UTF_8.name());
-    Assert.assertTrue(got.contains("200"));
-    Assert.assertTrue(got.contains("OK"));
-    Assert.assertTrue(got.contains("\"binaryData\": \"\""));
-
-    // Clean up
-    DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     try {
-      TopicAdminClient topicAdminClient = TopicAdminClient.create();
-    } catch (ApiException e) {
-      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
-        throw e;
-      }
+      topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
+      DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
+      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
+          REGISTRY_ID);
+      DeviceRegistryExample.listDevices(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+
+      // Device bootstrapped, time to connect and run.
+      String[] testArgs = {"-project_id=" + PROJECT_ID, "-registry_id=" + REGISTRY_ID,
+          "-device_id=" + deviceName, "-private_key_file=" + PKCS_PATH, "-num_messages=1",
+          "-message_type=event", "-algorithm=RS256"};
+      com.example.cloud.iot.examples.HttpExample.main(testArgs);
+      // End device test.
+
+      // Assertions
+      String got = bout.toString(StandardCharsets.UTF_8.name());
+      Assert.assertTrue(got.contains("200"));
+      Assert.assertTrue(got.contains("OK"));
+      Assert.assertTrue(got.contains("\"binaryData\": \"\""));
+
     } finally {
+      // Clean up
+      DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
+    }
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -539,40 +466,31 @@ public class ManagerIT {
   @Test
   public void testMqttDeviceConfig() throws Exception {
     final String deviceName = "rsa-device-mqtt-config";
-    topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
-    DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-    DeviceRegistryExample.createDeviceWithRs256(
-        deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.listDevices(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-
-    // Device bootstrapped, time to connect and run.
-    String[] testArgs = {
-      "-project_id=" + PROJECT_ID,
-      "-registry_id=" + REGISTRY_ID,
-      "-device_id=" + deviceName,
-      "-private_key_file=" + PKCS_PATH,
-      "-message_type=events",
-      "-num_messages=1",
-      "-algorithm=RS256"
-    };
-    com.example.cloud.iot.examples.MqttExample.main(testArgs);
-    // End device test.
-
-    // Assertions
-    String got = bout.toString(StandardCharsets.UTF_8.name());
-    System.out.println(got);
-    Assert.assertTrue(got.contains("Payload :"));
-
-    // Clean up
-    DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     try {
-      TopicAdminClient topicAdminClient = TopicAdminClient.create();
-    } catch (ApiException e) {
-      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
-        throw e;
-      }
+      topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
+      DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
+      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
+          REGISTRY_ID);
+      DeviceRegistryExample.listDevices(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+
+      // Device bootstrapped, time to connect and run.
+      String[] testArgs = {"-project_id=" + PROJECT_ID, "-registry_id=" + REGISTRY_ID,
+          "-device_id=" + deviceName, "-private_key_file=" + PKCS_PATH, "-message_type=events",
+          "-num_messages=1", "-algorithm=RS256"};
+      com.example.cloud.iot.examples.MqttExample.main(testArgs);
+      // End device test.
+
+      // Assertions
+      String got = bout.toString(StandardCharsets.UTF_8.name());
+      System.out.println(got);
+      Assert.assertTrue(got.contains("Payload :"));
+
     } finally {
+      // Clean up
+      DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
+    }
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -581,59 +499,49 @@ public class ManagerIT {
   @Test
   public void testMqttDeviceCommand() throws Exception {
     final String deviceName = "rsa-device-mqtt-commands";
-    topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
-    DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-    DeviceRegistryExample.createDeviceWithRs256(
-        deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-
-    // Device bootstrapped, time to connect and run.
-    String[] testArgs = {
-      "-project_id=" + PROJECT_ID,
-      "-registry_id=" + REGISTRY_ID,
-      "-cloud_region=" + CLOUD_REGION,
-      "-device_id=" + deviceName,
-      "-private_key_file=" + PKCS_PATH,
-      "-wait_time=" + 10,
-      "-algorithm=RS256"
-    };
-
-    Thread deviceThread =
-        new Thread() {
-          public void run() {
-            try {
-              com.example.cloud.iot.examples.MqttExample.main(testArgs);
-            } catch (Exception e) {
-              // TODO: Fail
-              System.out.println("Failure on Exception");
-            }
-          }
-        };
-    deviceThread.start();
-
-    Thread.sleep(500); // Give the device a chance to connect
-    com.example.cloud.iot.examples.DeviceRegistryExample.sendCommand(
-        deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID, "me want cookie!");
-
-    deviceThread.join();
-    // End device test.
-
-    // Assertions
-    String got = bout.toString(StandardCharsets.UTF_8.name());
-    System.out.println(got);
-    Assert.assertTrue(got.contains("Finished loop successfully."));
-    Assert.assertTrue(got.contains("me want cookie"));
-    Assert.assertFalse(got.contains("Failure on Exception"));
-
-    // Clean up
-    DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     try {
-      TopicAdminClient topicAdminClient = TopicAdminClient.create();
-    } catch (ApiException e) {
-      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
-        throw e;
-      }
+      topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
+      DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
+      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
+          REGISTRY_ID);
+
+      // Device bootstrapped, time to connect and run.
+      String[] testArgs = {"-project_id=" + PROJECT_ID, "-registry_id=" + REGISTRY_ID,
+          "-cloud_region=" + CLOUD_REGION, "-device_id=" + deviceName,
+          "-private_key_file=" + PKCS_PATH, "-wait_time=" + 10, "-algorithm=RS256"};
+
+      Thread deviceThread = new Thread() {
+        public void run() {
+          try {
+            com.example.cloud.iot.examples.MqttExample.main(testArgs);
+          } catch (Exception e) {
+            // TODO: Fail
+            System.out.println("Failure on Exception");
+          }
+        }
+      };
+      deviceThread.start();
+
+      Thread.sleep(500); // Give the device a chance to connect
+      com.example.cloud.iot.examples.DeviceRegistryExample.sendCommand(deviceName, PROJECT_ID,
+          CLOUD_REGION, REGISTRY_ID, "me want cookie!");
+
+      deviceThread.join();
+      // End device test.
+
+      // Assertions
+      String got = bout.toString(StandardCharsets.UTF_8.name());
+      System.out.println(got);
+      Assert.assertTrue(got.contains("Finished loop successfully."));
+      Assert.assertTrue(got.contains("me want cookie"));
+      Assert.assertFalse(got.contains("Failure on Exception"));
+
     } finally {
+      // Clean up
+      DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
+    }
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -641,43 +549,34 @@ public class ManagerIT {
   @Test
   public void testMqttDeviceEvents() throws Exception {
     final String deviceName = "rsa-device-mqtt-events";
-    topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
-    DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-    DeviceRegistryExample.createDeviceWithRs256(
-        deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.listDevices(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-
-    // Device bootstrapped, time to connect and run.
-    String[] testArgs = {
-      "-project_id=" + PROJECT_ID,
-      "-registry_id=" + REGISTRY_ID,
-      "-device_id=" + deviceName,
-      "-private_key_file=" + PKCS_PATH,
-      "-message_type=events",
-      "-num_messages=1",
-      "-algorithm=RS256"
-    };
-    com.example.cloud.iot.examples.MqttExample.main(testArgs);
-    // End device test.
-
-    // Assertions
-    String got = bout.toString(StandardCharsets.UTF_8.name());
-    //
-    // Finished loop successfully. Goodbye!
-
-    Assert.assertTrue(got.contains("Publishing events message 1"));
-    Assert.assertTrue(got.contains("Finished loop successfully. Goodbye!"));
-
-    // Clean up
-    DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     try {
-      TopicAdminClient topicAdminClient = TopicAdminClient.create();
-    } catch (ApiException e) {
-      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
-        throw e;
-      }
+      topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
+      DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
+      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
+          REGISTRY_ID);
+      DeviceRegistryExample.listDevices(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+
+      // Device bootstrapped, time to connect and run.
+      String[] testArgs = {"-project_id=" + PROJECT_ID, "-registry_id=" + REGISTRY_ID,
+          "-device_id=" + deviceName, "-private_key_file=" + PKCS_PATH, "-message_type=events",
+          "-num_messages=1", "-algorithm=RS256"};
+      com.example.cloud.iot.examples.MqttExample.main(testArgs);
+      // End device test.
+
+      // Assertions
+      String got = bout.toString(StandardCharsets.UTF_8.name());
+      //
+      // Finished loop successfully. Goodbye!
+
+      Assert.assertTrue(got.contains("Publishing events message 1"));
+      Assert.assertTrue(got.contains("Finished loop successfully. Goodbye!"));
+
     } finally {
+      // Clean up
+      DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
+    }
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -685,40 +584,31 @@ public class ManagerIT {
   @Test
   public void testMqttDeviceState() throws Exception {
     final String deviceName = "rsa-device-mqtt-state";
-    topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
-    DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-    DeviceRegistryExample.createDeviceWithRs256(
-        deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.listDevices(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-
-    // Device bootstrapped, time to connect and run.
-    String[] testArgs = {
-      "-project_id=" + PROJECT_ID,
-      "-registry_id=" + REGISTRY_ID,
-      "-device_id=" + deviceName,
-      "-private_key_file=" + PKCS_PATH,
-      "-message_type=state",
-      "-num_messages=10",
-      "-algorithm=RS256"
-    };
-    com.example.cloud.iot.examples.MqttExample.main(testArgs);
-    // End device test.
-
-    // Assertions
-    String got = bout.toString(StandardCharsets.UTF_8.name());
-    Assert.assertTrue(got.contains("Publishing state message 1"));
-    Assert.assertTrue(got.contains("Finished loop successfully. Goodbye!"));
-
-    // Clean up
-    DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     try {
-      TopicAdminClient topicAdminClient = TopicAdminClient.create();
-    } catch (ApiException e) {
-      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
-        throw e;
-      }
+      topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
+      DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
+      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
+          REGISTRY_ID);
+      DeviceRegistryExample.listDevices(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+
+      // Device bootstrapped, time to connect and run.
+      String[] testArgs = {"-project_id=" + PROJECT_ID, "-registry_id=" + REGISTRY_ID,
+          "-device_id=" + deviceName, "-private_key_file=" + PKCS_PATH, "-message_type=state",
+          "-num_messages=10", "-algorithm=RS256"};
+      com.example.cloud.iot.examples.MqttExample.main(testArgs);
+      // End device test.
+
+      // Assertions
+      String got = bout.toString(StandardCharsets.UTF_8.name());
+      Assert.assertTrue(got.contains("Publishing state message 1"));
+      Assert.assertTrue(got.contains("Finished loop successfully. Goodbye!"));
+
     } finally {
+      // Clean up
+      DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
+    }
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -728,56 +618,44 @@ public class ManagerIT {
   public void testGatewayListenForDevice() throws Exception {
     final String gatewayName = "rsa-listen-gateway";
     final String deviceName = "rsa-listen-device";
-    topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
-    DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-    DeviceRegistryExample.createGateway(
-        PROJECT_ID, CLOUD_REGION, REGISTRY_ID, gatewayName, RSA_PATH, "RS256");
-    DeviceRegistryExample.createDevice(PROJECT_ID, CLOUD_REGION, REGISTRY_ID, deviceName);
-    DeviceRegistryExample.bindDeviceToGateway(
-        PROJECT_ID, CLOUD_REGION, REGISTRY_ID, deviceName, gatewayName);
-
-    Thread deviceThread =
-        new Thread() {
-          public void run() {
-            try {
-              MqttExample.listenForConfigMessages(
-                  "mqtt.googleapis.com",
-                  (short) 443,
-                  PROJECT_ID,
-                  CLOUD_REGION,
-                  REGISTRY_ID,
-                  gatewayName,
-                  PKCS_PATH,
-                  "RS256",
-                  deviceName);
-            } catch (Exception e) {
-              // TODO: Fail
-              System.out.println("Failure on Exception");
-            }
-          }
-        };
-    deviceThread.start();
-    Thread.sleep(3000); // Give the device a chance to connect / receive configurations
-    deviceThread.join();
-
-    // Assertions
-    String got = bout.toString(StandardCharsets.UTF_8.name());
-    System.out.println(got);
-    Assert.assertTrue(got.contains("Payload"));
-
-    // Clean up
-    DeviceRegistryExample.unbindDeviceFromGateway(
-        PROJECT_ID, CLOUD_REGION, REGISTRY_ID, deviceName, gatewayName);
-    DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.deleteDevice(gatewayName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     try {
-      TopicAdminClient topicAdminClient = TopicAdminClient.create();
-    } catch (ApiException e) {
-      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
-        throw e;
-      }
+      topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
+      DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
+      DeviceRegistryExample.createGateway(PROJECT_ID, CLOUD_REGION, REGISTRY_ID, gatewayName,
+          RSA_PATH, "RS256");
+      DeviceRegistryExample.createDevice(PROJECT_ID, CLOUD_REGION, REGISTRY_ID, deviceName);
+      DeviceRegistryExample.bindDeviceToGateway(PROJECT_ID, CLOUD_REGION, REGISTRY_ID, deviceName,
+          gatewayName);
+
+      Thread deviceThread = new Thread() {
+        public void run() {
+          try {
+            MqttExample.listenForConfigMessages("mqtt.googleapis.com", (short) 443, PROJECT_ID,
+                CLOUD_REGION, REGISTRY_ID, gatewayName, PKCS_PATH, "RS256", deviceName);
+          } catch (Exception e) {
+            // TODO: Fail
+            System.out.println("Failure on Exception");
+          }
+        }
+      };
+      deviceThread.start();
+      Thread.sleep(3000); // Give the device a chance to connect / receive configurations
+      deviceThread.join();
+
+      // Assertions
+      String got = bout.toString(StandardCharsets.UTF_8.name());
+      System.out.println(got);
+      Assert.assertTrue(got.contains("Payload"));
+
     } finally {
+      // Clean up
+      DeviceRegistryExample.unbindDeviceFromGateway(PROJECT_ID, CLOUD_REGION, REGISTRY_ID,
+          deviceName, gatewayName);
+      DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.deleteDevice(gatewayName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
+    }
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -786,52 +664,40 @@ public class ManagerIT {
   @Test
   public void testErrorTopic() throws Exception {
     final String gatewayName = "rsa-listen-gateway-test";
-    topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
-    DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-    DeviceRegistryExample.createGateway(
-        PROJECT_ID, CLOUD_REGION, REGISTRY_ID, gatewayName, RSA_PATH, "RS256");
-    MqttClient client =
-        MqttExample.startMqtt(
-            "mqtt.googleapis.com",
-            (short) 443,
-            PROJECT_ID,
-            CLOUD_REGION,
-            REGISTRY_ID,
-            gatewayName,
-            PKCS_PATH,
-            "RS256");
-
-    Thread deviceThread =
-        new Thread() {
-          public void run() {
-            try {
-              MqttExample.attachDeviceToGateway(client, "garbage-device");
-              MqttExample.attachCallback(client, "garbage-device");
-            } catch (Exception e) {
-              // TODO: Fail
-              StringBuilder builder = new StringBuilder();
-              builder.append("Failure on exception: ").append(e);
-              System.out.println(builder);
-            }
-          }
-        };
-
-    deviceThread.start();
-    Thread.sleep(4000);
-
-    String got = bout.toString(StandardCharsets.UTF_8.name());
-    Assert.assertTrue(got.contains("error_type"));
-
-    // Clean up
-    DeviceRegistryExample.deleteDevice(gatewayName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     try {
-      TopicAdminClient topicAdminClient = TopicAdminClient.create();
-    } catch (ApiException e) {
-      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
-        throw e;
-      }
+      topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
+      DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
+      DeviceRegistryExample.createGateway(PROJECT_ID, CLOUD_REGION, REGISTRY_ID, gatewayName,
+          RSA_PATH, "RS256");
+      MqttClient client = MqttExample.startMqtt("mqtt.googleapis.com", (short) 443, PROJECT_ID,
+          CLOUD_REGION, REGISTRY_ID, gatewayName, PKCS_PATH, "RS256");
+
+      Thread deviceThread = new Thread() {
+        public void run() {
+          try {
+            MqttExample.attachDeviceToGateway(client, "garbage-device");
+            MqttExample.attachCallback(client, "garbage-device");
+          } catch (Exception e) {
+            // TODO: Fail
+            StringBuilder builder = new StringBuilder();
+            builder.append("Failure on exception: ").append(e);
+            System.out.println(builder);
+          }
+        }
+      };
+
+      deviceThread.start();
+      Thread.sleep(4000);
+
+      String got = bout.toString(StandardCharsets.UTF_8.name());
+      Assert.assertTrue(got.contains("error_type"));
+
     } finally {
+      // Clean up
+      DeviceRegistryExample.deleteDevice(gatewayName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
+    }
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -841,58 +707,45 @@ public class ManagerIT {
   public void testSendDataForBoundDevice() throws Exception {
     final String gatewayName = "rsa-send-gateway";
     final String deviceName = "rsa-send-device";
-    topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
-    DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-    DeviceRegistryExample.createGateway(
-        PROJECT_ID, CLOUD_REGION, REGISTRY_ID, gatewayName, RSA_PATH, "RS256");
-    DeviceRegistryExample.createDevice(PROJECT_ID, CLOUD_REGION, REGISTRY_ID, deviceName);
-    DeviceRegistryExample.bindDeviceToGateway(
-        PROJECT_ID, CLOUD_REGION, REGISTRY_ID, deviceName, gatewayName);
-
-    Thread deviceThread =
-        new Thread() {
-          public void run() {
-            try {
-              MqttExample.sendDataFromBoundDevice(
-                  "mqtt.googleapis.com",
-                  (short) 443,
-                  PROJECT_ID,
-                  CLOUD_REGION,
-                  REGISTRY_ID,
-                  gatewayName,
-                  PKCS_PATH,
-                  "RS256",
-                  deviceName,
-                  "state",
-                  "Cookies are delish");
-            } catch (Exception e) {
-              // TODO: Fail
-              System.out.println("Failure on Exception");
-            }
-          }
-        };
-    deviceThread.start();
-    Thread.sleep(3000); // Give the device a chance to connect / receive configurations
-    deviceThread.join();
-
-    // Assertions
-    String got = bout.toString("UTF-8");
-    System.out.println(got);
-    Assert.assertTrue(got.contains("Data sent"));
-
-    // Clean up
-    DeviceRegistryExample.unbindDeviceFromGateway(
-        PROJECT_ID, CLOUD_REGION, REGISTRY_ID, deviceName, gatewayName);
-    DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.deleteDevice(gatewayName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
-    DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     try {
-      TopicAdminClient topicAdminClient = TopicAdminClient.create();
-    } catch (ApiException e) {
-      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
-        throw e;
-      }
+      topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
+      DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
+      DeviceRegistryExample.createGateway(PROJECT_ID, CLOUD_REGION, REGISTRY_ID, gatewayName,
+          RSA_PATH, "RS256");
+      DeviceRegistryExample.createDevice(PROJECT_ID, CLOUD_REGION, REGISTRY_ID, deviceName);
+      DeviceRegistryExample.bindDeviceToGateway(PROJECT_ID, CLOUD_REGION, REGISTRY_ID, deviceName,
+          gatewayName);
+
+      Thread deviceThread = new Thread() {
+        public void run() {
+          try {
+            MqttExample.sendDataFromBoundDevice("mqtt.googleapis.com", (short) 443, PROJECT_ID,
+                CLOUD_REGION, REGISTRY_ID, gatewayName, PKCS_PATH, "RS256", deviceName, "state",
+                "Cookies are delish");
+          } catch (Exception e) {
+            // TODO: Fail
+            System.out.println("Failure on Exception");
+          }
+        }
+      };
+      deviceThread.start();
+      Thread.sleep(3000); // Give the device a chance to connect / receive configurations
+      deviceThread.join();
+
+      // Assertions
+      String got = bout.toString("UTF-8");
+      System.out.println(got);
+      Assert.assertTrue(got.contains("Data sent"));
+
     } finally {
+      // Clean up
+      DeviceRegistryExample.unbindDeviceFromGateway(PROJECT_ID, CLOUD_REGION, REGISTRY_ID,
+          deviceName, gatewayName);
+      DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.deleteDevice(gatewayName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
+    }
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }

--- a/iot/api-client/manager/src/test/java/com/example/cloud/iot/examples/ManagerIT.java
+++ b/iot/api-client/manager/src/test/java/com/example/cloud/iot/examples/ManagerIT.java
@@ -1,17 +1,17 @@
 /*
  * Copyright 2017 Google Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.example.cloud.iot.examples;
@@ -20,7 +20,6 @@ import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
-import com.google.api.gax.rpc.AlreadyExistsException;
 import com.google.api.services.cloudiot.v1.CloudIot;
 import com.google.api.services.cloudiot.v1.CloudIotScopes;
 import com.google.api.services.cloudiot.v1.model.DeviceRegistry;
@@ -50,12 +49,15 @@ public class ManagerIT {
   private static final String CLOUD_REGION = "us-central1";
   private static final String ES_PATH = "resources/ec_public.pem";
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
-  private static final String REGISTRY_ID = "java-reg-"
-      + UUID.randomUUID().toString().substring(0, 10) + "-" + System.currentTimeMillis();
+  private static final String REGISTRY_ID =
+      "java-reg-"
+              + UUID.randomUUID().toString().substring(0, 10) + "-"
+          + System.currentTimeMillis();
   private static final String RSA_PATH = "resources/rsa_cert.pem";
   private static final String PKCS_PATH = "resources/rsa_private_pkcs8";
-  private static final String TOPIC_ID = "java-pst-" + UUID.randomUUID().toString().substring(0, 10)
-      + "-" + System.currentTimeMillis();
+  private static final String TOPIC_ID =
+      "java-pst-"
+          + UUID.randomUUID().toString().substring(0, 10) + "-" + System.currentTimeMillis();
   private static final String MEMBER = "group:dpebot@google.com";
   private static final String ROLE = "roles/viewer";
   private static Topic topic;
@@ -87,12 +89,19 @@ public class ManagerIT {
     HttpRequestInitializer init = new HttpCredentialsAdapter(credential);
     final CloudIot service =
         new CloudIot.Builder(GoogleNetHttpTransport.newTrustedTransport(), jsonFactory, init)
-            .setApplicationName("TEST").build();
+            .setApplicationName("TEST")
+            .build();
 
     final String projectPath = "projects/" + PROJECT_ID + "/locations/" + CLOUD_REGION;
 
-    List<DeviceRegistry> registries = service.projects().locations().registries().list(projectPath)
-        .execute().getDeviceRegistries();
+    List<DeviceRegistry> registries =
+        service
+            .projects()
+            .locations()
+            .registries()
+            .list(projectPath)
+            .execute()
+            .getDeviceRegistries();
 
     if (registries != null) {
       for (DeviceRegistry r : registries) {
@@ -127,22 +136,22 @@ public class ManagerIT {
   @Test
   public void testPatchRsa() throws Exception {
     final String deviceName = "patchme-device-rsa";
-    topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
 
     try {
+      topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-      DeviceRegistryExample.createDeviceWithNoAuth(deviceName, PROJECT_ID, CLOUD_REGION,
-          REGISTRY_ID);
-      DeviceRegistryExample.patchRsa256ForAuth(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
-          REGISTRY_ID);
+      DeviceRegistryExample.createDeviceWithNoAuth(
+          deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.patchRsa256ForAuth(
+          deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
 
       String got = bout.toString(StandardCharsets.UTF_8.name());
       Assert.assertTrue(got.contains("Created device: {"));
-
     } finally {
       DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
+
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
@@ -151,22 +160,22 @@ public class ManagerIT {
   @Test
   public void testPatchEs() throws Exception {
     final String deviceName = "patchme-device-es";
-    topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
 
     try {
+      topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-      DeviceRegistryExample.createDeviceWithNoAuth(deviceName, PROJECT_ID, CLOUD_REGION,
-          REGISTRY_ID);
-      DeviceRegistryExample.patchEs256ForAuth(deviceName, ES_PATH, PROJECT_ID, CLOUD_REGION,
-          REGISTRY_ID);
+      DeviceRegistryExample.createDeviceWithNoAuth(
+          deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.patchEs256ForAuth(
+          deviceName, ES_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
 
       String got = bout.toString(StandardCharsets.UTF_8.name());
       Assert.assertTrue(got.contains("Created device: {"));
-
     } finally {
       DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
+
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
@@ -175,20 +184,19 @@ public class ManagerIT {
   @Test
   public void testCreateDeleteUnauthDevice() throws Exception {
     final String deviceName = "noauth-device";
-    topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
 
     try {
+      topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-      DeviceRegistryExample.createDeviceWithNoAuth(deviceName, PROJECT_ID, CLOUD_REGION,
-          REGISTRY_ID);
+      DeviceRegistryExample.createDeviceWithNoAuth(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
 
       String got = bout.toString(StandardCharsets.UTF_8.name());
       Assert.assertTrue(got.contains("Created device: {"));
-
     } finally {
       DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
+
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
@@ -197,20 +205,21 @@ public class ManagerIT {
   @Test
   public void testCreateDeleteEsDevice() throws Exception {
     final String deviceName = "es-device";
+
     try {
       topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-      DeviceRegistryExample.createDeviceWithEs256(deviceName, ES_PATH, PROJECT_ID, CLOUD_REGION,
-          REGISTRY_ID);
+      DeviceRegistryExample.createDeviceWithEs256(
+          deviceName, ES_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.getDeviceStates(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
 
       String got = bout.toString(StandardCharsets.UTF_8.name());
       Assert.assertTrue(got.contains("Created device: {"));
-
     } finally {
       DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
+
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
@@ -219,21 +228,21 @@ public class ManagerIT {
   @Test
   public void testCreateDeleteRsaDevice() throws Exception {
     final String deviceName = "rsa-device";
+
     try {
       topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
-          REGISTRY_ID);
-
+      DeviceRegistryExample.createDeviceWithRs256(
+          deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.getDeviceStates(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
 
       String got = bout.toString(StandardCharsets.UTF_8.name());
       Assert.assertTrue(got.contains("Created device: {"));
-
     } finally {
       DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
+
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
@@ -242,21 +251,22 @@ public class ManagerIT {
   @Test
   public void testCreateGetDevice() throws Exception {
     final String deviceName = "rsa-device";
+
     try {
       topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
-          REGISTRY_ID);
+      DeviceRegistryExample.createDeviceWithRs256(
+          deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.getDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
 
       String got = bout.toString(StandardCharsets.UTF_8.name());
       Assert.assertTrue(got.contains("Created device: {"));
       Assert.assertTrue(got.contains("Retrieving device"));
-
     } finally {
       DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
+
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
@@ -268,18 +278,18 @@ public class ManagerIT {
     try {
       topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
-          REGISTRY_ID);
-      DeviceRegistryExample.setDeviceConfiguration(deviceName, PROJECT_ID, CLOUD_REGION,
-          REGISTRY_ID, "some-test-data", 0L);
+      DeviceRegistryExample.createDeviceWithRs256(
+          deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.setDeviceConfiguration(
+          deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID, "some-test-data", 0L);
 
       String got = bout.toString(StandardCharsets.UTF_8.name());
       Assert.assertTrue(got.contains("Updated: 2"));
-
     } finally {
       DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
+
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
@@ -288,17 +298,17 @@ public class ManagerIT {
   @Test
   public void testCreateListDevices() throws Exception {
     final String deviceName = "rsa-device";
+
     try {
       topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
-          REGISTRY_ID);
+      DeviceRegistryExample.createDeviceWithRs256(
+          deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.listDevices(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
 
       String got = bout.toString(StandardCharsets.UTF_8.name());
       Assert.assertTrue(got.contains("Created device: {"));
       Assert.assertTrue(got.contains("Found"));
-
     } finally {
       DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
@@ -310,6 +320,7 @@ public class ManagerIT {
 
   @Test
   public void testCreateGetRegistry() throws Exception {
+
     try {
       topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
@@ -317,10 +328,10 @@ public class ManagerIT {
 
       String got = bout.toString(StandardCharsets.UTF_8.name());
       Assert.assertFalse(got.contains("eventNotificationConfigs"));
-
     } finally {
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
+
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
@@ -335,10 +346,10 @@ public class ManagerIT {
 
       String got = bout.toString(StandardCharsets.UTF_8.name());
       Assert.assertTrue(got.contains("ETAG"));
-
     } finally {
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
+
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
@@ -354,10 +365,10 @@ public class ManagerIT {
 
       String got = bout.toString(StandardCharsets.UTF_8.name());
       Assert.assertTrue(got.contains("ETAG"));
-
     } finally {
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
+
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
@@ -368,17 +379,24 @@ public class ManagerIT {
   @Test
   public void testHttpDeviceEvent() throws Exception {
     final String deviceName = "rsa-device-http-event";
+
     try {
       topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
-          REGISTRY_ID);
+      DeviceRegistryExample.createDeviceWithRs256(
+          deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.listDevices(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
 
       // Device bootstrapped, time to connect and run.
-      String[] testArgs = {"-project_id=" + PROJECT_ID, "-registry_id=" + REGISTRY_ID,
-          "-device_id=" + deviceName, "-private_key_file=" + PKCS_PATH, "-num_messages=1",
-          "-message_type=event", "-algorithm=RS256"};
+      String[] testArgs = {
+        "-project_id=" + PROJECT_ID,
+        "-registry_id=" + REGISTRY_ID,
+        "-device_id=" + deviceName,
+        "-private_key_file=" + PKCS_PATH,
+        "-num_messages=1",
+        "-message_type=event",
+        "-algorithm=RS256"
+      };
       com.example.cloud.iot.examples.HttpExample.main(testArgs);
       // End device test.
 
@@ -392,6 +410,7 @@ public class ManagerIT {
       DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
+
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
@@ -400,17 +419,24 @@ public class ManagerIT {
   @Test
   public void testHttpDeviceState() throws Exception {
     final String deviceName = "rsa-device-http-state";
+
     try {
       topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
-          REGISTRY_ID);
+      DeviceRegistryExample.createDeviceWithRs256(
+          deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.listDevices(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
 
       // Device bootstrapped, time to connect and run.
-      String[] testArgs = {"-project_id=" + PROJECT_ID, "-registry_id=" + REGISTRY_ID,
-          "-device_id=" + deviceName, "-private_key_file=" + PKCS_PATH, "-num_messages=1",
-          "-message_type=state", "-algorithm=RS256"};
+      String[] testArgs = {
+        "-project_id=" + PROJECT_ID,
+        "-registry_id=" + REGISTRY_ID,
+        "-device_id=" + deviceName,
+        "-private_key_file=" + PKCS_PATH,
+        "-num_messages=1",
+        "-message_type=state",
+        "-algorithm=RS256"
+      };
       com.example.cloud.iot.examples.HttpExample.main(testArgs);
       // End device test.
 
@@ -424,6 +450,7 @@ public class ManagerIT {
       DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
+
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
@@ -432,17 +459,24 @@ public class ManagerIT {
   @Test
   public void testHttpDeviceConfig() throws Exception {
     final String deviceName = "rsa-device-http-state";
+
     try {
       topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
-          REGISTRY_ID);
+      DeviceRegistryExample.createDeviceWithRs256(
+          deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.listDevices(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
 
       // Device bootstrapped, time to connect and run.
-      String[] testArgs = {"-project_id=" + PROJECT_ID, "-registry_id=" + REGISTRY_ID,
-          "-device_id=" + deviceName, "-private_key_file=" + PKCS_PATH, "-num_messages=1",
-          "-message_type=event", "-algorithm=RS256"};
+      String[] testArgs = {
+        "-project_id=" + PROJECT_ID,
+        "-registry_id=" + REGISTRY_ID,
+        "-device_id=" + deviceName,
+        "-private_key_file=" + PKCS_PATH,
+        "-num_messages=1",
+        "-message_type=event",
+        "-algorithm=RS256"
+      };
       com.example.cloud.iot.examples.HttpExample.main(testArgs);
       // End device test.
 
@@ -457,6 +491,7 @@ public class ManagerIT {
       DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
+
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
@@ -466,17 +501,24 @@ public class ManagerIT {
   @Test
   public void testMqttDeviceConfig() throws Exception {
     final String deviceName = "rsa-device-mqtt-config";
+
     try {
       topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
-          REGISTRY_ID);
+      DeviceRegistryExample.createDeviceWithRs256(
+          deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.listDevices(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
 
       // Device bootstrapped, time to connect and run.
-      String[] testArgs = {"-project_id=" + PROJECT_ID, "-registry_id=" + REGISTRY_ID,
-          "-device_id=" + deviceName, "-private_key_file=" + PKCS_PATH, "-message_type=events",
-          "-num_messages=1", "-algorithm=RS256"};
+      String[] testArgs = {
+        "-project_id=" + PROJECT_ID,
+        "-registry_id=" + REGISTRY_ID,
+        "-device_id=" + deviceName,
+        "-private_key_file=" + PKCS_PATH,
+        "-message_type=events",
+        "-num_messages=1",
+        "-algorithm=RS256"
+      };
       com.example.cloud.iot.examples.MqttExample.main(testArgs);
       // End device test.
 
@@ -490,6 +532,7 @@ public class ManagerIT {
       DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
+
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
@@ -499,32 +542,40 @@ public class ManagerIT {
   @Test
   public void testMqttDeviceCommand() throws Exception {
     final String deviceName = "rsa-device-mqtt-commands";
+
     try {
       topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
-          REGISTRY_ID);
+      DeviceRegistryExample.createDeviceWithRs256(
+          deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
 
       // Device bootstrapped, time to connect and run.
-      String[] testArgs = {"-project_id=" + PROJECT_ID, "-registry_id=" + REGISTRY_ID,
-          "-cloud_region=" + CLOUD_REGION, "-device_id=" + deviceName,
-          "-private_key_file=" + PKCS_PATH, "-wait_time=" + 10, "-algorithm=RS256"};
-
-      Thread deviceThread = new Thread() {
-        public void run() {
-          try {
-            com.example.cloud.iot.examples.MqttExample.main(testArgs);
-          } catch (Exception e) {
-            // TODO: Fail
-            System.out.println("Failure on Exception");
-          }
-        }
+      String[] testArgs = {
+        "-project_id=" + PROJECT_ID,
+        "-registry_id=" + REGISTRY_ID,
+        "-cloud_region=" + CLOUD_REGION,
+        "-device_id=" + deviceName,
+        "-private_key_file=" + PKCS_PATH,
+        "-wait_time=" + 10,
+        "-algorithm=RS256"
       };
+
+      Thread deviceThread =
+          new Thread() {
+            public void run() {
+              try {
+                com.example.cloud.iot.examples.MqttExample.main(testArgs);
+              } catch (Exception e) {
+                // TODO: Fail
+                System.out.println("Failure on Exception");
+              }
+            }
+          };
       deviceThread.start();
 
       Thread.sleep(500); // Give the device a chance to connect
-      com.example.cloud.iot.examples.DeviceRegistryExample.sendCommand(deviceName, PROJECT_ID,
-          CLOUD_REGION, REGISTRY_ID, "me want cookie!");
+      com.example.cloud.iot.examples.DeviceRegistryExample.sendCommand(
+          deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID, "me want cookie!");
 
       deviceThread.join();
       // End device test.
@@ -541,6 +592,7 @@ public class ManagerIT {
       DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
+
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
@@ -552,14 +604,20 @@ public class ManagerIT {
     try {
       topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
-          REGISTRY_ID);
+      DeviceRegistryExample.createDeviceWithRs256(
+          deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.listDevices(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
 
       // Device bootstrapped, time to connect and run.
-      String[] testArgs = {"-project_id=" + PROJECT_ID, "-registry_id=" + REGISTRY_ID,
-          "-device_id=" + deviceName, "-private_key_file=" + PKCS_PATH, "-message_type=events",
-          "-num_messages=1", "-algorithm=RS256"};
+      String[] testArgs = {
+        "-project_id=" + PROJECT_ID,
+        "-registry_id=" + REGISTRY_ID,
+        "-device_id=" + deviceName,
+        "-private_key_file=" + PKCS_PATH,
+        "-message_type=events",
+        "-num_messages=1",
+        "-algorithm=RS256"
+      };
       com.example.cloud.iot.examples.MqttExample.main(testArgs);
       // End device test.
 
@@ -576,6 +634,7 @@ public class ManagerIT {
       DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
+
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
@@ -584,17 +643,24 @@ public class ManagerIT {
   @Test
   public void testMqttDeviceState() throws Exception {
     final String deviceName = "rsa-device-mqtt-state";
+
     try {
       topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-      DeviceRegistryExample.createDeviceWithRs256(deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION,
-          REGISTRY_ID);
+      DeviceRegistryExample.createDeviceWithRs256(
+          deviceName, RSA_PATH, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.listDevices(PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
 
       // Device bootstrapped, time to connect and run.
-      String[] testArgs = {"-project_id=" + PROJECT_ID, "-registry_id=" + REGISTRY_ID,
-          "-device_id=" + deviceName, "-private_key_file=" + PKCS_PATH, "-message_type=state",
-          "-num_messages=10", "-algorithm=RS256"};
+      String[] testArgs = {
+        "-project_id=" + PROJECT_ID,
+        "-registry_id=" + REGISTRY_ID,
+        "-device_id=" + deviceName,
+        "-private_key_file=" + PKCS_PATH,
+        "-message_type=state",
+        "-num_messages=10",
+        "-algorithm=RS256"
+      };
       com.example.cloud.iot.examples.MqttExample.main(testArgs);
       // End device test.
 
@@ -608,6 +674,7 @@ public class ManagerIT {
       DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
+
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
@@ -618,26 +685,36 @@ public class ManagerIT {
   public void testGatewayListenForDevice() throws Exception {
     final String gatewayName = "rsa-listen-gateway";
     final String deviceName = "rsa-listen-device";
+
     try {
       topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-      DeviceRegistryExample.createGateway(PROJECT_ID, CLOUD_REGION, REGISTRY_ID, gatewayName,
-          RSA_PATH, "RS256");
+      DeviceRegistryExample.createGateway(
+          PROJECT_ID, CLOUD_REGION, REGISTRY_ID, gatewayName, RSA_PATH, "RS256");
       DeviceRegistryExample.createDevice(PROJECT_ID, CLOUD_REGION, REGISTRY_ID, deviceName);
-      DeviceRegistryExample.bindDeviceToGateway(PROJECT_ID, CLOUD_REGION, REGISTRY_ID, deviceName,
-          gatewayName);
+      DeviceRegistryExample.bindDeviceToGateway(
+          PROJECT_ID, CLOUD_REGION, REGISTRY_ID, deviceName, gatewayName);
 
-      Thread deviceThread = new Thread() {
-        public void run() {
-          try {
-            MqttExample.listenForConfigMessages("mqtt.googleapis.com", (short) 443, PROJECT_ID,
-                CLOUD_REGION, REGISTRY_ID, gatewayName, PKCS_PATH, "RS256", deviceName);
-          } catch (Exception e) {
-            // TODO: Fail
-            System.out.println("Failure on Exception");
-          }
-        }
-      };
+      Thread deviceThread =
+          new Thread() {
+            public void run() {
+              try {
+                MqttExample.listenForConfigMessages(
+                    "mqtt.googleapis.com",
+                    (short) 443,
+                    PROJECT_ID,
+                    CLOUD_REGION,
+                    REGISTRY_ID,
+                    gatewayName,
+                    PKCS_PATH,
+                    "RS256",
+                    deviceName);
+              } catch (Exception e) {
+                // TODO: Fail
+                System.out.println("Failure on Exception");
+              }
+            }
+          };
       deviceThread.start();
       Thread.sleep(3000); // Give the device a chance to connect / receive configurations
       deviceThread.join();
@@ -649,12 +726,13 @@ public class ManagerIT {
 
     } finally {
       // Clean up
-      DeviceRegistryExample.unbindDeviceFromGateway(PROJECT_ID, CLOUD_REGION, REGISTRY_ID,
-          deviceName, gatewayName);
+      DeviceRegistryExample.unbindDeviceFromGateway(
+          PROJECT_ID, CLOUD_REGION, REGISTRY_ID, deviceName, gatewayName);
       DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteDevice(gatewayName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
+
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
@@ -664,27 +742,37 @@ public class ManagerIT {
   @Test
   public void testErrorTopic() throws Exception {
     final String gatewayName = "rsa-listen-gateway-test";
+    
     try {
       topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-      DeviceRegistryExample.createGateway(PROJECT_ID, CLOUD_REGION, REGISTRY_ID, gatewayName,
-          RSA_PATH, "RS256");
-      MqttClient client = MqttExample.startMqtt("mqtt.googleapis.com", (short) 443, PROJECT_ID,
-          CLOUD_REGION, REGISTRY_ID, gatewayName, PKCS_PATH, "RS256");
+      DeviceRegistryExample.createGateway(
+          PROJECT_ID, CLOUD_REGION, REGISTRY_ID, gatewayName, RSA_PATH, "RS256");
+      MqttClient client =
+          MqttExample.startMqtt(
+              "mqtt.googleapis.com",
+              (short) 443,
+              PROJECT_ID,
+              CLOUD_REGION,
+              REGISTRY_ID,
+              gatewayName,
+              PKCS_PATH,
+              "RS256");
 
-      Thread deviceThread = new Thread() {
-        public void run() {
-          try {
-            MqttExample.attachDeviceToGateway(client, "garbage-device");
-            MqttExample.attachCallback(client, "garbage-device");
-          } catch (Exception e) {
-            // TODO: Fail
-            StringBuilder builder = new StringBuilder();
-            builder.append("Failure on exception: ").append(e);
-            System.out.println(builder);
-          }
-        }
-      };
+      Thread deviceThread =
+          new Thread() {
+            public void run() {
+              try {
+                MqttExample.attachDeviceToGateway(client, "garbage-device");
+                MqttExample.attachCallback(client, "garbage-device");
+              } catch (Exception e) {
+                // TODO: Fail
+                StringBuilder builder = new StringBuilder();
+                builder.append("Failure on exception: ").append(e);
+                System.out.println(builder);
+              }
+            }
+          };
 
       deviceThread.start();
       Thread.sleep(4000);
@@ -692,11 +780,12 @@ public class ManagerIT {
       String got = bout.toString(StandardCharsets.UTF_8.name());
       Assert.assertTrue(got.contains("error_type"));
 
-    } finally {
+      } finally {
       // Clean up
       DeviceRegistryExample.deleteDevice(gatewayName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
-    }
+      }
+
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
@@ -707,27 +796,38 @@ public class ManagerIT {
   public void testSendDataForBoundDevice() throws Exception {
     final String gatewayName = "rsa-send-gateway";
     final String deviceName = "rsa-send-device";
+
     try {
       topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-      DeviceRegistryExample.createGateway(PROJECT_ID, CLOUD_REGION, REGISTRY_ID, gatewayName,
-          RSA_PATH, "RS256");
+      DeviceRegistryExample.createGateway(
+          PROJECT_ID, CLOUD_REGION, REGISTRY_ID, gatewayName, RSA_PATH, "RS256");
       DeviceRegistryExample.createDevice(PROJECT_ID, CLOUD_REGION, REGISTRY_ID, deviceName);
-      DeviceRegistryExample.bindDeviceToGateway(PROJECT_ID, CLOUD_REGION, REGISTRY_ID, deviceName,
-          gatewayName);
+      DeviceRegistryExample.bindDeviceToGateway(
+          PROJECT_ID, CLOUD_REGION, REGISTRY_ID, deviceName, gatewayName);
 
-      Thread deviceThread = new Thread() {
-        public void run() {
-          try {
-            MqttExample.sendDataFromBoundDevice("mqtt.googleapis.com", (short) 443, PROJECT_ID,
-                CLOUD_REGION, REGISTRY_ID, gatewayName, PKCS_PATH, "RS256", deviceName, "state",
-                "Cookies are delish");
-          } catch (Exception e) {
-            // TODO: Fail
-            System.out.println("Failure on Exception");
-          }
-        }
-      };
+      Thread deviceThread =
+          new Thread() {
+            public void run() {
+              try {
+                MqttExample.sendDataFromBoundDevice(
+                    "mqtt.googleapis.com",
+                    (short) 443,
+                    PROJECT_ID,
+                    CLOUD_REGION,
+                    REGISTRY_ID,
+                    gatewayName,
+                    PKCS_PATH,
+                    "RS256",
+                    deviceName,
+                    "state",
+                    "Cookies are delish");
+              } catch (Exception e) {
+                // TODO: Fail
+                System.out.println("Failure on Exception");
+              }
+            }
+          };
       deviceThread.start();
       Thread.sleep(3000); // Give the device a chance to connect / receive configurations
       deviceThread.join();
@@ -739,12 +839,13 @@ public class ManagerIT {
 
     } finally {
       // Clean up
-      DeviceRegistryExample.unbindDeviceFromGateway(PROJECT_ID, CLOUD_REGION, REGISTRY_ID,
-          deviceName, gatewayName);
+      DeviceRegistryExample.unbindDeviceFromGateway(
+          PROJECT_ID, CLOUD_REGION, REGISTRY_ID, deviceName, gatewayName);
       DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteDevice(gatewayName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
+
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }

--- a/iot/api-client/manager/src/test/java/com/example/cloud/iot/examples/ManagerIT.java
+++ b/iot/api-client/manager/src/test/java/com/example/cloud/iot/examples/ManagerIT.java
@@ -188,7 +188,8 @@ public class ManagerIT {
     try {
       topic = DeviceRegistryExample.createIotTopic(PROJECT_ID, TOPIC_ID);
       DeviceRegistryExample.createRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID, TOPIC_ID);
-      DeviceRegistryExample.createDeviceWithNoAuth(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
+      DeviceRegistryExample.createDeviceWithNoAuth(deviceName, PROJECT_ID, CLOUD_REGION,
+          REGISTRY_ID);
 
       String got = bout.toString(StandardCharsets.UTF_8.name());
       Assert.assertTrue(got.contains("Created device: {"));
@@ -780,11 +781,11 @@ public class ManagerIT {
       String got = bout.toString(StandardCharsets.UTF_8.name());
       Assert.assertTrue(got.contains("error_type"));
 
-      } finally {
+    } finally {
       // Clean up
       DeviceRegistryExample.deleteDevice(gatewayName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
-      }
+    }
 
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));

--- a/iot/api-client/manager/src/test/java/com/example/cloud/iot/examples/ManagerIT.java
+++ b/iot/api-client/manager/src/test/java/com/example/cloud/iot/examples/ManagerIT.java
@@ -152,7 +152,13 @@ public class ManagerIT {
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
 
-    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+    try {
+      TopicAdminClient topicAdminClient = TopicAdminClient.create();
+    } catch (ApiException e) {
+      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
+        throw e;
+      }
+    } finally {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -176,7 +182,13 @@ public class ManagerIT {
       DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
     }
 
-    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+    try {
+      TopicAdminClient topicAdminClient = TopicAdminClient.create();
+    } catch (ApiException e) {
+      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
+        throw e;
+      }
+    } finally {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -194,7 +206,13 @@ public class ManagerIT {
 
     DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
     DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
-    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+    try {
+      TopicAdminClient topicAdminClient = TopicAdminClient.create();
+    } catch (ApiException e) {
+      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
+        throw e;
+      }
+    } finally {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -213,7 +231,13 @@ public class ManagerIT {
 
     DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
     DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
-    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+    try {
+      TopicAdminClient topicAdminClient = TopicAdminClient.create();
+    } catch (ApiException e) {
+      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
+        throw e;
+      }
+    } finally {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -232,9 +256,15 @@ public class ManagerIT {
 
     DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
     DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
-    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+    try {
+      TopicAdminClient topicAdminClient = TopicAdminClient.create();
+    } catch (ApiException e) {
+      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
+        throw e;
+      }
+    } finally {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
-    }
+    }    
   }
 
   @Test
@@ -252,7 +282,13 @@ public class ManagerIT {
 
     DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
     DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
-    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+    try {
+      TopicAdminClient topicAdminClient = TopicAdminClient.create();
+    } catch (ApiException e) {
+      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
+        throw e;
+      }
+    } finally {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -272,7 +308,13 @@ public class ManagerIT {
 
     DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
     DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
-    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+    try {
+      TopicAdminClient topicAdminClient = TopicAdminClient.create();
+    } catch (ApiException e) {
+      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
+        throw e;
+      }
+    } finally {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -292,7 +334,13 @@ public class ManagerIT {
 
     DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
     DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
-    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+    try {
+      TopicAdminClient topicAdminClient = TopicAdminClient.create();
+    } catch (ApiException e) {
+      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
+        throw e;
+      }
+    } finally {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -307,7 +355,13 @@ public class ManagerIT {
     Assert.assertFalse(got.contains("eventNotificationConfigs"));
 
     DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
-    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+    try {
+      TopicAdminClient topicAdminClient = TopicAdminClient.create();
+    } catch (ApiException e) {
+      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
+        throw e;
+      }
+    } finally {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -322,7 +376,13 @@ public class ManagerIT {
     Assert.assertTrue(got.contains("ETAG"));
 
     DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
-    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+    try {
+      TopicAdminClient topicAdminClient = TopicAdminClient.create();
+    } catch (ApiException e) {
+      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
+        throw e;
+      }
+    } finally {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -338,7 +398,13 @@ public class ManagerIT {
     Assert.assertTrue(got.contains("ETAG"));
 
     DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
-    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+    try {
+      TopicAdminClient topicAdminClient = TopicAdminClient.create();
+    } catch (ApiException e) {
+      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
+        throw e;
+      }
+    } finally {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -375,7 +441,13 @@ public class ManagerIT {
     // Clean up
     DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
     DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
-    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+    try {
+      TopicAdminClient topicAdminClient = TopicAdminClient.create();
+    } catch (ApiException e) {
+      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
+        throw e;
+      }
+    } finally {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -410,7 +482,13 @@ public class ManagerIT {
     // Clean up
     DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
     DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
-    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+    try {
+      TopicAdminClient topicAdminClient = TopicAdminClient.create();
+    } catch (ApiException e) {
+      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
+        throw e;
+      }
+    } finally {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -446,7 +524,13 @@ public class ManagerIT {
     // Clean up
     DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
     DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
-    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+    try {
+      TopicAdminClient topicAdminClient = TopicAdminClient.create();
+    } catch (ApiException e) {
+      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
+        throw e;
+      }
+    } finally {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -482,7 +566,13 @@ public class ManagerIT {
     // Clean up
     DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
     DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
-    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+    try {
+      TopicAdminClient topicAdminClient = TopicAdminClient.create();
+    } catch (ApiException e) {
+      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
+        throw e;
+      }
+    } finally {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -537,7 +627,13 @@ public class ManagerIT {
     // Clean up
     DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
     DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
-    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+    try {
+      TopicAdminClient topicAdminClient = TopicAdminClient.create();
+    } catch (ApiException e) {
+      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
+        throw e;
+      }
+    } finally {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -575,7 +671,13 @@ public class ManagerIT {
     // Clean up
     DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
     DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
-    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+    try {
+      TopicAdminClient topicAdminClient = TopicAdminClient.create();
+    } catch (ApiException e) {
+      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
+        throw e;
+      }
+    } finally {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -610,7 +712,13 @@ public class ManagerIT {
     // Clean up
     DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
     DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
-    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+    try {
+      TopicAdminClient topicAdminClient = TopicAdminClient.create();
+    } catch (ApiException e) {
+      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
+        throw e;
+      }
+    } finally {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -663,7 +771,13 @@ public class ManagerIT {
     DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
     DeviceRegistryExample.deleteDevice(gatewayName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
     DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
-    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+    try {
+      TopicAdminClient topicAdminClient = TopicAdminClient.create();
+    } catch (ApiException e) {
+      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
+        throw e;
+      }
+    } finally {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -711,7 +825,13 @@ public class ManagerIT {
     // Clean up
     DeviceRegistryExample.deleteDevice(gatewayName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
     DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
-    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+    try {
+      TopicAdminClient topicAdminClient = TopicAdminClient.create();
+    } catch (ApiException e) {
+      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
+        throw e;
+      }
+    } finally {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }
@@ -766,7 +886,13 @@ public class ManagerIT {
     DeviceRegistryExample.deleteDevice(deviceName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
     DeviceRegistryExample.deleteDevice(gatewayName, PROJECT_ID, CLOUD_REGION, REGISTRY_ID);
     DeviceRegistryExample.deleteRegistry(CLOUD_REGION, PROJECT_ID, REGISTRY_ID);
-    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+    try {
+      TopicAdminClient topicAdminClient = TopicAdminClient.create();
+    } catch (ApiException e) {
+      if (e.getStatusCode() != Status.Code.ALREADY_EXISTS) {
+        throw e;
+      }
+    } finally {
       topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
     }
   }


### PR DESCRIPTION
Some of the tests, but not all, had try/finally blocks to delete resources at the end. This fix applies that logic consistently to catch most of the issues.

More robust error-handling could be added later to handle ignore `AlreadyExistsException` or to deal with resources individually rather than in bulk within each test function.

Fixes #7330
Fixes #7331 
Fixes #7322 