### PR TITLE
chore: migrate samples from googleapis/java-securitycenter

### DIFF
--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -74,7 +74,8 @@ if [[ "$SCRIPT_DEBUG" != "true" ]]; then
     "java-functions-samples-secrets.txt" \
     "java-firestore-samples-secrets.txt" \
     "java-cts-v4-samples-secrets.txt" \
-    "java-cloud-sql-samples-secrets.txt")
+    "java-cloud-sql-samples-secrets.txt" \
+    "java-scc-samples-secrets.txt")
 
     # create secret dir
     mkdir -p "${KOKORO_GFILE_DIR}/secrets"

--- a/security-command-center/snippets/pom.xml
+++ b/security-command-center/snippets/pom.xml
@@ -32,7 +32,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>26.1.4</version>
+        <version>26.1.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-securitycenter</artifactId>
-      <version>2.13.0</version>
+      <version>2.11.1</version>
     </dependency>
 
     <dependency>

--- a/security-command-center/snippets/src/main/java/NotificationReceiver.java
+++ b/security-command-center/snippets/src/main/java/NotificationReceiver.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START securitycenter_receive_notifications]
+
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.cloud.securitycenter.v1.NotificationMessage;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PubsubMessage;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class NotificationReceiver {
+
+  private NotificationReceiver() {
+  }
+
+  public static void receiveNotificationMessages(String projectId, String subscriptionId) {
+    // String projectId = "{your-project}";
+    // String subscriptionId = "{your-subscription}";
+    ProjectSubscriptionName subscriptionName =
+        ProjectSubscriptionName.of(projectId, subscriptionId);
+
+    try {
+      Subscriber subscriber =
+          Subscriber.newBuilder(subscriptionName, new NotificationMessageReceiver()).build();
+      subscriber.startAsync().awaitRunning();
+
+      // This sets the timeout value of the subscriber to 10s.
+      subscriber.awaitTerminated(10_000, TimeUnit.MILLISECONDS);
+    } catch (IllegalStateException | TimeoutException e) {
+      System.out.println("Subscriber stopped: " + e);
+    }
+  }
+
+  static class NotificationMessageReceiver implements MessageReceiver {
+
+    @Override
+    public void receiveMessage(PubsubMessage message, AckReplyConsumer consumer) {
+      NotificationMessage.Builder notificationMessageBuilder = NotificationMessage.newBuilder();
+
+      try {
+        String jsonString = message.getData().toStringUtf8();
+        JsonFormat.parser().merge(jsonString, notificationMessageBuilder);
+
+        NotificationMessage notificationMessage = notificationMessageBuilder.build();
+        System.out.println(
+            String.format("Config id: %s", notificationMessage.getNotificationConfigName()));
+        System.out.println(String.format("Finding: %s", notificationMessage.getFinding()));
+      } catch (InvalidProtocolBufferException e) {
+        System.out.println("Could not parse message: " + e);
+      } finally {
+        consumer.ack();
+      }
+    }
+  }
+}
+// [END securitycenter_receive_notifications]

--- a/security-command-center/snippets/src/main/java/bigqueryexport/CreateBigQueryExport.java
+++ b/security-command-center/snippets/src/main/java/bigqueryexport/CreateBigQueryExport.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bigqueryexport;
+
+// [START securitycenter_create_bigquery_export]
+
+import com.google.cloud.securitycenter.v1.BigQueryExport;
+import com.google.cloud.securitycenter.v1.CreateBigQueryExportRequest;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
+import java.io.IOException;
+import java.util.UUID;
+
+public class CreateBigQueryExport {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(Developer): Modify the following variable values.
+
+    // parent: Use any one of the following resource paths:
+    //              - organizations/{organization_id}
+    //              - folders/{folder_id}
+    //              - projects/{project_id}
+    String parent = String.format("projects/%s", "your-google-cloud-project-id");
+
+    // filter: Expression that defines the filter to apply across create/update events of findings.
+    String filter =
+        "severity=\"LOW\" OR severity=\"MEDIUM\" AND "
+            + "category=\"Persistence: IAM Anomalous Grant\" AND "
+            + "-resource.type:\"compute\"";
+
+    // bigQueryDatasetId: The BigQuery dataset to write findings' updates to.
+    String bigQueryDatasetId = "your-bigquery-dataset-id";
+
+    // bigQueryExportId: Unique identifier provided by the client.
+    // For more info, see:
+    // https://cloud.google.com/security-command-center/docs/how-to-analyze-findings-in-big-query#export_findings_from_to
+    String bigQueryExportId = "default-" + UUID.randomUUID().toString().split("-")[0];
+
+    createBigQueryExport(parent, filter, bigQueryDatasetId, bigQueryExportId);
+  }
+
+  // Create export configuration to export findings from a project to a BigQuery dataset.
+  // Optionally specify filter to export certain findings only.
+  public static void createBigQueryExport(
+      String parent, String filter, String bigQueryDatasetId, String bigQueryExportId)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (SecurityCenterClient client = SecurityCenterClient.create()) {
+
+      // Create the BigQuery export configuration.
+      BigQueryExport bigQueryExport =
+          BigQueryExport.newBuilder()
+              .setDescription(
+                  "Export low and medium findings if the compute resource "
+                      + "has an IAM anomalous grant")
+              .setFilter(filter)
+              .setDataset(String.format("%s/datasets/%s", parent, bigQueryDatasetId))
+              .build();
+
+      CreateBigQueryExportRequest bigQueryExportRequest =
+          CreateBigQueryExportRequest.newBuilder()
+              .setParent(parent)
+              .setBigQueryExport(bigQueryExport)
+              .setBigQueryExportId(bigQueryExportId)
+              .build();
+
+      // Create the export request.
+      BigQueryExport response = client.createBigQueryExport(bigQueryExportRequest);
+
+      System.out.printf("BigQuery export request created successfully: %s\n", response.getName());
+    }
+  }
+}
+// [END securitycenter_create_bigquery_export]

