### PR TITLE
test: handle expected exception in GUI test

### DIFF
--- a/iot/api-client/codelab/manager/src/test/java/com/example/cloud/iot/examples/ManagerIT.java
+++ b/iot/api-client/codelab/manager/src/test/java/com/example/cloud/iot/examples/ManagerIT.java
@@ -78,7 +78,7 @@ public class ManagerIT {
       Assert.assertTrue(terminal.getTerminalSize().toString().contains("x"));
       Assert.assertTrue(terminal.getTerminalSize().toString().contains("{"));
       Assert.assertTrue(terminal.getTerminalSize().toString().contains("}"));
-    } catch (FileNotFoundException e) {
+    } catch (IOException e) {
       // Don't fail when GUI not available: "/dev/tty (No such device or address)"
       System.out.println(e.getMessage());
     }


### PR DESCRIPTION
#7349 was too specific, as it handled the `FileNotFoundException` but not its superclass `IOException`. The build for #6766 is still failing:

```
java.io.IOException: Cannot run program "/bin/stty": /dev/tty (No such device or address)
	at cloudiot.manager.demo@1.0/com.example.cloud.iot.examples.ManagerIT.testTerminal(ManagerIT.java:61)
Caused by: java.io.FileNotFoundException: /dev/tty (No such device or address)
	at cloudiot.manager.demo@1.0/com.example.cloud.iot.examples.ManagerIT.testTerminal(ManagerIT.java:61)
```	