### PR TITLE
feat: add example for manage logging metrics with gcp client

### DIFF
--- a/monitoring/log-metrics-client/.gitignore
+++ b/monitoring/log-metrics-client/.gitignore
@@ -1,0 +1,99 @@
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser

--- a/monitoring/log-metrics-client/pom.xml
+++ b/monitoring/log-metrics-client/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example.monitoring</groupId>
+    <artifactId>log-metrics-client</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-logging</artifactId>
+            <version>1.98.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-monitoring</artifactId>
+            <version>1.98.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-trace</artifactId>
+            <version>0.108.0-beta</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/monitoring/log-metrics-client/src/main/java/Console.java
+++ b/monitoring/log-metrics-client/src/main/java/Console.java
@@ -1,0 +1,74 @@
+import service.MetricService;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public final class Console {
+
+    private final MetricService metricService;
+
+    public Console() throws IOException {
+        Properties prop = new Properties();
+
+        InputStream inputStream = ConsoleRunner.class.getClassLoader()
+                .getResourceAsStream("console.properties");
+        prop.load(inputStream);
+
+        metricService = new MetricService(prop.getProperty("gcp.domain"), prop.getProperty("gcp.project"));
+    }
+
+    public static void usage() {
+        System.out.println("Usage:");
+        System.out.println();
+        System.out.println("  list-log-metrics            | Lists of log metrics");
+        System.out.println("  new-log-metrics             | Creates a log metrics");
+        System.out.println("  delete-log-metrics          | Deletes a log metrics");
+        System.out.println("  exit                        | Exit from console");
+        System.out.println();
+    }
+
+    /**
+     * Handles a single command.
+     *
+     * @param commandLine A line of input provided by the user
+     */
+    public void handleCommandLine(String commandLine) throws IOException {
+        String[] args = commandLine.split("\\s+");
+
+        if (args.length < 1) {
+            throw new IllegalArgumentException("not enough args");
+        }
+
+        String command = args[0];
+        switch (command) {
+            case "list-log-metrics":
+                args = commandLine.split("\\s+", 2);
+                if (args.length != 1) {
+                    throw new IllegalArgumentException("usage: no arguments");
+                }
+                metricService.listLogMetrics();
+                break;
+            case "new-log-metrics":
+                args = commandLine.split("\\s+", 4);
+                if (args.length != 4) {
+                    throw new IllegalArgumentException("usage: <type>");
+                }
+                metricService.createLogMetrics(args[1], args[2], args[3]);
+                break;
+            case "delete-log-metrics":
+                args = commandLine.split("\\s+", 2);
+                if (args.length != 2) {
+                    throw new IllegalArgumentException("usage: <type>");
+                }
+                metricService.deleteLogMetrics(args[1]);
+                break;
+            case "exit":
+                System.out.println("exiting...");
+                System.exit(0);
+                break;
+            default:
+                throw new IllegalArgumentException("unrecognized command: " + command);
+        }
+    }
+}

--- a/monitoring/log-metrics-client/src/main/java/service/MetricService.java
+++ b/monitoring/log-metrics-client/src/main/java/service/MetricService.java
@@ -1,0 +1,84 @@
+package service;
+
+import com.google.api.LabelDescriptor;
+import com.google.api.MetricDescriptor;
+import com.google.api.MonitoredResourceDescriptor;
+import com.google.cloud.logging.v2.MetricsClient;
+import com.google.cloud.monitoring.v3.MetricServiceClient;
+import com.google.cloud.monitoring.v3.MetricServiceClient.ListMonitoredResourceDescriptorsPagedResponse;
+import com.google.gson.Gson;
+import com.google.logging.v2.CreateLogMetricRequest;
+import com.google.logging.v2.ListLogMetricsRequest;
+import com.google.logging.v2.LogMetric;
+import com.google.monitoring.v3.*;
+
+import java.io.IOException;
+import java.util.List;
+
+public class MetricService {
+
+    private final String metricDomain;
+    private final String projectId;
+
+    public MetricService(String metricDomain, String projectId) {
+        this.metricDomain = metricDomain;
+        this.projectId = projectId;
+    }
+
+    public void listLogMetrics() throws IOException {
+        // [START list-log-metrics]
+        ProjectName name = ProjectName.of(projectId);
+
+        MetricsClient client = MetricsClient.create();
+
+        ListLogMetricsRequest request = ListLogMetricsRequest.newBuilder()
+                .setParent(name.toString())
+                .build();
+
+        MetricsClient.ListLogMetricsPagedResponse response = client.listLogMetrics(request);
+
+        System.out.println("Listing Log Metrics: ");
+
+        for (LogMetric d : response.iterateAll()) {
+            System.out.println(d.getName() + " " + d.getDescription());
+        }
+        client.close();
+        // [END list-log-metrics]
+    }
+
+    public void createLogMetrics(String name, String description, String filter) throws IOException {
+
+        ProjectName name = ProjectName.of(projectId);
+
+        MetricsClient client = MetricsClient.create();
+
+        LogMetric inputMetric = LogMetric.newBuilder()
+                .setName(name)
+                .setDescription(description)
+                .setFilter(filter)
+                .build();
+
+        CreateLogMetricRequest request = CreateLogMetricRequest.newBuilder()
+                .setParent(name.toString())
+                .setMetric(inputMetric)
+                .build();
+
+        LogMetric response = client.createLogMetric(request);
+        System.out.println("Log Metric successfully created: " + response.getName());
+
+        client.close();
+    }
+
+    public void deleteLogMetrics(String logMetricName) throws IOException {
+
+        ProjectName name = ProjectName.of(projectId);
+
+        MetricsClient client = MetricsClient.create();
+
+        String path = String.format("%s/metrics/%s", name, logMetricName);
+
+        client.deleteLogMetric(path);
+        System.out.println("Log Metric successfully deleted.");
+        client.close();
+    }
+}

--- a/monitoring/log-metrics-client/src/main/resources/console.properties
+++ b/monitoring/log-metrics-client/src/main/resources/console.properties
@@ -1,0 +1,2 @@
+gcp.project=projectId
+gcp.domain=custom.googleapis.com

--- a/monitoring/log-metrics-client/src/main/resources/metrics.json
+++ b/monitoring/log-metrics-client/src/main/resources/metrics.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "metric_name",
+    "description": "Metric log description",
+    "filter": ""
+  }
+]


### PR DESCRIPTION
Hi maintainers 👋🏻, 
this pr will add a new example with 3 basic methods: create, delete and list; for the gcp log metrics.