### PR TITLE
chore: migrated left out samples

### DIFF
--- a/dialogflow/snippets/src/main/java/com/example/dialogflow/ConversationManagement.java
+++ b/dialogflow/snippets/src/main/java/com/example/dialogflow/ConversationManagement.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.dialogflow;
+
+// [START dialogflow_create_conversation]
+
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.dialogflow.v2.Conversation;
+import com.google.cloud.dialogflow.v2.ConversationProfileName;
+import com.google.cloud.dialogflow.v2.ConversationsClient;
+import com.google.cloud.dialogflow.v2.LocationName;
+import java.io.IOException;
+
+public class ConversationManagement {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project-id";
+    String location = "my-location";
+
+    // Set conversation profile id for the new conversation.
+    // See com.example.dialogflow.ConversationProfileManagement sample code for how to create a
+    // conversation profile. You can also create a conversation profile using Agent Assist console,
+    // https://cloud.google.com/agent-assist/docs/conversation-profile.
+    String conversationProfileId = "my-conversation-profile-id";
+
+    // Create a conversation
+    createConversation(projectId, location, conversationProfileId);
+  }
+
+  public static void createConversation(
+      String projectId, String location, String conversationProfileId)
+      throws ApiException, IOException {
+    try (ConversationsClient conversationsClient = ConversationsClient.create()) {
+      LocationName locationName = LocationName.of(projectId, location);
+      ConversationProfileName conversationProfileName =
+          ConversationProfileName.ofProjectLocationConversationProfileName(
+              projectId, location, conversationProfileId);
+      Conversation conversation =
+          Conversation.newBuilder()
+              .setConversationProfile(conversationProfileName.toString())
+              .build();
+      Conversation newConversation =
+          conversationsClient.createConversation(locationName, conversation);
+      System.out.println("====================");
+      System.out.println("Conversation Created:");
+      System.out.format("Life Cycle State: %s\n", newConversation.getLifecycleState());
+      System.out.format(
+          "Conversation Profile Name: %s\n", newConversation.getConversationProfile());
+      System.out.format("Name: %s\n", newConversation.getName());
+    }
+  }
+}
+// [END dialogflow_create_conversation]

