### PR TITLE
chore(deps): cleanup trace dependencies

### DIFF
--- a/trace/pom.xml
+++ b/trace/pom.xml
@@ -38,13 +38,20 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.1.3</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <!-- [START trace_setup_java_maven] -->
-    <dependency>
-      <groupId>io.opencensus</groupId>
-      <artifactId>opencensus-api</artifactId>
-      <version>0.31.1</version>
-    </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-exporter-trace-stackdriver</artifactId>
@@ -57,30 +64,17 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>io.opencensus</groupId>
-      <artifactId>opencensus-impl</artifactId>
-      <version>0.31.1</version>
-      <scope>runtime</scope>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <version>2.10.13</version>
     </dependency>
     <dependency>
-       <groupId>joda-time</groupId>
-       <artifactId>joda-time</artifactId>
-       <version>2.10.13</version>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-core</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
-      <version>2.7.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.auth</groupId>
-      <artifactId>google-auth-library-credentials</artifactId>
-      <version>1.8.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.auth</groupId>
-      <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.8.1</version>
     </dependency>
     <!-- [END trace_setup_java_maven] -->
 
@@ -89,18 +83,6 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.truth</groupId>
-      <artifactId>truth</artifactId>
-      <version>1.1.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client-jackson2</artifactId>
-      <version>1.41.8</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
By using `cloud-libraries-bom` for dependency management, we can simplify `pom.xml` to use the latest recommended library dependencies. This should make the failed renovate PR #6452 unnecessary.