--- a/security-command-center/snippets/src/main/java/bigqueryexport/DeleteBigQueryExport.java
+++ b/security-command-center/snippets/src/main/java/bigqueryexport/DeleteBigQueryExport.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bigqueryexport;
+
+// [START securitycenter_delete_bigquery_export]
+
+import com.google.cloud.securitycenter.v1.DeleteBigQueryExportRequest;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
+import java.io.IOException;
+
+public class DeleteBigQueryExport {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(Developer): Modify the following variable values.
+
+    // parent: Use any one of the following resource paths:
+    //              - organizations/{organization_id}
+    //              - folders/{folder_id}
+    //              - projects/{project_id}
+    String parent = String.format("projects/%s", "your-google-cloud-project-id");
+
+    // bigQueryExportId: Unique identifier that is used to identify the export.
+    String bigQueryExportId = "export-id";
+
+    deleteBigQueryExport(parent, bigQueryExportId);
+  }
+
+  // Delete an existing BigQuery export.
+  public static void deleteBigQueryExport(String parent, String bigQueryExportId)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (SecurityCenterClient client = SecurityCenterClient.create()) {
+
+      DeleteBigQueryExportRequest bigQueryExportRequest =
+          DeleteBigQueryExportRequest.newBuilder()
+              .setName(String.format("%s/bigQueryExports/%s", parent, bigQueryExportId))
+              .build();
+
+      client.deleteBigQueryExport(bigQueryExportRequest);
+      System.out.printf("BigQuery export request deleted successfully: %s", bigQueryExportId);
+    }
+  }
+}
+// [END securitycenter_delete_bigquery_export]

--- a/security-command-center/snippets/src/main/java/bigqueryexport/GetBigQueryExport.java
+++ b/security-command-center/snippets/src/main/java/bigqueryexport/GetBigQueryExport.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bigqueryexport;
+
+// [START securitycenter_get_bigquery_export]
+
+import com.google.cloud.securitycenter.v1.BigQueryExport;
+import com.google.cloud.securitycenter.v1.GetBigQueryExportRequest;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
+import java.io.IOException;
+
+public class GetBigQueryExport {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(Developer): Modify the following variable values.
+
+    // parent: Use any one of the following resource paths:
+    //              - organizations/{organization_id}
+    //              - folders/{folder_id}
+    //              - projects/{project_id}
+    String parent = String.format("projects/%s", "your-google-cloud-project-id");
+
+    // bigQueryExportId: Unique identifier that is used to identify the export.
+    String bigQueryExportId = "export-id";
+
+    getBigQueryExport(parent, bigQueryExportId);
+  }
+
+  // Retrieve an existing BigQuery export.
+  public static void getBigQueryExport(String parent, String bigQueryExportId) throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (SecurityCenterClient client = SecurityCenterClient.create()) {
+
+      GetBigQueryExportRequest bigQueryExportRequest =
+          GetBigQueryExportRequest.newBuilder()
+              .setName(String.format("%s/bigQueryExports/%s", parent, bigQueryExportId))
+              .build();
+
+      BigQueryExport response = client.getBigQueryExport(bigQueryExportRequest);
+      System.out.printf("Retrieved the BigQuery export: %s", response.getName());
+    }
+  }
+}
+// [END securitycenter_get_bigquery_export]

--- a/security-command-center/snippets/src/main/java/bigqueryexport/ListBigQueryExports.java
+++ b/security-command-center/snippets/src/main/java/bigqueryexport/ListBigQueryExports.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bigqueryexport;
+
+// [START securitycenter_list_bigquery_export]
+
+import com.google.cloud.securitycenter.v1.BigQueryExport;
+import com.google.cloud.securitycenter.v1.ListBigQueryExportsRequest;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient.ListBigQueryExportsPagedResponse;
+import java.io.IOException;
+
+public class ListBigQueryExports {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(Developer): Modify the following variable values.
+
+    // parent: The parent, which owns the collection of BigQuery exports.
+    //         Use any one of the following resource paths:
+    //              - organizations/{organization_id}
+    //              - folders/{folder_id}
+    //              - projects/{project_id}
+    String parent = String.format("projects/%s", "your-google-cloud-project-id");
+
+    listBigQueryExports(parent);
+  }
+
+  // List BigQuery exports in the given parent.
+  public static void listBigQueryExports(String parent) throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (SecurityCenterClient client = SecurityCenterClient.create()) {
+
+      ListBigQueryExportsRequest request =
+          ListBigQueryExportsRequest.newBuilder().setParent(parent).build();
+
+      ListBigQueryExportsPagedResponse response = client.listBigQueryExports(request);
+
+      System.out.println("Listing BigQuery exports:");
+      for (BigQueryExport bigQueryExport : response.iterateAll()) {
+        System.out.println(bigQueryExport.getName());
+      }
+    }
+  }
+}
+// [END securitycenter_list_bigquery_export]

