### PR TITLE
docs(scc-samples): add notification config snippets and samples with …

### DIFF
--- a/security-command-center/snippets/pom.xml
+++ b/security-command-center/snippets/pom.xml
@@ -1,0 +1,79 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>securitycenter-snippets</artifactId>
+  <packaging>jar</packaging>
+  <name>Google Security Command Center Snippets</name>
+  <url>https://github.com/googleapis/java-securitycenter</url>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.2.0</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+
+  <!-- [START securitycenter_install_with_bom] -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.1.3</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-securitycenter</artifactId>
+      <version>2.13.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-pubsub</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigquery</artifactId>
+    </dependency>
+    <!-- [END securitycenter_install_with_bom] -->
+
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+      <version>3.21.7</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.1.3</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/security-command-center/snippets/src/main/java/CreateNotificationConfigSnippets.java
+++ b/security-command-center/snippets/src/main/java/CreateNotificationConfigSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/security-command-center/snippets/src/main/java/CreateNotificationConfigSnippets.java
+++ b/security-command-center/snippets/src/main/java/CreateNotificationConfigSnippets.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START securitycenter_create_notification_config]
+
+import com.google.cloud.securitycenter.v1.CreateNotificationConfigRequest;
+import com.google.cloud.securitycenter.v1.NotificationConfig;
+import com.google.cloud.securitycenter.v1.NotificationConfig.StreamingConfig;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
+import java.io.IOException;
+
+public class CreateNotificationConfigSnippets {
+
+  public static void main(String[] args) throws IOException {
+    // parentId: must be in one of the following formats:
+    //    "organizations/{organization_id}"
+    //    "projects/{project_id}"
+    //    "folders/{folder_id}"
+    String parentId = String.format("organizations/%s", "ORG_ID");
+    String notificationConfigId = "{config-id}";
+    String projectId = "{your-project}";
+    String topicName = "{your-topic}";
+
+    createNotificationConfig(parentId, notificationConfigId, projectId, topicName);
+  }
+
+  // Crete a notification config.
+  // Ensure the ServiceAccount has the "pubsub.topics.setIamPolicy" permission on the new topic.
+  public static NotificationConfig createNotificationConfig(
+      String parentId, String notificationConfigId, String projectId, String topicName)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (SecurityCenterClient client = SecurityCenterClient.create()) {
+
+      // Ensure this ServiceAccount has the "pubsub.topics.setIamPolicy" permission on the topic.
+      String pubsubTopic = String.format("projects/%s/topics/%s", projectId, topicName);
+
+      CreateNotificationConfigRequest request =
+          CreateNotificationConfigRequest.newBuilder()
+              .setParent(parentId)
+              .setConfigId(notificationConfigId)
+              .setNotificationConfig(
+                  NotificationConfig.newBuilder()
+                      .setDescription("Java notification config")
+                      .setPubsubTopic(pubsubTopic)
+                      .setStreamingConfig(
+                          StreamingConfig.newBuilder().setFilter("state = \"ACTIVE\"").build())
+                      .build())
+              .build();
+
+      NotificationConfig response = client.createNotificationConfig(request);
+      System.out.printf("Notification config was created: %s%n", response);
+      return response;
+    }
+  }
+}
+// [END securitycenter_create_notification_config]

--- a/security-command-center/snippets/src/main/java/DeleteNotificationConfigSnippets.java
+++ b/security-command-center/snippets/src/main/java/DeleteNotificationConfigSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/security-command-center/snippets/src/main/java/DeleteNotificationConfigSnippets.java
+++ b/security-command-center/snippets/src/main/java/DeleteNotificationConfigSnippets.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START securitycenter_delete_notification_config]
+
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
+import java.io.IOException;
+
+public class DeleteNotificationConfigSnippets {
+
+  public static void main(String[] args) throws IOException {
+    // parentId: must be in one of the following formats:
+    //    "organizations/{organization_id}"
+    //    "projects/{project_id}"
+    //    "folders/{folder_id}"
+    String parentId = String.format("organizations/%s", "ORG_ID");
+
+    String notificationConfigId = "{config-id}";
+
+    deleteNotificationConfig(parentId, notificationConfigId);
+  }
+
+  // Delete a notification config.
+  public static boolean deleteNotificationConfig(String parentId, String notificationConfigId)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (SecurityCenterClient client = SecurityCenterClient.create()) {
+
+      client.deleteNotificationConfig(String.format("%s/notificationConfigs/%s",
+          parentId, notificationConfigId));
+
+      System.out.printf("Deleted Notification config: %s%n", notificationConfigId);
+    }
+    return true;
+  }
+}
+// [END securitycenter_delete_notification_config]

