### PR TITLE
chore: remove conflicting README

### DIFF
--- a/vision/spring-framework/README.md
+++ b/vision/spring-framework/README.md
@@ -1,3 +1,0 @@
-# Google Vision Spring Framework Samples
-
-These samples have moved to [googleapis/java-vision](https://github.com/googleapis/java-vision/tree/main/samples).


### PR DESCRIPTION
Removing the conflicting README in preparation for the [java-vision](https://github.com/googleapis/java-vision/tree/main/samples/spring-framework) samples migration