### PR TITLE
docs(compute-samples): improving snapshot samples

### DIFF
--- a/compute/cloud-client/src/main/java/compute/disks/DeleteSnapshotsByFilter.java
+++ b/compute/cloud-client/src/main/java/compute/disks/DeleteSnapshotsByFilter.java
@@ -1,0 +1,91 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START compute_snapshot_delete_by_filter]
+
+package compute.disks;
+
+import com.google.cloud.compute.v1.ListSnapshotsRequest;
+import com.google.cloud.compute.v1.Operation;
+import com.google.cloud.compute.v1.Snapshot;
+import com.google.cloud.compute.v1.SnapshotsClient;
+import com.google.cloud.compute.v1.SnapshotsClient.ListPagedResponse;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class DeleteSnapshotsByFilter {
+
+  public static void main(String[] args)
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    // TODO(developer): Replace these variables before running the sample.
+    // Project ID or project number of the Cloud project you want to use.
+    String projectId = "YOUR_PROJECT_ID";
+
+    // Filter to be applied when looking for snapshots for deletion. Learn more about filters here:
+    // https://cloud.google.com/java/docs/reference/google-cloud-compute/latest/com.google.cloud.compute.v1.ListSnapshotsRequest
+    String filter = "FILTER";
+
+    deleteSnapshotsByFilter(projectId, filter);
+  }
+
+  // Delete a snapshot of a disk.
+  private static void deleteSnapshot(String projectId, String snapshotName)
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the `snapshotsClient.close()` method on the client to safely
+    // clean up any remaining background resources.
+    try (SnapshotsClient snapshotsClient = SnapshotsClient.create()) {
+
+      Operation operation = snapshotsClient.deleteAsync(projectId, snapshotName)
+          .get(3, TimeUnit.MINUTES);
+
+      if (operation.hasError()) {
+        throw new Error("Snapshot deletion failed!" + operation.getError());
+      }
+      System.out.printf("Snapshot deleted: %s", snapshotName);
+    }
+  }
+
+  // List snapshots from a project.
+  private static ListPagedResponse listSnapshots(String projectId, String filter)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the `snapshotsClient.close()` method on the client to safely
+    // clean up any remaining background resources.
+    try (SnapshotsClient snapshotsClient = SnapshotsClient.create()) {
+
+      // Create the List Snapshot request.
+      ListSnapshotsRequest listSnapshotsRequest = ListSnapshotsRequest.newBuilder()
+          .setProject(projectId)
+          .setFilter(filter)
+          .build();
+
+      return snapshotsClient.list(listSnapshotsRequest);
+    }
+  }
+
+  // Deletes all snapshots in project that meet the filter criteria.
+  public static void deleteSnapshotsByFilter(String projectId, String filter)
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+
+    for (Snapshot snapshot : listSnapshots(projectId, filter).iterateAll()) {
+      deleteSnapshot(projectId, snapshot.getName());
+    }
+  }
+}
+// [END compute_snapshot_delete_by_filter]

--- a/compute/cloud-client/src/main/java/compute/disks/GetSnapshot.java
+++ b/compute/cloud-client/src/main/java/compute/disks/GetSnapshot.java
@@ -1,0 +1,49 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START compute_snapshot_get]
+
+package compute.disks;
+
+import com.google.cloud.compute.v1.Snapshot;
+import com.google.cloud.compute.v1.SnapshotsClient;
+import java.io.IOException;
+
+public class GetSnapshot {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    // Project ID or project number of the Cloud project you want to use.
+    String projectId = "YOUR_PROJECT_ID";
+
+    // Name of the snapshot to look up.
+    String snapshotName = "YOUR_SNAPSHOT_NAME";
+
+    getSnapshot(projectId, snapshotName);
+  }
+
+  // Get information about a snapshot.
+  public static void getSnapshot(String projectId, String snapshotName) throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the `snapshotsClient.close()` method on the client to safely
+    // clean up any remaining background resources.
+    try (SnapshotsClient snapshotsClient = SnapshotsClient.create()) {
+
+      Snapshot snapshot = snapshotsClient.get(projectId, snapshotName);
+      System.out.printf("Retrieved the snapshot: %s", snapshot.getName());
+    }
+  }
+}
+// [END compute_snapshot_get]

