### PR TITLE
fix(deps): update dependency com.google.cloud:libraries-bom to v26

### DIFF
--- a/appengine-java11/guestbook-cloud-firestore/pom.xml
+++ b/appengine-java11/guestbook-cloud-firestore/pom.xml
@@ -45,7 +45,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/appengine-java11/spanner/pom.xml
+++ b/appengine-java11/spanner/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/appengine-java11/tasks/pom.xml
+++ b/appengine-java11/tasks/pom.xml
@@ -47,7 +47,7 @@ Copyright 2019 Google LLC
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/appengine-java8/firebase-backend/pom.xml
+++ b/appengine-java8/firebase-backend/pom.xml
@@ -35,7 +35,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/appengine-java8/pubsub/pom.xml
+++ b/appengine-java8/pubsub/pom.xml
@@ -45,7 +45,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/appengine-java8/spanner/pom.xml
+++ b/appengine-java8/spanner/pom.xml
@@ -45,7 +45,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/appengine-java8/translate-pubsub/pom.xml
+++ b/appengine-java8/translate-pubsub/pom.xml
@@ -44,7 +44,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -45,7 +45,7 @@ limitations under the License.
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bigtable/use-cases/fraudDetection/pom.xml
+++ b/bigtable/use-cases/fraudDetection/pom.xml
@@ -80,7 +80,7 @@
         <groupId>com.google.cloud</groupId>
         <scope>import</scope>
         <type>pom</type>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/bigtable/use-cases/fraudDetection/pom.xml
+++ b/bigtable/use-cases/fraudDetection/pom.xml
@@ -80,7 +80,7 @@
         <groupId>com.google.cloud</groupId>
         <scope>import</scope>
         <type>pom</type>
-        <version>26.1.3</version>
+        <version>25.4.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/cloud-sql/mysql/client-side-encryption/pom.xml
+++ b/cloud-sql/mysql/client-side-encryption/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
           <groupId>com.google.cloud</groupId>
           <artifactId>libraries-bom</artifactId>
-          <version>25.4.0</version>
+          <version>26.1.3</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/cloud-sql/postgres/client-side-encryption/pom.xml
+++ b/cloud-sql/postgres/client-side-encryption/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
           <groupId>com.google.cloud</groupId>
           <artifactId>libraries-bom</artifactId>
-          <version>25.4.0</version>
+          <version>26.1.3</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/cloud-sql/sqlserver/client-side-encryption/pom.xml
+++ b/cloud-sql/sqlserver/client-side-encryption/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
           <groupId>com.google.cloud</groupId>
           <artifactId>libraries-bom</artifactId>
-          <version>25.4.0</version>
+          <version>26.1.3</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/compute/cloud-client/pom.xml
+++ b/compute/cloud-client/pom.xml
@@ -86,7 +86,7 @@
         <groupId>com.google.cloud</groupId>
         <scope>import</scope>
         <type>pom</type>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/container-registry/container-analysis/pom.xml