--- a/security-command-center/snippets/src/main/java/GetNotificationConfigSnippets.java
+++ b/security-command-center/snippets/src/main/java/GetNotificationConfigSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/security-command-center/snippets/src/main/java/GetNotificationConfigSnippets.java
+++ b/security-command-center/snippets/src/main/java/GetNotificationConfigSnippets.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START securitycenter_get_notification_config]
+
+import com.google.cloud.securitycenter.v1.NotificationConfig;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
+import java.io.IOException;
+
+public class GetNotificationConfigSnippets {
+
+  public static void main(String[] args) throws IOException {
+    // parentId: must be in one of the following formats:
+    //    "organizations/{organization_id}"
+    //    "projects/{project_id}"
+    //    "folders/{folder_id}"
+    String parentId = String.format("organizations/%s", "ORG_ID");
+
+    String notificationConfigId = "{config-id}";
+
+    getNotificationConfig(parentId, notificationConfigId);
+  }
+
+  // Retrieve an existing notification config.
+  public static NotificationConfig getNotificationConfig(
+      String parentId, String notificationConfigId) throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (SecurityCenterClient client = SecurityCenterClient.create()) {
+      NotificationConfig response =
+          client.getNotificationConfig(String.format("%s/notificationConfigs/%s",
+              parentId, notificationConfigId));
+
+      System.out.printf("Notification config: %s%n", response);
+      return response;
+    }
+  }
+}
+// [END securitycenter_get_notification_config]

--- a/security-command-center/snippets/src/main/java/ListNotificationConfigSnippets.java
+++ b/security-command-center/snippets/src/main/java/ListNotificationConfigSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/security-command-center/snippets/src/main/java/ListNotificationConfigSnippets.java
+++ b/security-command-center/snippets/src/main/java/ListNotificationConfigSnippets.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START securitycenter_list_notification_configs]
+
+import com.google.cloud.securitycenter.v1.NotificationConfig;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient.ListNotificationConfigsPagedResponse;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+
+public class ListNotificationConfigSnippets {
+
+  public static void main(String[] args) throws IOException {
+    // parentId: must be in one of the following formats:
+    //    "organizations/{organization_id}"
+    //    "projects/{project_id}"
+    //    "folders/{folder_id}"
+    String parentId = String.format("organizations/%s", "ORG_ID");
+
+    listNotificationConfigs(parentId);
+  }
+
+  // List notification configs present in the given parent.
+  public static ImmutableList<NotificationConfig> listNotificationConfigs(String parentId)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (SecurityCenterClient client = SecurityCenterClient.create()) {
+
+      ListNotificationConfigsPagedResponse response = client.listNotificationConfigs(parentId);
+
+      ImmutableList<NotificationConfig> notificationConfigs =
+          ImmutableList.copyOf(response.iterateAll());
+
+      System.out.printf("List notifications response: %s%n", response.getPage().getValues());
+      return notificationConfigs;
+    }
+  }
+}
+// [END securitycenter_list_notification_configs]