--- a/security-command-center/snippets/src/main/java/bigqueryexport/UpdateBigQueryExport.java
+++ b/security-command-center/snippets/src/main/java/bigqueryexport/UpdateBigQueryExport.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bigqueryexport;
+
+// [START securitycenter_update_bigquery_export]
+
+import com.google.cloud.securitycenter.v1.BigQueryExport;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
+import com.google.cloud.securitycenter.v1.UpdateBigQueryExportRequest;
+import com.google.protobuf.FieldMask;
+import java.io.IOException;
+
+public class UpdateBigQueryExport {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(Developer): Modify the following variable values.
+
+    // parent: Use any one of the following resource paths:
+    //              - organizations/{organization_id}
+    //              - folders/{folder_id}
+    //              - projects/{project_id}
+    String parent = String.format("projects/%s", "your-google-cloud-project-id");
+
+    // filter: Expression that defines the filter to apply across create/update events of findings.
+    String filter =
+        "severity=\"LOW\" OR severity=\"MEDIUM\" AND "
+            + "category=\"Persistence: IAM Anomalous Grant\" AND "
+            + "-resource.type:\"compute\"";
+
+    // bigQueryExportId: Unique identifier provided by the client.
+    // For more info, see:
+    // https://cloud.google.com/security-command-center/docs/how-to-analyze-findings-in-big-query#export_findings_from_to
+    String bigQueryExportId = "big-query-export-id";
+
+    updateBigQueryExport(parent, filter, bigQueryExportId);
+  }
+
+  // Updates an existing BigQuery export.
+  public static void updateBigQueryExport(String parent, String filter, String bigQueryExportId)
+      throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (SecurityCenterClient client = SecurityCenterClient.create()) {
+
+      //  Set the new values for export configuration.
+      BigQueryExport bigQueryExport =
+          BigQueryExport.newBuilder()
+              .setName(String.format("%s/bigQueryExports/%s", parent, bigQueryExportId))
+              .setFilter(filter)
+              .build();
+
+      UpdateBigQueryExportRequest request =
+          UpdateBigQueryExportRequest.newBuilder()
+              .setBigQueryExport(bigQueryExport)
+              // Set the update mask to specify which properties should be updated.
+              // If empty, all mutable fields will be updated.
+              // For more info on constructing field mask path, see the proto or:
+              // https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.FieldMask
+              .setUpdateMask(FieldMask.newBuilder().addPaths("filter").build())
+              .build();
+
+      BigQueryExport response = client.updateBigQueryExport(request);
+      if (!response.getFilter().equalsIgnoreCase(filter)) {
+        System.out.println("Failed to update BigQueryExport!");
+        return;
+      }
+      System.out.println("BigQueryExport updated successfully!");
+    }
+  }
+}
+// [END securitycenter_update_bigquery_export]

--- a/security-command-center/snippets/src/main/java/muteconfig/BulkMuteFindings.java
+++ b/security-command-center/snippets/src/main/java/muteconfig/BulkMuteFindings.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package muteconfig;
+
+// [START securitycenter_bulk_mute]
+
+import com.google.cloud.securitycenter.v1.BulkMuteFindingsRequest;
+import com.google.cloud.securitycenter.v1.BulkMuteFindingsResponse;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+public class BulkMuteFindings {
+
+  public static void main(String[] args) {
+    // TODO: Replace the variables within {}
+
+    // parentPath: Use any one of the following options:
+    //             - organizations/{organization_id}
+    //             - folders/{folder_id}
+    //             - projects/{project_id}
+    String parentPath = String.format("projects/%s", "your-google-cloud-project-id");
+
+    // muteRule: Expression that identifies findings that should be muted.
+    // eg: "resource.project_display_name=\"PROJECT_ID\""
+    String muteRule = "{filter-condition}";
+
+    bulkMute(parentPath, muteRule);
+  }
+
+  // Kicks off a long-running operation (LRO) to bulk mute findings for a parent based on a filter.
+  // The parent can be either an organization, folder, or project. The findings
+  // matched by the filter will be muted after the LRO is done.
+  public static void bulkMute(String parentPath, String muteRule) {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (SecurityCenterClient client = SecurityCenterClient.create()) {
+
+      BulkMuteFindingsRequest bulkMuteFindingsRequest =
+          BulkMuteFindingsRequest.newBuilder()
+              .setParent(parentPath)
+              // To create mute rules, see:
+              // https://cloud.google.com/security-command-center/docs/how-to-mute-findings#create_mute_rules
+              .setFilter(muteRule)
+              .build();
+
+      // ExecutionException is thrown if the below call fails.
+      BulkMuteFindingsResponse response =
+          client.bulkMuteFindingsAsync(bulkMuteFindingsRequest).get();
+      System.out.println("Bulk mute findings completed successfully! " + response);
+    } catch (IOException | InterruptedException | ExecutionException e) {
+      System.out.println("Bulk mute findings failed! \n Exception: " + e);
+    }
+  }
+}
+// [END securitycenter_bulk_mute]