--- a/dialogflow/snippets/src/main/java/com/example/dialogflow/ConversationProfileManagement.java
+++ b/dialogflow/snippets/src/main/java/com/example/dialogflow/ConversationProfileManagement.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.dialogflow;
+
+// [START dialogflow_create_conversation_profile_article_suggestion]
+
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.dialogflow.v2.ConversationProfile;
+import com.google.cloud.dialogflow.v2.ConversationProfilesClient;
+import com.google.cloud.dialogflow.v2.CreateConversationProfileRequest;
+import com.google.cloud.dialogflow.v2.HumanAgentAssistantConfig;
+import com.google.cloud.dialogflow.v2.HumanAgentAssistantConfig.SuggestionConfig;
+import com.google.cloud.dialogflow.v2.HumanAgentAssistantConfig.SuggestionFeatureConfig;
+import com.google.cloud.dialogflow.v2.HumanAgentAssistantConfig.SuggestionQueryConfig;
+import com.google.cloud.dialogflow.v2.HumanAgentAssistantConfig.SuggestionQueryConfig.KnowledgeBaseQuerySource;
+import com.google.cloud.dialogflow.v2.HumanAgentAssistantConfig.SuggestionTriggerSettings;
+import com.google.cloud.dialogflow.v2.KnowledgeBaseName;
+import com.google.cloud.dialogflow.v2.LocationName;
+import com.google.cloud.dialogflow.v2.SuggestionFeature;
+import com.google.cloud.dialogflow.v2.SuggestionFeature.Type;
+import java.io.IOException;
+import java.util.Optional;
+
+public class ConversationProfileManagement {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project-id";
+    String location = "my-location";
+
+    // Set display name of the new conversation profile
+    String conversationProfileDisplayName = "my-conversation-profile-display-name";
+
+    // Set knowledge base id for Article Suggestion feature.
+    // See details about how to create a knowledge base here,
+    // https://cloud.google.com/agent-assist/docs/article-suggestion.
+    String articleSuggestionKnowledgeBaseId = "my-article-suggestion-knowledge-base-id";
+
+    // Create a conversation profile
+    createConversationProfileArticleSuggestion(
+        projectId,
+        conversationProfileDisplayName,
+        location,
+        Optional.of(articleSuggestionKnowledgeBaseId));
+  }
+
+  // Set suggestion trigger with no_smalltalk and only_send_user both true, which means that
+  // the suggestion is not triggered if last utterance is small talk and is only triggered
+  // if participant role of last utterance is END_USER.
+  public static SuggestionTriggerSettings buildSuggestionTriggerSettings() {
+    return SuggestionTriggerSettings.newBuilder().setNoSmalltalk(true).setOnlyEndUser(true).build();
+  }
+
+  // Set the configuration for suggestion query, including the knowledge base query source
+  // and maximum number of results to return.
+  public static SuggestionQueryConfig buildSuggestionQueryConfig(
+      KnowledgeBaseName knowledgeBaseName) {
+    return SuggestionQueryConfig.newBuilder()
+        .setKnowledgeBaseQuerySource(
+            KnowledgeBaseQuerySource.newBuilder().addKnowledgeBases(knowledgeBaseName.toString()))
+        .setMaxResults(3)
+        .build();
+  }
+
+  // Create a conversation profile with given values about Article Suggestion.
+  public static void createConversationProfileArticleSuggestion(
+      String projectId,
+      String displayName,
+      String location,
+      Optional<String> articleSuggestionKnowledgeBaseId)
+      throws ApiException, IOException {
+    try (ConversationProfilesClient conversationProfilesClient =
+        ConversationProfilesClient.create()) {
+      // Create a builder for agent assistance configuration
+      SuggestionConfig.Builder suggestionConfigBuilder = SuggestionConfig.newBuilder();
+
+      // Add knowledge base for Article Suggestion feature
+      if (articleSuggestionKnowledgeBaseId.isPresent()) {
+        KnowledgeBaseName articleSuggestionKbName =
+            KnowledgeBaseName.of(projectId, articleSuggestionKnowledgeBaseId.get());
+
+        // Build configuration for Article Suggestion feature
+        SuggestionFeatureConfig articleSuggestionFeatureConfig =
+            SuggestionFeatureConfig.newBuilder()
+                .setSuggestionFeature(
+                    SuggestionFeature.newBuilder().setType(Type.ARTICLE_SUGGESTION).build())
+                .setSuggestionTriggerSettings(buildSuggestionTriggerSettings())
+                .setQueryConfig(buildSuggestionQueryConfig(articleSuggestionKbName))
+                .build();
+
+        // Add Article Suggestion feature to agent assistance configuration
+        suggestionConfigBuilder.addFeatureConfigs(articleSuggestionFeatureConfig);
+      }
+
+      LocationName locationName = LocationName.of(projectId, location);
+      // Set a conversation profile with target configurations
+      ConversationProfile targetConversationProfile =
+          ConversationProfile.newBuilder()
+              .setDisplayName(displayName)
+              .setLanguageCode("en-US")
+              .setHumanAgentAssistantConfig(
+                  HumanAgentAssistantConfig.newBuilder()
+                      .setHumanAgentSuggestionConfig(suggestionConfigBuilder.build()))
+              .build();
+
+      // Create a conversation profile
+      ConversationProfile createdConversationProfile =
+          conversationProfilesClient.createConversationProfile(
+              CreateConversationProfileRequest.newBuilder()
+                  .setParent(locationName.toString())
+                  .setConversationProfile(targetConversationProfile)
+                  .build());
+      System.out.println("====================");
+      System.out.println("Conversation Profile created:\n");
+      System.out.format("Display name: %s\n", createdConversationProfile.getDisplayName());
+      System.out.format("Name: %s\n", createdConversationProfile.getName());
+    }
+  }
+}
+// [END dialogflow_create_conversation_profile_article_suggestion]

--- a/dialogflow/snippets/src/main/java/com/example/dialogflow/ParticipantManagement.java
+++ b/dialogflow/snippets/src/main/java/com/example/dialogflow/ParticipantManagement.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.dialogflow;
+
+// [START dialogflow_create_participant]
+
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.dialogflow.v2.ConversationName;
+import com.google.cloud.dialogflow.v2.Participant;
+import com.google.cloud.dialogflow.v2.Participant.Role;
+import com.google.cloud.dialogflow.v2.ParticipantsClient;
+import java.io.IOException;
+
+public class ParticipantManagement {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project-id";
+    String location = "my-location";
+
+    // Set conversation id for the new participant,
+    // See com.example.dialogflow.ConversationManagement sample code
+    // for how to create a conversation.
+    String conversationId = "my-conversation-id";
+    Role role = Role.END_USER;
+
+    // Create a participant
+    createParticipant(projectId, location, conversationId, role);
+  }
+
+  // Create a participant with given role
+  public static void createParticipant(
+      String projectId, String location, String conversationId, Role role)
+      throws ApiException, IOException {
+    try (ParticipantsClient participantsClient = ParticipantsClient.create()) {
+      ConversationName conversationName =
+          ConversationName.ofProjectLocationConversationName(projectId, location, conversationId);
+      Participant participant = Participant.newBuilder().setRole(role).build();
+      Participant newParticipant =
+          participantsClient.createParticipant(conversationName, participant);
+      System.out.println("====================");
+      System.out.println("Participant Created:");
+      System.out.format("Role: %s\n", newParticipant.getRole());
+      System.out.format("Name: %s\n", newParticipant.getName());
+    }
+  }
+}
+// [END dialogflow_create_participant]

