### PR TITLE
fix: bump spark version in readme

### DIFF
--- a/bigtable/spark/README.md
+++ b/bigtable/spark/README.md
@@ -22,7 +22,7 @@ Apache Spark provides DataSource API for external systems to plug into as data s
 
 1. [sbt](https://www.scala-sbt.org/) installed.
 
-1. [Apache Spark](https://spark.apache.org/) installed. Download Spark built for Scala 2.11. This sample uses Spark 2.4.7 and Scala 2.11.2.
+1. [Apache Spark](https://spark.apache.org/) installed. Download Spark built for Scala 2.11. This sample uses Spark 2.4.8 and Scala 2.11.2.
 
 1. A basic familiarity with [Apache Spark](https://spark.apache.org/) and [Scala](https://www.scala-lang.org/).
 
@@ -54,7 +54,7 @@ Instructions for running the emulator can be found [here](https://cloud.google.c
 Set the following environment variables.
 
 ```
-SPARK_HOME=/PATH/TO/spark-2.4.7-bin-hadoop2.7
+SPARK_HOME=/PATH/TO/spark-2.4.8-bin-hadoop2.7
 BIGTABLE_SPARK_PROJECT_ID=your-project-id
 BIGTABLE_SPARK_INSTANCE_ID=your-instance-id
 
@@ -164,7 +164,7 @@ Turn off the emulator as described [here](https://cloud.google.com/bigtable/docs
 Set the following environment variables:
 
 ```
-SPARK_HOME=/PATH/TO/spark-2.4.7-bin-hadoop2.7
+SPARK_HOME=/PATH/TO/spark-2.4.8-bin-hadoop2.7
 BIGTABLE_SPARK_PROJECT_ID=your-project-id
 BIGTABLE_SPARK_INSTANCE_ID=your-instance-id
 


### PR DESCRIPTION
update readme spark version to match spark version the example refers to with [2.4.8](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/bigtable/spark/build.sbt#L24)