--- a/security-command-center/snippets/src/main/java/muteconfig/CreateMuteRule.java
+++ b/security-command-center/snippets/src/main/java/muteconfig/CreateMuteRule.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package muteconfig;
+
+// [START securitycenter_create_mute_config]
+
+import com.google.cloud.securitycenter.v1.CreateMuteConfigRequest;
+import com.google.cloud.securitycenter.v1.MuteConfig;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
+import java.io.IOException;
+import java.util.UUID;
+
+public class CreateMuteRule {
+
+  public static void main(String[] args) {
+    // TODO: Replace the variables within {}
+
+    // parentPath: Use any one of the following options:
+    //             - organizations/{organization_id}
+    //             - folders/{folder_id}
+    //             - projects/{project_id}
+    String parentPath = String.format("projects/%s", "your-google-cloud-project-id");
+
+    // muteConfigId: Set a random id; max of 63 chars.
+    String muteConfigId = "random-mute-id-" + UUID.randomUUID();
+    createMuteRule(parentPath, muteConfigId);
+  }
+
+  // Creates a mute configuration under a given scope that will mute
+  // all new findings that match a given filter.
+  // Existing findings will not be muted.
+  public static void createMuteRule(String parentPath, String muteConfigId) {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (SecurityCenterClient client = SecurityCenterClient.create()) {
+
+      MuteConfig muteConfig =
+          MuteConfig.newBuilder()
+              .setDescription("Mute low-medium IAM grants excluding 'compute' ")
+              // Set mute rule(s).
+              // To construct mute rules and for supported properties, see:
+              // https://cloud.google.com/security-command-center/docs/how-to-mute-findings#create_mute_rules
+              .setFilter(
+                  "severity=\"LOW\" OR severity=\"MEDIUM\" AND "
+                      + "category=\"Persistence: IAM Anomalous Grant\" AND "
+                      + "-resource.type:\"compute\"")
+              .build();
+
+      CreateMuteConfigRequest request =
+          CreateMuteConfigRequest.newBuilder()
+              .setParent(parentPath)
+              .setMuteConfigId(muteConfigId)
+              .setMuteConfig(muteConfig)
+              .build();
+
+      // ExecutionException is thrown if the below call fails.
+      MuteConfig response = client.createMuteConfig(request);
+      System.out.println("Mute rule created successfully: " + response.getName());
+    } catch (IOException e) {
+      System.out.println("Mute rule creation failed! \n Exception: " + e);
+    }
+  }
+}
+// [END securitycenter_create_mute_config]

--- a/security-command-center/snippets/src/main/java/muteconfig/DeleteMuteRule.java
+++ b/security-command-center/snippets/src/main/java/muteconfig/DeleteMuteRule.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package muteconfig;
+
+// [START securitycenter_delete_mute_config]
+
+import com.google.cloud.securitycenter.v1.MuteConfigName;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
+import java.io.IOException;
+
+public class DeleteMuteRule {
+
+  public static void main(String[] args) {
+    // TODO(Developer): Replace the following variables
+    // parentPath: Use any one of the following options:
+    //             - organizations/{organization_id}
+    //             - folders/{folder_id}
+    //             - projects/{project_id}
+    String parentPath = String.format("projects/%s", "your-google-cloud-project-id");
+
+    // muteConfigId: Specify the name of the mute config to delete.
+    String muteConfigId = "mute-config-id";
+
+    deleteMuteRule(parentPath, muteConfigId);
+  }
+
+  // Deletes a mute configuration given its resource name.
+  // Note: Previously muted findings are not affected when a mute config is deleted.
+  public static void deleteMuteRule(String projectId, String muteConfigId) {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (SecurityCenterClient client = SecurityCenterClient.create()) {
+      // Use appropriate MuteConfigName methods depending on the type of parent.
+      // org -> MuteConfigName.ofOrganizationMuteConfigName()
+      // folder -> MuteConfigName.ofFolderMuteConfigName()
+      // project -> MuteConfigName.ofProjectMuteConfigName)
+      client.deleteMuteConfig(MuteConfigName.ofProjectMuteConfigName(projectId, muteConfigId));
+
+      System.out.println("Mute rule deleted successfully: " + muteConfigId);
+    } catch (IOException e) {
+      System.out.println("Mute rule deletion failed! \n Exception: " + e);
+    }
+  }
+}
+// [END securitycenter_delete_mute_config]

--- a/security-command-center/snippets/src/main/java/muteconfig/GetMuteRule.java
+++ b/security-command-center/snippets/src/main/java/muteconfig/GetMuteRule.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package muteconfig;
+
+// [START securitycenter_get_mute_config]
+
+import com.google.cloud.securitycenter.v1.MuteConfig;
+import com.google.cloud.securitycenter.v1.MuteConfigName;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
+import java.io.IOException;
+
+public class GetMuteRule {
+
+  public static void main(String[] args) {
+    // TODO(Developer): Replace the following variables
+
+    // parentPath: Use any one of the following options:
+    //             - organizations/{organization_id}
+    //             - folders/{folder_id}
+    //             - projects/{project_id}
+    String parentPath = String.format("projects/%s", "your-google-cloud-project-id");
+
+    // muteConfigId: Name of the mute config to retrieve.
+    String muteConfigId = "mute-config-id";
+
+    getMuteRule(parentPath, muteConfigId);
+  }
+
+  // Retrieves a mute configuration given its resource name.
+  public static void getMuteRule(String projectId, String muteConfigId) {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (SecurityCenterClient client = SecurityCenterClient.create()) {
+      // Use appropriate MuteConfigName methods depending on the type of parent.
+      // (org -> MuteConfigName.ofOrganizationMuteConfigName()
+      // folder -> MuteConfigName.ofFolderMuteConfigName()
+      // project -> MuteConfigName.ofProjectMuteConfigName)
+      MuteConfig muteConfig =
+          client.getMuteConfig(MuteConfigName.ofProjectMuteConfigName(projectId, muteConfigId));
+
+      System.out.println("Retrieved the mute config: " + muteConfig);
+    } catch (IOException e) {
+      System.out.println("Mute rule retrieval failed! \n Exception: " + e);
+    }
+  }
+}
+// [END securitycenter_get_mute_config]