--- a/dialogflow/snippets/src/test/java/com/example/dialogflow/CreateConversationProfileTest.java
+++ b/dialogflow/snippets/src/test/java/com/example/dialogflow/CreateConversationProfileTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.dialogflow;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+import com.google.cloud.dialogflow.v2.ConversationProfilesClient;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+@SuppressWarnings("checkstyle:abbreviationaswordinname")
+public class CreateConversationProfileTest {
+
+  private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static final String LOCATION = "global";
+  private static final String NAME_PREFIX_IN_OUTPUT = "Name: ";
+  private static String conversationProfileNameToDelete = null;
+  private ByteArrayOutputStream bout;
+  private PrintStream newOutputStream;
+  private PrintStream originalOutputStream;
+
+  private static void requireEnvVar(String varName) {
+    assertNotNull(System.getenv(varName));
+  }
+
+  // Extract the name of a newly created resource from latest "Name: %s\n" in sample code output
+  private static String getResourceNameFromOutputString(String output) {
+    return output.substring(
+        output.lastIndexOf(NAME_PREFIX_IN_OUTPUT) + NAME_PREFIX_IN_OUTPUT.length(),
+        output.length() - 1);
+  }
+
+  private static void deleteConversationProfile(String conversationProfileName) throws IOException {
+    try (ConversationProfilesClient conversationProfilesClient =
+        ConversationProfilesClient.create()) {
+      conversationProfilesClient.deleteConversationProfile(conversationProfileName);
+    }
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() {
+    originalOutputStream = System.out;
+    bout = new ByteArrayOutputStream();
+    newOutputStream = new PrintStream(bout);
+    System.setOut(newOutputStream);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    if (conversationProfileNameToDelete != null) {
+      deleteConversationProfile(conversationProfileNameToDelete);
+      conversationProfileNameToDelete = null;
+    }
+
+    System.setOut(originalOutputStream);
+  }
+
+  @Test
+  public void testCreateConversationProfileArticleSuggestion() throws IOException {
+    String conversationProfileDisplayName = UUID.randomUUID().toString();
+
+    // Create a conversation profile
+    String articleSuggestionKnowledgeBaseId = UUID.randomUUID().toString();
+    ConversationProfileManagement.createConversationProfileArticleSuggestion(
+        PROJECT_ID,
+        conversationProfileDisplayName,
+        LOCATION,
+        Optional.of(articleSuggestionKnowledgeBaseId));
+
+    String output = bout.toString();
+    conversationProfileNameToDelete = getResourceNameFromOutputString(output);
+    assertThat(output).contains(conversationProfileDisplayName);
+
+    // Delete the conversation profile
+    deleteConversationProfile(conversationProfileNameToDelete);
+    conversationProfileNameToDelete = null;
+  }
+}

--- a/dialogflow/snippets/src/test/java/com/example/dialogflow/CreateConversationTest.java
+++ b/dialogflow/snippets/src/test/java/com/example/dialogflow/CreateConversationTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.dialogflow;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.dialogflow.v2.ConversationProfileName;
+import com.google.cloud.dialogflow.v2.ConversationProfilesClient;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+@SuppressWarnings("checkstyle:abbreviationaswordinname")
+public class CreateConversationTest {
+  private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static final String CONVERSATION_PROFILE_DISPLAY_NAME = UUID.randomUUID().toString();
+  private static final String LOCATION = "global";
+  private static final String NAME_PREFIX_IN_OUTPUT = "Name: ";
+  private ConversationProfileName conversationProfileName;
+  private ByteArrayOutputStream bout;
+  private PrintStream newOutputStream;
+  private PrintStream originalOutputStream;
+
+  private static void requireEnvVar(String varName) {
+    assertNotNull(System.getenv(varName));
+  }
+
+  // Extract the name of a newly created resource from latest "Name: %s\n" in sample code output
+  private static String getResourceNameFromOutputString(String output) {
+    return output.substring(
+        output.lastIndexOf(NAME_PREFIX_IN_OUTPUT) + NAME_PREFIX_IN_OUTPUT.length(),
+        output.length() - 1);
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    originalOutputStream = System.out;
+    bout = new ByteArrayOutputStream();
+    newOutputStream = new PrintStream(bout);
+    System.setOut(newOutputStream);
+
+    // Create a conversation profile
+    ConversationProfileManagement.createConversationProfileArticleSuggestion(
+        PROJECT_ID, CONVERSATION_PROFILE_DISPLAY_NAME, LOCATION, Optional.empty());
+    String output = bout.toString();
+    assertThat(output).contains(NAME_PREFIX_IN_OUTPUT);
+    conversationProfileName =
+        ConversationProfileName.parse(getResourceNameFromOutputString(output));
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    // Delete the created conversation profile
+    try (ConversationProfilesClient conversationProfilesClient =
+        ConversationProfilesClient.create()) {
+      conversationProfilesClient.deleteConversationProfile(conversationProfileName.toString());
+    }
+
+    System.setOut(originalOutputStream);
+  }
+
+  @Test
+  public void testCreateConversation() throws ApiException, IOException {
+    String conversationProfileId = conversationProfileName.getConversationProfile();
+    ConversationManagement.createConversation(PROJECT_ID, LOCATION, conversationProfileId);
+
+    String output = bout.toString();
+    assertThat(output).contains("Life Cycle State: IN_PROGRESS");
+    assertThat(output)
+        .contains(
+            String.format("Conversation Profile Name: %s", conversationProfileName.toString()));
+  }
+}

--- a/dialogflow/snippets/src/test/java/com/example/dialogflow/CreateParticipantTest.java
+++ b/dialogflow/snippets/src/test/java/com/example/dialogflow/CreateParticipantTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.dialogflow;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+import com.google.cloud.dialogflow.v2.ConversationName;
+import com.google.cloud.dialogflow.v2.ConversationProfileName;
+import com.google.cloud.dialogflow.v2.ConversationProfilesClient;
+import com.google.cloud.dialogflow.v2.Participant.Role;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+@SuppressWarnings("checkstyle:abbreviationaswordinname")
+public class CreateParticipantTest {
+  private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static final String CONVERSATION_PROFILE_DISPLAY_NAME = UUID.randomUUID().toString();
+  private static final String LOCATION = "global";
+  private static final String NAME_PREFIX_IN_OUTPUT = "Name: ";
+  private ConversationProfileName conversationProfileName;
+  private ByteArrayOutputStream bout;
+  private PrintStream newOutputStream;
+  private PrintStream originalOutputStream;
+
+  private static void requireEnvVar(String varName) {
+    assertNotNull(System.getenv(varName));
+  }
+
+  // Extract the name of a newly created resource from latest "Name: %s\n" in sample code output
+  private static String getResourceNameFromOutputString(String output) {
+    return output.substring(
+        output.lastIndexOf(NAME_PREFIX_IN_OUTPUT) + NAME_PREFIX_IN_OUTPUT.length(),
+        output.length() - 1);
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    originalOutputStream = System.out;
+    bout = new ByteArrayOutputStream();
+    newOutputStream = new PrintStream(bout);
+    System.setOut(newOutputStream);
+
+    // Create a conversation profile
+    ConversationProfileManagement.createConversationProfileArticleSuggestion(
+        PROJECT_ID, CONVERSATION_PROFILE_DISPLAY_NAME, LOCATION, Optional.empty());
+    String output = bout.toString();
+    assertThat(output).contains(NAME_PREFIX_IN_OUTPUT);
+    conversationProfileName =
+        ConversationProfileName.parse(getResourceNameFromOutputString(output));
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    // Delete the created conversation profile
+    try (ConversationProfilesClient conversationProfilesClient =
+        ConversationProfilesClient.create()) {
+      conversationProfilesClient.deleteConversationProfile(conversationProfileName.toString());
+    }
+
+    System.setOut(originalOutputStream);
+  }
+
+  @Test
+  public void testCreateParticipant() throws IOException {
+    // Create a conversation
+    ConversationManagement.createConversation(
+        PROJECT_ID, LOCATION, conversationProfileName.getConversationProfile());
+    ConversationName conversationName =
+        ConversationName.parse(getResourceNameFromOutputString(bout.toString()));
+
+    // Create a participant
+    ParticipantManagement.createParticipant(
+        PROJECT_ID, LOCATION, conversationName.getConversation(), Role.END_USER);
+    assertThat(bout.toString()).contains("Role: END_USER");
+  }
+}


### PR DESCRIPTION
### Migrating samples from [googleapis/java-dialogflow](https://github.com/googleapis/java-dialogflow/tree/main/samples) into [java-docs-samples/dialogflow](https://github.com/GoogleCloudPlatform/java-docs-samples)
---

#### Related PR: https://github.com/GoogleCloudPlatform/java-docs-samples/pull/7420
#### Context:
- During the initial migration of the samples from the client repo some samples were left out since they were not being referenced anywhere in the documentation.
- However, in later discussions with the Eng Team and DEE Team for dialogflow, it was deemed that some of these samples have to be migrated and used in documentation

#### Eng Team contact: @deliaqi 
#### DEE Team contact: @nicain 