### PR TITLE
chore: change [START_EXCLUDE] annotation to [START_EXCLUDE silent]

### DIFF
--- a/monitoring/v3/pom.xml
+++ b/monitoring/v3/pom.xml
@@ -19,7 +19,7 @@
   <groupId>com.example.monitoring</groupId>
   <artifactId>monitoring-google-cloud-v3-samples</artifactId>
   <version>0.1-SNAPSHOT</version>
-  <packaging>jar</packaging>  
+  <packaging>jar</packaging>
   <!--
     The parent pom defines common style checks and testing strategies for our samples.
     Removing or replacing it should not affect the execution of the samples in anyway.
@@ -28,11 +28,11 @@
     <groupId>com.google.cloud.samples</groupId>
     <artifactId>shared-configuration</artifactId>
     <version>1.2.0</version>
-  </parent>  
+  </parent>
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-  </properties>  
+  </properties>
   <!-- [START monitoring_install_with_bom] -->
   <dependencyManagement>
     <dependencies>
@@ -44,13 +44,13 @@
         <scope>import</scope>
       </dependency>
     </dependencies>
-  </dependencyManagement>  
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-monitoring</artifactId>
     </dependency>
-    <!-- [START_EXCLUDE] -->
+    <!-- [START_EXCLUDE silent] -->
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>


### PR DESCRIPTION
The `[START_EXCLUDE]` annotation lets us omit part of Cloud Monitoring's pom.xml file from the documentation on cloud.google.com. However, the text before `[START_EXCLUDE]` isn't stripped out by default. As a result, the docs end up with something like this:

```xml
<dependencies>
  <dependency>
    <groupId>com.google.cloud</groupId>
    <artifactId>google-cloud-monitoring</artifactId>
  </dependency>
  <!-- ...
</dependencies>
```

By changing the annotation to `[START_EXCLUDE silent]`, we prevent the line `<!-- ...` from appearing in the docs.

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [x] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] **Tests** pass:   `mvn clean verify` **SOME TESTS FAILED, but I don't think this PR could have caused them to fail.** 
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [x] Please **merge** this PR for me once it is approved.