--- a/security-command-center/snippets/src/main/java/muteconfig/ListMuteRules.java
+++ b/security-command-center/snippets/src/main/java/muteconfig/ListMuteRules.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package muteconfig;
+
+// [START securitycenter_list_mute_configs]
+
+import com.google.cloud.securitycenter.v1.ListMuteConfigsRequest;
+import com.google.cloud.securitycenter.v1.MuteConfig;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
+import java.io.IOException;
+
+public class ListMuteRules {
+
+  public static void main(String[] args) {
+    // TODO: Replace variables enclosed within {}
+
+    // parent: Use any one of the following resource paths to list mute configurations:
+    //         - organizations/{organization_id}
+    //         - folders/{folder_id}
+    //         - projects/{project_id}
+    String parentPath = String.format("projects/%s", "your-google-cloud-project-id");
+    listMuteRules(parentPath);
+  }
+
+  // Listing mute configs at the organization level will return all the configs
+  // at the org, folder, and project levels.
+  // Similarly, listing configs at folder level will list all the configs
+  // at the folder and project levels.
+  public static void listMuteRules(String parent) {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (SecurityCenterClient client = SecurityCenterClient.create()) {
+
+      ListMuteConfigsRequest listMuteConfigsRequest =
+          ListMuteConfigsRequest.newBuilder().setParent(parent).build();
+
+      // List all mute configs present in the resource.
+      for (MuteConfig muteConfig : client.listMuteConfigs(listMuteConfigsRequest).iterateAll()) {
+        System.out.println(muteConfig.getName());
+      }
+    } catch (IOException e) {
+      System.out.println("Listing Mute rule failed! \n Exception: " + e);
+    }
+  }
+}
+// [END securitycenter_list_mute_configs]

--- a/security-command-center/snippets/src/main/java/muteconfig/SetMuteFinding.java
+++ b/security-command-center/snippets/src/main/java/muteconfig/SetMuteFinding.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package muteconfig;
+
+// [START securitycenter_set_mute]
+
+import com.google.cloud.securitycenter.v1.Finding;
+import com.google.cloud.securitycenter.v1.Finding.Mute;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
+import com.google.cloud.securitycenter.v1.SetMuteRequest;
+import java.io.IOException;
+
+public class SetMuteFinding {
+
+  public static void main(String[] args) {
+    // TODO: Replace the variables within {}
+
+    // findingPath: The relative resource name of the finding. See:
+    // https://cloud.google.com/apis/design/resource_names#relative_resource_name
+    // Use any one of the following formats:
+    //  - organizations/{organization_id}/sources/{source_id}/finding/{finding_id}
+    //  - folders/{folder_id}/sources/{source_id}/finding/{finding_id}
+    //  - projects/{project_id}/sources/{source_id}/finding/{finding_id}
+    String findingPath = "{path-to-the-finding}";
+    setMute(findingPath);
+  }
+
+  // Mute an individual finding.
+  // If a finding is already muted, muting it again has no effect.
+  // Various mute states are: MUTE_UNSPECIFIED/MUTE/UNMUTE.
+  public static void setMute(String findingPath) {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (SecurityCenterClient client = SecurityCenterClient.create()) {
+
+      SetMuteRequest setMuteRequest =
+          SetMuteRequest.newBuilder().setName(findingPath).setMute(Mute.MUTED).build();
+
+      Finding finding = client.setMute(setMuteRequest);
+      System.out.println(
+          "Mute value for the finding " + finding.getName() + " is: " + finding.getMute());
+    } catch (IOException e) {
+      System.out.println("Failed to set the specified mute value. \n Exception: " + e);
+    }
+  }
+}
+// [END securitycenter_set_mute]

--- a/security-command-center/snippets/src/main/java/muteconfig/SetUnmuteFinding.java
+++ b/security-command-center/snippets/src/main/java/muteconfig/SetUnmuteFinding.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package muteconfig;
+
+// [START securitycenter_set_unmute]
+
+import com.google.cloud.securitycenter.v1.Finding;
+import com.google.cloud.securitycenter.v1.Finding.Mute;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
+import com.google.cloud.securitycenter.v1.SetMuteRequest;
+import java.io.IOException;
+
+public class SetUnmuteFinding {
+
+  public static void main(String[] args) {
+    // TODO: Replace the variables within {}
+
+    // findingPath: The relative resource name of the finding. See:
+    // https://cloud.google.com/apis/design/resource_names#relative_resource_name
+    // Use any one of the following formats:
+    //  - organizations/{organization_id}/sources/{source_id}/finding/{finding_id}
+    //  - folders/{folder_id}/sources/{source_id}/finding/{finding_id}
+    //  - projects/{project_id}/sources/{source_id}/finding/{finding_id}
+    String findingPath = "{path-to-the-finding}";
+    setUnmute(findingPath);
+  }
+
+  // Unmute an individual finding.
+  // Unmuting a finding that isn't muted has no effect.
+  // Various mute states are: MUTE_UNSPECIFIED/MUTE/UNMUTE.
+  public static void setUnmute(String findingPath) {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (SecurityCenterClient client = SecurityCenterClient.create()) {
+
+      SetMuteRequest setMuteRequest =
+          SetMuteRequest.newBuilder().setName(findingPath).setMute(Mute.UNMUTED).build();
+
+      Finding finding = client.setMute(setMuteRequest);
+      System.out.println(
+          "Mute value for the finding " + finding.getName() + " is: " + finding.getMute());
+    } catch (IOException e) {
+      System.out.println("Failed to set the specified mute value. \n Exception: " + e);
+    }
+  }
+}
+// [END securitycenter_set_unmute]

