### PR TITLE
test: increased timeout and added retries to flaky tests

### DIFF
--- a/.kokoro/tests/run_test_java.sh
+++ b/.kokoro/tests/run_test_java.sh
@@ -66,9 +66,7 @@ mvn --quiet --batch-mode --fail-at-end clean verify \
     -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
     -Dmaven.test.redirectTestOutputToFile=true \
     -Dbigtable.projectID="${GOOGLE_CLOUD_PROJECT}" \
-    -Dbigtable.instanceID=instance \
-    -X \
-    -DtrimStackTrace=false
+    -Dbigtable.instanceID=instance
 EXIT=$?
 
 # Tear down (deployed) Cloud Functions after deployment tests are run

--- a/.kokoro/tests/run_test_java.sh
+++ b/.kokoro/tests/run_test_java.sh
@@ -66,7 +66,9 @@ mvn --quiet --batch-mode --fail-at-end clean verify \
     -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
     -Dmaven.test.redirectTestOutputToFile=true \
     -Dbigtable.projectID="${GOOGLE_CLOUD_PROJECT}" \
-    -Dbigtable.instanceID=instance
+    -Dbigtable.instanceID=instance \
+    -X \
+    -DtrimStackTrace=false
 EXIT=$?
 
 # Tear down (deployed) Cloud Functions after deployment tests are run

--- a/asset/src/test/java/com/example/asset/QuickStartIT.java
+++ b/asset/src/test/java/com/example/asset/QuickStartIT.java
@@ -17,7 +17,6 @@
 package com.example.asset;
 
 import static com.google.common.truth.Truth.assertThat;
-
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.asset.v1.ContentType;
 import com.google.cloud.bigquery.BigQuery;
