### PR TITLE
(WIP) samples: migrate code from googleapis/java-servicedirectory

### DIFF
--- a/servicedirectory/snippets/pom.xml
+++ b/servicedirectory/snippets/pom.xml
@@ -1,0 +1,56 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>google-cloud-servicedirectory-samples</artifactId>
+  <version>0.0.1-SNAPSHOT</version><!-- This artifact should not be released -->
+  <packaging>pom</packaging>
+  <name>Google Service Directory Samples Parent</name>
+  <url>https://github.com/googleapis/java-servicedirectory</url>
+  <description>
+    Java idiomatic client for Google Cloud Platform services.
+  </description>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.2.0</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <modules>
+    <module>install-without-bom</module>
+    <module>snapshot</module>
+    <module>snippets</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.13</version>
+        <configuration>
+          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project> 

--- a/servicedirectory/snippets/snippets/README.md
+++ b/servicedirectory/snippets/snippets/README.md
@@ -1,0 +1,46 @@
+# Service Directory
+
+[Service Directory](https://cloud.google.com/service-directory/) is a platform
+for discovering, publishing, and connecting services. It offers customers a
+single place to register and discover their services in a consistent and
+reliable way, regardless of their environment. These sample Java applications
+demonstrate how to access the Service Directory API using the Google Java API
+Client Libraries.
+
+## Prerequisites
+
+### Enable the API
+
+You must enable the Service Directory API for your project in order to use these
+samples. You can do so
+[here](https://console.cloud.google.com/flows/enableapi?apiid=servicedirectory.googleapis.com&_ga=2.140387959.57242806.1585772225-360187285.1585772225).
+
+### Set Environment Variables
+
+You must set your project ID in order to run the tests
+
+`$ export GOOGLE_CLOUD_PROJECT=<your-project-id-here>`
+
+### Grant Permissions
+
+You must ensure that the
+[user account or service account](https://cloud.google.com/iam/docs/service-accounts#differences_between_a_service_account_and_a_user_account)
+you used to authorize your gcloud session has the proper permissions to edit
+Service Directory resources for your project. In the Cloud Console under IAM,
+add the `Service Directory Admin` role to the project whose service account
+you're using to test.
+
+More information can be found in the
+[Authentication docs](https://cloud.google.com/docs/authentication/production).
+
+## Quickstart
+
+Install [Maven](https://maven.apache.org/).
+
+Build your project with:
+
+    mvn clean package -DskipTests
+
+You can run all tests with:
+
+    mvn clean verify

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/lookupservice/create/SyncCreateSetCredentialsProvider.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/lookupservice/create/SyncCreateSetCredentialsProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_LookupService_Create_SetCredentialsProvider_sync]
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.cloud.servicedirectory.v1.LookupServiceClient;
+import com.google.cloud.servicedirectory.v1.LookupServiceSettings;
+import com.google.cloud.servicedirectory.v1.myCredentials;
+
+public class SyncCreateSetCredentialsProvider {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateSetCredentialsProvider();
+  }
+
+  public static void syncCreateSetCredentialsProvider() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    LookupServiceSettings lookupServiceSettings =
+        LookupServiceSettings.newBuilder()
+            .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
+            .build();
+    LookupServiceClient lookupServiceClient = LookupServiceClient.create(lookupServiceSettings);
+  }
+}
+// [END servicedirectory_v1_generated_LookupService_Create_SetCredentialsProvider_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/lookupservice/create/SyncCreateSetCredentialsProvider1.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/lookupservice/create/SyncCreateSetCredentialsProvider1.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_LookupService_Create_SetCredentialsProvider1_sync]
+import com.google.cloud.servicedirectory.v1.LookupServiceClient;
+import com.google.cloud.servicedirectory.v1.LookupServiceSettings;
+
+public class SyncCreateSetCredentialsProvider1 {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateSetCredentialsProvider1();
+  }
+
+  public static void syncCreateSetCredentialsProvider1() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    LookupServiceSettings lookupServiceSettings =
+        LookupServiceSettings.newHttpJsonBuilder().build();
+    LookupServiceClient lookupServiceClient = LookupServiceClient.create(lookupServiceSettings);
+  }
+}
+// [END servicedirectory_v1_generated_LookupService_Create_SetCredentialsProvider1_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/lookupservice/create/SyncCreateSetEndpoint.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/lookupservice/create/SyncCreateSetEndpoint.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_LookupService_Create_SetEndpoint_sync]
+import com.google.cloud.servicedirectory.v1.LookupServiceClient;
+import com.google.cloud.servicedirectory.v1.LookupServiceSettings;
+import com.google.cloud.servicedirectory.v1.myEndpoint;
+
+public class SyncCreateSetEndpoint {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateSetEndpoint();
+  }
+
+  public static void syncCreateSetEndpoint() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    LookupServiceSettings lookupServiceSettings =
+        LookupServiceSettings.newBuilder().setEndpoint(myEndpoint).build();
+    LookupServiceClient lookupServiceClient = LookupServiceClient.create(lookupServiceSettings);
+  }
+}
+// [END servicedirectory_v1_generated_LookupService_Create_SetEndpoint_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/lookupservice/resolveservice/AsyncResolveService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/lookupservice/resolveservice/AsyncResolveService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_LookupService_ResolveService_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1.LookupServiceClient;
+import com.google.cloud.servicedirectory.v1.ResolveServiceRequest;
+import com.google.cloud.servicedirectory.v1.ResolveServiceResponse;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+
+public class AsyncResolveService {
+
+  public static void main(String[] args) throws Exception {
+    asyncResolveService();
+  }
+
+  public static void asyncResolveService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (LookupServiceClient lookupServiceClient = LookupServiceClient.create()) {
+      ResolveServiceRequest request =
+          ResolveServiceRequest.newBuilder()
+              .setName(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .setMaxEndpoints(2074789987)
+              .setEndpointFilter("endpointFilter-1834249875")
+              .build();
+      ApiFuture<ResolveServiceResponse> future =
+          lookupServiceClient.resolveServiceCallable().futureCall(request);
+      // Do something.
+      ResolveServiceResponse response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1_generated_LookupService_ResolveService_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/lookupservice/resolveservice/SyncResolveService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/lookupservice/resolveservice/SyncResolveService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_LookupService_ResolveService_sync]
+import com.google.cloud.servicedirectory.v1.LookupServiceClient;
+import com.google.cloud.servicedirectory.v1.ResolveServiceRequest;
+import com.google.cloud.servicedirectory.v1.ResolveServiceResponse;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+
+public class SyncResolveService {
+
+  public static void main(String[] args) throws Exception {
+    syncResolveService();
+  }
+
+  public static void syncResolveService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (LookupServiceClient lookupServiceClient = LookupServiceClient.create()) {
+      ResolveServiceRequest request =
+          ResolveServiceRequest.newBuilder()
+              .setName(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .setMaxEndpoints(2074789987)
+              .setEndpointFilter("endpointFilter-1834249875")
+              .build();
+      ResolveServiceResponse response = lookupServiceClient.resolveService(request);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_LookupService_ResolveService_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/lookupservicesettings/resolveservice/SyncResolveService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/lookupservicesettings/resolveservice/SyncResolveService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_LookupServiceSettings_ResolveService_sync]
+import com.google.cloud.servicedirectory.v1.LookupServiceSettings;
+import java.time.Duration;
+
+public class SyncResolveService {
+
+  public static void main(String[] args) throws Exception {
+    syncResolveService();
+  }
+
+  public static void syncResolveService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    LookupServiceSettings.Builder lookupServiceSettingsBuilder = LookupServiceSettings.newBuilder();
+    lookupServiceSettingsBuilder
+        .resolveServiceSettings()
+        .setRetrySettings(
+            lookupServiceSettingsBuilder.resolveServiceSettings().getRetrySettings().toBuilder()
+                .setTotalTimeout(Duration.ofSeconds(30))
+                .build());
+    LookupServiceSettings lookupServiceSettings = lookupServiceSettingsBuilder.build();
+  }
+}
+// [END servicedirectory_v1_generated_LookupServiceSettings_ResolveService_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/create/SyncCreateSetCredentialsProvider.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/create/SyncCreateSetCredentialsProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_Create_SetCredentialsProvider_sync]
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceSettings;
+import com.google.cloud.servicedirectory.v1.myCredentials;
+
+public class SyncCreateSetCredentialsProvider {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateSetCredentialsProvider();
+  }
+
+  public static void syncCreateSetCredentialsProvider() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    RegistrationServiceSettings registrationServiceSettings =
+        RegistrationServiceSettings.newBuilder()
+            .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
+            .build();
+    RegistrationServiceClient registrationServiceClient =
+        RegistrationServiceClient.create(registrationServiceSettings);
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_Create_SetCredentialsProvider_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/create/SyncCreateSetCredentialsProvider1.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/create/SyncCreateSetCredentialsProvider1.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_Create_SetCredentialsProvider1_sync]
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceSettings;
+
+public class SyncCreateSetCredentialsProvider1 {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateSetCredentialsProvider1();
+  }
+
+  public static void syncCreateSetCredentialsProvider1() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    RegistrationServiceSettings registrationServiceSettings =
+        RegistrationServiceSettings.newHttpJsonBuilder().build();
+    RegistrationServiceClient registrationServiceClient =
+        RegistrationServiceClient.create(registrationServiceSettings);
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_Create_SetCredentialsProvider1_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/create/SyncCreateSetEndpoint.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/create/SyncCreateSetEndpoint.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_Create_SetEndpoint_sync]
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceSettings;
+import com.google.cloud.servicedirectory.v1.myEndpoint;
+
+public class SyncCreateSetEndpoint {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateSetEndpoint();
+  }
+
+  public static void syncCreateSetEndpoint() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    RegistrationServiceSettings registrationServiceSettings =
+        RegistrationServiceSettings.newBuilder().setEndpoint(myEndpoint).build();
+    RegistrationServiceClient registrationServiceClient =
+        RegistrationServiceClient.create(registrationServiceSettings);
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_Create_SetEndpoint_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createendpoint/AsyncCreateEndpoint.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createendpoint/AsyncCreateEndpoint.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_CreateEndpoint_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1.CreateEndpointRequest;
+import com.google.cloud.servicedirectory.v1.Endpoint;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+
+public class AsyncCreateEndpoint {
+
+  public static void main(String[] args) throws Exception {
+    asyncCreateEndpoint();
+  }
+
+  public static void asyncCreateEndpoint() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      CreateEndpointRequest request =
+          CreateEndpointRequest.newBuilder()
+              .setParent(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .setEndpointId("endpointId-1837754992")
+              .setEndpoint(Endpoint.newBuilder().build())
+              .build();
+      ApiFuture<Endpoint> future =
+          registrationServiceClient.createEndpointCallable().futureCall(request);
+      // Do something.
+      Endpoint response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_CreateEndpoint_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createendpoint/SyncCreateEndpoint.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createendpoint/SyncCreateEndpoint.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_CreateEndpoint_sync]
+import com.google.cloud.servicedirectory.v1.CreateEndpointRequest;
+import com.google.cloud.servicedirectory.v1.Endpoint;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+
+public class SyncCreateEndpoint {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateEndpoint();
+  }
+
+  public static void syncCreateEndpoint() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      CreateEndpointRequest request =
+          CreateEndpointRequest.newBuilder()
+              .setParent(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .setEndpointId("endpointId-1837754992")
+              .setEndpoint(Endpoint.newBuilder().build())
+              .build();
+      Endpoint response = registrationServiceClient.createEndpoint(request);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_CreateEndpoint_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createendpoint/SyncCreateEndpointServicenameEndpointString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createendpoint/SyncCreateEndpointServicenameEndpointString.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_CreateEndpoint_ServicenameEndpointString_sync]
+import com.google.cloud.servicedirectory.v1.Endpoint;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+
+public class SyncCreateEndpointServicenameEndpointString {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateEndpointServicenameEndpointString();
+  }
+
+  public static void syncCreateEndpointServicenameEndpointString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ServiceName parent = ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]");
+      Endpoint endpoint = Endpoint.newBuilder().build();
+      String endpointId = "endpointId-1837754992";
+      Endpoint response = registrationServiceClient.createEndpoint(parent, endpoint, endpointId);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_CreateEndpoint_ServicenameEndpointString_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createendpoint/SyncCreateEndpointStringEndpointString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createendpoint/SyncCreateEndpointStringEndpointString.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_CreateEndpoint_StringEndpointString_sync]
+import com.google.cloud.servicedirectory.v1.Endpoint;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+
+public class SyncCreateEndpointStringEndpointString {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateEndpointStringEndpointString();
+  }
+
+  public static void syncCreateEndpointStringEndpointString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String parent =
+          ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString();
+      Endpoint endpoint = Endpoint.newBuilder().build();
+      String endpointId = "endpointId-1837754992";
+      Endpoint response = registrationServiceClient.createEndpoint(parent, endpoint, endpointId);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_CreateEndpoint_StringEndpointString_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createnamespace/AsyncCreateNamespace.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createnamespace/AsyncCreateNamespace.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_CreateNamespace_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1.CreateNamespaceRequest;
+import com.google.cloud.servicedirectory.v1.LocationName;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+
+public class AsyncCreateNamespace {
+
+  public static void main(String[] args) throws Exception {
+    asyncCreateNamespace();
+  }
+
+  public static void asyncCreateNamespace() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      CreateNamespaceRequest request =
+          CreateNamespaceRequest.newBuilder()
+              .setParent(LocationName.of("[PROJECT]", "[LOCATION]").toString())
+              .setNamespaceId("namespaceId790852566")
+              .setNamespace(Namespace.newBuilder().build())
+              .build();
+      ApiFuture<Namespace> future =
+          registrationServiceClient.createNamespaceCallable().futureCall(request);
+      // Do something.
+      Namespace response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_CreateNamespace_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createnamespace/SyncCreateNamespace.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createnamespace/SyncCreateNamespace.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_CreateNamespace_sync]
+import com.google.cloud.servicedirectory.v1.CreateNamespaceRequest;
+import com.google.cloud.servicedirectory.v1.LocationName;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+
+public class SyncCreateNamespace {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateNamespace();
+  }
+
+  public static void syncCreateNamespace() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      CreateNamespaceRequest request =
+          CreateNamespaceRequest.newBuilder()
+              .setParent(LocationName.of("[PROJECT]", "[LOCATION]").toString())
+              .setNamespaceId("namespaceId790852566")
+              .setNamespace(Namespace.newBuilder().build())
+              .build();
+      Namespace response = registrationServiceClient.createNamespace(request);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_CreateNamespace_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createnamespace/SyncCreateNamespaceLocationnameNamespaceString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createnamespace/SyncCreateNamespaceLocationnameNamespaceString.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_CreateNamespace_LocationnameNamespaceString_sync]
+import com.google.cloud.servicedirectory.v1.LocationName;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+
+public class SyncCreateNamespaceLocationnameNamespaceString {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateNamespaceLocationnameNamespaceString();
+  }
+
+  public static void syncCreateNamespaceLocationnameNamespaceString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      LocationName parent = LocationName.of("[PROJECT]", "[LOCATION]");
+      Namespace namespace = Namespace.newBuilder().build();
+      String namespaceId = "namespaceId790852566";
+      Namespace response =
+          registrationServiceClient.createNamespace(parent, namespace, namespaceId);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_CreateNamespace_LocationnameNamespaceString_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createnamespace/SyncCreateNamespaceStringNamespaceString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createnamespace/SyncCreateNamespaceStringNamespaceString.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_CreateNamespace_StringNamespaceString_sync]
+import com.google.cloud.servicedirectory.v1.LocationName;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+
+public class SyncCreateNamespaceStringNamespaceString {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateNamespaceStringNamespaceString();
+  }
+
+  public static void syncCreateNamespaceStringNamespaceString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String parent = LocationName.of("[PROJECT]", "[LOCATION]").toString();
+      Namespace namespace = Namespace.newBuilder().build();
+      String namespaceId = "namespaceId790852566";
+      Namespace response =
+          registrationServiceClient.createNamespace(parent, namespace, namespaceId);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_CreateNamespace_StringNamespaceString_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createservice/AsyncCreateService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createservice/AsyncCreateService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_CreateService_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1.CreateServiceRequest;
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.Service;
+
+public class AsyncCreateService {
+
+  public static void main(String[] args) throws Exception {
+    asyncCreateService();
+  }
+
+  public static void asyncCreateService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      CreateServiceRequest request =
+          CreateServiceRequest.newBuilder()
+              .setParent(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .setServiceId("serviceId-194185552")
+              .setService(Service.newBuilder().build())
+              .build();
+      ApiFuture<Service> future =
+          registrationServiceClient.createServiceCallable().futureCall(request);
+      // Do something.
+      Service response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_CreateService_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createservice/SyncCreateService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createservice/SyncCreateService.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_CreateService_sync]
+import com.google.cloud.servicedirectory.v1.CreateServiceRequest;
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.Service;
+
+public class SyncCreateService {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateService();
+  }
+
+  public static void syncCreateService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      CreateServiceRequest request =
+          CreateServiceRequest.newBuilder()
+              .setParent(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .setServiceId("serviceId-194185552")
+              .setService(Service.newBuilder().build())
+              .build();
+      Service response = registrationServiceClient.createService(request);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_CreateService_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createservice/SyncCreateServiceNamespacenameServiceString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createservice/SyncCreateServiceNamespacenameServiceString.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_CreateService_NamespacenameServiceString_sync]
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.Service;
+
+public class SyncCreateServiceNamespacenameServiceString {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateServiceNamespacenameServiceString();
+  }
+
+  public static void syncCreateServiceNamespacenameServiceString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      NamespaceName parent = NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]");
+      Service service = Service.newBuilder().build();
+      String serviceId = "serviceId-194185552";
+      Service response = registrationServiceClient.createService(parent, service, serviceId);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_CreateService_NamespacenameServiceString_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createservice/SyncCreateServiceStringServiceString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/createservice/SyncCreateServiceStringServiceString.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_CreateService_StringServiceString_sync]
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.Service;
+
+public class SyncCreateServiceStringServiceString {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateServiceStringServiceString();
+  }
+
+  public static void syncCreateServiceStringServiceString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String parent = NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString();
+      Service service = Service.newBuilder().build();
+      String serviceId = "serviceId-194185552";
+      Service response = registrationServiceClient.createService(parent, service, serviceId);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_CreateService_StringServiceString_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deleteendpoint/AsyncDeleteEndpoint.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deleteendpoint/AsyncDeleteEndpoint.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_DeleteEndpoint_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1.DeleteEndpointRequest;
+import com.google.cloud.servicedirectory.v1.EndpointName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.protobuf.Empty;
+
+public class AsyncDeleteEndpoint {
+
+  public static void main(String[] args) throws Exception {
+    asyncDeleteEndpoint();
+  }
+
+  public static void asyncDeleteEndpoint() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      DeleteEndpointRequest request =
+          DeleteEndpointRequest.newBuilder()
+              .setName(
+                  EndpointName.of(
+                          "[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]", "[ENDPOINT]")
+                      .toString())
+              .build();
+      ApiFuture<Empty> future =
+          registrationServiceClient.deleteEndpointCallable().futureCall(request);
+      // Do something.
+      future.get();
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_DeleteEndpoint_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deleteendpoint/SyncDeleteEndpoint.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deleteendpoint/SyncDeleteEndpoint.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_DeleteEndpoint_sync]
+import com.google.cloud.servicedirectory.v1.DeleteEndpointRequest;
+import com.google.cloud.servicedirectory.v1.EndpointName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.protobuf.Empty;
+
+public class SyncDeleteEndpoint {
+
+  public static void main(String[] args) throws Exception {
+    syncDeleteEndpoint();
+  }
+
+  public static void syncDeleteEndpoint() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      DeleteEndpointRequest request =
+          DeleteEndpointRequest.newBuilder()
+              .setName(
+                  EndpointName.of(
+                          "[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]", "[ENDPOINT]")
+                      .toString())
+              .build();
+      registrationServiceClient.deleteEndpoint(request);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_DeleteEndpoint_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deleteendpoint/SyncDeleteEndpointEndpointname.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deleteendpoint/SyncDeleteEndpointEndpointname.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_DeleteEndpoint_Endpointname_sync]
+import com.google.cloud.servicedirectory.v1.EndpointName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.protobuf.Empty;
+
+public class SyncDeleteEndpointEndpointname {
+
+  public static void main(String[] args) throws Exception {
+    syncDeleteEndpointEndpointname();
+  }
+
+  public static void syncDeleteEndpointEndpointname() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      EndpointName name =
+          EndpointName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]", "[ENDPOINT]");
+      registrationServiceClient.deleteEndpoint(name);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_DeleteEndpoint_Endpointname_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deleteendpoint/SyncDeleteEndpointString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deleteendpoint/SyncDeleteEndpointString.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_DeleteEndpoint_String_sync]
+import com.google.cloud.servicedirectory.v1.EndpointName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.protobuf.Empty;
+
+public class SyncDeleteEndpointString {
+
+  public static void main(String[] args) throws Exception {
+    syncDeleteEndpointString();
+  }
+
+  public static void syncDeleteEndpointString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String name =
+          EndpointName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]", "[ENDPOINT]")
+              .toString();
+      registrationServiceClient.deleteEndpoint(name);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_DeleteEndpoint_String_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deletenamespace/AsyncDeleteNamespace.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deletenamespace/AsyncDeleteNamespace.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_DeleteNamespace_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1.DeleteNamespaceRequest;
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.protobuf.Empty;
+
+public class AsyncDeleteNamespace {
+
+  public static void main(String[] args) throws Exception {
+    asyncDeleteNamespace();
+  }
+
+  public static void asyncDeleteNamespace() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      DeleteNamespaceRequest request =
+          DeleteNamespaceRequest.newBuilder()
+              .setName(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .build();
+      ApiFuture<Empty> future =
+          registrationServiceClient.deleteNamespaceCallable().futureCall(request);
+      // Do something.
+      future.get();
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_DeleteNamespace_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deletenamespace/SyncDeleteNamespace.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deletenamespace/SyncDeleteNamespace.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_DeleteNamespace_sync]
+import com.google.cloud.servicedirectory.v1.DeleteNamespaceRequest;
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.protobuf.Empty;
+
+public class SyncDeleteNamespace {
+
+  public static void main(String[] args) throws Exception {
+    syncDeleteNamespace();
+  }
+
+  public static void syncDeleteNamespace() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      DeleteNamespaceRequest request =
+          DeleteNamespaceRequest.newBuilder()
+              .setName(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .build();
+      registrationServiceClient.deleteNamespace(request);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_DeleteNamespace_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deletenamespace/SyncDeleteNamespaceNamespacename.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deletenamespace/SyncDeleteNamespaceNamespacename.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_DeleteNamespace_Namespacename_sync]
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.protobuf.Empty;
+
+public class SyncDeleteNamespaceNamespacename {
+
+  public static void main(String[] args) throws Exception {
+    syncDeleteNamespaceNamespacename();
+  }
+
+  public static void syncDeleteNamespaceNamespacename() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      NamespaceName name = NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]");
+      registrationServiceClient.deleteNamespace(name);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_DeleteNamespace_Namespacename_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deletenamespace/SyncDeleteNamespaceString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deletenamespace/SyncDeleteNamespaceString.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_DeleteNamespace_String_sync]
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.protobuf.Empty;
+
+public class SyncDeleteNamespaceString {
+
+  public static void main(String[] args) throws Exception {
+    syncDeleteNamespaceString();
+  }
+
+  public static void syncDeleteNamespaceString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String name = NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString();
+      registrationServiceClient.deleteNamespace(name);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_DeleteNamespace_String_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deleteservice/AsyncDeleteService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deleteservice/AsyncDeleteService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_DeleteService_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1.DeleteServiceRequest;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+import com.google.protobuf.Empty;
+
+public class AsyncDeleteService {
+
+  public static void main(String[] args) throws Exception {
+    asyncDeleteService();
+  }
+
+  public static void asyncDeleteService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      DeleteServiceRequest request =
+          DeleteServiceRequest.newBuilder()
+              .setName(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .build();
+      ApiFuture<Empty> future =
+          registrationServiceClient.deleteServiceCallable().futureCall(request);
+      // Do something.
+      future.get();
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_DeleteService_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deleteservice/SyncDeleteService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deleteservice/SyncDeleteService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_DeleteService_sync]
+import com.google.cloud.servicedirectory.v1.DeleteServiceRequest;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+import com.google.protobuf.Empty;
+
+public class SyncDeleteService {
+
+  public static void main(String[] args) throws Exception {
+    syncDeleteService();
+  }
+
+  public static void syncDeleteService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      DeleteServiceRequest request =
+          DeleteServiceRequest.newBuilder()
+              .setName(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .build();
+      registrationServiceClient.deleteService(request);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_DeleteService_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deleteservice/SyncDeleteServiceServicename.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deleteservice/SyncDeleteServiceServicename.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_DeleteService_Servicename_sync]
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+import com.google.protobuf.Empty;
+
+public class SyncDeleteServiceServicename {
+
+  public static void main(String[] args) throws Exception {
+    syncDeleteServiceServicename();
+  }
+
+  public static void syncDeleteServiceServicename() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ServiceName name = ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]");
+      registrationServiceClient.deleteService(name);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_DeleteService_Servicename_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deleteservice/SyncDeleteServiceString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/deleteservice/SyncDeleteServiceString.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_DeleteService_String_sync]
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+import com.google.protobuf.Empty;
+
+public class SyncDeleteServiceString {
+
+  public static void main(String[] args) throws Exception {
+    syncDeleteServiceString();
+  }
+
+  public static void syncDeleteServiceString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String name =
+          ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString();
+      registrationServiceClient.deleteService(name);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_DeleteService_String_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getendpoint/AsyncGetEndpoint.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getendpoint/AsyncGetEndpoint.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_GetEndpoint_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1.Endpoint;
+import com.google.cloud.servicedirectory.v1.EndpointName;
+import com.google.cloud.servicedirectory.v1.GetEndpointRequest;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+
+public class AsyncGetEndpoint {
+
+  public static void main(String[] args) throws Exception {
+    asyncGetEndpoint();
+  }
+
+  public static void asyncGetEndpoint() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      GetEndpointRequest request =
+          GetEndpointRequest.newBuilder()
+              .setName(
+                  EndpointName.of(
+                          "[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]", "[ENDPOINT]")
+                      .toString())
+              .build();
+      ApiFuture<Endpoint> future =
+          registrationServiceClient.getEndpointCallable().futureCall(request);
+      // Do something.
+      Endpoint response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_GetEndpoint_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getendpoint/SyncGetEndpoint.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getendpoint/SyncGetEndpoint.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_GetEndpoint_sync]
+import com.google.cloud.servicedirectory.v1.Endpoint;
+import com.google.cloud.servicedirectory.v1.EndpointName;
+import com.google.cloud.servicedirectory.v1.GetEndpointRequest;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+
+public class SyncGetEndpoint {
+
+  public static void main(String[] args) throws Exception {
+    syncGetEndpoint();
+  }
+
+  public static void syncGetEndpoint() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      GetEndpointRequest request =
+          GetEndpointRequest.newBuilder()
+              .setName(
+                  EndpointName.of(
+                          "[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]", "[ENDPOINT]")
+                      .toString())
+              .build();
+      Endpoint response = registrationServiceClient.getEndpoint(request);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_GetEndpoint_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getendpoint/SyncGetEndpointEndpointname.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getendpoint/SyncGetEndpointEndpointname.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_GetEndpoint_Endpointname_sync]
+import com.google.cloud.servicedirectory.v1.Endpoint;
+import com.google.cloud.servicedirectory.v1.EndpointName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+
+public class SyncGetEndpointEndpointname {
+
+  public static void main(String[] args) throws Exception {
+    syncGetEndpointEndpointname();
+  }
+
+  public static void syncGetEndpointEndpointname() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      EndpointName name =
+          EndpointName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]", "[ENDPOINT]");
+      Endpoint response = registrationServiceClient.getEndpoint(name);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_GetEndpoint_Endpointname_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getendpoint/SyncGetEndpointString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getendpoint/SyncGetEndpointString.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_GetEndpoint_String_sync]
+import com.google.cloud.servicedirectory.v1.Endpoint;
+import com.google.cloud.servicedirectory.v1.EndpointName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+
+public class SyncGetEndpointString {
+
+  public static void main(String[] args) throws Exception {
+    syncGetEndpointString();
+  }
+
+  public static void syncGetEndpointString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String name =
+          EndpointName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]", "[ENDPOINT]")
+              .toString();
+      Endpoint response = registrationServiceClient.getEndpoint(name);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_GetEndpoint_String_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getiampolicy/AsyncGetIamPolicy.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getiampolicy/AsyncGetIamPolicy.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_GetIamPolicy_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.GetPolicyOptions;
+import com.google.iam.v1.Policy;
+
+public class AsyncGetIamPolicy {
+
+  public static void main(String[] args) throws Exception {
+    asyncGetIamPolicy();
+  }
+
+  public static void asyncGetIamPolicy() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      GetIamPolicyRequest request =
+          GetIamPolicyRequest.newBuilder()
+              .setResource(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .setOptions(GetPolicyOptions.newBuilder().build())
+              .build();
+      ApiFuture<Policy> future =
+          registrationServiceClient.getIamPolicyCallable().futureCall(request);
+      // Do something.
+      Policy response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_GetIamPolicy_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getiampolicy/SyncGetIamPolicy.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getiampolicy/SyncGetIamPolicy.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_GetIamPolicy_sync]
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.GetPolicyOptions;
+import com.google.iam.v1.Policy;
+
+public class SyncGetIamPolicy {
+
+  public static void main(String[] args) throws Exception {
+    syncGetIamPolicy();
+  }
+
+  public static void syncGetIamPolicy() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      GetIamPolicyRequest request =
+          GetIamPolicyRequest.newBuilder()
+              .setResource(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .setOptions(GetPolicyOptions.newBuilder().build())
+              .build();
+      Policy response = registrationServiceClient.getIamPolicy(request);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_GetIamPolicy_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getnamespace/AsyncGetNamespace.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getnamespace/AsyncGetNamespace.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_GetNamespace_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1.GetNamespaceRequest;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+
+public class AsyncGetNamespace {
+
+  public static void main(String[] args) throws Exception {
+    asyncGetNamespace();
+  }
+
+  public static void asyncGetNamespace() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      GetNamespaceRequest request =
+          GetNamespaceRequest.newBuilder()
+              .setName(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .build();
+      ApiFuture<Namespace> future =
+          registrationServiceClient.getNamespaceCallable().futureCall(request);
+      // Do something.
+      Namespace response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_GetNamespace_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getnamespace/SyncGetNamespace.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getnamespace/SyncGetNamespace.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_GetNamespace_sync]
+import com.google.cloud.servicedirectory.v1.GetNamespaceRequest;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+
+public class SyncGetNamespace {
+
+  public static void main(String[] args) throws Exception {
+    syncGetNamespace();
+  }
+
+  public static void syncGetNamespace() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      GetNamespaceRequest request =
+          GetNamespaceRequest.newBuilder()
+              .setName(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .build();
+      Namespace response = registrationServiceClient.getNamespace(request);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_GetNamespace_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getnamespace/SyncGetNamespaceNamespacename.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getnamespace/SyncGetNamespaceNamespacename.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_GetNamespace_Namespacename_sync]
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+
+public class SyncGetNamespaceNamespacename {
+
+  public static void main(String[] args) throws Exception {
+    syncGetNamespaceNamespacename();
+  }
+
+  public static void syncGetNamespaceNamespacename() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      NamespaceName name = NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]");
+      Namespace response = registrationServiceClient.getNamespace(name);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_GetNamespace_Namespacename_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getnamespace/SyncGetNamespaceString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getnamespace/SyncGetNamespaceString.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_GetNamespace_String_sync]
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+
+public class SyncGetNamespaceString {
+
+  public static void main(String[] args) throws Exception {
+    syncGetNamespaceString();
+  }
+
+  public static void syncGetNamespaceString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String name = NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString();
+      Namespace response = registrationServiceClient.getNamespace(name);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_GetNamespace_String_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getservice/AsyncGetService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getservice/AsyncGetService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_GetService_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1.GetServiceRequest;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.Service;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+
+public class AsyncGetService {
+
+  public static void main(String[] args) throws Exception {
+    asyncGetService();
+  }
+
+  public static void asyncGetService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      GetServiceRequest request =
+          GetServiceRequest.newBuilder()
+              .setName(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .build();
+      ApiFuture<Service> future =
+          registrationServiceClient.getServiceCallable().futureCall(request);
+      // Do something.
+      Service response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_GetService_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getservice/SyncGetService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getservice/SyncGetService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_GetService_sync]
+import com.google.cloud.servicedirectory.v1.GetServiceRequest;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.Service;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+
+public class SyncGetService {
+
+  public static void main(String[] args) throws Exception {
+    syncGetService();
+  }
+
+  public static void syncGetService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      GetServiceRequest request =
+          GetServiceRequest.newBuilder()
+              .setName(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .build();
+      Service response = registrationServiceClient.getService(request);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_GetService_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getservice/SyncGetServiceServicename.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getservice/SyncGetServiceServicename.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_GetService_Servicename_sync]
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.Service;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+
+public class SyncGetServiceServicename {
+
+  public static void main(String[] args) throws Exception {
+    syncGetServiceServicename();
+  }
+
+  public static void syncGetServiceServicename() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ServiceName name = ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]");
+      Service response = registrationServiceClient.getService(name);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_GetService_Servicename_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getservice/SyncGetServiceString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/getservice/SyncGetServiceString.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_GetService_String_sync]
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.Service;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+
+public class SyncGetServiceString {
+
+  public static void main(String[] args) throws Exception {
+    syncGetServiceString();
+  }
+
+  public static void syncGetServiceString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String name =
+          ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString();
+      Service response = registrationServiceClient.getService(name);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_GetService_String_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listendpoints/AsyncListEndpoints.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listendpoints/AsyncListEndpoints.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_ListEndpoints_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1.Endpoint;
+import com.google.cloud.servicedirectory.v1.ListEndpointsRequest;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+
+public class AsyncListEndpoints {
+
+  public static void main(String[] args) throws Exception {
+    asyncListEndpoints();
+  }
+
+  public static void asyncListEndpoints() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ListEndpointsRequest request =
+          ListEndpointsRequest.newBuilder()
+              .setParent(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .setFilter("filter-1274492040")
+              .setOrderBy("orderBy-1207110587")
+              .build();
+      ApiFuture<Endpoint> future =
+          registrationServiceClient.listEndpointsPagedCallable().futureCall(request);
+      // Do something.
+      for (Endpoint element : future.get().iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_ListEndpoints_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listendpoints/AsyncListEndpointsPaged.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listendpoints/AsyncListEndpointsPaged.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_ListEndpoints_Paged_async]
+import com.google.cloud.servicedirectory.v1.Endpoint;
+import com.google.cloud.servicedirectory.v1.ListEndpointsRequest;
+import com.google.cloud.servicedirectory.v1.ListEndpointsResponse;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+import com.google.common.base.Strings;
+
+public class AsyncListEndpointsPaged {
+
+  public static void main(String[] args) throws Exception {
+    asyncListEndpointsPaged();
+  }
+
+  public static void asyncListEndpointsPaged() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ListEndpointsRequest request =
+          ListEndpointsRequest.newBuilder()
+              .setParent(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .setFilter("filter-1274492040")
+              .setOrderBy("orderBy-1207110587")
+              .build();
+      while (true) {
+        ListEndpointsResponse response =
+            registrationServiceClient.listEndpointsCallable().call(request);
+        for (Endpoint element : response.getEndpointsList()) {
+          // doThingsWith(element);
+        }
+        String nextPageToken = response.getNextPageToken();
+        if (!Strings.isNullOrEmpty(nextPageToken)) {
+          request = request.toBuilder().setPageToken(nextPageToken).build();
+        } else {
+          break;
+        }
+      }
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_ListEndpoints_Paged_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listendpoints/SyncListEndpoints.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listendpoints/SyncListEndpoints.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_ListEndpoints_sync]
+import com.google.cloud.servicedirectory.v1.Endpoint;
+import com.google.cloud.servicedirectory.v1.ListEndpointsRequest;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+
+public class SyncListEndpoints {
+
+  public static void main(String[] args) throws Exception {
+    syncListEndpoints();
+  }
+
+  public static void syncListEndpoints() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ListEndpointsRequest request =
+          ListEndpointsRequest.newBuilder()
+              .setParent(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .setFilter("filter-1274492040")
+              .setOrderBy("orderBy-1207110587")
+              .build();
+      for (Endpoint element : registrationServiceClient.listEndpoints(request).iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_ListEndpoints_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listendpoints/SyncListEndpointsServicename.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listendpoints/SyncListEndpointsServicename.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_ListEndpoints_Servicename_sync]
+import com.google.cloud.servicedirectory.v1.Endpoint;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+
+public class SyncListEndpointsServicename {
+
+  public static void main(String[] args) throws Exception {
+    syncListEndpointsServicename();
+  }
+
+  public static void syncListEndpointsServicename() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ServiceName parent = ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]");
+      for (Endpoint element : registrationServiceClient.listEndpoints(parent).iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_ListEndpoints_Servicename_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listendpoints/SyncListEndpointsString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listendpoints/SyncListEndpointsString.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_ListEndpoints_String_sync]
+import com.google.cloud.servicedirectory.v1.Endpoint;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+
+public class SyncListEndpointsString {
+
+  public static void main(String[] args) throws Exception {
+    syncListEndpointsString();
+  }
+
+  public static void syncListEndpointsString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String parent =
+          ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString();
+      for (Endpoint element : registrationServiceClient.listEndpoints(parent).iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_ListEndpoints_String_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listnamespaces/AsyncListNamespaces.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listnamespaces/AsyncListNamespaces.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_ListNamespaces_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1.ListNamespacesRequest;
+import com.google.cloud.servicedirectory.v1.LocationName;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+
+public class AsyncListNamespaces {
+
+  public static void main(String[] args) throws Exception {
+    asyncListNamespaces();
+  }
+
+  public static void asyncListNamespaces() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ListNamespacesRequest request =
+          ListNamespacesRequest.newBuilder()
+              .setParent(LocationName.of("[PROJECT]", "[LOCATION]").toString())
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .setFilter("filter-1274492040")
+              .setOrderBy("orderBy-1207110587")
+              .build();
+      ApiFuture<Namespace> future =
+          registrationServiceClient.listNamespacesPagedCallable().futureCall(request);
+      // Do something.
+      for (Namespace element : future.get().iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_ListNamespaces_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listnamespaces/AsyncListNamespacesPaged.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listnamespaces/AsyncListNamespacesPaged.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_ListNamespaces_Paged_async]
+import com.google.cloud.servicedirectory.v1.ListNamespacesRequest;
+import com.google.cloud.servicedirectory.v1.ListNamespacesResponse;
+import com.google.cloud.servicedirectory.v1.LocationName;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.common.base.Strings;
+
+public class AsyncListNamespacesPaged {
+
+  public static void main(String[] args) throws Exception {
+    asyncListNamespacesPaged();
+  }
+
+  public static void asyncListNamespacesPaged() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ListNamespacesRequest request =
+          ListNamespacesRequest.newBuilder()
+              .setParent(LocationName.of("[PROJECT]", "[LOCATION]").toString())
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .setFilter("filter-1274492040")
+              .setOrderBy("orderBy-1207110587")
+              .build();
+      while (true) {
+        ListNamespacesResponse response =
+            registrationServiceClient.listNamespacesCallable().call(request);
+        for (Namespace element : response.getNamespacesList()) {
+          // doThingsWith(element);
+        }
+        String nextPageToken = response.getNextPageToken();
+        if (!Strings.isNullOrEmpty(nextPageToken)) {
+          request = request.toBuilder().setPageToken(nextPageToken).build();
+        } else {
+          break;
+        }
+      }
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_ListNamespaces_Paged_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listnamespaces/SyncListNamespaces.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listnamespaces/SyncListNamespaces.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_ListNamespaces_sync]
+import com.google.cloud.servicedirectory.v1.ListNamespacesRequest;
+import com.google.cloud.servicedirectory.v1.LocationName;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+
+public class SyncListNamespaces {
+
+  public static void main(String[] args) throws Exception {
+    syncListNamespaces();
+  }
+
+  public static void syncListNamespaces() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ListNamespacesRequest request =
+          ListNamespacesRequest.newBuilder()
+              .setParent(LocationName.of("[PROJECT]", "[LOCATION]").toString())
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .setFilter("filter-1274492040")
+              .setOrderBy("orderBy-1207110587")
+              .build();
+      for (Namespace element : registrationServiceClient.listNamespaces(request).iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_ListNamespaces_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listnamespaces/SyncListNamespacesLocationname.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listnamespaces/SyncListNamespacesLocationname.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_ListNamespaces_Locationname_sync]
+import com.google.cloud.servicedirectory.v1.LocationName;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+
+public class SyncListNamespacesLocationname {
+
+  public static void main(String[] args) throws Exception {
+    syncListNamespacesLocationname();
+  }
+
+  public static void syncListNamespacesLocationname() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      LocationName parent = LocationName.of("[PROJECT]", "[LOCATION]");
+      for (Namespace element : registrationServiceClient.listNamespaces(parent).iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_ListNamespaces_Locationname_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listnamespaces/SyncListNamespacesString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listnamespaces/SyncListNamespacesString.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_ListNamespaces_String_sync]
+import com.google.cloud.servicedirectory.v1.LocationName;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+
+public class SyncListNamespacesString {
+
+  public static void main(String[] args) throws Exception {
+    syncListNamespacesString();
+  }
+
+  public static void syncListNamespacesString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String parent = LocationName.of("[PROJECT]", "[LOCATION]").toString();
+      for (Namespace element : registrationServiceClient.listNamespaces(parent).iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_ListNamespaces_String_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listservices/AsyncListServices.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listservices/AsyncListServices.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_ListServices_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1.ListServicesRequest;
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.Service;
+
+public class AsyncListServices {
+
+  public static void main(String[] args) throws Exception {
+    asyncListServices();
+  }
+
+  public static void asyncListServices() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ListServicesRequest request =
+          ListServicesRequest.newBuilder()
+              .setParent(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .setFilter("filter-1274492040")
+              .setOrderBy("orderBy-1207110587")
+              .build();
+      ApiFuture<Service> future =
+          registrationServiceClient.listServicesPagedCallable().futureCall(request);
+      // Do something.
+      for (Service element : future.get().iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_ListServices_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listservices/AsyncListServicesPaged.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listservices/AsyncListServicesPaged.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_ListServices_Paged_async]
+import com.google.cloud.servicedirectory.v1.ListServicesRequest;
+import com.google.cloud.servicedirectory.v1.ListServicesResponse;
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.Service;
+import com.google.common.base.Strings;
+
+public class AsyncListServicesPaged {
+
+  public static void main(String[] args) throws Exception {
+    asyncListServicesPaged();
+  }
+
+  public static void asyncListServicesPaged() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ListServicesRequest request =
+          ListServicesRequest.newBuilder()
+              .setParent(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .setFilter("filter-1274492040")
+              .setOrderBy("orderBy-1207110587")
+              .build();
+      while (true) {
+        ListServicesResponse response =
+            registrationServiceClient.listServicesCallable().call(request);
+        for (Service element : response.getServicesList()) {
+          // doThingsWith(element);
+        }
+        String nextPageToken = response.getNextPageToken();
+        if (!Strings.isNullOrEmpty(nextPageToken)) {
+          request = request.toBuilder().setPageToken(nextPageToken).build();
+        } else {
+          break;
+        }
+      }
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_ListServices_Paged_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listservices/SyncListServices.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listservices/SyncListServices.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_ListServices_sync]
+import com.google.cloud.servicedirectory.v1.ListServicesRequest;
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.Service;
+
+public class SyncListServices {
+
+  public static void main(String[] args) throws Exception {
+    syncListServices();
+  }
+
+  public static void syncListServices() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ListServicesRequest request =
+          ListServicesRequest.newBuilder()
+              .setParent(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .setFilter("filter-1274492040")
+              .setOrderBy("orderBy-1207110587")
+              .build();
+      for (Service element : registrationServiceClient.listServices(request).iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_ListServices_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listservices/SyncListServicesNamespacename.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listservices/SyncListServicesNamespacename.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_ListServices_Namespacename_sync]
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.Service;
+
+public class SyncListServicesNamespacename {
+
+  public static void main(String[] args) throws Exception {
+    syncListServicesNamespacename();
+  }
+
+  public static void syncListServicesNamespacename() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      NamespaceName parent = NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]");
+      for (Service element : registrationServiceClient.listServices(parent).iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_ListServices_Namespacename_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listservices/SyncListServicesString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/listservices/SyncListServicesString.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_ListServices_String_sync]
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.Service;
+
+public class SyncListServicesString {
+
+  public static void main(String[] args) throws Exception {
+    syncListServicesString();
+  }
+
+  public static void syncListServicesString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String parent = NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString();
+      for (Service element : registrationServiceClient.listServices(parent).iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_ListServices_String_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/setiampolicy/AsyncSetIamPolicy.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/setiampolicy/AsyncSetIamPolicy.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_SetIamPolicy_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.SetIamPolicyRequest;
+import com.google.protobuf.FieldMask;
+
+public class AsyncSetIamPolicy {
+
+  public static void main(String[] args) throws Exception {
+    asyncSetIamPolicy();
+  }
+
+  public static void asyncSetIamPolicy() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      SetIamPolicyRequest request =
+          SetIamPolicyRequest.newBuilder()
+              .setResource(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .setPolicy(Policy.newBuilder().build())
+              .setUpdateMask(FieldMask.newBuilder().build())
+              .build();
+      ApiFuture<Policy> future =
+          registrationServiceClient.setIamPolicyCallable().futureCall(request);
+      // Do something.
+      Policy response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_SetIamPolicy_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/setiampolicy/SyncSetIamPolicy.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/setiampolicy/SyncSetIamPolicy.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_SetIamPolicy_sync]
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.SetIamPolicyRequest;
+import com.google.protobuf.FieldMask;
+
+public class SyncSetIamPolicy {
+
+  public static void main(String[] args) throws Exception {
+    syncSetIamPolicy();
+  }
+
+  public static void syncSetIamPolicy() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      SetIamPolicyRequest request =
+          SetIamPolicyRequest.newBuilder()
+              .setResource(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .setPolicy(Policy.newBuilder().build())
+              .setUpdateMask(FieldMask.newBuilder().build())
+              .build();
+      Policy response = registrationServiceClient.setIamPolicy(request);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_SetIamPolicy_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/testiampermissions/AsyncTestIamPermissions.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/testiampermissions/AsyncTestIamPermissions.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_TestIamPermissions_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.iam.v1.TestIamPermissionsResponse;
+import java.util.ArrayList;
+
+public class AsyncTestIamPermissions {
+
+  public static void main(String[] args) throws Exception {
+    asyncTestIamPermissions();
+  }
+
+  public static void asyncTestIamPermissions() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      TestIamPermissionsRequest request =
+          TestIamPermissionsRequest.newBuilder()
+              .setResource(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .addAllPermissions(new ArrayList<String>())
+              .build();
+      ApiFuture<TestIamPermissionsResponse> future =
+          registrationServiceClient.testIamPermissionsCallable().futureCall(request);
+      // Do something.
+      TestIamPermissionsResponse response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_TestIamPermissions_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/testiampermissions/SyncTestIamPermissions.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/testiampermissions/SyncTestIamPermissions.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_TestIamPermissions_sync]
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.iam.v1.TestIamPermissionsResponse;
+import java.util.ArrayList;
+
+public class SyncTestIamPermissions {
+
+  public static void main(String[] args) throws Exception {
+    syncTestIamPermissions();
+  }
+
+  public static void syncTestIamPermissions() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      TestIamPermissionsRequest request =
+          TestIamPermissionsRequest.newBuilder()
+              .setResource(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .addAllPermissions(new ArrayList<String>())
+              .build();
+      TestIamPermissionsResponse response = registrationServiceClient.testIamPermissions(request);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_TestIamPermissions_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/updateendpoint/AsyncUpdateEndpoint.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/updateendpoint/AsyncUpdateEndpoint.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_UpdateEndpoint_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1.Endpoint;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.UpdateEndpointRequest;
+import com.google.protobuf.FieldMask;
+
+public class AsyncUpdateEndpoint {
+
+  public static void main(String[] args) throws Exception {
+    asyncUpdateEndpoint();
+  }
+
+  public static void asyncUpdateEndpoint() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      UpdateEndpointRequest request =
+          UpdateEndpointRequest.newBuilder()
+              .setEndpoint(Endpoint.newBuilder().build())
+              .setUpdateMask(FieldMask.newBuilder().build())
+              .build();
+      ApiFuture<Endpoint> future =
+          registrationServiceClient.updateEndpointCallable().futureCall(request);
+      // Do something.
+      Endpoint response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_UpdateEndpoint_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/updateendpoint/SyncUpdateEndpoint.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/updateendpoint/SyncUpdateEndpoint.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_UpdateEndpoint_sync]
+import com.google.cloud.servicedirectory.v1.Endpoint;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.UpdateEndpointRequest;
+import com.google.protobuf.FieldMask;
+
+public class SyncUpdateEndpoint {
+
+  public static void main(String[] args) throws Exception {
+    syncUpdateEndpoint();
+  }
+
+  public static void syncUpdateEndpoint() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      UpdateEndpointRequest request =
+          UpdateEndpointRequest.newBuilder()
+              .setEndpoint(Endpoint.newBuilder().build())
+              .setUpdateMask(FieldMask.newBuilder().build())
+              .build();
+      Endpoint response = registrationServiceClient.updateEndpoint(request);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_UpdateEndpoint_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/updateendpoint/SyncUpdateEndpointEndpointFieldmask.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/updateendpoint/SyncUpdateEndpointEndpointFieldmask.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_UpdateEndpoint_EndpointFieldmask_sync]
+import com.google.cloud.servicedirectory.v1.Endpoint;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.protobuf.FieldMask;
+
+public class SyncUpdateEndpointEndpointFieldmask {
+
+  public static void main(String[] args) throws Exception {
+    syncUpdateEndpointEndpointFieldmask();
+  }
+
+  public static void syncUpdateEndpointEndpointFieldmask() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      Endpoint endpoint = Endpoint.newBuilder().build();
+      FieldMask updateMask = FieldMask.newBuilder().build();
+      Endpoint response = registrationServiceClient.updateEndpoint(endpoint, updateMask);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_UpdateEndpoint_EndpointFieldmask_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/updatenamespace/AsyncUpdateNamespace.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/updatenamespace/AsyncUpdateNamespace.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_UpdateNamespace_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.UpdateNamespaceRequest;
+import com.google.protobuf.FieldMask;
+
+public class AsyncUpdateNamespace {
+
+  public static void main(String[] args) throws Exception {
+    asyncUpdateNamespace();
+  }
+
+  public static void asyncUpdateNamespace() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      UpdateNamespaceRequest request =
+          UpdateNamespaceRequest.newBuilder()
+              .setNamespace(Namespace.newBuilder().build())
+              .setUpdateMask(FieldMask.newBuilder().build())
+              .build();
+      ApiFuture<Namespace> future =
+          registrationServiceClient.updateNamespaceCallable().futureCall(request);
+      // Do something.
+      Namespace response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_UpdateNamespace_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/updatenamespace/SyncUpdateNamespace.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/updatenamespace/SyncUpdateNamespace.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_UpdateNamespace_sync]
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.UpdateNamespaceRequest;
+import com.google.protobuf.FieldMask;
+
+public class SyncUpdateNamespace {
+
+  public static void main(String[] args) throws Exception {
+    syncUpdateNamespace();
+  }
+
+  public static void syncUpdateNamespace() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      UpdateNamespaceRequest request =
+          UpdateNamespaceRequest.newBuilder()
+              .setNamespace(Namespace.newBuilder().build())
+              .setUpdateMask(FieldMask.newBuilder().build())
+              .build();
+      Namespace response = registrationServiceClient.updateNamespace(request);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_UpdateNamespace_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/updatenamespace/SyncUpdateNamespaceNamespaceFieldmask.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/updatenamespace/SyncUpdateNamespaceNamespaceFieldmask.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_UpdateNamespace_NamespaceFieldmask_sync]
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.protobuf.FieldMask;
+
+public class SyncUpdateNamespaceNamespaceFieldmask {
+
+  public static void main(String[] args) throws Exception {
+    syncUpdateNamespaceNamespaceFieldmask();
+  }
+
+  public static void syncUpdateNamespaceNamespaceFieldmask() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      Namespace namespace = Namespace.newBuilder().build();
+      FieldMask updateMask = FieldMask.newBuilder().build();
+      Namespace response = registrationServiceClient.updateNamespace(namespace, updateMask);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_UpdateNamespace_NamespaceFieldmask_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/updateservice/AsyncUpdateService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/updateservice/AsyncUpdateService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_UpdateService_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.Service;
+import com.google.cloud.servicedirectory.v1.UpdateServiceRequest;
+import com.google.protobuf.FieldMask;
+
+public class AsyncUpdateService {
+
+  public static void main(String[] args) throws Exception {
+    asyncUpdateService();
+  }
+
+  public static void asyncUpdateService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      UpdateServiceRequest request =
+          UpdateServiceRequest.newBuilder()
+              .setService(Service.newBuilder().build())
+              .setUpdateMask(FieldMask.newBuilder().build())
+              .build();
+      ApiFuture<Service> future =
+          registrationServiceClient.updateServiceCallable().futureCall(request);
+      // Do something.
+      Service response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_UpdateService_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/updateservice/SyncUpdateService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/updateservice/SyncUpdateService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_UpdateService_sync]
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.Service;
+import com.google.cloud.servicedirectory.v1.UpdateServiceRequest;
+import com.google.protobuf.FieldMask;
+
+public class SyncUpdateService {
+
+  public static void main(String[] args) throws Exception {
+    syncUpdateService();
+  }
+
+  public static void syncUpdateService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      UpdateServiceRequest request =
+          UpdateServiceRequest.newBuilder()
+              .setService(Service.newBuilder().build())
+              .setUpdateMask(FieldMask.newBuilder().build())
+              .build();
+      Service response = registrationServiceClient.updateService(request);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_UpdateService_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/updateservice/SyncUpdateServiceServiceFieldmask.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservice/updateservice/SyncUpdateServiceServiceFieldmask.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationService_UpdateService_ServiceFieldmask_sync]
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.Service;
+import com.google.protobuf.FieldMask;
+
+public class SyncUpdateServiceServiceFieldmask {
+
+  public static void main(String[] args) throws Exception {
+    syncUpdateServiceServiceFieldmask();
+  }
+
+  public static void syncUpdateServiceServiceFieldmask() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      Service service = Service.newBuilder().build();
+      FieldMask updateMask = FieldMask.newBuilder().build();
+      Service response = registrationServiceClient.updateService(service, updateMask);
+    }
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationService_UpdateService_ServiceFieldmask_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservicesettings/createnamespace/SyncCreateNamespace.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/registrationservicesettings/createnamespace/SyncCreateNamespace.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.samples;
+
+// [START servicedirectory_v1_generated_RegistrationServiceSettings_CreateNamespace_sync]
+import com.google.cloud.servicedirectory.v1.RegistrationServiceSettings;
+import java.time.Duration;
+
+public class SyncCreateNamespace {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateNamespace();
+  }
+
+  public static void syncCreateNamespace() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    RegistrationServiceSettings.Builder registrationServiceSettingsBuilder =
+        RegistrationServiceSettings.newBuilder();
+    registrationServiceSettingsBuilder
+        .createNamespaceSettings()
+        .setRetrySettings(
+            registrationServiceSettingsBuilder
+                .createNamespaceSettings()
+                .getRetrySettings()
+                .toBuilder()
+                .setTotalTimeout(Duration.ofSeconds(30))
+                .build());
+    RegistrationServiceSettings registrationServiceSettings =
+        registrationServiceSettingsBuilder.build();
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationServiceSettings_CreateNamespace_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/stub/lookupservicestubsettings/resolveservice/SyncResolveService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/stub/lookupservicestubsettings/resolveservice/SyncResolveService.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.stub.samples;
+
+// [START servicedirectory_v1_generated_LookupServiceStubSettings_ResolveService_sync]
+import com.google.cloud.servicedirectory.v1.stub.LookupServiceStubSettings;
+import java.time.Duration;
+
+public class SyncResolveService {
+
+  public static void main(String[] args) throws Exception {
+    syncResolveService();
+  }
+
+  public static void syncResolveService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    LookupServiceStubSettings.Builder lookupServiceSettingsBuilder =
+        LookupServiceStubSettings.newBuilder();
+    lookupServiceSettingsBuilder
+        .resolveServiceSettings()
+        .setRetrySettings(
+            lookupServiceSettingsBuilder.resolveServiceSettings().getRetrySettings().toBuilder()
+                .setTotalTimeout(Duration.ofSeconds(30))
+                .build());
+    LookupServiceStubSettings lookupServiceSettings = lookupServiceSettingsBuilder.build();
+  }
+}
+// [END servicedirectory_v1_generated_LookupServiceStubSettings_ResolveService_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/stub/registrationservicestubsettings/createnamespace/SyncCreateNamespace.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1/stub/registrationservicestubsettings/createnamespace/SyncCreateNamespace.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1.stub.samples;
+
+// [START servicedirectory_v1_generated_RegistrationServiceStubSettings_CreateNamespace_sync]
+import com.google.cloud.servicedirectory.v1.stub.RegistrationServiceStubSettings;
+import java.time.Duration;
+
+public class SyncCreateNamespace {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateNamespace();
+  }
+
+  public static void syncCreateNamespace() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    RegistrationServiceStubSettings.Builder registrationServiceSettingsBuilder =
+        RegistrationServiceStubSettings.newBuilder();
+    registrationServiceSettingsBuilder
+        .createNamespaceSettings()
+        .setRetrySettings(
+            registrationServiceSettingsBuilder
+                .createNamespaceSettings()
+                .getRetrySettings()
+                .toBuilder()
+                .setTotalTimeout(Duration.ofSeconds(30))
+                .build());
+    RegistrationServiceStubSettings registrationServiceSettings =
+        registrationServiceSettingsBuilder.build();
+  }
+}
+// [END servicedirectory_v1_generated_RegistrationServiceStubSettings_CreateNamespace_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/lookupservice/create/SyncCreateSetCredentialsProvider.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/lookupservice/create/SyncCreateSetCredentialsProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_LookupService_Create_SetCredentialsProvider_sync]
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.cloud.servicedirectory.v1beta1.LookupServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.LookupServiceSettings;
+import com.google.cloud.servicedirectory.v1beta1.myCredentials;
+
+public class SyncCreateSetCredentialsProvider {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateSetCredentialsProvider();
+  }
+
+  public static void syncCreateSetCredentialsProvider() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    LookupServiceSettings lookupServiceSettings =
+        LookupServiceSettings.newBuilder()
+            .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
+            .build();
+    LookupServiceClient lookupServiceClient = LookupServiceClient.create(lookupServiceSettings);
+  }
+}
+// [END servicedirectory_v1beta1_generated_LookupService_Create_SetCredentialsProvider_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/lookupservice/create/SyncCreateSetCredentialsProvider1.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/lookupservice/create/SyncCreateSetCredentialsProvider1.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_LookupService_Create_SetCredentialsProvider1_sync]
+import com.google.cloud.servicedirectory.v1beta1.LookupServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.LookupServiceSettings;
+
+public class SyncCreateSetCredentialsProvider1 {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateSetCredentialsProvider1();
+  }
+
+  public static void syncCreateSetCredentialsProvider1() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    LookupServiceSettings lookupServiceSettings =
+        LookupServiceSettings.newHttpJsonBuilder().build();
+    LookupServiceClient lookupServiceClient = LookupServiceClient.create(lookupServiceSettings);
+  }
+}
+// [END servicedirectory_v1beta1_generated_LookupService_Create_SetCredentialsProvider1_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/lookupservice/create/SyncCreateSetEndpoint.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/lookupservice/create/SyncCreateSetEndpoint.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_LookupService_Create_SetEndpoint_sync]
+import com.google.cloud.servicedirectory.v1beta1.LookupServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.LookupServiceSettings;
+import com.google.cloud.servicedirectory.v1beta1.myEndpoint;
+
+public class SyncCreateSetEndpoint {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateSetEndpoint();
+  }
+
+  public static void syncCreateSetEndpoint() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    LookupServiceSettings lookupServiceSettings =
+        LookupServiceSettings.newBuilder().setEndpoint(myEndpoint).build();
+    LookupServiceClient lookupServiceClient = LookupServiceClient.create(lookupServiceSettings);
+  }
+}
+// [END servicedirectory_v1beta1_generated_LookupService_Create_SetEndpoint_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/lookupservice/resolveservice/AsyncResolveService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/lookupservice/resolveservice/AsyncResolveService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_LookupService_ResolveService_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1beta1.LookupServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.ResolveServiceRequest;
+import com.google.cloud.servicedirectory.v1beta1.ResolveServiceResponse;
+import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+
+public class AsyncResolveService {
+
+  public static void main(String[] args) throws Exception {
+    asyncResolveService();
+  }
+
+  public static void asyncResolveService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (LookupServiceClient lookupServiceClient = LookupServiceClient.create()) {
+      ResolveServiceRequest request =
+          ResolveServiceRequest.newBuilder()
+              .setName(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .setMaxEndpoints(2074789987)
+              .setEndpointFilter("endpointFilter-1834249875")
+              .build();
+      ApiFuture<ResolveServiceResponse> future =
+          lookupServiceClient.resolveServiceCallable().futureCall(request);
+      // Do something.
+      ResolveServiceResponse response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_LookupService_ResolveService_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/lookupservice/resolveservice/SyncResolveService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/lookupservice/resolveservice/SyncResolveService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_LookupService_ResolveService_sync]
+import com.google.cloud.servicedirectory.v1beta1.LookupServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.ResolveServiceRequest;
+import com.google.cloud.servicedirectory.v1beta1.ResolveServiceResponse;
+import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+
+public class SyncResolveService {
+
+  public static void main(String[] args) throws Exception {
+    syncResolveService();
+  }
+
+  public static void syncResolveService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (LookupServiceClient lookupServiceClient = LookupServiceClient.create()) {
+      ResolveServiceRequest request =
+          ResolveServiceRequest.newBuilder()
+              .setName(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .setMaxEndpoints(2074789987)
+              .setEndpointFilter("endpointFilter-1834249875")
+              .build();
+      ResolveServiceResponse response = lookupServiceClient.resolveService(request);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_LookupService_ResolveService_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/lookupservicesettings/resolveservice/SyncResolveService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/lookupservicesettings/resolveservice/SyncResolveService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_LookupServiceSettings_ResolveService_sync]
+import com.google.cloud.servicedirectory.v1beta1.LookupServiceSettings;
+import java.time.Duration;
+
+public class SyncResolveService {
+
+  public static void main(String[] args) throws Exception {
+    syncResolveService();
+  }
+
+  public static void syncResolveService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    LookupServiceSettings.Builder lookupServiceSettingsBuilder = LookupServiceSettings.newBuilder();
+    lookupServiceSettingsBuilder
+        .resolveServiceSettings()
+        .setRetrySettings(
+            lookupServiceSettingsBuilder.resolveServiceSettings().getRetrySettings().toBuilder()
+                .setTotalTimeout(Duration.ofSeconds(30))
+                .build());
+    LookupServiceSettings lookupServiceSettings = lookupServiceSettingsBuilder.build();
+  }
+}
+// [END servicedirectory_v1beta1_generated_LookupServiceSettings_ResolveService_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/create/SyncCreateSetCredentialsProvider.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/create/SyncCreateSetCredentialsProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_Create_SetCredentialsProvider_sync]
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceSettings;
+import com.google.cloud.servicedirectory.v1beta1.myCredentials;
+
+public class SyncCreateSetCredentialsProvider {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateSetCredentialsProvider();
+  }
+
+  public static void syncCreateSetCredentialsProvider() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    RegistrationServiceSettings registrationServiceSettings =
+        RegistrationServiceSettings.newBuilder()
+            .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
+            .build();
+    RegistrationServiceClient registrationServiceClient =
+        RegistrationServiceClient.create(registrationServiceSettings);
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_Create_SetCredentialsProvider_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/create/SyncCreateSetCredentialsProvider1.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/create/SyncCreateSetCredentialsProvider1.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_Create_SetCredentialsProvider1_sync]
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceSettings;
+
+public class SyncCreateSetCredentialsProvider1 {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateSetCredentialsProvider1();
+  }
+
+  public static void syncCreateSetCredentialsProvider1() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    RegistrationServiceSettings registrationServiceSettings =
+        RegistrationServiceSettings.newHttpJsonBuilder().build();
+    RegistrationServiceClient registrationServiceClient =
+        RegistrationServiceClient.create(registrationServiceSettings);
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_Create_SetCredentialsProvider1_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/create/SyncCreateSetEndpoint.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/create/SyncCreateSetEndpoint.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_Create_SetEndpoint_sync]
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceSettings;
+import com.google.cloud.servicedirectory.v1beta1.myEndpoint;
+
+public class SyncCreateSetEndpoint {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateSetEndpoint();
+  }
+
+  public static void syncCreateSetEndpoint() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    RegistrationServiceSettings registrationServiceSettings =
+        RegistrationServiceSettings.newBuilder().setEndpoint(myEndpoint).build();
+    RegistrationServiceClient registrationServiceClient =
+        RegistrationServiceClient.create(registrationServiceSettings);
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_Create_SetEndpoint_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createendpoint/AsyncCreateEndpoint.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createendpoint/AsyncCreateEndpoint.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_CreateEndpoint_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1beta1.CreateEndpointRequest;
+import com.google.cloud.servicedirectory.v1beta1.Endpoint;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+
+public class AsyncCreateEndpoint {
+
+  public static void main(String[] args) throws Exception {
+    asyncCreateEndpoint();
+  }
+
+  public static void asyncCreateEndpoint() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      CreateEndpointRequest request =
+          CreateEndpointRequest.newBuilder()
+              .setParent(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .setEndpointId("endpointId-1837754992")
+              .setEndpoint(Endpoint.newBuilder().build())
+              .build();
+      ApiFuture<Endpoint> future =
+          registrationServiceClient.createEndpointCallable().futureCall(request);
+      // Do something.
+      Endpoint response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_CreateEndpoint_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createendpoint/SyncCreateEndpoint.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createendpoint/SyncCreateEndpoint.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_CreateEndpoint_sync]
+import com.google.cloud.servicedirectory.v1beta1.CreateEndpointRequest;
+import com.google.cloud.servicedirectory.v1beta1.Endpoint;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+
+public class SyncCreateEndpoint {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateEndpoint();
+  }
+
+  public static void syncCreateEndpoint() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      CreateEndpointRequest request =
+          CreateEndpointRequest.newBuilder()
+              .setParent(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .setEndpointId("endpointId-1837754992")
+              .setEndpoint(Endpoint.newBuilder().build())
+              .build();
+      Endpoint response = registrationServiceClient.createEndpoint(request);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_CreateEndpoint_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createendpoint/SyncCreateEndpointServicenameEndpointString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createendpoint/SyncCreateEndpointServicenameEndpointString.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_CreateEndpoint_ServicenameEndpointString_sync]
+import com.google.cloud.servicedirectory.v1beta1.Endpoint;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+
+public class SyncCreateEndpointServicenameEndpointString {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateEndpointServicenameEndpointString();
+  }
+
+  public static void syncCreateEndpointServicenameEndpointString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ServiceName parent = ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]");
+      Endpoint endpoint = Endpoint.newBuilder().build();
+      String endpointId = "endpointId-1837754992";
+      Endpoint response = registrationServiceClient.createEndpoint(parent, endpoint, endpointId);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_CreateEndpoint_ServicenameEndpointString_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createendpoint/SyncCreateEndpointStringEndpointString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createendpoint/SyncCreateEndpointStringEndpointString.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_CreateEndpoint_StringEndpointString_sync]
+import com.google.cloud.servicedirectory.v1beta1.Endpoint;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+
+public class SyncCreateEndpointStringEndpointString {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateEndpointStringEndpointString();
+  }
+
+  public static void syncCreateEndpointStringEndpointString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String parent =
+          ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString();
+      Endpoint endpoint = Endpoint.newBuilder().build();
+      String endpointId = "endpointId-1837754992";
+      Endpoint response = registrationServiceClient.createEndpoint(parent, endpoint, endpointId);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_CreateEndpoint_StringEndpointString_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createnamespace/AsyncCreateNamespace.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createnamespace/AsyncCreateNamespace.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_CreateNamespace_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1beta1.CreateNamespaceRequest;
+import com.google.cloud.servicedirectory.v1beta1.LocationName;
+import com.google.cloud.servicedirectory.v1beta1.Namespace;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+
+public class AsyncCreateNamespace {
+
+  public static void main(String[] args) throws Exception {
+    asyncCreateNamespace();
+  }
+
+  public static void asyncCreateNamespace() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      CreateNamespaceRequest request =
+          CreateNamespaceRequest.newBuilder()
+              .setParent(LocationName.of("[PROJECT]", "[LOCATION]").toString())
+              .setNamespaceId("namespaceId790852566")
+              .setNamespace(Namespace.newBuilder().build())
+              .build();
+      ApiFuture<Namespace> future =
+          registrationServiceClient.createNamespaceCallable().futureCall(request);
+      // Do something.
+      Namespace response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_CreateNamespace_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createnamespace/SyncCreateNamespace.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createnamespace/SyncCreateNamespace.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_CreateNamespace_sync]
+import com.google.cloud.servicedirectory.v1beta1.CreateNamespaceRequest;
+import com.google.cloud.servicedirectory.v1beta1.LocationName;
+import com.google.cloud.servicedirectory.v1beta1.Namespace;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+
+public class SyncCreateNamespace {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateNamespace();
+  }
+
+  public static void syncCreateNamespace() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      CreateNamespaceRequest request =
+          CreateNamespaceRequest.newBuilder()
+              .setParent(LocationName.of("[PROJECT]", "[LOCATION]").toString())
+              .setNamespaceId("namespaceId790852566")
+              .setNamespace(Namespace.newBuilder().build())
+              .build();
+      Namespace response = registrationServiceClient.createNamespace(request);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_CreateNamespace_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createnamespace/SyncCreateNamespaceLocationnameNamespaceString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createnamespace/SyncCreateNamespaceLocationnameNamespaceString.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_CreateNamespace_LocationnameNamespaceString_sync]
+import com.google.cloud.servicedirectory.v1beta1.LocationName;
+import com.google.cloud.servicedirectory.v1beta1.Namespace;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+
+public class SyncCreateNamespaceLocationnameNamespaceString {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateNamespaceLocationnameNamespaceString();
+  }
+
+  public static void syncCreateNamespaceLocationnameNamespaceString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      LocationName parent = LocationName.of("[PROJECT]", "[LOCATION]");
+      Namespace namespace = Namespace.newBuilder().build();
+      String namespaceId = "namespaceId790852566";
+      Namespace response =
+          registrationServiceClient.createNamespace(parent, namespace, namespaceId);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_CreateNamespace_LocationnameNamespaceString_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createnamespace/SyncCreateNamespaceStringNamespaceString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createnamespace/SyncCreateNamespaceStringNamespaceString.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_CreateNamespace_StringNamespaceString_sync]
+import com.google.cloud.servicedirectory.v1beta1.LocationName;
+import com.google.cloud.servicedirectory.v1beta1.Namespace;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+
+public class SyncCreateNamespaceStringNamespaceString {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateNamespaceStringNamespaceString();
+  }
+
+  public static void syncCreateNamespaceStringNamespaceString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String parent = LocationName.of("[PROJECT]", "[LOCATION]").toString();
+      Namespace namespace = Namespace.newBuilder().build();
+      String namespaceId = "namespaceId790852566";
+      Namespace response =
+          registrationServiceClient.createNamespace(parent, namespace, namespaceId);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_CreateNamespace_StringNamespaceString_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createservice/AsyncCreateService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createservice/AsyncCreateService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_CreateService_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1beta1.CreateServiceRequest;
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.Service;
+
+public class AsyncCreateService {
+
+  public static void main(String[] args) throws Exception {
+    asyncCreateService();
+  }
+
+  public static void asyncCreateService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      CreateServiceRequest request =
+          CreateServiceRequest.newBuilder()
+              .setParent(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .setServiceId("serviceId-194185552")
+              .setService(Service.newBuilder().build())
+              .build();
+      ApiFuture<Service> future =
+          registrationServiceClient.createServiceCallable().futureCall(request);
+      // Do something.
+      Service response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_CreateService_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createservice/SyncCreateService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createservice/SyncCreateService.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_CreateService_sync]
+import com.google.cloud.servicedirectory.v1beta1.CreateServiceRequest;
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.Service;
+
+public class SyncCreateService {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateService();
+  }
+
+  public static void syncCreateService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      CreateServiceRequest request =
+          CreateServiceRequest.newBuilder()
+              .setParent(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .setServiceId("serviceId-194185552")
+              .setService(Service.newBuilder().build())
+              .build();
+      Service response = registrationServiceClient.createService(request);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_CreateService_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createservice/SyncCreateServiceNamespacenameServiceString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createservice/SyncCreateServiceNamespacenameServiceString.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_CreateService_NamespacenameServiceString_sync]
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.Service;
+
+public class SyncCreateServiceNamespacenameServiceString {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateServiceNamespacenameServiceString();
+  }
+
+  public static void syncCreateServiceNamespacenameServiceString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      NamespaceName parent = NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]");
+      Service service = Service.newBuilder().build();
+      String serviceId = "serviceId-194185552";
+      Service response = registrationServiceClient.createService(parent, service, serviceId);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_CreateService_NamespacenameServiceString_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createservice/SyncCreateServiceStringServiceString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/createservice/SyncCreateServiceStringServiceString.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_CreateService_StringServiceString_sync]
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.Service;
+
+public class SyncCreateServiceStringServiceString {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateServiceStringServiceString();
+  }
+
+  public static void syncCreateServiceStringServiceString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String parent = NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString();
+      Service service = Service.newBuilder().build();
+      String serviceId = "serviceId-194185552";
+      Service response = registrationServiceClient.createService(parent, service, serviceId);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_CreateService_StringServiceString_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deleteendpoint/AsyncDeleteEndpoint.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deleteendpoint/AsyncDeleteEndpoint.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_DeleteEndpoint_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1beta1.DeleteEndpointRequest;
+import com.google.cloud.servicedirectory.v1beta1.EndpointName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.protobuf.Empty;
+
+public class AsyncDeleteEndpoint {
+
+  public static void main(String[] args) throws Exception {
+    asyncDeleteEndpoint();
+  }
+
+  public static void asyncDeleteEndpoint() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      DeleteEndpointRequest request =
+          DeleteEndpointRequest.newBuilder()
+              .setName(
+                  EndpointName.of(
+                          "[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]", "[ENDPOINT]")
+                      .toString())
+              .build();
+      ApiFuture<Empty> future =
+          registrationServiceClient.deleteEndpointCallable().futureCall(request);
+      // Do something.
+      future.get();
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_DeleteEndpoint_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deleteendpoint/SyncDeleteEndpoint.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deleteendpoint/SyncDeleteEndpoint.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_DeleteEndpoint_sync]
+import com.google.cloud.servicedirectory.v1beta1.DeleteEndpointRequest;
+import com.google.cloud.servicedirectory.v1beta1.EndpointName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.protobuf.Empty;
+
+public class SyncDeleteEndpoint {
+
+  public static void main(String[] args) throws Exception {
+    syncDeleteEndpoint();
+  }
+
+  public static void syncDeleteEndpoint() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      DeleteEndpointRequest request =
+          DeleteEndpointRequest.newBuilder()
+              .setName(
+                  EndpointName.of(
+                          "[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]", "[ENDPOINT]")
+                      .toString())
+              .build();
+      registrationServiceClient.deleteEndpoint(request);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_DeleteEndpoint_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deleteendpoint/SyncDeleteEndpointEndpointname.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deleteendpoint/SyncDeleteEndpointEndpointname.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_DeleteEndpoint_Endpointname_sync]
+import com.google.cloud.servicedirectory.v1beta1.EndpointName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.protobuf.Empty;
+
+public class SyncDeleteEndpointEndpointname {
+
+  public static void main(String[] args) throws Exception {
+    syncDeleteEndpointEndpointname();
+  }
+
+  public static void syncDeleteEndpointEndpointname() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      EndpointName name =
+          EndpointName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]", "[ENDPOINT]");
+      registrationServiceClient.deleteEndpoint(name);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_DeleteEndpoint_Endpointname_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deleteendpoint/SyncDeleteEndpointString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deleteendpoint/SyncDeleteEndpointString.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_DeleteEndpoint_String_sync]
+import com.google.cloud.servicedirectory.v1beta1.EndpointName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.protobuf.Empty;
+
+public class SyncDeleteEndpointString {
+
+  public static void main(String[] args) throws Exception {
+    syncDeleteEndpointString();
+  }
+
+  public static void syncDeleteEndpointString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String name =
+          EndpointName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]", "[ENDPOINT]")
+              .toString();
+      registrationServiceClient.deleteEndpoint(name);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_DeleteEndpoint_String_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deletenamespace/AsyncDeleteNamespace.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deletenamespace/AsyncDeleteNamespace.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_DeleteNamespace_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1beta1.DeleteNamespaceRequest;
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.protobuf.Empty;
+
+public class AsyncDeleteNamespace {
+
+  public static void main(String[] args) throws Exception {
+    asyncDeleteNamespace();
+  }
+
+  public static void asyncDeleteNamespace() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      DeleteNamespaceRequest request =
+          DeleteNamespaceRequest.newBuilder()
+              .setName(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .build();
+      ApiFuture<Empty> future =
+          registrationServiceClient.deleteNamespaceCallable().futureCall(request);
+      // Do something.
+      future.get();
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_DeleteNamespace_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deletenamespace/SyncDeleteNamespace.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deletenamespace/SyncDeleteNamespace.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_DeleteNamespace_sync]
+import com.google.cloud.servicedirectory.v1beta1.DeleteNamespaceRequest;
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.protobuf.Empty;
+
+public class SyncDeleteNamespace {
+
+  public static void main(String[] args) throws Exception {
+    syncDeleteNamespace();
+  }
+
+  public static void syncDeleteNamespace() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      DeleteNamespaceRequest request =
+          DeleteNamespaceRequest.newBuilder()
+              .setName(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .build();
+      registrationServiceClient.deleteNamespace(request);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_DeleteNamespace_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deletenamespace/SyncDeleteNamespaceNamespacename.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deletenamespace/SyncDeleteNamespaceNamespacename.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_DeleteNamespace_Namespacename_sync]
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.protobuf.Empty;
+
+public class SyncDeleteNamespaceNamespacename {
+
+  public static void main(String[] args) throws Exception {
+    syncDeleteNamespaceNamespacename();
+  }
+
+  public static void syncDeleteNamespaceNamespacename() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      NamespaceName name = NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]");
+      registrationServiceClient.deleteNamespace(name);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_DeleteNamespace_Namespacename_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deletenamespace/SyncDeleteNamespaceString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deletenamespace/SyncDeleteNamespaceString.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_DeleteNamespace_String_sync]
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.protobuf.Empty;
+
+public class SyncDeleteNamespaceString {
+
+  public static void main(String[] args) throws Exception {
+    syncDeleteNamespaceString();
+  }
+
+  public static void syncDeleteNamespaceString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String name = NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString();
+      registrationServiceClient.deleteNamespace(name);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_DeleteNamespace_String_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deleteservice/AsyncDeleteService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deleteservice/AsyncDeleteService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_DeleteService_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1beta1.DeleteServiceRequest;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+import com.google.protobuf.Empty;
+
+public class AsyncDeleteService {
+
+  public static void main(String[] args) throws Exception {
+    asyncDeleteService();
+  }
+
+  public static void asyncDeleteService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      DeleteServiceRequest request =
+          DeleteServiceRequest.newBuilder()
+              .setName(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .build();
+      ApiFuture<Empty> future =
+          registrationServiceClient.deleteServiceCallable().futureCall(request);
+      // Do something.
+      future.get();
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_DeleteService_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deleteservice/SyncDeleteService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deleteservice/SyncDeleteService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_DeleteService_sync]
+import com.google.cloud.servicedirectory.v1beta1.DeleteServiceRequest;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+import com.google.protobuf.Empty;
+
+public class SyncDeleteService {
+
+  public static void main(String[] args) throws Exception {
+    syncDeleteService();
+  }
+
+  public static void syncDeleteService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      DeleteServiceRequest request =
+          DeleteServiceRequest.newBuilder()
+              .setName(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .build();
+      registrationServiceClient.deleteService(request);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_DeleteService_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deleteservice/SyncDeleteServiceServicename.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deleteservice/SyncDeleteServiceServicename.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_DeleteService_Servicename_sync]
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+import com.google.protobuf.Empty;
+
+public class SyncDeleteServiceServicename {
+
+  public static void main(String[] args) throws Exception {
+    syncDeleteServiceServicename();
+  }
+
+  public static void syncDeleteServiceServicename() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ServiceName name = ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]");
+      registrationServiceClient.deleteService(name);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_DeleteService_Servicename_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deleteservice/SyncDeleteServiceString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/deleteservice/SyncDeleteServiceString.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_DeleteService_String_sync]
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+import com.google.protobuf.Empty;
+
+public class SyncDeleteServiceString {
+
+  public static void main(String[] args) throws Exception {
+    syncDeleteServiceString();
+  }
+
+  public static void syncDeleteServiceString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String name =
+          ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString();
+      registrationServiceClient.deleteService(name);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_DeleteService_String_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getendpoint/AsyncGetEndpoint.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getendpoint/AsyncGetEndpoint.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_GetEndpoint_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1beta1.Endpoint;
+import com.google.cloud.servicedirectory.v1beta1.EndpointName;
+import com.google.cloud.servicedirectory.v1beta1.GetEndpointRequest;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+
+public class AsyncGetEndpoint {
+
+  public static void main(String[] args) throws Exception {
+    asyncGetEndpoint();
+  }
+
+  public static void asyncGetEndpoint() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      GetEndpointRequest request =
+          GetEndpointRequest.newBuilder()
+              .setName(
+                  EndpointName.of(
+                          "[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]", "[ENDPOINT]")
+                      .toString())
+              .build();
+      ApiFuture<Endpoint> future =
+          registrationServiceClient.getEndpointCallable().futureCall(request);
+      // Do something.
+      Endpoint response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_GetEndpoint_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getendpoint/SyncGetEndpoint.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getendpoint/SyncGetEndpoint.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_GetEndpoint_sync]
+import com.google.cloud.servicedirectory.v1beta1.Endpoint;
+import com.google.cloud.servicedirectory.v1beta1.EndpointName;
+import com.google.cloud.servicedirectory.v1beta1.GetEndpointRequest;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+
+public class SyncGetEndpoint {
+
+  public static void main(String[] args) throws Exception {
+    syncGetEndpoint();
+  }
+
+  public static void syncGetEndpoint() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      GetEndpointRequest request =
+          GetEndpointRequest.newBuilder()
+              .setName(
+                  EndpointName.of(
+                          "[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]", "[ENDPOINT]")
+                      .toString())
+              .build();
+      Endpoint response = registrationServiceClient.getEndpoint(request);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_GetEndpoint_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getendpoint/SyncGetEndpointEndpointname.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getendpoint/SyncGetEndpointEndpointname.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_GetEndpoint_Endpointname_sync]
+import com.google.cloud.servicedirectory.v1beta1.Endpoint;
+import com.google.cloud.servicedirectory.v1beta1.EndpointName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+
+public class SyncGetEndpointEndpointname {
+
+  public static void main(String[] args) throws Exception {
+    syncGetEndpointEndpointname();
+  }
+
+  public static void syncGetEndpointEndpointname() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      EndpointName name =
+          EndpointName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]", "[ENDPOINT]");
+      Endpoint response = registrationServiceClient.getEndpoint(name);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_GetEndpoint_Endpointname_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getendpoint/SyncGetEndpointString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getendpoint/SyncGetEndpointString.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_GetEndpoint_String_sync]
+import com.google.cloud.servicedirectory.v1beta1.Endpoint;
+import com.google.cloud.servicedirectory.v1beta1.EndpointName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+
+public class SyncGetEndpointString {
+
+  public static void main(String[] args) throws Exception {
+    syncGetEndpointString();
+  }
+
+  public static void syncGetEndpointString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String name =
+          EndpointName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]", "[ENDPOINT]")
+              .toString();
+      Endpoint response = registrationServiceClient.getEndpoint(name);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_GetEndpoint_String_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getiampolicy/AsyncGetIamPolicy.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getiampolicy/AsyncGetIamPolicy.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_GetIamPolicy_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.GetPolicyOptions;
+import com.google.iam.v1.Policy;
+
+public class AsyncGetIamPolicy {
+
+  public static void main(String[] args) throws Exception {
+    asyncGetIamPolicy();
+  }
+
+  public static void asyncGetIamPolicy() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      GetIamPolicyRequest request =
+          GetIamPolicyRequest.newBuilder()
+              .setResource(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .setOptions(GetPolicyOptions.newBuilder().build())
+              .build();
+      ApiFuture<Policy> future =
+          registrationServiceClient.getIamPolicyCallable().futureCall(request);
+      // Do something.
+      Policy response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_GetIamPolicy_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getiampolicy/SyncGetIamPolicy.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getiampolicy/SyncGetIamPolicy.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_GetIamPolicy_sync]
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.GetPolicyOptions;
+import com.google.iam.v1.Policy;
+
+public class SyncGetIamPolicy {
+
+  public static void main(String[] args) throws Exception {
+    syncGetIamPolicy();
+  }
+
+  public static void syncGetIamPolicy() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      GetIamPolicyRequest request =
+          GetIamPolicyRequest.newBuilder()
+              .setResource(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .setOptions(GetPolicyOptions.newBuilder().build())
+              .build();
+      Policy response = registrationServiceClient.getIamPolicy(request);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_GetIamPolicy_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getnamespace/AsyncGetNamespace.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getnamespace/AsyncGetNamespace.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_GetNamespace_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1beta1.GetNamespaceRequest;
+import com.google.cloud.servicedirectory.v1beta1.Namespace;
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+
+public class AsyncGetNamespace {
+
+  public static void main(String[] args) throws Exception {
+    asyncGetNamespace();
+  }
+
+  public static void asyncGetNamespace() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      GetNamespaceRequest request =
+          GetNamespaceRequest.newBuilder()
+              .setName(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .build();
+      ApiFuture<Namespace> future =
+          registrationServiceClient.getNamespaceCallable().futureCall(request);
+      // Do something.
+      Namespace response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_GetNamespace_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getnamespace/SyncGetNamespace.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getnamespace/SyncGetNamespace.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_GetNamespace_sync]
+import com.google.cloud.servicedirectory.v1beta1.GetNamespaceRequest;
+import com.google.cloud.servicedirectory.v1beta1.Namespace;
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+
+public class SyncGetNamespace {
+
+  public static void main(String[] args) throws Exception {
+    syncGetNamespace();
+  }
+
+  public static void syncGetNamespace() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      GetNamespaceRequest request =
+          GetNamespaceRequest.newBuilder()
+              .setName(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .build();
+      Namespace response = registrationServiceClient.getNamespace(request);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_GetNamespace_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getnamespace/SyncGetNamespaceNamespacename.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getnamespace/SyncGetNamespaceNamespacename.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_GetNamespace_Namespacename_sync]
+import com.google.cloud.servicedirectory.v1beta1.Namespace;
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+
+public class SyncGetNamespaceNamespacename {
+
+  public static void main(String[] args) throws Exception {
+    syncGetNamespaceNamespacename();
+  }
+
+  public static void syncGetNamespaceNamespacename() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      NamespaceName name = NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]");
+      Namespace response = registrationServiceClient.getNamespace(name);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_GetNamespace_Namespacename_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getnamespace/SyncGetNamespaceString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getnamespace/SyncGetNamespaceString.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_GetNamespace_String_sync]
+import com.google.cloud.servicedirectory.v1beta1.Namespace;
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+
+public class SyncGetNamespaceString {
+
+  public static void main(String[] args) throws Exception {
+    syncGetNamespaceString();
+  }
+
+  public static void syncGetNamespaceString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String name = NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString();
+      Namespace response = registrationServiceClient.getNamespace(name);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_GetNamespace_String_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getservice/AsyncGetService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getservice/AsyncGetService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_GetService_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1beta1.GetServiceRequest;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.Service;
+import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+
+public class AsyncGetService {
+
+  public static void main(String[] args) throws Exception {
+    asyncGetService();
+  }
+
+  public static void asyncGetService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      GetServiceRequest request =
+          GetServiceRequest.newBuilder()
+              .setName(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .build();
+      ApiFuture<Service> future =
+          registrationServiceClient.getServiceCallable().futureCall(request);
+      // Do something.
+      Service response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_GetService_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getservice/SyncGetService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getservice/SyncGetService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_GetService_sync]
+import com.google.cloud.servicedirectory.v1beta1.GetServiceRequest;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.Service;
+import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+
+public class SyncGetService {
+
+  public static void main(String[] args) throws Exception {
+    syncGetService();
+  }
+
+  public static void syncGetService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      GetServiceRequest request =
+          GetServiceRequest.newBuilder()
+              .setName(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .build();
+      Service response = registrationServiceClient.getService(request);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_GetService_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getservice/SyncGetServiceServicename.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getservice/SyncGetServiceServicename.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_GetService_Servicename_sync]
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.Service;
+import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+
+public class SyncGetServiceServicename {
+
+  public static void main(String[] args) throws Exception {
+    syncGetServiceServicename();
+  }
+
+  public static void syncGetServiceServicename() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ServiceName name = ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]");
+      Service response = registrationServiceClient.getService(name);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_GetService_Servicename_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getservice/SyncGetServiceString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/getservice/SyncGetServiceString.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_GetService_String_sync]
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.Service;
+import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+
+public class SyncGetServiceString {
+
+  public static void main(String[] args) throws Exception {
+    syncGetServiceString();
+  }
+
+  public static void syncGetServiceString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String name =
+          ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString();
+      Service response = registrationServiceClient.getService(name);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_GetService_String_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listendpoints/AsyncListEndpoints.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listendpoints/AsyncListEndpoints.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_ListEndpoints_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1beta1.Endpoint;
+import com.google.cloud.servicedirectory.v1beta1.ListEndpointsRequest;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+
+public class AsyncListEndpoints {
+
+  public static void main(String[] args) throws Exception {
+    asyncListEndpoints();
+  }
+
+  public static void asyncListEndpoints() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ListEndpointsRequest request =
+          ListEndpointsRequest.newBuilder()
+              .setParent(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .setFilter("filter-1274492040")
+              .setOrderBy("orderBy-1207110587")
+              .build();
+      ApiFuture<Endpoint> future =
+          registrationServiceClient.listEndpointsPagedCallable().futureCall(request);
+      // Do something.
+      for (Endpoint element : future.get().iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_ListEndpoints_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listendpoints/AsyncListEndpointsPaged.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listendpoints/AsyncListEndpointsPaged.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_ListEndpoints_Paged_async]
+import com.google.cloud.servicedirectory.v1beta1.Endpoint;
+import com.google.cloud.servicedirectory.v1beta1.ListEndpointsRequest;
+import com.google.cloud.servicedirectory.v1beta1.ListEndpointsResponse;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+import com.google.common.base.Strings;
+
+public class AsyncListEndpointsPaged {
+
+  public static void main(String[] args) throws Exception {
+    asyncListEndpointsPaged();
+  }
+
+  public static void asyncListEndpointsPaged() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ListEndpointsRequest request =
+          ListEndpointsRequest.newBuilder()
+              .setParent(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .setFilter("filter-1274492040")
+              .setOrderBy("orderBy-1207110587")
+              .build();
+      while (true) {
+        ListEndpointsResponse response =
+            registrationServiceClient.listEndpointsCallable().call(request);
+        for (Endpoint element : response.getEndpointsList()) {
+          // doThingsWith(element);
+        }
+        String nextPageToken = response.getNextPageToken();
+        if (!Strings.isNullOrEmpty(nextPageToken)) {
+          request = request.toBuilder().setPageToken(nextPageToken).build();
+        } else {
+          break;
+        }
+      }
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_ListEndpoints_Paged_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listendpoints/SyncListEndpoints.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listendpoints/SyncListEndpoints.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_ListEndpoints_sync]
+import com.google.cloud.servicedirectory.v1beta1.Endpoint;
+import com.google.cloud.servicedirectory.v1beta1.ListEndpointsRequest;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+
+public class SyncListEndpoints {
+
+  public static void main(String[] args) throws Exception {
+    syncListEndpoints();
+  }
+
+  public static void syncListEndpoints() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ListEndpointsRequest request =
+          ListEndpointsRequest.newBuilder()
+              .setParent(
+                  ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString())
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .setFilter("filter-1274492040")
+              .setOrderBy("orderBy-1207110587")
+              .build();
+      for (Endpoint element : registrationServiceClient.listEndpoints(request).iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_ListEndpoints_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listendpoints/SyncListEndpointsServicename.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listendpoints/SyncListEndpointsServicename.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_ListEndpoints_Servicename_sync]
+import com.google.cloud.servicedirectory.v1beta1.Endpoint;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+
+public class SyncListEndpointsServicename {
+
+  public static void main(String[] args) throws Exception {
+    syncListEndpointsServicename();
+  }
+
+  public static void syncListEndpointsServicename() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ServiceName parent = ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]");
+      for (Endpoint element : registrationServiceClient.listEndpoints(parent).iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_ListEndpoints_Servicename_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listendpoints/SyncListEndpointsString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listendpoints/SyncListEndpointsString.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_ListEndpoints_String_sync]
+import com.google.cloud.servicedirectory.v1beta1.Endpoint;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+
+public class SyncListEndpointsString {
+
+  public static void main(String[] args) throws Exception {
+    syncListEndpointsString();
+  }
+
+  public static void syncListEndpointsString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String parent =
+          ServiceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]", "[SERVICE]").toString();
+      for (Endpoint element : registrationServiceClient.listEndpoints(parent).iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_ListEndpoints_String_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listnamespaces/AsyncListNamespaces.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listnamespaces/AsyncListNamespaces.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_ListNamespaces_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1beta1.ListNamespacesRequest;
+import com.google.cloud.servicedirectory.v1beta1.LocationName;
+import com.google.cloud.servicedirectory.v1beta1.Namespace;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+
+public class AsyncListNamespaces {
+
+  public static void main(String[] args) throws Exception {
+    asyncListNamespaces();
+  }
+
+  public static void asyncListNamespaces() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ListNamespacesRequest request =
+          ListNamespacesRequest.newBuilder()
+              .setParent(LocationName.of("[PROJECT]", "[LOCATION]").toString())
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .setFilter("filter-1274492040")
+              .setOrderBy("orderBy-1207110587")
+              .build();
+      ApiFuture<Namespace> future =
+          registrationServiceClient.listNamespacesPagedCallable().futureCall(request);
+      // Do something.
+      for (Namespace element : future.get().iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_ListNamespaces_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listnamespaces/AsyncListNamespacesPaged.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listnamespaces/AsyncListNamespacesPaged.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_ListNamespaces_Paged_async]
+import com.google.cloud.servicedirectory.v1beta1.ListNamespacesRequest;
+import com.google.cloud.servicedirectory.v1beta1.ListNamespacesResponse;
+import com.google.cloud.servicedirectory.v1beta1.LocationName;
+import com.google.cloud.servicedirectory.v1beta1.Namespace;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.common.base.Strings;
+
+public class AsyncListNamespacesPaged {
+
+  public static void main(String[] args) throws Exception {
+    asyncListNamespacesPaged();
+  }
+
+  public static void asyncListNamespacesPaged() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ListNamespacesRequest request =
+          ListNamespacesRequest.newBuilder()
+              .setParent(LocationName.of("[PROJECT]", "[LOCATION]").toString())
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .setFilter("filter-1274492040")
+              .setOrderBy("orderBy-1207110587")
+              .build();
+      while (true) {
+        ListNamespacesResponse response =
+            registrationServiceClient.listNamespacesCallable().call(request);
+        for (Namespace element : response.getNamespacesList()) {
+          // doThingsWith(element);
+        }
+        String nextPageToken = response.getNextPageToken();
+        if (!Strings.isNullOrEmpty(nextPageToken)) {
+          request = request.toBuilder().setPageToken(nextPageToken).build();
+        } else {
+          break;
+        }
+      }
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_ListNamespaces_Paged_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listnamespaces/SyncListNamespaces.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listnamespaces/SyncListNamespaces.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_ListNamespaces_sync]
+import com.google.cloud.servicedirectory.v1beta1.ListNamespacesRequest;
+import com.google.cloud.servicedirectory.v1beta1.LocationName;
+import com.google.cloud.servicedirectory.v1beta1.Namespace;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+
+public class SyncListNamespaces {
+
+  public static void main(String[] args) throws Exception {
+    syncListNamespaces();
+  }
+
+  public static void syncListNamespaces() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ListNamespacesRequest request =
+          ListNamespacesRequest.newBuilder()
+              .setParent(LocationName.of("[PROJECT]", "[LOCATION]").toString())
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .setFilter("filter-1274492040")
+              .setOrderBy("orderBy-1207110587")
+              .build();
+      for (Namespace element : registrationServiceClient.listNamespaces(request).iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_ListNamespaces_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listnamespaces/SyncListNamespacesLocationname.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listnamespaces/SyncListNamespacesLocationname.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_ListNamespaces_Locationname_sync]
+import com.google.cloud.servicedirectory.v1beta1.LocationName;
+import com.google.cloud.servicedirectory.v1beta1.Namespace;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+
+public class SyncListNamespacesLocationname {
+
+  public static void main(String[] args) throws Exception {
+    syncListNamespacesLocationname();
+  }
+
+  public static void syncListNamespacesLocationname() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      LocationName parent = LocationName.of("[PROJECT]", "[LOCATION]");
+      for (Namespace element : registrationServiceClient.listNamespaces(parent).iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_ListNamespaces_Locationname_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listnamespaces/SyncListNamespacesString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listnamespaces/SyncListNamespacesString.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_ListNamespaces_String_sync]
+import com.google.cloud.servicedirectory.v1beta1.LocationName;
+import com.google.cloud.servicedirectory.v1beta1.Namespace;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+
+public class SyncListNamespacesString {
+
+  public static void main(String[] args) throws Exception {
+    syncListNamespacesString();
+  }
+
+  public static void syncListNamespacesString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String parent = LocationName.of("[PROJECT]", "[LOCATION]").toString();
+      for (Namespace element : registrationServiceClient.listNamespaces(parent).iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_ListNamespaces_String_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listservices/AsyncListServices.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listservices/AsyncListServices.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_ListServices_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1beta1.ListServicesRequest;
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.Service;
+
+public class AsyncListServices {
+
+  public static void main(String[] args) throws Exception {
+    asyncListServices();
+  }
+
+  public static void asyncListServices() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ListServicesRequest request =
+          ListServicesRequest.newBuilder()
+              .setParent(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .setFilter("filter-1274492040")
+              .setOrderBy("orderBy-1207110587")
+              .build();
+      ApiFuture<Service> future =
+          registrationServiceClient.listServicesPagedCallable().futureCall(request);
+      // Do something.
+      for (Service element : future.get().iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_ListServices_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listservices/AsyncListServicesPaged.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listservices/AsyncListServicesPaged.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_ListServices_Paged_async]
+import com.google.cloud.servicedirectory.v1beta1.ListServicesRequest;
+import com.google.cloud.servicedirectory.v1beta1.ListServicesResponse;
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.Service;
+import com.google.common.base.Strings;
+
+public class AsyncListServicesPaged {
+
+  public static void main(String[] args) throws Exception {
+    asyncListServicesPaged();
+  }
+
+  public static void asyncListServicesPaged() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ListServicesRequest request =
+          ListServicesRequest.newBuilder()
+              .setParent(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .setFilter("filter-1274492040")
+              .setOrderBy("orderBy-1207110587")
+              .build();
+      while (true) {
+        ListServicesResponse response =
+            registrationServiceClient.listServicesCallable().call(request);
+        for (Service element : response.getServicesList()) {
+          // doThingsWith(element);
+        }
+        String nextPageToken = response.getNextPageToken();
+        if (!Strings.isNullOrEmpty(nextPageToken)) {
+          request = request.toBuilder().setPageToken(nextPageToken).build();
+        } else {
+          break;
+        }
+      }
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_ListServices_Paged_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listservices/SyncListServices.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listservices/SyncListServices.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_ListServices_sync]
+import com.google.cloud.servicedirectory.v1beta1.ListServicesRequest;
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.Service;
+
+public class SyncListServices {
+
+  public static void main(String[] args) throws Exception {
+    syncListServices();
+  }
+
+  public static void syncListServices() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      ListServicesRequest request =
+          ListServicesRequest.newBuilder()
+              .setParent(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .setPageSize(883849137)
+              .setPageToken("pageToken873572522")
+              .setFilter("filter-1274492040")
+              .setOrderBy("orderBy-1207110587")
+              .build();
+      for (Service element : registrationServiceClient.listServices(request).iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_ListServices_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listservices/SyncListServicesNamespacename.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listservices/SyncListServicesNamespacename.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_ListServices_Namespacename_sync]
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.Service;
+
+public class SyncListServicesNamespacename {
+
+  public static void main(String[] args) throws Exception {
+    syncListServicesNamespacename();
+  }
+
+  public static void syncListServicesNamespacename() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      NamespaceName parent = NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]");
+      for (Service element : registrationServiceClient.listServices(parent).iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_ListServices_Namespacename_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listservices/SyncListServicesString.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/listservices/SyncListServicesString.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_ListServices_String_sync]
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.Service;
+
+public class SyncListServicesString {
+
+  public static void main(String[] args) throws Exception {
+    syncListServicesString();
+  }
+
+  public static void syncListServicesString() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      String parent = NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString();
+      for (Service element : registrationServiceClient.listServices(parent).iterateAll()) {
+        // doThingsWith(element);
+      }
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_ListServices_String_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/setiampolicy/AsyncSetIamPolicy.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/setiampolicy/AsyncSetIamPolicy.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_SetIamPolicy_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.SetIamPolicyRequest;
+import com.google.protobuf.FieldMask;
+
+public class AsyncSetIamPolicy {
+
+  public static void main(String[] args) throws Exception {
+    asyncSetIamPolicy();
+  }
+
+  public static void asyncSetIamPolicy() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      SetIamPolicyRequest request =
+          SetIamPolicyRequest.newBuilder()
+              .setResource(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .setPolicy(Policy.newBuilder().build())
+              .setUpdateMask(FieldMask.newBuilder().build())
+              .build();
+      ApiFuture<Policy> future =
+          registrationServiceClient.setIamPolicyCallable().futureCall(request);
+      // Do something.
+      Policy response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_SetIamPolicy_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/setiampolicy/SyncSetIamPolicy.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/setiampolicy/SyncSetIamPolicy.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_SetIamPolicy_sync]
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.SetIamPolicyRequest;
+import com.google.protobuf.FieldMask;
+
+public class SyncSetIamPolicy {
+
+  public static void main(String[] args) throws Exception {
+    syncSetIamPolicy();
+  }
+
+  public static void syncSetIamPolicy() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      SetIamPolicyRequest request =
+          SetIamPolicyRequest.newBuilder()
+              .setResource(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .setPolicy(Policy.newBuilder().build())
+              .setUpdateMask(FieldMask.newBuilder().build())
+              .build();
+      Policy response = registrationServiceClient.setIamPolicy(request);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_SetIamPolicy_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/testiampermissions/AsyncTestIamPermissions.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/testiampermissions/AsyncTestIamPermissions.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_TestIamPermissions_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.iam.v1.TestIamPermissionsResponse;
+import java.util.ArrayList;
+
+public class AsyncTestIamPermissions {
+
+  public static void main(String[] args) throws Exception {
+    asyncTestIamPermissions();
+  }
+
+  public static void asyncTestIamPermissions() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      TestIamPermissionsRequest request =
+          TestIamPermissionsRequest.newBuilder()
+              .setResource(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .addAllPermissions(new ArrayList<String>())
+              .build();
+      ApiFuture<TestIamPermissionsResponse> future =
+          registrationServiceClient.testIamPermissionsCallable().futureCall(request);
+      // Do something.
+      TestIamPermissionsResponse response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_TestIamPermissions_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/testiampermissions/SyncTestIamPermissions.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/testiampermissions/SyncTestIamPermissions.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_TestIamPermissions_sync]
+import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.iam.v1.TestIamPermissionsResponse;
+import java.util.ArrayList;
+
+public class SyncTestIamPermissions {
+
+  public static void main(String[] args) throws Exception {
+    syncTestIamPermissions();
+  }
+
+  public static void syncTestIamPermissions() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      TestIamPermissionsRequest request =
+          TestIamPermissionsRequest.newBuilder()
+              .setResource(NamespaceName.of("[PROJECT]", "[LOCATION]", "[NAMESPACE]").toString())
+              .addAllPermissions(new ArrayList<String>())
+              .build();
+      TestIamPermissionsResponse response = registrationServiceClient.testIamPermissions(request);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_TestIamPermissions_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/updateendpoint/AsyncUpdateEndpoint.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/updateendpoint/AsyncUpdateEndpoint.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_UpdateEndpoint_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1beta1.Endpoint;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.UpdateEndpointRequest;
+import com.google.protobuf.FieldMask;
+
+public class AsyncUpdateEndpoint {
+
+  public static void main(String[] args) throws Exception {
+    asyncUpdateEndpoint();
+  }
+
+  public static void asyncUpdateEndpoint() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      UpdateEndpointRequest request =
+          UpdateEndpointRequest.newBuilder()
+              .setEndpoint(Endpoint.newBuilder().build())
+              .setUpdateMask(FieldMask.newBuilder().build())
+              .build();
+      ApiFuture<Endpoint> future =
+          registrationServiceClient.updateEndpointCallable().futureCall(request);
+      // Do something.
+      Endpoint response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_UpdateEndpoint_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/updateendpoint/SyncUpdateEndpoint.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/updateendpoint/SyncUpdateEndpoint.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_UpdateEndpoint_sync]
+import com.google.cloud.servicedirectory.v1beta1.Endpoint;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.UpdateEndpointRequest;
+import com.google.protobuf.FieldMask;
+
+public class SyncUpdateEndpoint {
+
+  public static void main(String[] args) throws Exception {
+    syncUpdateEndpoint();
+  }
+
+  public static void syncUpdateEndpoint() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      UpdateEndpointRequest request =
+          UpdateEndpointRequest.newBuilder()
+              .setEndpoint(Endpoint.newBuilder().build())
+              .setUpdateMask(FieldMask.newBuilder().build())
+              .build();
+      Endpoint response = registrationServiceClient.updateEndpoint(request);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_UpdateEndpoint_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/updateendpoint/SyncUpdateEndpointEndpointFieldmask.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/updateendpoint/SyncUpdateEndpointEndpointFieldmask.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_UpdateEndpoint_EndpointFieldmask_sync]
+import com.google.cloud.servicedirectory.v1beta1.Endpoint;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.protobuf.FieldMask;
+
+public class SyncUpdateEndpointEndpointFieldmask {
+
+  public static void main(String[] args) throws Exception {
+    syncUpdateEndpointEndpointFieldmask();
+  }
+
+  public static void syncUpdateEndpointEndpointFieldmask() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      Endpoint endpoint = Endpoint.newBuilder().build();
+      FieldMask updateMask = FieldMask.newBuilder().build();
+      Endpoint response = registrationServiceClient.updateEndpoint(endpoint, updateMask);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_UpdateEndpoint_EndpointFieldmask_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/updatenamespace/AsyncUpdateNamespace.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/updatenamespace/AsyncUpdateNamespace.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_UpdateNamespace_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1beta1.Namespace;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.UpdateNamespaceRequest;
+import com.google.protobuf.FieldMask;
+
+public class AsyncUpdateNamespace {
+
+  public static void main(String[] args) throws Exception {
+    asyncUpdateNamespace();
+  }
+
+  public static void asyncUpdateNamespace() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      UpdateNamespaceRequest request =
+          UpdateNamespaceRequest.newBuilder()
+              .setNamespace(Namespace.newBuilder().build())
+              .setUpdateMask(FieldMask.newBuilder().build())
+              .build();
+      ApiFuture<Namespace> future =
+          registrationServiceClient.updateNamespaceCallable().futureCall(request);
+      // Do something.
+      Namespace response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_UpdateNamespace_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/updatenamespace/SyncUpdateNamespace.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/updatenamespace/SyncUpdateNamespace.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_UpdateNamespace_sync]
+import com.google.cloud.servicedirectory.v1beta1.Namespace;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.UpdateNamespaceRequest;
+import com.google.protobuf.FieldMask;
+
+public class SyncUpdateNamespace {
+
+  public static void main(String[] args) throws Exception {
+    syncUpdateNamespace();
+  }
+
+  public static void syncUpdateNamespace() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      UpdateNamespaceRequest request =
+          UpdateNamespaceRequest.newBuilder()
+              .setNamespace(Namespace.newBuilder().build())
+              .setUpdateMask(FieldMask.newBuilder().build())
+              .build();
+      Namespace response = registrationServiceClient.updateNamespace(request);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_UpdateNamespace_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/updatenamespace/SyncUpdateNamespaceNamespaceFieldmask.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/updatenamespace/SyncUpdateNamespaceNamespaceFieldmask.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_UpdateNamespace_NamespaceFieldmask_sync]
+import com.google.cloud.servicedirectory.v1beta1.Namespace;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.protobuf.FieldMask;
+
+public class SyncUpdateNamespaceNamespaceFieldmask {
+
+  public static void main(String[] args) throws Exception {
+    syncUpdateNamespaceNamespaceFieldmask();
+  }
+
+  public static void syncUpdateNamespaceNamespaceFieldmask() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      Namespace namespace = Namespace.newBuilder().build();
+      FieldMask updateMask = FieldMask.newBuilder().build();
+      Namespace response = registrationServiceClient.updateNamespace(namespace, updateMask);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_UpdateNamespace_NamespaceFieldmask_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/updateservice/AsyncUpdateService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/updateservice/AsyncUpdateService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_UpdateService_async]
+import com.google.api.core.ApiFuture;
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.Service;
+import com.google.cloud.servicedirectory.v1beta1.UpdateServiceRequest;
+import com.google.protobuf.FieldMask;
+
+public class AsyncUpdateService {
+
+  public static void main(String[] args) throws Exception {
+    asyncUpdateService();
+  }
+
+  public static void asyncUpdateService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      UpdateServiceRequest request =
+          UpdateServiceRequest.newBuilder()
+              .setService(Service.newBuilder().build())
+              .setUpdateMask(FieldMask.newBuilder().build())
+              .build();
+      ApiFuture<Service> future =
+          registrationServiceClient.updateServiceCallable().futureCall(request);
+      // Do something.
+      Service response = future.get();
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_UpdateService_async]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/updateservice/SyncUpdateService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/updateservice/SyncUpdateService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_UpdateService_sync]
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.Service;
+import com.google.cloud.servicedirectory.v1beta1.UpdateServiceRequest;
+import com.google.protobuf.FieldMask;
+
+public class SyncUpdateService {
+
+  public static void main(String[] args) throws Exception {
+    syncUpdateService();
+  }
+
+  public static void syncUpdateService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      UpdateServiceRequest request =
+          UpdateServiceRequest.newBuilder()
+              .setService(Service.newBuilder().build())
+              .setUpdateMask(FieldMask.newBuilder().build())
+              .build();
+      Service response = registrationServiceClient.updateService(request);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_UpdateService_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/updateservice/SyncUpdateServiceServiceFieldmask.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservice/updateservice/SyncUpdateServiceServiceFieldmask.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationService_UpdateService_ServiceFieldmask_sync]
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1beta1.Service;
+import com.google.protobuf.FieldMask;
+
+public class SyncUpdateServiceServiceFieldmask {
+
+  public static void main(String[] args) throws Exception {
+    syncUpdateServiceServiceFieldmask();
+  }
+
+  public static void syncUpdateServiceServiceFieldmask() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    try (RegistrationServiceClient registrationServiceClient = RegistrationServiceClient.create()) {
+      Service service = Service.newBuilder().build();
+      FieldMask updateMask = FieldMask.newBuilder().build();
+      Service response = registrationServiceClient.updateService(service, updateMask);
+    }
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationService_UpdateService_ServiceFieldmask_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservicesettings/createnamespace/SyncCreateNamespace.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/registrationservicesettings/createnamespace/SyncCreateNamespace.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationServiceSettings_CreateNamespace_sync]
+import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceSettings;
+import java.time.Duration;
+
+public class SyncCreateNamespace {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateNamespace();
+  }
+
+  public static void syncCreateNamespace() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    RegistrationServiceSettings.Builder registrationServiceSettingsBuilder =
+        RegistrationServiceSettings.newBuilder();
+    registrationServiceSettingsBuilder
+        .createNamespaceSettings()
+        .setRetrySettings(
+            registrationServiceSettingsBuilder
+                .createNamespaceSettings()
+                .getRetrySettings()
+                .toBuilder()
+                .setTotalTimeout(Duration.ofSeconds(30))
+                .build());
+    RegistrationServiceSettings registrationServiceSettings =
+        registrationServiceSettingsBuilder.build();
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationServiceSettings_CreateNamespace_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/stub/lookupservicestubsettings/resolveservice/SyncResolveService.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/stub/lookupservicestubsettings/resolveservice/SyncResolveService.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.stub.samples;
+
+// [START servicedirectory_v1beta1_generated_LookupServiceStubSettings_ResolveService_sync]
+import com.google.cloud.servicedirectory.v1beta1.stub.LookupServiceStubSettings;
+import java.time.Duration;
+
+public class SyncResolveService {
+
+  public static void main(String[] args) throws Exception {
+    syncResolveService();
+  }
+
+  public static void syncResolveService() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    LookupServiceStubSettings.Builder lookupServiceSettingsBuilder =
+        LookupServiceStubSettings.newBuilder();
+    lookupServiceSettingsBuilder
+        .resolveServiceSettings()
+        .setRetrySettings(
+            lookupServiceSettingsBuilder.resolveServiceSettings().getRetrySettings().toBuilder()
+                .setTotalTimeout(Duration.ofSeconds(30))
+                .build());
+    LookupServiceStubSettings lookupServiceSettings = lookupServiceSettingsBuilder.build();
+  }
+}
+// [END servicedirectory_v1beta1_generated_LookupServiceStubSettings_ResolveService_sync]

--- a/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/stub/registrationservicestubsettings/createnamespace/SyncCreateNamespace.java
+++ b/servicedirectory/snippets/snippets/generated/com/google/cloud/servicedirectory/v1beta1/stub/registrationservicestubsettings/createnamespace/SyncCreateNamespace.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.servicedirectory.v1beta1.stub.samples;
+
+// [START servicedirectory_v1beta1_generated_RegistrationServiceStubSettings_CreateNamespace_sync]
+import com.google.cloud.servicedirectory.v1beta1.stub.RegistrationServiceStubSettings;
+import java.time.Duration;
+
+public class SyncCreateNamespace {
+
+  public static void main(String[] args) throws Exception {
+    syncCreateNamespace();
+  }
+
+  public static void syncCreateNamespace() throws Exception {
+    // This snippet has been automatically generated and should be regarded as a code template only.
+    // It will require modifications to work:
+    // - It may require correct/in-range values for request initialization.
+    // - It may require specifying regional endpoints when creating the service client as shown in
+    // https://cloud.google.com/java/docs/setup#configure_endpoints_for_the_client_library
+    RegistrationServiceStubSettings.Builder registrationServiceSettingsBuilder =
+        RegistrationServiceStubSettings.newBuilder();
+    registrationServiceSettingsBuilder
+        .createNamespaceSettings()
+        .setRetrySettings(
+            registrationServiceSettingsBuilder
+                .createNamespaceSettings()
+                .getRetrySettings()
+                .toBuilder()
+                .setTotalTimeout(Duration.ofSeconds(30))
+                .build());
+    RegistrationServiceStubSettings registrationServiceSettings =
+        registrationServiceSettingsBuilder.build();
+  }
+}
+// [END servicedirectory_v1beta1_generated_RegistrationServiceStubSettings_CreateNamespace_sync]

--- a/servicedirectory/snippets/snippets/pom.xml
+++ b/servicedirectory/snippets/snippets/pom.xml
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+ Copyright 2020 Google Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>servicedirectory-snippets</artifactId>
+  <packaging>jar</packaging>
+  <name>Google Service Directory Snippets</name>
+  <url>https://github.com/googleapis/java-servicedirectory</url>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.2.0</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+
+  <!-- [START servicedirectory_install_with_bom] -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.1.4</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-servicedirectory</artifactId>
+    </dependency>
+    <!-- [END servicedirectory_install_with_bom] -->
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.1.3</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/servicedirectory/snippets/snippets/src/main/java/com/example/servicedirectory/EndpointsCreate.java
+++ b/servicedirectory/snippets/snippets/src/main/java/com/example/servicedirectory/EndpointsCreate.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.servicedirectory;
+
+// [START servicedirectory_create_endpoint]
+
+import com.google.cloud.servicedirectory.v1.Endpoint;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+import java.io.IOException;
+
+public class EndpointsCreate {
+
+  public static void createEndpoint() throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    // These variables should refer to an existing Service Directory service.
+    String projectId = "your-project-id";
+    String locationId = "your-region";
+    String namespaceId = "your-namespace";
+    String serviceId = "your-service";
+    // This is user-created; must be unique within the service above.
+    String endpointId = "your-endpoint";
+    createEndpoint(projectId, locationId, namespaceId, serviceId, endpointId);
+  }
+
+  // Create a new endpoint.
+  public static void createEndpoint(
+      String projectId, String locationId, String namespaceId, String serviceId, String endpointId)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (RegistrationServiceClient client = RegistrationServiceClient.create()) {
+
+      // The service to create the endpoint in.
+      ServiceName parent = ServiceName.of(projectId, locationId, namespaceId, serviceId);
+
+      // The endpoint to create, with fields filled in.
+      // Optionally set an IP address and port for the endpoint.
+      Endpoint endpoint = Endpoint.newBuilder().setAddress("10.0.0.1").setPort(443).build();
+
+      // Send the request to create the endpoint.
+      Endpoint createdEndpoint = client.createEndpoint(parent, endpoint, endpointId);
+
+      // Process the response.
+      System.out.println("Created Endpoint: " + createdEndpoint.getName());
+      System.out.println("IP Address: " + createdEndpoint.getAddress());
+      System.out.println("Port: " + createdEndpoint.getPort());
+    }
+  }
+}
+// [END servicedirectory_create_endpoint]

--- a/servicedirectory/snippets/snippets/src/main/java/com/example/servicedirectory/EndpointsDelete.java
+++ b/servicedirectory/snippets/snippets/src/main/java/com/example/servicedirectory/EndpointsDelete.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.servicedirectory;
+
+// [START servicedirectory_delete_endpoint]
+
+import com.google.cloud.servicedirectory.v1.EndpointName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import java.io.IOException;
+
+public class EndpointsDelete {
+
+  public static void deleteEndpoint() throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    // These variables should refer to an existing Service Directory endpoint.
+    String projectId = "your-project-id";
+    String locationId = "your-region";
+    String namespaceId = "your-namespace";
+    String serviceId = "your-service";
+    String endpointId = "your-endpoint";
+    deleteEndpoint(projectId, locationId, namespaceId, serviceId, endpointId);
+  }
+
+  // Delete an endpoint.
+  public static void deleteEndpoint(
+      String projectId, String locationId, String namespaceId, String serviceId, String endpointId)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (RegistrationServiceClient client = RegistrationServiceClient.create()) {
+
+      // The endpoint to delete.
+      EndpointName endpointName =
+          EndpointName.of(projectId, locationId, namespaceId, serviceId, endpointId);
+
+      // Send the request to delete the endpoint.
+      client.deleteEndpoint(endpointName);
+
+      // Log the action.
+      System.out.println("Deleted Endpoint: " + endpointName.toString());
+    }
+  }
+}
+// [END servicedirectory_delete_endpoint]

--- a/servicedirectory/snippets/snippets/src/main/java/com/example/servicedirectory/NamespacesCreate.java
+++ b/servicedirectory/snippets/snippets/src/main/java/com/example/servicedirectory/NamespacesCreate.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.servicedirectory;
+
+// [START servicedirectory_create_namespace]
+
+import com.google.cloud.servicedirectory.v1.LocationName;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import java.io.IOException;
+
+public class NamespacesCreate {
+
+  public static void createNamespace() throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String locationId = "your-region";
+    // This is user-created; must be unique within the project/region above.
+    String namespaceId = "your-namespace";
+    createNamespace(projectId, locationId, namespaceId);
+  }
+
+  // Create a new namespace.
+  public static void createNamespace(String projectId, String locationId, String namespaceId)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (RegistrationServiceClient client = RegistrationServiceClient.create()) {
+
+      // The project and location to create the namespace in.
+      LocationName parent = LocationName.of(projectId, locationId);
+
+      // The namespace object to create. Here, we use the default instance.
+      Namespace namespace = Namespace.newBuilder().build();
+
+      // Send the request to create the namespace.
+      Namespace createdNamespace = client.createNamespace(parent, namespace, namespaceId);
+
+      // Process the response.
+      System.out.println("Created Namespace: " + createdNamespace.getName());
+    }
+  }
+}
+// [END servicedirectory_create_namespace]

--- a/servicedirectory/snippets/snippets/src/main/java/com/example/servicedirectory/NamespacesDelete.java
+++ b/servicedirectory/snippets/snippets/src/main/java/com/example/servicedirectory/NamespacesDelete.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.servicedirectory;
+
+// [START servicedirectory_delete_namespace]
+
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import java.io.IOException;
+
+public class NamespacesDelete {
+
+  public static void deleteNamespace() throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    // These variables should refer to an existing Service Directory namespace.
+    String projectId = "your-project-id";
+    String locationId = "your-region";
+    String namespaceId = "your-namespace";
+    deleteNamespace(projectId, locationId, namespaceId);
+  }
+
+  // Delete a namespace.
+  public static void deleteNamespace(String projectId, String locationId, String namespaceId)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (RegistrationServiceClient client = RegistrationServiceClient.create()) {
+
+      // The namespace to delete.
+      NamespaceName namespaceName = NamespaceName.of(projectId, locationId, namespaceId);
+
+      // Send the request to delete the namespace.
+      client.deleteNamespace(namespaceName);
+
+      // Log the action.
+      System.out.println("Deleted Namespace: " + namespaceName.toString());
+    }
+  }
+}
+// [END servicedirectory_delete_namespace]

--- a/servicedirectory/snippets/snippets/src/main/java/com/example/servicedirectory/Quickstart.java
+++ b/servicedirectory/snippets/snippets/src/main/java/com/example/servicedirectory/Quickstart.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.servicedirectory;
+
+// [START servicedirectory_quickstart]
+
+import com.google.cloud.servicedirectory.v1.LocationName;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient.ListNamespacesPagedResponse;
+import java.io.IOException;
+
+public class Quickstart {
+
+  public static void quickstart() throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String locationId = "your-region";
+    quickstart(projectId, locationId);
+  }
+
+  public static void quickstart(String projectId, String locationId) throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (RegistrationServiceClient client = RegistrationServiceClient.create()) {
+
+      // The project and location that hold the namespace to list.
+      LocationName parent = LocationName.of(projectId, locationId);
+
+      // Call the API.
+      ListNamespacesPagedResponse response = client.listNamespaces(parent);
+
+      // Iterate over each namespace and print its name.
+      System.out.println("Namespaces:");
+      for (Namespace namespace : response.iterateAll()) {
+        System.out.println(namespace.getName());
+      }
+    }
+  }
+}
+// [END servicedirectory_quickstart]

--- a/servicedirectory/snippets/snippets/src/main/java/com/example/servicedirectory/ServicesCreate.java
+++ b/servicedirectory/snippets/snippets/src/main/java/com/example/servicedirectory/ServicesCreate.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.servicedirectory;
+
+// [START servicedirectory_create_service]
+
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.Service;
+import java.io.IOException;
+
+public class ServicesCreate {
+
+  public static void createService() throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    // These variables should refer to an existing Service Directory namespace.
+    String projectId = "your-project-id";
+    String locationId = "your-region";
+    String namespaceId = "your-namespace";
+    // This is user-created; must be unique within the namespace above.
+    String serviceId = "your-service";
+    createService(projectId, locationId, namespaceId, serviceId);
+  }
+
+  // Create a new service.
+  public static void createService(
+      String projectId, String locationId, String namespaceId, String serviceId)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (RegistrationServiceClient client = RegistrationServiceClient.create()) {
+
+      // The namespace to create the service in.
+      NamespaceName parent = NamespaceName.of(projectId, locationId, namespaceId);
+
+      // The service object to create.
+      // Optionally add some annotations for the service.
+      Service service = Service.newBuilder().putAnnotations("protocol", "tcp").build();
+
+      // Send the request to create the namespace.
+      Service createdService = client.createService(parent, service, serviceId);
+
+      // Process the response.
+      System.out.println("Created Service: " + createdService.getName());
+      System.out.println("Annotations: " + createdService.getAnnotations());
+    }
+  }
+}
+// [END servicedirectory_create_service]

--- a/servicedirectory/snippets/snippets/src/main/java/com/example/servicedirectory/ServicesDelete.java
+++ b/servicedirectory/snippets/snippets/src/main/java/com/example/servicedirectory/ServicesDelete.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.servicedirectory;
+
+// [START servicedirectory_delete_service]
+
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+import java.io.IOException;
+
+public class ServicesDelete {
+
+  public static void deleteService() throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    // These variables should refer to an existing Service Directory service.
+    String projectId = "your-project-id";
+    String locationId = "your-region";
+    String namespaceId = "your-namespace";
+    String serviceId = "your-service";
+    deleteService(projectId, locationId, namespaceId, serviceId);
+  }
+
+  // Delete a service.
+  public static void deleteService(
+      String projectId, String locationId, String namespaceId, String serviceId)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (RegistrationServiceClient client = RegistrationServiceClient.create()) {
+
+      // The service to delete.
+      ServiceName serviceName = ServiceName.of(projectId, locationId, namespaceId, serviceId);
+
+      // Send the request to delete the service.
+      client.deleteService(serviceName);
+
+      // Log the action.
+      System.out.println("Deleted Service: " + serviceName.toString());
+    }
+  }
+}
+// [END servicedirectory_delete_service]

--- a/servicedirectory/snippets/snippets/src/main/java/com/example/servicedirectory/ServicesResolve.java
+++ b/servicedirectory/snippets/snippets/src/main/java/com/example/servicedirectory/ServicesResolve.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.servicedirectory;
+
+// [START servicedirectory_resolve_service]
+
+import com.google.cloud.servicedirectory.v1.Endpoint;
+import com.google.cloud.servicedirectory.v1.LookupServiceClient;
+import com.google.cloud.servicedirectory.v1.ResolveServiceRequest;
+import com.google.cloud.servicedirectory.v1.ResolveServiceResponse;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+import java.io.IOException;
+
+public class ServicesResolve {
+
+  public static void resolveService() throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    // These variables should refer to an existing Service Directory service.
+    String projectId = "your-project-id";
+    String locationId = "your-region";
+    String namespaceId = "your-namespace";
+    String serviceId = "your-service";
+    resolveService(projectId, locationId, namespaceId, serviceId);
+  }
+
+  // Resolve a service.
+  public static void resolveService(
+      String projectId, String locationId, String namespaceId, String serviceId)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (LookupServiceClient client = LookupServiceClient.create()) {
+      // The service to resolve.
+      ServiceName name = ServiceName.of(projectId, locationId, namespaceId, serviceId);
+
+      // Construct the resolve request to be sent to the client.
+      ResolveServiceRequest request =
+          ResolveServiceRequest.newBuilder().setName(name.toString()).build();
+
+      // Send the request to resolve the service.
+      ResolveServiceResponse resolveResponse = client.resolveService(request);
+
+      // Process the response.
+      System.out.println("Resolved Service: " + resolveResponse.getService().getName());
+
+      System.out.println("Endpoints found:");
+      for (Endpoint endpoint : resolveResponse.getService().getEndpointsList()) {
+        System.out.println(
+            endpoint.getName() + " -- " + endpoint.getAddress() + ":" + endpoint.getPort());
+      }
+    }
+  }
+}
+// [END servicedirectory_resolve_service]

--- a/servicedirectory/snippets/snippets/src/test/java/com/example/servicedirectory/EndpointsTests.java
+++ b/servicedirectory/snippets/snippets/src/test/java/com/example/servicedirectory/EndpointsTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.servicedirectory;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import com.google.cloud.servicedirectory.v1.EndpointName;
+import com.google.cloud.servicedirectory.v1.LocationName;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient.ListNamespacesPagedResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.UUID;
+import org.hamcrest.CoreMatchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class EndpointsTests {
+
+  private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static final String LOCATION_ID = "us-central1";
+  private static final String NAMESPACE_ID = "namespace-" + UUID.randomUUID().toString();
+  private static final String SERVICE_ID = "service-" + UUID.randomUUID().toString();
+  private static final String ENDPOINT_ID = "endpoint-" + UUID.randomUUID().toString();
+
+  private ByteArrayOutputStream bout;
+
+  private static void requireEnvVar(String varName) {
+    assertNotNull(
+        String.format("Environment variable '%s' must be set to perform these tests.", varName),
+        System.getenv(varName));
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    bout = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(bout));
+
+    // Setup: create a namespace for the endpoints to live in.
+    NamespacesCreate.createNamespace(PROJECT_ID, LOCATION_ID, NAMESPACE_ID);
+
+    // Setup: create a service for the endpoints to live in.
+    ServicesCreate.createService(PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    System.setOut(null);
+    bout.reset();
+
+    // Deletes all resources created during these tests.
+    try (RegistrationServiceClient client = RegistrationServiceClient.create()) {
+      // List the namespaces.
+      String locationPath = LocationName.format(PROJECT_ID, LOCATION_ID);
+      ListNamespacesPagedResponse response = client.listNamespaces(locationPath);
+
+      // Delete each namespace.
+      for (Namespace namespace : response.iterateAll()) {
+        client.deleteNamespace(namespace.getName());
+      }
+    }
+  }
+
+  @Test
+  public void testCreateEndpoint() throws Exception {
+    EndpointsCreate.createEndpoint(PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID, ENDPOINT_ID);
+    String endpointName =
+        EndpointName.format(PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID, ENDPOINT_ID);
+    String output = bout.toString();
+    assertThat(
+        output, CoreMatchers.containsString(String.format("Created Endpoint: %s", endpointName)));
+  }
+
+  @Test
+  public void testDeleteService() throws Exception {
+    // Setup: create an endpoint.
+    EndpointsCreate.createEndpoint(PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID, ENDPOINT_ID);
+    String endpointName =
+        EndpointName.format(PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID, ENDPOINT_ID);
+
+    // Delete the endpoint with the specified ID.
+    EndpointsDelete.deleteEndpoint(PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID, ENDPOINT_ID);
+    String output = bout.toString();
+    assertThat(
+        output, CoreMatchers.containsString(String.format("Deleted Endpoint: %s", endpointName)));
+  }
+}

--- a/servicedirectory/snippets/snippets/src/test/java/com/example/servicedirectory/NamespacesTests.java
+++ b/servicedirectory/snippets/snippets/src/test/java/com/example/servicedirectory/NamespacesTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.servicedirectory;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import com.google.cloud.servicedirectory.v1.LocationName;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient.ListNamespacesPagedResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.UUID;
+import org.hamcrest.CoreMatchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class NamespacesTests {
+
+  private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static final String LOCATION_ID = "us-central1";
+  private static final String NAMESPACE_ID = "namespace-" + UUID.randomUUID().toString();
+
+  private ByteArrayOutputStream bout;
+
+  private static void requireEnvVar(String varName) {
+    assertNotNull(
+        String.format("Environment variable '%s' must be set to perform these tests.", varName),
+        System.getenv(varName));
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(bout));
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    System.setOut(null);
+    bout.reset();
+
+    // Deletes any namespaces created during these tests.
+    try (RegistrationServiceClient client = RegistrationServiceClient.create()) {
+      // List the namespaces.
+      String locationPath = LocationName.format(PROJECT_ID, LOCATION_ID);
+      ListNamespacesPagedResponse response = client.listNamespaces(locationPath);
+
+      // Delete each namespace.
+      for (Namespace ns : response.iterateAll()) {
+        client.deleteNamespace(ns.getName());
+      }
+    }
+  }
+
+  @Test
+  public void testCreateNamespace() throws Exception {
+    NamespacesCreate.createNamespace(PROJECT_ID, LOCATION_ID, NAMESPACE_ID);
+    String namespaceName = NamespaceName.format(PROJECT_ID, LOCATION_ID, NAMESPACE_ID);
+    String output = bout.toString();
+    assertThat(
+        output, CoreMatchers.containsString(String.format("Created Namespace: %s", namespaceName)));
+  }
+
+  @Test
+  public void testDeleteNamespace() throws Exception {
+    // Setup: create a namespace.
+    NamespacesCreate.createNamespace(PROJECT_ID, LOCATION_ID, NAMESPACE_ID);
+    String namespaceName = NamespaceName.format(PROJECT_ID, LOCATION_ID, NAMESPACE_ID);
+
+    // Delete the namespace with the specified ID.
+    NamespacesDelete.deleteNamespace(PROJECT_ID, LOCATION_ID, NAMESPACE_ID);
+    String output = bout.toString();
+    assertThat(
+        output, CoreMatchers.containsString(String.format("Deleted Namespace: %s", namespaceName)));
+  }
+}

--- a/servicedirectory/snippets/snippets/src/test/java/com/example/servicedirectory/ServicesTests.java
+++ b/servicedirectory/snippets/snippets/src/test/java/com/example/servicedirectory/ServicesTests.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.servicedirectory;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import com.google.cloud.servicedirectory.v1.EndpointName;
+import com.google.cloud.servicedirectory.v1.LocationName;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient.ListNamespacesPagedResponse;
+import com.google.cloud.servicedirectory.v1.ServiceName;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.UUID;
+import org.hamcrest.CoreMatchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ServicesTests {
+
+  private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static final String LOCATION_ID = "us-central1";
+  private static final String NAMESPACE_ID = "namespace-" + UUID.randomUUID().toString();
+  private static final String SERVICE_ID = "service-" + UUID.randomUUID().toString();
+
+  private ByteArrayOutputStream bout;
+
+  private static void requireEnvVar(String varName) {
+    assertNotNull(
+        String.format("Environment variable '%s' must be set to perform these tests.", varName),
+        System.getenv(varName));
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    bout = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(bout));
+
+    // Setup: create a namespace for the services to live in.
+    NamespacesCreate.createNamespace(PROJECT_ID, LOCATION_ID, NAMESPACE_ID);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    System.setOut(null);
+    bout.reset();
+
+    // Deletes all resources created during these tests.
+    try (RegistrationServiceClient client = RegistrationServiceClient.create()) {
+      // List the namespaces.
+      String locationPath = LocationName.format(PROJECT_ID, LOCATION_ID);
+      ListNamespacesPagedResponse response = client.listNamespaces(locationPath);
+
+      // Delete each namespace.
+      for (Namespace namespace : response.iterateAll()) {
+        client.deleteNamespace(namespace.getName());
+      }
+    }
+  }
+
+  @Test
+  public void testCreateService() throws Exception {
+    ServicesCreate.createService(PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID);
+    String serviceName = ServiceName.format(PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID);
+    String output = bout.toString();
+    assertThat(
+        output, CoreMatchers.containsString(String.format("Created Service: %s", serviceName)));
+  }
+
+  @Test
+  public void testResolveService() throws Exception {
+    // Setup: create a service.
+    ServicesCreate.createService(PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID);
+    String serviceName = ServiceName.format(PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID);
+    // Setup: Create an endpoint in the service.
+    EndpointsCreate.createEndpoint(
+        PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID, "default-endpoint");
+    String endpointName =
+        EndpointName.format(PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID, "default-endpoint");
+
+    // Resolve the service with the specified ID.
+    ServicesResolve.resolveService(PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID);
+    String output = bout.toString();
+    assertThat(
+        output, CoreMatchers.containsString(String.format("Resolved Service: %s", serviceName)));
+    assertThat(
+        output, CoreMatchers.containsString(String.format("Endpoints found:\n%s", endpointName)));
+  }
+
+  @Test
+  public void testDeleteService() throws Exception {
+    // Setup: create a service.
+    ServicesCreate.createService(PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID);
+    String serviceName = ServiceName.format(PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID);
+
+    // Delete the service with the specified ID.
+    ServicesDelete.deleteService(PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID);
+    String output = bout.toString();
+    assertThat(
+        output, CoreMatchers.containsString(String.format("Deleted Service: %s", serviceName)));
+  }
+}


### PR DESCRIPTION
### Migrating samples from[ googleapis/java-servicedirectory](https://github.com/googleapis/java-servicedirectory/tree/main/samples) into [java-docs-samples/servicedirectory](https://github.com/GoogleCloudPlatform/java-docs-samples)
---

- chore: updated grpc code output, add samples scaffold (#12)
- chore(deps): update dependency com.google.cloud:libraries-bom to v4.3.0 (#15)
- chore(deps): update dependency com.google.cloud.samples:shared-configuration to v1.0.13 (#19)
- chore(deps): update dependency com.google.cloud.samples:shared-configuration to v1.0.14 (#24)
- chore(deps): update dependency com.google.cloud:libraries-bom to v4.4.0 (#25)
- chore(deps): update dependency com.google.cloud.samples:shared-configuration to v1.0.15 (#29)
- chore(deps): update dependency com.google.cloud:libraries-bom to v4.4.1 (#30)
- chore(deps): update dependency com.google.cloud:libraries-bom to v5 (#40)
- chore(deps): update dependency com.google.cloud:libraries-bom to v5.1.0 (#41)
- samples: add code snippets for Service Directory. (#28)
- chore(deps): update dependency com.google.cloud.samples:shared-configuration to v1.0.16 (#46)
- chore(deps): update dependency com.google.cloud.samples:shared-configuration to v1.0.17 (#48)
- chore(deps): update dependency com.google.cloud:libraries-bom to v5.2.0 (#51)
- chore(deps): update dependency com.google.cloud:libraries-bom to v5.3.0 (#56)
- chore(deps): update dependency com.google.cloud:libraries-bom to v5.4.0 (#64)
- chore(deps): update dependency com.google.cloud:libraries-bom to v5.5.0 (#71)
- chore(deps): update dependency com.google.cloud.samples:shared-configuration to v1.0.18 (#84)
- chore(deps): update dependency com.google.cloud:libraries-bom to v5.7.0 (#83)
- chore(deps): update dependency com.google.cloud:libraries-bom to v6 (#91)
- chore(deps): update dependency com.google.cloud:libraries-bom to v7 (#93)
- chore(deps): update dependency com.google.cloud:libraries-bom to v7.0.1 (#99)
- chore(deps): update dependency com.google.cloud:libraries-bom to v8 (#104)
- samples: add quickstart (#82)
- chore(deps): update dependency com.google.cloud:libraries-bom to v8.1.0 (#115)
- chore(deps): update dependency com.google.cloud:libraries-bom to v9 (#126)
- chore(deps): update dependency com.google.cloud:libraries-bom to v9.1.0
- chore(deps): update dependency com.google.cloud:libraries-bom to v10 (#136)
- chore(deps): update dependency com.google.cloud:libraries-bom to v11 (#159)
- chore(deps): update dependency com.google.cloud:libraries-bom to v12 (#165)
- chore(deps): update dependency com.google.cloud.samples:shared-configuration to v1.0.21 (#160)
- test(deps): update dependency junit:junit to v4.13.1
- chore(deps): update dependency com.google.cloud:libraries-bom to v12.1.0 (#176)
- chore(deps): update dependency com.google.cloud:libraries-bom to v13 (#188)
- chore(deps): update dependency com.google.cloud:libraries-bom to v13.1.0 (#194)
- test(deps): update dependency com.google.truth:truth to v1.1 (#189)
- chore(deps): update dependency com.google.cloud:libraries-bom to v13.2.0 (#201)
- chore(deps): update dependency com.google.cloud:libraries-bom to v13.3.0 (#203)
- chore(deps): update dependency com.google.cloud:libraries-bom to v13.4.0 (#208)
- chore(deps): update dependency com.google.cloud:libraries-bom to v14 (#214)
- chore(deps): update dependency com.google.cloud:libraries-bom to v15 (#217)
- chore(deps): update dependency com.google.cloud:libraries-bom to v15.1.0 (#224)
- chore(deps): update dependency com.google.cloud:libraries-bom to v16 (#235)
- chore(deps): update dependency com.google.cloud:libraries-bom to v16.2.0 (#262)
- chore(deps): update dependency com.google.cloud:libraries-bom to v16.2.1 (#269)
- test(deps): update dependency com.google.truth:truth to v1.1.2 (#281)
- chore(deps): update dependency com.google.cloud:libraries-bom to v16.3.0 (#279)
- chore(deps): update dependency com.google.cloud:libraries-bom to v16.4.0 (#293)
- feat: update java samples to v1 (#274)
- test(deps): update dependency junit:junit to v4.13.2 (#298)
- chore(deps): update dependency com.google.cloud:libraries-bom to v17 (#311)
- chore(deps): update dependency com.google.cloud:libraries-bom to v18 (#314)
- chore(deps): update dependency com.google.cloud:libraries-bom to v18.1.0 (#325)
- chore(deps): update dependency com.google.cloud:libraries-bom to v19 (#328)
- chore(deps): update dependency com.google.cloud:libraries-bom to v19.2.1 (#339)
- chore(deps): update dependency com.google.cloud.samples:shared-configuration to v1.0.22 (#345)
- chore(deps): update dependency com.google.cloud:libraries-bom to v20 (#354)
- chore(deps): update dependency com.google.cloud:libraries-bom to v20.1.0 (#361)
- chore(deps): update dependency com.google.cloud:libraries-bom to v20.2.0 (#377)
- chore(deps): update dependency com.google.cloud:libraries-bom to v20.3.0 (#388)
- chore(deps): update dependency com.google.cloud:libraries-bom to v20.4.0 (#398)
- test(deps): update dependency com.google.truth:truth to v1.1.3 (#412)
- chore(deps): update dependency com.google.cloud:libraries-bom to v20.5.0 (#411)
- chore(deps): update dependency com.google.cloud:libraries-bom to v20.6.0 (#424)
- chore(deps): update dependency com.google.cloud.samples:shared-configuration to v1.0.23 (#423)
- chore(deps): update dependency com.google.cloud:libraries-bom to v20.7.0 (#436)
- chore(deps): update dependency com.google.cloud:libraries-bom to v20.8.0 (#447)
- chore(deps): update dependency com.google.cloud:libraries-bom to v20.9.0 (#456)
- chore(deps): update dependency com.google.cloud:libraries-bom to v21 (#498)
- chore(deps): update dependency com.google.cloud:libraries-bom to v22 (#510)
- chore(deps): update dependency com.google.cloud:libraries-bom to v23 (#520)
- chore(deps): update dependency com.google.cloud:libraries-bom to v23.1.0 (#544)
- chore(deps): update dependency com.google.cloud:libraries-bom to v24 (#560)
- chore(deps): update dependency com.google.cloud.samples:shared-configuration to v1.2.0 (#573)
- chore(deps): update dependency com.google.cloud:libraries-bom to v24.1.0 (#589)
- chore(deps): update dependency com.google.cloud:libraries-bom to v24.1.1 (#590)
- chore(deps): update dependency com.google.cloud:libraries-bom to v24.1.2 (#594)
- chore(deps): update dependency com.google.cloud:libraries-bom to v24.2.0 (#604)
- chore(deps): update dependency com.google.cloud:libraries-bom to v24.3.0 (#621)
- build(deps): update dependency org.sonatype.plugins:nexus-staging-maven-plugin to v1.6.9 (#626)
- build(deps): update dependency org.sonatype.plugins:nexus-staging-maven-plugin to v1.6.10 (#627)
- build(deps): update dependency org.sonatype.plugins:nexus-staging-maven-plugin to v1.6.11 (#629)
- chore(deps): update dependency com.google.cloud:libraries-bom to v25 (#647)
- chore(deps): update dependency com.google.cloud:libraries-bom to v25.1.0 (#654)
- build(deps): update dependency org.sonatype.plugins:nexus-staging-maven-plugin to v1.6.13 (#663)
- chore(deps): update dependency com.google.cloud:libraries-bom to v25.2.0 (#665)
- chore(deps): update dependency com.google.cloud:libraries-bom to v25.3.0 (#670)
- chore(deps): update dependency com.google.cloud:libraries-bom to v25.4.0 (#676)
- feat: Enable REST transport for most of Java and Go clients (#681)
- chore(deps): update dependency com.google.cloud:libraries-bom to v26 (#691)
- build(deps): update dependency org.apache.maven.plugins:maven-deploy-plugin to v3 (#695)
- chore(deps): update dependency com.google.cloud:libraries-bom to v26.1.0 (#700)
- chore: remove unused proto imports (#703)
- chore(deps): update dependency com.google.cloud:libraries-bom to v26.1.1 (#704)
- chore(bazel): Update WORKSPACE files for rules_gapic, gax_java, generator_java versions (#705)
- chore(deps): update dependency com.google.cloud:libraries-bom to v26.1.2 (#715)
- chore(deps): update dependency com.google.cloud:libraries-bom to v26.1.3 (#748)
- chore(deps): update dependency com.google.cloud:libraries-bom to v26.1.4 (#762)
- chore: Set `rest_numeric_enums = False` for all gapic rules explicitly (#764)

Fixes #issue

> It's a good idea to open an issue first for discussion.

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] Please **merge** this PR for me once it is approved.