--- a/security-command-center/snippets/src/main/java/muteconfig/UpdateMuteRule.java
+++ b/security-command-center/snippets/src/main/java/muteconfig/UpdateMuteRule.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package muteconfig;
+
+// [START securitycenter_update_mute_config]
+
+import com.google.cloud.securitycenter.v1.MuteConfig;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
+import com.google.cloud.securitycenter.v1.UpdateMuteConfigRequest;
+import com.google.protobuf.FieldMask;
+import java.io.IOException;
+
+public class UpdateMuteRule {
+
+  public static void main(String[] args) {
+    // TODO: Replace the variables within {}
+
+    // Specify the name of the mute config to delete.
+    // muteConfigName: Use any one of the following formats:
+    //                 - organizations/{organization}/muteConfigs/{config_id}
+    //                 - folders/{folder}/muteConfigs/{config_id}
+    //                 - projects/{project}/muteConfigs/{config_id}
+    String muteConfigName = "{any-one-of-the-above-formats}";
+    updateMuteRule(muteConfigName);
+  }
+
+  // Updates an existing mute configuration.
+  // The following can be updated in a mute config: description and filter.
+  public static void updateMuteRule(String muteConfigName) {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (SecurityCenterClient securityCenterClient = SecurityCenterClient.create()) {
+
+      MuteConfig updateMuteConfig =
+          MuteConfig.newBuilder()
+              .setName(muteConfigName)
+              .setDescription("Updated mute config description")
+              .build();
+
+      UpdateMuteConfigRequest updateMuteConfigRequest =
+          UpdateMuteConfigRequest.newBuilder()
+              .setMuteConfig(updateMuteConfig)
+              // Set the update mask to specify which properties of the mute config should be
+              // updated.
+              // If empty, all mutable fields will be updated.
+              // Make sure that the mask fields match the properties changed in 'updateMuteConfig'.
+              // For more info on constructing update mask path, see the proto or:
+              // https://cloud.google.com/security-command-center/docs/reference/rest/v1/folders.muteConfigs/patch?hl=en#query-parameters
+              .setUpdateMask(FieldMask.newBuilder().addPaths("description").build())
+              .build();
+
+      MuteConfig response = securityCenterClient.updateMuteConfig(updateMuteConfigRequest);
+      System.out.println(response);
+    } catch (IOException e) {
+      System.out.println("Mute rule update failed! \n Exception: " + e);
+    }
+  }
+}
+// [END securitycenter_update_mute_config]

--- a/security-command-center/snippets/src/test/java/BigQueryExportIT.java
+++ b/security-command-center/snippets/src/test/java/BigQueryExportIT.java
@@ -105,6 +105,9 @@ public class BigQueryExportIT {
       String newDatasetName = newDataset.getDatasetId().getDataset();
       System.out.println(newDatasetName + " created successfully");
     } catch (BigQueryException e) {
+      if (e.toString().contains("Already Exists: Dataset")) {
+        return;
+      }
       Assert.fail("Dataset was not created. \n" + e);
     }
   }

--- a/security-command-center/snippets/src/test/java/BigQueryExportIT.java
+++ b/security-command-center/snippets/src/test/java/BigQueryExportIT.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import bigqueryexport.CreateBigQueryExport;
+import bigqueryexport.DeleteBigQueryExport;
+import bigqueryexport.GetBigQueryExport;
+import bigqueryexport.ListBigQueryExports;
+import bigqueryexport.UpdateBigQueryExport;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.Dataset;
+import com.google.cloud.bigquery.DatasetInfo;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class BigQueryExportIT {
+
+  // TODO(Developer): Replace the below variables.
+  private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static final String BQ_DATASET_NAME = "sampledataset";
+  private static final String BQ_EXPORT_ID =
+      "default-" + UUID.randomUUID().toString().split("-")[0];
+
+  private static ByteArrayOutputStream stdOut;
+
+  // Check if the required environment variables are set.
+  public static void requireEnvVar(String envVarName) {
+    assertWithMessage(String.format("Missing environment variable '%s' ", envVarName))
+        .that(System.getenv(envVarName))
+        .isNotEmpty();
+  }
+
+  @BeforeClass
+  public static void setUp() throws IOException {
+    final PrintStream out = System.out;
+    stdOut = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(stdOut));
+
+    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+
+    // Create a BigQuery dataset.
+    createBigQueryDataset(BQ_DATASET_NAME);
+    // Create export request.
+    String filter = "severity=\"LOW\" OR severity=\"MEDIUM\"";
+    CreateBigQueryExport.createBigQueryExport(
+        String.format("projects/%s", PROJECT_ID), filter, BQ_DATASET_NAME, BQ_EXPORT_ID);
+
+    stdOut = null;
+    System.setOut(out);
+  }
+
+  @AfterClass
+  public static void cleanUp() throws IOException {
+    final PrintStream out = System.out;
+    stdOut = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(stdOut));
+
+    // Delete BigQuery Dataset and export request.
+    deleteBigQueryDataset(BQ_DATASET_NAME);
+    DeleteBigQueryExport.deleteBigQueryExport(
+        String.format("projects/%s", PROJECT_ID), BQ_EXPORT_ID);
+    assertThat(stdOut.toString())
+        .contains(String.format("BigQuery export request deleted successfully: %s", BQ_EXPORT_ID));
+
+    stdOut = null;
+    System.setOut(out);
+  }
+
+  private static void createBigQueryDataset(String datasetName) {
+    try {
+      BigQuery bigquery = BigQueryOptions.getDefaultInstance().getService();
+
+      DatasetInfo datasetInfo = DatasetInfo.newBuilder(datasetName).build();
+
+      Dataset newDataset = bigquery.create(datasetInfo);
+      String newDatasetName = newDataset.getDatasetId().getDataset();
+      System.out.println(newDatasetName + " created successfully");
+    } catch (BigQueryException e) {
+      Assert.fail("Dataset was not created. \n" + e);
+    }
+  }
+
+  private static void deleteBigQueryDataset(String datasetName) {
+    try {
+      BigQuery bigquery = BigQueryOptions.getDefaultInstance().getService();
+      Assert.assertTrue("Deleted BigQuery dataset", bigquery.delete(datasetName));
+    } catch (BigQueryException e) {
+      Assert.fail("Dataset was not deleted. \n" + e);
+    }
+  }
+
+  @Before
+  public void beforeEach() {
+    stdOut = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(stdOut));
+  }
+
+  @After
+  public void afterEach() {
+    stdOut = null;
+    System.setOut(null);
+  }
+
+  @Test
+  public void testGetBigQueryExport() throws IOException {
+    GetBigQueryExport.getBigQueryExport(String.format("projects/%s", PROJECT_ID), BQ_EXPORT_ID);
+    assertThat(stdOut.toString()).contains(BQ_EXPORT_ID);
+  }
+
+  @Test
+  public void testListBigQueryExports() throws IOException {
+    ListBigQueryExports.listBigQueryExports(String.format("projects/%s", PROJECT_ID));
+    assertThat(stdOut.toString()).contains(BQ_EXPORT_ID);
+  }
+
+  @Test
+  public void testUpdateBigQueryExport() throws IOException {
+    String filter = "severity=\"MEDIUM\"";
+    UpdateBigQueryExport.updateBigQueryExport(
+        String.format("projects/%s", PROJECT_ID), filter, BQ_EXPORT_ID);
+    assertThat(stdOut.toString()).contains("BigQueryExport updated successfully!");
+  }
+}