+++ b/container-registry/container-analysis/pom.xml
@@ -35,7 +35,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/container-registry/vulnerability-notification-function/pom.xml
+++ b/container-registry/vulnerability-notification-function/pom.xml
@@ -78,7 +78,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/flexible/cloudstorage/pom.xml
+++ b/flexible/cloudstorage/pom.xml
@@ -48,7 +48,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/flexible/datastore/pom.xml
+++ b/flexible/datastore/pom.xml
@@ -48,7 +48,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/functions/helloworld/hello-gcs/pom.xml
+++ b/functions/helloworld/hello-gcs/pom.xml
@@ -42,7 +42,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/functions/helloworld/hello-pubsub/pom.xml
+++ b/functions/helloworld/hello-pubsub/pom.xml
@@ -42,7 +42,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/functions/imagemagick/pom.xml
+++ b/functions/imagemagick/pom.xml
@@ -41,7 +41,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/functions/ocr/ocr-process-image/pom.xml
+++ b/functions/ocr/ocr-process-image/pom.xml
@@ -41,7 +41,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/functions/ocr/ocr-save-result/pom.xml
+++ b/functions/ocr/ocr-save-result/pom.xml
@@ -41,7 +41,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/functions/ocr/ocr-translate-text/pom.xml
+++ b/functions/ocr/ocr-translate-text/pom.xml
@@ -41,7 +41,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/functions/pubsub/publish-message/pom.xml
+++ b/functions/pubsub/publish-message/pom.xml
@@ -41,7 +41,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/functions/slack/pom.xml
+++ b/functions/slack/pom.xml
@@ -41,7 +41,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/functions/slack/pom.xml
+++ b/functions/slack/pom.xml
@@ -41,7 +41,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>26.1.3</version>
+        <version>25.4.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/functions/spanner/pom.xml
+++ b/functions/spanner/pom.xml
@@ -41,7 +41,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/functions/v2/hello-gcs/pom.xml
+++ b/functions/v2/hello-gcs/pom.xml
@@ -40,7 +40,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/functions/v2/imagemagick/pom.xml
+++ b/functions/v2/imagemagick/pom.xml
@@ -39,7 +39,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/healthcare/v1/pom.xml
+++ b/healthcare/v1/pom.xml
@@ -64,7 +64,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/jobs/v4/pom.xml
+++ b/jobs/v4/pom.xml
@@ -32,7 +32,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>25.4.0</version>
+                <version>26.1.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/language/analysis/pom.xml
+++ b/language/analysis/pom.xml
@@ -42,7 +42,7 @@ limitations under the License.
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/media/livestream/pom.xml
+++ b/media/livestream/pom.xml
@@ -42,7 +42,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/media/stitcher/pom.xml
+++ b/media/stitcher/pom.xml
@@ -42,7 +42,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/media/transcoder/pom.xml
+++ b/media/transcoder/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-video-transcoder</artifactId>
-      <version>1.0.4</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>2.10.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/media/transcoder/pom.xml
+++ b/media/transcoder/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/monitoring/cloud-client/pom.xml
+++ b/monitoring/cloud-client/pom.xml
@@ -39,7 +39,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/monitoring/v3/pom.xml
+++ b/monitoring/v3/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
           <groupId>com.google.cloud</groupId>
           <artifactId>libraries-bom</artifactId>
-          <version>25.4.0</version>
+          <version>26.1.3</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/pubsublite/streaming-analytics/pom.xml
+++ b/pubsublite/streaming-analytics/pom.xml
@@ -66,7 +66,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/spanner/changestreams/pom.xml
+++ b/spanner/changestreams/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/spanner/jdbc/pom.xml
+++ b/spanner/jdbc/pom.xml
@@ -28,7 +28,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/spanner/leaderboard/complete/pom.xml
+++ b/spanner/leaderboard/complete/pom.xml
@@ -33,7 +33,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/spanner/leaderboard/step4/pom.xml
+++ b/spanner/leaderboard/step4/pom.xml
@@ -33,7 +33,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/spanner/leaderboard/step5/pom.xml
+++ b/spanner/leaderboard/step5/pom.xml
@@ -33,7 +33,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/spanner/leaderboard/step6/pom.xml
+++ b/spanner/leaderboard/step6/pom.xml
@@ -33,7 +33,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/spanner/opencensus/pom.xml
+++ b/spanner/opencensus/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-census</artifactId>
-      <version>1.42.0</version>
+      <version>1.50.2</version>
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.20.1</version>
+      <version>3.21.8</version>
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>

--- a/spanner/opencensus/pom.xml
+++ b/spanner/opencensus/pom.xml
@@ -30,7 +30,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/spanner/r2dbc/pom.xml
+++ b/spanner/r2dbc/pom.xml
@@ -29,7 +29,7 @@
      <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/texttospeech/beta/pom.xml
+++ b/texttospeech/beta/pom.xml
@@ -40,7 +40,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/texttospeech/cloud-client/pom.xml
+++ b/texttospeech/cloud-client/pom.xml
@@ -40,7 +40,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/workflows/cloud-client/pom.xml
+++ b/workflows/cloud-client/pom.xml
@@ -44,7 +44,7 @@ limitations under the License.
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>25.4.0</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
A couple of the pom.xml files needed to be manually edited for this PR to land.

However, now it's stuck and can't be recreated. Testing a fix that will hopefully close the renovate branch.