--- a/compute/cloud-client/src/main/java/compute/disks/GetSnapshot.java
+++ b/compute/cloud-client/src/main/java/compute/disks/GetSnapshot.java
@@ -40,7 +40,6 @@ public class GetSnapshot {
     // the `snapshotsClient.close()` method on the client to safely
     // clean up any remaining background resources.
     try (SnapshotsClient snapshotsClient = SnapshotsClient.create()) {
-
       Snapshot snapshot = snapshotsClient.get(projectId, snapshotName);
       System.out.printf("Retrieved the snapshot: %s", snapshot.getName());
     }

--- a/compute/cloud-client/src/test/java/compute/InstanceTemplatesIT.java
+++ b/compute/cloud-client/src/test/java/compute/InstanceTemplatesIT.java
@@ -134,6 +134,9 @@ public class InstanceTemplatesIT {
     DeleteInstanceTemplate.deleteInstanceTemplate(PROJECT_ID, TEMPLATE_NAME);
     assertThat(stdOut.toString())
         .contains("Instance template deletion operation status for " + TEMPLATE_NAME);
+    DeleteInstanceTemplate.deleteInstanceTemplate(PROJECT_ID, TEMPLATE_NAME_WITH_DISK);
+    assertThat(stdOut.toString())
+        .contains("Instance template deletion operation status for " + TEMPLATE_NAME_WITH_DISK);
     DeleteInstanceTemplate.deleteInstanceTemplate(PROJECT_ID, TEMPLATE_NAME_FROM_INSTANCE);
     assertThat(stdOut.toString())
         .contains("Instance template deletion operation status for " + TEMPLATE_NAME_FROM_INSTANCE);

--- a/compute/cloud-client/src/test/java/compute/disks/SnapshotsIT.java
+++ b/compute/cloud-client/src/test/java/compute/disks/SnapshotsIT.java
@@ -54,6 +54,7 @@ public class SnapshotsIT {
   private static String DISK_NAME;
   private static String REGIONAL_DISK_NAME;
   private static String SNAPSHOT_NAME;
+  private static String SNAPSHOT_NAME_DELETE_BY_FILTER;
   private static String SNAPSHOT_NAME_REGIONAL;
 
   private ByteArrayOutputStream stdOut;
@@ -79,6 +80,7 @@ public class SnapshotsIT {
     DISK_NAME = "gcloud-test-disk-" + uuid;
     REGIONAL_DISK_NAME = "gcloud-regional-test-disk-" + uuid;
     SNAPSHOT_NAME = "gcloud-test-snapshot-" + uuid;
+    SNAPSHOT_NAME_DELETE_BY_FILTER = "gcloud-test-snapshot-dbf-" + uuid;
     SNAPSHOT_NAME_REGIONAL = "gcloud-test-regional-snap-" + uuid;
 
     Image debianImage = null;
@@ -89,7 +91,10 @@ public class SnapshotsIT {
     // Create zonal snapshot.
     createDisk(PROJECT_ID, ZONE, DISK_NAME, debianImage.getSelfLink());
     CreateSnapshot.createSnapshot(PROJECT_ID, DISK_NAME, SNAPSHOT_NAME, ZONE, "", LOCATION, "");
+    CreateSnapshot.createSnapshot(PROJECT_ID, DISK_NAME, SNAPSHOT_NAME_DELETE_BY_FILTER, ZONE, "",
+        LOCATION, "");
     assertThat(stdOut.toString()).contains("Snapshot created: " + SNAPSHOT_NAME);
+    assertThat(stdOut.toString()).contains("Snapshot created: " + SNAPSHOT_NAME_DELETE_BY_FILTER);
 
     // Create regional snapshot.
     createRegionalDisk(PROJECT_ID, LOCATION, REGIONAL_DISK_NAME);
@@ -212,6 +217,20 @@ public class SnapshotsIT {
     ListSnapshots.listSnapshots(PROJECT_ID, "");
     assertThat(stdOut.toString()).contains(SNAPSHOT_NAME);
     assertThat(stdOut.toString()).contains(SNAPSHOT_NAME_REGIONAL);
+  }
+
+  @Test
+  public void testGetSnapshot() throws IOException {
+    GetSnapshot.getSnapshot(PROJECT_ID, SNAPSHOT_NAME);
+    assertThat(stdOut.toString()).contains("Retrieved the snapshot: ");
+  }
+
+  @Test
+  public void testDeleteSnapshotsByFilter()
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    DeleteSnapshotsByFilter.deleteSnapshotsByFilter(PROJECT_ID,
+        "name = " + SNAPSHOT_NAME_DELETE_BY_FILTER);
+    assertThat(stdOut.toString()).contains("Snapshot deleted: " + SNAPSHOT_NAME_DELETE_BY_FILTER);
   }
 
 }


### PR DESCRIPTION
Improving the code snippets for disk snapshots, so they can be used on this page: [Create and manage disk snapshots](https://cloud.google.com/compute/docs/disks/create-snapshots)