### PR TITLE
docs(compute-samples): add samples for image creation and deletion

### DIFF
--- a/compute/cloud-client/src/main/java/compute/windows/osimage/CreateImage.java
+++ b/compute/cloud-client/src/main/java/compute/windows/osimage/CreateImage.java
@@ -15,6 +15,7 @@
 package compute.windows.osimage;
 
 // [START compute_windows_image_create]
+// [START compute_images_create]
 
 import com.google.cloud.compute.v1.Disk;
 import com.google.cloud.compute.v1.DisksClient;
@@ -32,7 +33,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-public class CreateWindowsOsImage {
+public class CreateImage {
 
   public static void main(String[] args)
       throws IOException, ExecutionException, InterruptedException, TimeoutException {
@@ -52,14 +53,17 @@ public class CreateWindowsOsImage {
     // Create the image even if the source disk is attached to a running instance.
     boolean forceCreate = false;
 
-    createWindowsOsImage(project, zone, sourceDiskName, imageName, storageLocation, forceCreate);
+    createImage(project, zone, sourceDiskName, imageName, storageLocation, forceCreate);
   }
 
-  // Creates a new Windows image from the specified source disk.
-  public static void createWindowsOsImage(String project, String zone, String sourceDiskName,
+  // Creates a new disk image from the specified source disk.
+  public static void createImage(String project, String zone, String sourceDiskName,
       String imageName, String storageLocation, boolean forceCreate)
       throws IOException, ExecutionException, InterruptedException, TimeoutException {
-
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the `client.close()` method on the client to safely
+    // clean up any remaining background resources.
     try (ImagesClient imagesClient = ImagesClient.create();
         InstancesClient instancesClient = InstancesClient.create();
         DisksClient disksClient = DisksClient.create()) {
@@ -72,12 +76,18 @@ public class CreateWindowsOsImage {
         Instance instance = instancesClient.get(instanceInfo.get("instanceProjectId"),
             instanceInfo.get("instanceZone"), instanceInfo.get("instanceName"));
 
-        // Сhecking whether the instances is stopped.
+        // Сheck whether the instances are stopped.
         if (!Arrays.asList("TERMINATED", "STOPPED").contains(instance.getStatus())
             && !forceCreate) {
           throw new IllegalStateException(
               String.format(
-                  "Instance %s should be stopped. Please stop the instance using GCESysprep command or set forceCreate parameter to true (not recommended). More information here: https://cloud.google.com/compute/docs/instances/windows/creating-windows-os-image#api.",
+                  "Instance %s should be stopped. For Windows instances please stop the instance "
+                      + "using 'GCESysprep' command. For Linux instances just shut it down normally."
+                      + " You can suppress this error and create an image of the disk by setting "
+                      + "'forceCreate' parameter to true (not recommended). "
+                      + "More information here: "
+                      + "* https://cloud.google.com/compute/docs/instances/windows/creating-windows-os-image#api"
+                      + "* https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images#prepare_instance_for_image",
                   instanceInfo.get("instanceName")));
         }
       }
@@ -104,7 +114,7 @@ public class CreateWindowsOsImage {
       Operation response = imagesClient.insertAsync(insertImageRequest).get(3, TimeUnit.MINUTES);
 
       if (response.hasError()) {
-        System.out.println("Windows OS Image creation failed ! ! " + response);
+        System.out.println("Image creation failed ! ! " + response);
         return;
       }
 
@@ -133,4 +143,5 @@ public class CreateWindowsOsImage {
   }
 
 }
+// [END compute_images_create]
 // [END compute_windows_image_create]

--- a/compute/cloud-client/src/main/java/compute/windows/osimage/CreateImage.java
+++ b/compute/cloud-client/src/main/java/compute/windows/osimage/CreateImage.java
@@ -82,7 +82,7 @@ public class CreateImage {
           throw new IllegalStateException(
               String.format(
                   "Instance %s should be stopped. For Windows instances please stop the instance "
-                      + "using 'GCESysprep' command. For Linux instances just shut it down normally."
+                      + "using GCESysprep command. For Linux instances just shut it down normally."
                       + " You can suppress this error and create an image of the disk by setting "
                       + "'forceCreate' parameter to true (not recommended). "
                       + "More information here: "

--- a/compute/cloud-client/src/main/java/compute/windows/osimage/DeleteImage.java
+++ b/compute/cloud-client/src/main/java/compute/windows/osimage/DeleteImage.java
@@ -1,0 +1,57 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compute.windows.osimage;
+
+// [START compute_images_delete]
+
+import com.google.cloud.compute.v1.ImagesClient;
+import com.google.cloud.compute.v1.Operation;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class DeleteImage {
+
+  public static void main(String[] args)
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    // TODO(developer): Replace these variables before running the sample.
+    // Project ID or project number of the Cloud project you use.
+    String project = "your-project-id";
+    // Name of the image you want to delete.
+    String imageName = "your-image-name";
+
+    deleteImage(project, imageName);
+  }
+
+  // Deletes a disk image.
+  public static void deleteImage(String project, String imageName)
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the `imagesClient.close()` method on the client to safely
+    // clean up any remaining background resources.
+    try (ImagesClient imagesClient = ImagesClient.create()) {
+      Operation response = imagesClient.deleteAsync(project, imageName).get(3, TimeUnit.MINUTES);
+
+      if (response.hasError()) {
+        System.out.println("Image deletion failed ! ! " + response);
+        return;
+      }
+      System.out.printf("Operation Status for Image Name %s: %s ", imageName, response.getStatus());
+    }
+  }
+}
+// [END compute_images_delete]

--- a/compute/cloud-client/src/test/java/compute/windows/osimage/WindowsOsImageIT.java
+++ b/compute/cloud-client/src/test/java/compute/windows/osimage/WindowsOsImageIT.java
@@ -19,7 +19,6 @@ import static com.google.common.truth.Truth.assertWithMessage;
 
 import com.google.cloud.compute.v1.AttachedDisk;
 import com.google.cloud.compute.v1.AttachedDiskInitializeParams;
-import com.google.cloud.compute.v1.ImagesClient;
 import com.google.cloud.compute.v1.InsertInstanceRequest;
 import com.google.cloud.compute.v1.Instance;
 import com.google.cloud.compute.v1.InstancesClient;
@@ -128,11 +127,7 @@ public class WindowsOsImageIT {
     System.setOut(new PrintStream(stdOut));
 
     // Delete image.
-    ImagesClient imagesClient = ImagesClient.create();
-    Operation operation = imagesClient.deleteAsync(PROJECT_ID, IMAGE_NAME).get();
-    if (operation.hasError()) {
-      System.out.println("Image not deleted.");
-    }
+    DeleteImage.deleteImage(PROJECT_ID, IMAGE_NAME);
 
     // Delete instance.
     DeleteInstance.deleteInstance(PROJECT_ID, ZONE, INSTANCE_NAME);
@@ -158,7 +153,7 @@ public class WindowsOsImageIT {
       throws IOException, ExecutionException, InterruptedException, TimeoutException {
     Assertions.assertThrows(
         IllegalStateException.class,
-        () -> CreateWindowsOsImage.createWindowsOsImage(PROJECT_ID, ZONE, DISK_NAME, IMAGE_NAME,
+        () -> CreateImage.createImage(PROJECT_ID, ZONE, DISK_NAME, IMAGE_NAME,
             "eu", false),
         String.format("Instance %s should be stopped.", INSTANCE_NAME));
   }
@@ -167,7 +162,7 @@ public class WindowsOsImageIT {
   @Test
   public void testCreateWindowsImage_pass()
       throws IOException, ExecutionException, InterruptedException, TimeoutException {
-    CreateWindowsOsImage.createWindowsOsImage(
+    CreateImage.createImage(
         PROJECT_ID, ZONE, DISK_NAME, IMAGE_NAME, "eu", true);
     assertThat(stdOut.toString()).contains("Image created.");
   }


### PR DESCRIPTION
Samples to create and delete images. The compute_windows_image_create region is here to match https://github.com/googleapis/nodejs-compute/pull/703/files

Changes:
1. Create sample: added second region tag and made changes to comments.
2. Added a new delete sample
3. Modified test file to include the delete sample