--- a/security-command-center/snippets/src/main/java/UpdateNotificationConfigSnippets.java
+++ b/security-command-center/snippets/src/main/java/UpdateNotificationConfigSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/security-command-center/snippets/src/main/java/UpdateNotificationConfigSnippets.java
+++ b/security-command-center/snippets/src/main/java/UpdateNotificationConfigSnippets.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START securitycenter_update_notification_config]
+
+import com.google.cloud.securitycenter.v1.NotificationConfig;
+import com.google.cloud.securitycenter.v1.NotificationConfig.StreamingConfig;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
+import com.google.protobuf.FieldMask;
+import java.io.IOException;
+
+public class UpdateNotificationConfigSnippets {
+
+  public static void main(String[] args) throws IOException {
+    // parentId: must be in one of the following formats:
+    //    "organizations/{organization_id}"
+    //    "projects/{project_id}"
+    //    "folders/{folder_id}"
+    String parentId = String.format("organizations/%s", "ORG_ID");
+    String notificationConfigId = "{config-id}";
+    String projectId = "{your-project}";
+    String topicName = "{your-topic}";
+
+    updateNotificationConfig(parentId, notificationConfigId, projectId, topicName);
+  }
+
+  // Update an existing notification config.
+  // If updating a Pubsub Topic, ensure the ServiceAccount has the
+  // "pubsub.topics.setIamPolicy" permission on the new topic.
+  public static NotificationConfig updateNotificationConfig(
+      String parentId, String notificationConfigId, String projectId, String topicName)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (SecurityCenterClient client = SecurityCenterClient.create()) {
+
+      String notificationConfigName =
+          String.format(
+              "%s/notificationConfigs/%s", parentId, notificationConfigId);
+
+      // Ensure this ServiceAccount has the "pubsub.topics.setIamPolicy" permission on the topic.
+      String pubsubTopic = String.format("projects/%s/topics/%s", projectId, topicName);
+
+      NotificationConfig configToUpdate =
+          NotificationConfig.newBuilder()
+              .setName(notificationConfigName)
+              .setDescription("updated description")
+              .setPubsubTopic(pubsubTopic)
+              .setStreamingConfig(StreamingConfig.newBuilder().setFilter("state = \"ACTIVE\""))
+              .build();
+
+      FieldMask fieldMask =
+          FieldMask.newBuilder()
+              .addPaths("description")
+              .addPaths("pubsub_topic")
+              .addPaths("streaming_config.filter")
+              .build();
+
+      NotificationConfig updatedConfig = client.updateNotificationConfig(configToUpdate, fieldMask);
+
+      System.out.printf("Notification config: %s%n", updatedConfig);
+      return updatedConfig;
+    }
+  }
+}
+// [END securitycenter_update_notification_config]

--- a/security-command-center/snippets/src/test/java/NotificationConfigSnippetTests.java
+++ b/security-command-center/snippets/src/test/java/NotificationConfigSnippetTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/security-command-center/snippets/src/test/java/NotificationConfigSnippetTests.java
+++ b/security-command-center/snippets/src/test/java/NotificationConfigSnippetTests.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class NotificationConfigSnippetTests {
+
+  private static void createConfig(String configId) throws IOException {
+    CreateNotificationConfigSnippets.createNotificationConfig(
+        String.format("organizations/%s", getOrganizationId()), configId, getProject(),
+        getTopicName());
+  }
+
+  private static void deleteConfig(String configId) throws IOException {
+    assertTrue(
+        DeleteNotificationConfigSnippets.deleteNotificationConfig(
+            String.format("organizations/%s", getOrganizationId()), configId));
+  }
+
+  private static String getOrganizationId() {
+    return "1081635000895";
+  }
+
+  private static String getProject() {
+    return "project-a-id";
+  }
+
+  private static String getTopicName() {
+    return "notifications-sample-topic";
+  }
+
+  @Test
+  public void testCreateNotificationConfig() throws IOException {
+    String configId = String.format("java-config-%s", UUID.randomUUID());
+    assertNotNull(
+        CreateNotificationConfigSnippets.createNotificationConfig(
+            String.format("organizations/%s", getOrganizationId()), configId, getProject(),
+            getTopicName()));
+
+    deleteConfig(configId);
+  }
+
+  @Test
+  public void testDeleteNotificationConfig() throws IOException {
+    String configId = String.format("java-config-%s", UUID.randomUUID());
+    createConfig(configId);
+
+    assertTrue(
+        DeleteNotificationConfigSnippets.deleteNotificationConfig(
+            String.format("organizations/%s", getOrganizationId()), configId));
+  }
+
+  @Test
+  public void testListNotificationConfig() throws IOException {
+    String configId = String.format("java-config-%s", UUID.randomUUID());
+    createConfig(configId);
+
+    assertNotNull(ListNotificationConfigSnippets.listNotificationConfigs(
+        String.format("organizations/%s", getOrganizationId())));
+
+    deleteConfig(configId);
+  }
+
+  @Test
+  public void testGetNotificationConfig() throws IOException {
+    String configId = String.format("java-config-%s", UUID.randomUUID());
+    createConfig(configId);
+
+    assertNotNull(
+        GetNotificationConfigSnippets.getNotificationConfig(
+            String.format("organizations/%s", getOrganizationId()), configId));
+
+    deleteConfig(configId);
+  }
+
+  @Test
+  public void testUpdateNotificationConfig() throws IOException {
+    String configId = String.format("java-config-%s", UUID.randomUUID());
+    createConfig(configId);
+
+    assertNotNull(
+        UpdateNotificationConfigSnippets.updateNotificationConfig(
+            String.format("organizations/%s", getOrganizationId()), configId, getProject(),
+            getTopicName()));
+
+    deleteConfig(configId);
+  }
+}


### PR DESCRIPTION
…new parent levels

Updated samples to include parent levels: folder and project