--- a/security-command-center/snippets/src/test/java/MuteFindingIT.java
+++ b/security-command-center/snippets/src/test/java/MuteFindingIT.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.google.cloud.securitycenter.v1.CreateSourceRequest;
+import com.google.cloud.securitycenter.v1.Finding;
+import com.google.cloud.securitycenter.v1.Finding.FindingClass;
+import com.google.cloud.securitycenter.v1.Finding.Mute;
+import com.google.cloud.securitycenter.v1.Finding.Severity;
+import com.google.cloud.securitycenter.v1.Finding.State;
+import com.google.cloud.securitycenter.v1.ListFindingsRequest;
+import com.google.cloud.securitycenter.v1.ListFindingsResponse.ListFindingsResult;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient.ListFindingsPagedResponse;
+import com.google.cloud.securitycenter.v1.Source;
+import com.google.protobuf.Timestamp;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.time.Instant;
+import java.util.UUID;
+import muteconfig.BulkMuteFindings;
+import muteconfig.CreateMuteRule;
+import muteconfig.DeleteMuteRule;
+import muteconfig.GetMuteRule;
+import muteconfig.ListMuteRules;
+import muteconfig.SetMuteFinding;
+import muteconfig.SetUnmuteFinding;
+import muteconfig.UpdateMuteRule;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class MuteFindingIT {
+
+  // TODO(Developer): Replace the below variables.
+  private static final String PROJECT_ID = System.getenv("SCC_PROJECT_ID");
+  private static final String ORGANIZATION_ID = System.getenv("SCC_PROJECT_ORG_ID");
+
+  private static final String MUTE_RULE_CREATE = "random-mute-id-" + UUID.randomUUID();
+  private static final String MUTE_RULE_UPDATE = "random-mute-id-" + UUID.randomUUID();
+  private static Source SOURCE;
+  // The findings will be used to test bulk mute.
+  private static Finding FINDING_1;
+  private static Finding FINDING_2;
+  private static Finding FINDING_3;
+
+  private static ByteArrayOutputStream stdOut;
+
+  // Check if the required environment variables are set.
+  public static void requireEnvVar(String envVarName) {
+    assertWithMessage(String.format("Missing environment variable '%s' ", envVarName))
+        .that(System.getenv(envVarName))
+        .isNotEmpty();
+  }
+
+  @BeforeClass
+  public static void setUp() throws IOException {
+    final PrintStream out = System.out;
+    stdOut = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(stdOut));
+
+    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+    requireEnvVar("SCC_PROJECT_ID");
+    requireEnvVar("SCC_PROJECT_ORG_ID");
+
+    // Create mute rules.
+    CreateMuteRule.createMuteRule(String.format("projects/%s", PROJECT_ID), MUTE_RULE_CREATE);
+    CreateMuteRule.createMuteRule(String.format("projects/%s", PROJECT_ID), MUTE_RULE_UPDATE);
+    // Create source.
+    SOURCE = createSource(ORGANIZATION_ID);
+    // Create findings within the source.
+    String uuid = UUID.randomUUID().toString().split("-")[0];
+    FINDING_1 = createFinding(SOURCE.getName(), "1testingscc" + uuid);
+    FINDING_2 = createFinding(SOURCE.getName(), "2testingscc" + uuid);
+    FINDING_3 = createFinding(SOURCE.getName(), "3testingscc" + uuid);
+
+    stdOut = null;
+    System.setOut(out);
+  }
+
+  @AfterClass
+  public static void cleanUp() {
+    final PrintStream out = System.out;
+    stdOut = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(stdOut));
+    DeleteMuteRule.deleteMuteRule(PROJECT_ID, MUTE_RULE_CREATE);
+    assertThat(stdOut.toString()).contains("Mute rule deleted successfully: " + MUTE_RULE_CREATE);
+    DeleteMuteRule.deleteMuteRule(PROJECT_ID, MUTE_RULE_UPDATE);
+    assertThat(stdOut.toString()).contains("Mute rule deleted successfully: " + MUTE_RULE_UPDATE);
+    stdOut = null;
+    System.setOut(out);
+  }
+
+  public static Source createSource(String organizationId) throws IOException {
+    try (SecurityCenterClient client = SecurityCenterClient.create()) {
+
+      Source source =
+          Source.newBuilder()
+              .setDisplayName("Custom display name")
+              .setDescription("A source that does X")
+              .build();
+
+      CreateSourceRequest createSourceRequest =
+          CreateSourceRequest.newBuilder()
+              .setParent(String.format("organizations/%s", organizationId))
+              .setSource(source)
+              .build();
+
+      Source response = client.createSource(createSourceRequest);
+      System.out.println("Created source : " + response.getName());
+      return response;
+    }
+  }
+
+  public static Finding createFinding(String sourceName, String findingId) throws IOException {
+    try (SecurityCenterClient client = SecurityCenterClient.create()) {
+
+      Instant eventTime = Instant.now();
+
+      // The resource this finding applies to. The Cloud Security Command Center UI can link
+      // the findings for a resource to the corresponding asset of a resource
+      // if there are matches.
+      // TODO(Developer): Replace the sample resource name
+      String resourceName = "//cloudresourcemanager.googleapis.com/organizations/11232";
+
+      // Set up a request to create a finding in a source.
+      Finding finding =
+          Finding.newBuilder()
+              .setParent(sourceName)
+              .setState(State.ACTIVE)
+              .setSeverity(Severity.LOW)
+              .setMute(Mute.UNMUTED)
+              .setFindingClass(FindingClass.OBSERVATION)
+              .setResourceName(resourceName)
+              .setEventTime(
+                  Timestamp.newBuilder()
+                      .setSeconds(eventTime.getEpochSecond())
+                      .setNanos(eventTime.getNano()))
+              .setCategory("LOW_RISK_ONE")
+              .build();
+
+      Finding response = client.createFinding(sourceName, findingId, finding);
+
+      System.out.println("Created Finding: " + response);
+      return response;
+    }
+  }
+
+  public static ListFindingsPagedResponse getAllFindings(String sourceName) throws IOException {
+    try (SecurityCenterClient client = SecurityCenterClient.create()) {
+
+      ListFindingsRequest request = ListFindingsRequest.newBuilder().setParent(sourceName).build();
+
+      return client.listFindings(request);
+    }
+  }
+
+  private static String getOrganizationId() {
+    return "1081635000895";
+  }
+
+  private static String getProject() {
+    return "project-a-id";
+  }
+
+  @Before
+  public void beforeEach() {
+    stdOut = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(stdOut));
+  }
+
+  @After
+  public void afterEach() {
+    stdOut = null;
+    System.setOut(null);
+  }
+
+  @Test
+  public void testGetMuteRule() {
+    GetMuteRule.getMuteRule(PROJECT_ID, MUTE_RULE_CREATE);
+    assertThat(stdOut.toString()).contains("Retrieved the mute config: ");
+    assertThat(stdOut.toString()).contains(MUTE_RULE_CREATE);
+  }
+
+  @Test
+  public void testListMuteRules() {
+    ListMuteRules.listMuteRules(String.format("projects/%s", PROJECT_ID));
+    assertThat(stdOut.toString()).contains(MUTE_RULE_CREATE);
+    assertThat(stdOut.toString()).contains(MUTE_RULE_UPDATE);
+  }
+
+  @Test
+  public void testUpdateMuteRules() {
+    UpdateMuteRule.updateMuteRule(
+        String.format("projects/%s/muteConfigs/%s", PROJECT_ID, MUTE_RULE_UPDATE));
+    GetMuteRule.getMuteRule(PROJECT_ID, MUTE_RULE_UPDATE);
+    assertThat(stdOut.toString()).contains("Updated mute config description");
+  }
+
+  @Test
+  public void testSetMuteFinding() {
+    SetMuteFinding.setMute(FINDING_1.getName());
+    assertThat(stdOut.toString())
+        .contains("Mute value for the finding " + FINDING_1.getName() + " is: " + "MUTED");
+    SetUnmuteFinding.setUnmute(FINDING_1.getName());
+    assertThat(stdOut.toString())
+        .contains("Mute value for the finding " + FINDING_1.getName() + " is: " + "UNMUTED");
+  }
+
+  @Test
+  public void testBulkMuteFindings() throws IOException {
+    // Mute findings that belong to this project.
+    BulkMuteFindings.bulkMute(
+        String.format("projects/%s", PROJECT_ID),
+        String.format("resource.project_display_name=\"%s\"", PROJECT_ID));
+
+    // Get all findings in the source to check if they are muted.
+    ListFindingsPagedResponse response =
+        getAllFindings(
+            String.format("projects/%s/sources/%s", PROJECT_ID, SOURCE.getName().split("/")[3]));
+    for (ListFindingsResult finding : response.iterateAll()) {
+      Assert.assertEquals(finding.getFinding().getMute(), Mute.MUTED);
+    }
+  }
+}


### PR DESCRIPTION
Manual updation due to merge conflicts. No critical history has been omitted for the samples.