### PR TITLE
test: Renovate/com.google.code.gson gson 2.x

### DIFF
--- a/appengine-java11/gaeinfo/pom.xml
+++ b/appengine-java11/gaeinfo/pom.xml
@@ -66,7 +66,7 @@ Copyright 2019 Google LLC
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
       <scope>provided</scope>
     </dependency>
 

--- a/appengine-java8/firebase-tictactoe/pom.xml
+++ b/appengine-java8/firebase-tictactoe/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.objectify</groupId>

--- a/appengine-java8/gaeinfo/pom.xml
+++ b/appengine-java8/gaeinfo/pom.xml
@@ -62,7 +62,7 @@ Copyright 2017 Google Inc.
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
     </dependency>
 
     <dependency>

--- a/appengine-java8/metadata/pom.xml
+++ b/appengine-java8/metadata/pom.xml
@@ -57,7 +57,7 @@ Copyright 2017 Google Inc.
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
     </dependency>
 
     <dependency>

--- a/bigtable/scheduled-backups/pom.xml
+++ b/bigtable/scheduled-backups/pom.xml
@@ -46,7 +46,7 @@ limitations under the License.
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>

--- a/compute/signed-metadata/pom.xml
+++ b/compute/signed-metadata/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
   </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/container-registry/vulnerability-notification-function/pom.xml
+++ b/container-registry/vulnerability-notification-function/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
     </dependency>
 
     <dependency>

--- a/endpoints/getting-started/pom.xml
+++ b/endpoints/getting-started/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/endpoints/multiple-versions/pom.xml
+++ b/endpoints/multiple-versions/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/flexible/gaeinfo/pom.xml
+++ b/flexible/gaeinfo/pom.xml
@@ -59,7 +59,7 @@ Copyright 2017 Google Inc.
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
     </dependency>
 
     <dependency>

--- a/flexible/sparkjava/pom.xml
+++ b/flexible/sparkjava/pom.xml
@@ -54,7 +54,7 @@ limitations under the License.
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.8</version>
+      <version>2.8.7</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/flexible/sparkjava/pom.xml
+++ b/flexible/sparkjava/pom.xml
@@ -54,7 +54,7 @@ limitations under the License.
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/functions/concepts/retry-pubsub/pom.xml
+++ b/functions/concepts/retry-pubsub/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
     </dependency>
 
     <!-- Required for Function primitives -->

--- a/functions/concepts/retry-timeout/pom.xml
+++ b/functions/concepts/retry-timeout/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
     </dependency>
 
     <!-- Required for Function primitives -->

--- a/functions/firebase/auth/pom.xml
+++ b/functions/firebase/auth/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
     </dependency>
 
     <!-- Required for Function primitives -->

--- a/functions/firebase/remote-config/pom.xml
+++ b/functions/firebase/remote-config/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
     </dependency>
 
     <!-- Required for Function primitives -->

--- a/functions/firebase/rtdb/pom.xml
+++ b/functions/firebase/rtdb/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
     </dependency>
     <!-- Required for Function primitives -->
     <dependency>

--- a/functions/helloworld/hello-gcs/pom.xml
+++ b/functions/helloworld/hello-gcs/pom.xml
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
     </dependency>
 
     <!-- Used in ExampleSystemTest AND ExampleIntegrationTest -->

--- a/functions/helloworld/hello-http-gradle/build.gradle
+++ b/functions/helloworld/hello-http-gradle/build.gradle
@@ -25,7 +25,7 @@ dependencies {
   compileOnly 'com.google.cloud.functions:functions-framework-api:1.0.4'
 
   // Function implementations can have additional dependencies like this.
-  implementation 'com.google.code.gson:gson:2.8.6'
+  implementation 'com.google.code.gson:gson:2.8.8'
   implementation 'io.github.resilience4j:resilience4j-retry:1.7.1'
 
   // These dependencies are only used by the tests.

--- a/functions/helloworld/hello-http/pom.xml
+++ b/functions/helloworld/hello-http/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
     </dependency>
 
     <!-- Required for Function primitives -->

--- a/functions/helloworld/hello-pubsub/pom.xml
+++ b/functions/helloworld/hello-pubsub/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
     </dependency>
 
     <!-- Used in ExampleIntegrationTest (to make POST requests -->

--- a/functions/http/parse-content-type/pom.xml
+++ b/functions/http/parse-content-type/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.functions</groupId>

--- a/functions/logging/stackdriver-logging/pom.xml
+++ b/functions/logging/stackdriver-logging/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
     </dependency>
 
     <!-- Required for Function primitives -->

--- a/functions/slack/pom.xml
+++ b/functions/slack/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
     </dependency>
 
     <dependency>

--- a/monitoring/cloud-client/pom.xml
+++ b/monitoring/cloud-client/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>

--- a/monitoring/v3/pom.xml
+++ b/monitoring/v3/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.7</version>
+            <version>2.8.8</version>
         </dependency>
 
         <!-- FIXME: remove after client fixes depenency issue => BOM 9.0.0   -->

--- a/run/image-processing/pom.xml
+++ b/run/image-processing/pom.xml
@@ -79,7 +79,7 @@ limitations under the License.
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.7</version>
+      <version>2.8.8</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
It looks like the Java 17 build is failing due to a JSON parsing issue with GSON. The GSON library shows that it has improved Java 17 support since the last update.

However, the renovate GSON branch has been stuck open for over a year with no updates, since there was a manual change to it. This PR will be created and then closed. In the past, this has help to trigger another Renovate update.