@@ -31,11 +30,13 @@ import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobListOption;
 import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -44,6 +45,9 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class QuickStartIT {
+  @Rule
+  public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
+  
   private static final String bucketName = "java-docs-samples-testing";
   private static final String path = UUID.randomUUID().toString();
   private static final String datasetName = RemoteBigQueryHelper.generateDatasetName();

--- a/asset/src/test/java/com/example/asset/QuickStartIT.java
+++ b/asset/src/test/java/com/example/asset/QuickStartIT.java
@@ -47,7 +47,7 @@ import org.junit.runners.JUnit4;
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class QuickStartIT {
   @Rule
-  public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
+  public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(1);
   
   private static final String bucketName = "java-docs-samples-testing";
   private static final String path = UUID.randomUUID().toString();

--- a/asset/src/test/java/com/example/asset/QuickStartIT.java
+++ b/asset/src/test/java/com/example/asset/QuickStartIT.java
@@ -34,11 +34,13 @@ import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.concurrent.TimeUnit;
 import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -46,8 +48,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class QuickStartIT {
-  @Rule
-  public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(1);
+  @Rule public final Timeout testTimeout = new Timeout(10, TimeUnit.MINUTES);
+  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(1);
   
   private static final String bucketName = "java-docs-samples-testing";
   private static final String path = UUID.randomUUID().toString();
@@ -82,6 +84,8 @@ public class QuickStartIT {
     originalPrintStream = System.out;
     System.setOut(out);
   }
+
+
 
   @After
   public void tearDown() {

--- a/asset/src/test/java/com/example/asset/QuickStartIT.java
+++ b/asset/src/test/java/com/example/asset/QuickStartIT.java
@@ -17,6 +17,7 @@
 package com.example.asset;
 
 import static com.google.common.truth.Truth.assertThat;
+
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.asset.v1.ContentType;
 import com.google.cloud.bigquery.BigQuery;

--- a/asset/src/test/java/com/example/asset/QuickStartIT.java
+++ b/asset/src/test/java/com/example/asset/QuickStartIT.java
@@ -34,8 +34,8 @@ import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.util.concurrent.TimeUnit;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -49,7 +49,7 @@ import org.junit.runners.JUnit4;
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class QuickStartIT {
   @Rule public final Timeout testTimeout = new Timeout(10, TimeUnit.MINUTES);
-  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(1);
+  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
   
   private static final String bucketName = "java-docs-samples-testing";
   private static final String path = UUID.randomUUID().toString();

--- a/asset/src/test/java/com/example/asset/QuickStartIT.java
+++ b/asset/src/test/java/com/example/asset/QuickStartIT.java
@@ -22,8 +22,8 @@ import com.google.cloud.ServiceOptions;
 import com.google.cloud.asset.v1.ContentType;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQuery.DatasetDeleteOption;
+import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.BigQueryOptions;
-import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.DatasetInfo;
 import com.google.cloud.bigquery.testing.RemoteBigQueryHelper;
@@ -76,16 +76,11 @@ public class QuickStartIT {
   @Before
   public void setUp() {
     bigquery = BigQueryOptions.getDefaultInstance().getService();
-    if (bigquery.getDataset(datasetName) == null) {
-      Dataset dataset = bigquery.create(DatasetInfo.newBuilder(datasetName).build());
-    }
     bout = new ByteArrayOutputStream();
     out = new PrintStream(bout);
     originalPrintStream = System.out;
     System.setOut(out);
   }
-
-
 
   @After
   public void tearDown() {
@@ -107,8 +102,7 @@ public class QuickStartIT {
 
   @Test
   public void testExportAssetBigqueryPerTypeExample() throws Exception {
-    String dataset =
-        String.format("projects/%s/datasets/%s", ServiceOptions.getDefaultProjectId(), datasetName);
+    String dataset = getDataset();
     String table = "java_test_per_type";
     ExportAssetsBigqueryExample.exportBigQuery(
         dataset, table, ContentType.RESOURCE, /*perType*/ true);
@@ -118,8 +112,7 @@ public class QuickStartIT {
 
   @Test
   public void testExportAssetBigqueryExample() throws Exception {
-    String dataset =
-        String.format("projects/%s/datasets/%s", ServiceOptions.getDefaultProjectId(), datasetName);
+    String dataset = getDataset();
     String table = "java_test";
     ExportAssetsBigqueryExample.exportBigQuery(
         dataset, table, ContentType.RESOURCE, /*perType*/ false);
@@ -135,5 +128,14 @@ public class QuickStartIT {
     if (!got.isEmpty()) {
       assertThat(got).contains(bucketAssetName);
     }
+  }
+
+  protected String getDataset() throws BigQueryException {
+    if (bigquery.getDataset(datasetName) == null) {
+      bigquery.create(DatasetInfo.newBuilder(datasetName).build());
+    }
+    return String.format(
+      "projects/%s/datasets/%s", ServiceOptions.getDefaultProjectId(), datasetName);
+
   }
 }

--- a/automl/src/test/java/beta/automl/TablesCreateModelTest.java
+++ b/automl/src/test/java/beta/automl/TablesCreateModelTest.java
@@ -19,6 +19,7 @@ package beta.automl;
 import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.TestCase.assertNotNull;
 
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -27,6 +28,7 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -34,6 +36,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class TablesCreateModelTest {
+  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
 
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
   private static final String DATASET_ID = "TBL00000000000000000000";

--- a/automl/src/test/java/beta/automl/TablesPredictTest.java
+++ b/automl/src/test/java/beta/automl/TablesPredictTest.java
@@ -42,8 +42,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class TablesPredictTest {
-  @Rule
-  public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
+  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
 
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
   private static final String MODEL_ID = "TBL7972827093840953344";

--- a/automl/src/test/java/beta/automl/TablesPredictTest.java
+++ b/automl/src/test/java/beta/automl/TablesPredictTest.java
@@ -23,6 +23,7 @@ import com.google.cloud.automl.v1.AutoMlClient;
 import com.google.cloud.automl.v1.DeployModelRequest;
 import com.google.cloud.automl.v1.Model;
 import com.google.cloud.automl.v1.ModelName;
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import com.google.protobuf.Value;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -40,6 +42,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class TablesPredictTest {
+  @Rule
+  public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
 
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
   private static final String MODEL_ID = "TBL7972827093840953344";

--- a/automl/src/test/java/com/example/automl/LanguageTextClassificationCreateModelTest.java
+++ b/automl/src/test/java/com/example/automl/LanguageTextClassificationCreateModelTest.java
@@ -19,6 +19,7 @@ package com.example.automl;
 import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.TestCase.assertNotNull;
 
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -27,6 +28,7 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -34,6 +36,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class LanguageTextClassificationCreateModelTest {
+  @Rule
+  public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
 
   private static final String PROJECT_ID = System.getenv("AUTOML_PROJECT_ID");
   private static final String DATASET_ID = "TCN00000000000000000000";

--- a/automl/src/test/java/com/example/automl/LanguageTextClassificationCreateModelTest.java
+++ b/automl/src/test/java/com/example/automl/LanguageTextClassificationCreateModelTest.java
@@ -36,8 +36,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class LanguageTextClassificationCreateModelTest {
-  @Rule
-  public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
+  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
 
   private static final String PROJECT_ID = System.getenv("AUTOML_PROJECT_ID");
   private static final String DATASET_ID = "TCN00000000000000000000";


### PR DESCRIPTION
- Asset/AutoML: Adds retries to failing tests
- Asset: 
  - Updates timeout from 5->10 min (later we could apply a filter on asset type to speed up test)
  - Refactors dataset creation to occur in helper method
    - Dataset creation fails sometimes and should be included when retrying

Fixes #7463, Fixes #7456, Fixes #7446
