### PR TITLE
migrate code from googleapis/java-notification

### DIFF
--- a/notification/pom.xml
+++ b/notification/pom.xml
@@ -1,0 +1,56 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>google-cloud-notification-samples</artifactId>
+  <version>0.0.1-SNAPSHOT</version><!-- This artifact should not be released -->
+  <packaging>pom</packaging>
+  <name>Google Google Cloud Pub/Sub Notifications for GCS Samples Parent</name>
+  <url>https://github.com/googleapis/java-notification</url>
+  <description>
+    Java idiomatic client for Google Cloud Platform services.
+  </description>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.2.0</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <modules>
+    <module>install-without-bom</module>
+    <module>snapshot</module>
+    <module>snippets</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.13</version>
+        <configuration>
+          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project> 

--- a/notification/snippets/pom.xml
+++ b/notification/snippets/pom.xml
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>notification-snippets</artifactId>
+  <packaging>jar</packaging>
+  <name>Google Google Cloud Pub/Sub Notifications for GCS Snippets</name>
+  <url>https://github.com/googleapis/java-notification</url>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.2.0</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.1.4</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-notification</artifactId>
+      <!-- TODO: REMOVE VERSION SPECIFIED BELOW WHEN THE CLIENT GOES GA-->
+      <version>0.123.21-beta</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.1.3</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
- chore: regenerate README (#53)
- deps: update dependency com.google.cloud.samples:shared-configuration to v1.0.13 (#55)
- chore(deps): update dependency com.google.cloud.samples:shared-configuration to v1.0.14 (#58)
- chore(deps): update dependency com.google.cloud.samples:shared-configuration to v1.0.15 (#60)
- chore(deps): update dependency com.google.cloud.samples:shared-configuration to v1.0.16 (#66)
- chore(deps): update dependency com.google.cloud.samples:shared-configuration to v1.0.17 (#68)
- chore(deps): update dependency com.google.cloud.samples:shared-configuration to v1.0.18 (#84)
- feat(deps): adopt flatten plugin and google-cloud-shared-dependencies (#89)
- chore(deps): update dependency com.google.cloud:libraries-bom to v8 (#94)
- chore(deps): update dependency com.google.cloud:libraries-bom to v8.1.0 (#106)
- chore(deps): update dependency com.google.cloud:libraries-bom to v9
- chore(deps): update dependency com.google.cloud:libraries-bom to v9.1.0
- chore(deps): update dependency com.google.cloud:libraries-bom to v10
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.121.0-beta (#110)
- chore(deps): update dependency com.google.cloud:libraries-bom to v11
- chore(deps): update dependency com.google.cloud.samples:shared-configuration to v1.0.21 (#140)
- chore(deps): update dependency com.google.cloud:libraries-bom to v12 (#147)
- test(deps): update dependency junit:junit to v4.13.1
- chore(deps): update dependency com.google.cloud:libraries-bom to v12.1.0 (#155)
- chore(deps): update dependency com.google.cloud:libraries-bom to v13 (#163)
- chore(deps): update dependency com.google.cloud:libraries-bom to v13.1.0 (#166)
- test(deps): update dependency com.google.truth:truth to v1.1 (#164)
- chore(deps): update dependency com.google.cloud:libraries-bom to v13.2.0 (#168)
- chore(deps): update dependency com.google.cloud:libraries-bom to v13.3.0 (#170)
- chore(deps): update dependency com.google.cloud:libraries-bom to v13.4.0 (#174)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.121.1-beta (#176)
- chore(deps): update dependency com.google.cloud:libraries-bom to v15 (#181)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.121.2-beta (#191)
- chore(deps): update dependency com.google.cloud:libraries-bom to v16 (#196)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.121.3-beta (#204)
- chore(deps): update dependency com.google.cloud:libraries-bom to v16.2.0 (#215)
- chore(deps): update dependency com.google.cloud:libraries-bom to v16.2.1 (#222)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.121.5-beta (#217)
- chore(deps): update dependency com.google.cloud:libraries-bom to v16.3.0 (#226)
- test(deps): update dependency com.google.truth:truth to v1.1.2 (#227)
- test(deps): update dependency junit:junit to v4.13.2 (#242)
- chore(deps): update dependency com.google.cloud:libraries-bom to v17 (#251)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.121.6-beta (#250)
- chore(deps): update dependency com.google.cloud:libraries-bom to v18 (#253)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.121.7-beta (#259)
- chore(deps): update dependency com.google.cloud:libraries-bom to v18.1.0 (#263)
- chore(deps): update dependency com.google.cloud:libraries-bom to v19 (#264)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.121.8-beta (#270)
- chore(deps): update dependency com.google.cloud:libraries-bom to v19.2.1 (#272)
- chore(deps): update dependency com.google.cloud.samples:shared-configuration to v1.0.22 (#277)
- chore(deps): update dependency com.google.cloud:libraries-bom to v20 (#286)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.121.9-beta (#285)
- chore(deps): update dependency com.google.cloud:libraries-bom to v20.1.0 (#293)
- chore(deps): update dependency com.google.cloud:libraries-bom to v20.2.0 (#301)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.121.10-beta (#299)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.121.11-beta (#310)
- chore(deps): update dependency com.google.cloud:libraries-bom to v20.4.0 (#306)
- chore(deps): update dependency com.google.cloud:libraries-bom to v20.5.0 (#322)
- test(deps): update dependency com.google.truth:truth to v1.1.3 (#323)
- chore(deps): update dependency com.google.cloud:libraries-bom to v20.6.0 (#329)
- chore(deps): update dependency com.google.cloud.samples:shared-configuration to v1.0.23 (#328)
- chore(deps): update dependency com.google.cloud:libraries-bom to v20.7.0 (#345)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.2-beta (#326)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.4-beta (#349)
- chore(deps): update dependency com.google.cloud:libraries-bom to v20.8.0 (#355)
- chore(deps): update dependency com.google.cloud:libraries-bom to v20.9.0 (#359)
- chore(deps): update dependency com.google.cloud:libraries-bom to v21 (#376)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.5-beta (#374)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.6-beta (#383)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.7-beta (#388)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.8-beta (#393)
- chore(deps): update dependency com.google.cloud:libraries-bom to v22 (#399)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.9-beta (#404)
- chore(deps): update dependency com.google.cloud:libraries-bom to v23 (#409)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.10-beta (#419)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.11-beta (#428)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.12-beta (#435)
- chore(deps): update dependency com.google.cloud:libraries-bom to v23.1.0 (#444)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.13-beta (#455)
- chore(deps): update dependency com.google.cloud:libraries-bom to v24 (#460)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.14-beta (#475)
- chore(deps): update dependency com.google.cloud.samples:shared-configuration to v1.2.0 (#472)
- chore(deps): update dependency com.google.cloud:libraries-bom to v24.1.0 (#481)
- chore(deps): update dependency com.google.cloud:libraries-bom to v24.1.1 (#483)
- chore(deps): update dependency com.google.cloud:libraries-bom to v24.1.2 (#487)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.16-beta (#494)
- chore(deps): update dependency com.google.cloud:libraries-bom to v24.2.0 (#501)
- chore(deps): update dependency com.google.cloud:libraries-bom to v24.3.0 (#518)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.18-beta (#513)
- build(deps): update dependency org.sonatype.plugins:nexus-staging-maven-plugin to v1.6.9 (#526)
- build(deps): update dependency org.sonatype.plugins:nexus-staging-maven-plugin to v1.6.10 (#530)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.19-beta (#528)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.20-beta (#534)
- build(deps): update dependency org.sonatype.plugins:nexus-staging-maven-plugin to v1.6.11 (#533)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.21-beta (#538)
- chore(deps): update dependency com.google.cloud:libraries-bom to v24.4.0 (#549)
- chore(deps): update dependency com.google.cloud:libraries-bom to v25 (#558)
- build(deps): update dependency org.sonatype.plugins:nexus-staging-maven-plugin to v1.6.12 (#559)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.23-beta (#545)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.24-beta (#564)
- chore(deps): update dependency com.google.cloud:libraries-bom to v25.1.0 (#567)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.25-beta (#572)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.26-beta (#576)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.27-beta (#580)
- build(deps): update dependency org.sonatype.plugins:nexus-staging-maven-plugin to v1.6.13 (#584)
- chore(deps): update dependency com.google.cloud:libraries-bom to v25.2.0 (#585)
- chore(deps): update dependency com.google.cloud:libraries-bom to v25.3.0 (#592)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.28-beta (#590)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.122.29-beta (#595)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.123.0-beta (#601)
- chore(deps): update dependency com.google.cloud:libraries-bom to v25.4.0 (#608)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.123.1-beta (#607)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.123.2-beta (#619)
- chore(deps): update dependency com.google.cloud:libraries-bom to v26 (#622)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.123.4-beta (#627)
- build(deps): update dependency org.apache.maven.plugins:maven-deploy-plugin to v3 (#634)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.123.7-beta (#646)
- chore(deps): update dependency com.google.cloud:libraries-bom to v26.1.0 (#649)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.123.8-beta (#655)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.123.9-beta (#659)
- chore(deps): update dependency com.google.cloud:libraries-bom to v26.1.1 (#660)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.123.10-beta (#664)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.123.11-beta (#669)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.123.12-beta (#675)
- chore(deps): update dependency com.google.cloud:libraries-bom to v26.1.2 (#676)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.123.13-beta (#679)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.123.14-beta (#683)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.123.15-beta (#687)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.123.16-beta (#720)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.123.17-beta (#730)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.123.18-beta (#731)
- chore(deps): update dependency com.google.cloud:libraries-bom to v26.1.3 (#732)
- chore(deps): update dependency com.google.cloud:libraries-bom to v26.1.4 (#749)
- chore(deps): update dependency com.google.cloud:google-cloud-notification to v0.123.21-beta (#739)

Fixes #issue

> It's a good idea to open an issue first for discussion.

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] Please **merge** this PR for me once it is approved.
