### PR TITLE
chore(jobs): add normalized region tags with product prefix

### DIFF
--- a/jobs/v3/src/main/java/com/google/samples/GeneralSearchSample.java
+++ b/jobs/v3/src/main/java/com/google/samples/GeneralSearchSample.java
@@ -58,6 +58,7 @@ public final class GeneralSearchSample {
   private static CloudTalentSolution talentSolutionClient =
       JobServiceQuickstart.getTalentSolutionClient();
 
+  // [START job_discovery_basic_keyword_search]
   // [START basic_keyword_search]
 
   /** Simple search jobs with keyword. */
@@ -95,7 +96,9 @@ public final class GeneralSearchSample {
     System.out.printf("Simple search jobs results: %s\n", searchJobsResponse);
   }
   // [END basic_keyword_search]
-
+  // [END job_discovery_basic_keyword_search]
+  
+  // [START job_discovery_category_filter_search]
   // [START category_filter]
 
   /** Search on category filter. */
@@ -133,7 +136,9 @@ public final class GeneralSearchSample {
     System.out.printf("Category search jobs results: %s\n", searchJobsResponse);
   }
   // [END category_filter]
+  // [END job_discovery_category_filter_search]
 
+  // [START job_discovery_employment_types_filter_search]
   // [START employment_types_filter]
 
   /** Search on employment types. */
@@ -171,7 +176,9 @@ public final class GeneralSearchSample {
     System.out.printf("Employee type search jobs results: %s\n", searchJobsResponse);
   }
   // [END employment_types_filter]
+  // [END job_discovery_employment_types_filter_search]
 
+  // [START job_discovery_date_range_filter_search]
   // [START date_range_filter]
 
   /**
@@ -218,7 +225,9 @@ public final class GeneralSearchSample {
     System.out.printf("Search results on jobs with a date range: %s\n", searchJobsResponse);
   }
   // [END date_range_filter]
+  // [END job_discovery_date_range_filter_search]
 
+  // [START job_discovery_language_code_filter_search]
   // [START language_code_filter]
 
   /** Search on language codes. */
@@ -256,7 +265,9 @@ public final class GeneralSearchSample {
     System.out.printf("Search results on jobs with a language code: %s\n", searchJobsResponse);
   }
   // [END language_code_filter]
+  // [END job_discovery_language_code_filter_search]
 
+  // [START job_discovery_company_display_name_search]
   // [START company_display_name_filter]
 
   /** Search on company display name. */
@@ -294,7 +305,9 @@ public final class GeneralSearchSample {
     System.out.printf("Search results by display name of company: %s\n", searchJobsResponse);
   }
   // [END company_display_name_filter]
-
+  // [END job_discovery_company_display_name_search]
+  
+  // [START job_discovery_compensation_search]
   // [START compensation_filter]
 
   /** Search on compensation. */
@@ -346,6 +359,7 @@ public final class GeneralSearchSample {
     System.out.printf("Search results by compensation: %s\n", searchJobsResponse);
   }
   // [END compensation_filter]
+  // [END job_discovery_compensation_search]
 
   public static void main(String... args) throws Exception {
     Company companyToBeCreated = BasicCompanySample.generateCompany().setDisplayName("Google");


### PR DESCRIPTION
Adds "dual-homed" region tags with product prefix to enable better sample tracking. Will send a CL to update relevant docs and then remove the obsolete region tags in a separate PR. 
