### PR TITLE
test: fix flaky asset tests

### DIFF
--- a/asset/src/main/java/com/example/asset/ExportAssetsBigqueryExample.java
+++ b/asset/src/main/java/com/example/asset/ExportAssetsBigqueryExample.java
@@ -24,21 +24,31 @@ import com.google.cloud.asset.v1.AssetServiceClient;
 import com.google.cloud.asset.v1.BigQueryDestination;
 import com.google.cloud.asset.v1.ContentType;
 import com.google.cloud.asset.v1.ExportAssetsRequest;
+import com.google.cloud.asset.v1.ExportAssetsRequest.Builder;
 import com.google.cloud.asset.v1.ExportAssetsResponse;
 import com.google.cloud.asset.v1.OutputConfig;
 import com.google.cloud.asset.v1.PartitionSpec;
 import com.google.cloud.asset.v1.ProjectName;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
+import java.util.Arrays;
 
 public class ExportAssetsBigqueryExample {
 
   // Use the default project Id.
   private static final String projectId = ServiceOptions.getDefaultProjectId();
 
-  // Export assets to BigQuery for a project.
+  /** 
+   * Export assets to BigQuery for a project.
+   * 
+   * @param bigqueryDataset which dataset the results will be exported to
+   * @param bigqueryTable which table the results will be exported to
+   * @param contentType determines the schema for the table
+   * @param assetTypes a list of asset types to export. if empty, export all.
+   * @param isPerType separate BigQuery tables for each resource type
+   */
   public static void exportBigQuery(
-      String bigqueryDataset, String bigqueryTable, ContentType contentType, boolean isPerType)
+      String bigqueryDataset, String bigqueryTable, ContentType contentType, String[] assetTypes, boolean isPerType)
       throws IOException, IllegalArgumentException, InterruptedException, ExecutionException {
     try (AssetServiceClient client = AssetServiceClient.create()) {
       ProjectName parent = ProjectName.of(projectId);
@@ -70,12 +80,12 @@ public class ExportAssetsBigqueryExample {
                         .build())
                 .build();
       }
-      ExportAssetsRequest request =
-          ExportAssetsRequest.newBuilder()
-              .setParent(parent.toString())
-              .setContentType(contentType)
-              .setOutputConfig(outputConfig)
-              .build();
+      Builder exportAssetsRequestBuilder = ExportAssetsRequest.newBuilder()
+          .setParent(parent.toString()).setContentType(contentType).setOutputConfig(outputConfig);
+      if (assetTypes.length > 0) {
+        exportAssetsRequestBuilder.addAllAssetTypes(Arrays.asList(assetTypes));
+      }
+      ExportAssetsRequest request = exportAssetsRequestBuilder.build();
       ExportAssetsResponse response = client.exportAssetsAsync(request).get();
       System.out.println(response);
     }

--- a/asset/src/main/java/com/example/asset/ExportAssetsBigqueryExample.java
+++ b/asset/src/main/java/com/example/asset/ExportAssetsBigqueryExample.java
@@ -30,8 +30,8 @@ import com.google.cloud.asset.v1.OutputConfig;
 import com.google.cloud.asset.v1.PartitionSpec;
 import com.google.cloud.asset.v1.ProjectName;
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
 import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
 
 public class ExportAssetsBigqueryExample {
 
@@ -40,15 +40,15 @@ public class ExportAssetsBigqueryExample {
 
   /** 
    * Export assets to BigQuery for a project.
-   * 
+
    * @param bigqueryDataset which dataset the results will be exported to
    * @param bigqueryTable which table the results will be exported to
    * @param contentType determines the schema for the table
    * @param assetTypes a list of asset types to export. if empty, export all.
    * @param isPerType separate BigQuery tables for each resource type
    */
-  public static void exportBigQuery(
-      String bigqueryDataset, String bigqueryTable, ContentType contentType, String[] assetTypes, boolean isPerType)
+  public static void exportBigQuery(String bigqueryDataset, String bigqueryTable,
+      ContentType contentType, String[] assetTypes, boolean isPerType)
       throws IOException, IllegalArgumentException, InterruptedException, ExecutionException {
     try (AssetServiceClient client = AssetServiceClient.create()) {
       ProjectName parent = ProjectName.of(projectId);

--- a/asset/src/main/java/com/example/asset/ExportAssetsExample.java
+++ b/asset/src/main/java/com/example/asset/ExportAssetsExample.java
@@ -23,21 +23,28 @@ import com.google.cloud.ServiceOptions;
 import com.google.cloud.asset.v1.AssetServiceClient;
 import com.google.cloud.asset.v1.ContentType;
 import com.google.cloud.asset.v1.ExportAssetsRequest;
+import com.google.cloud.asset.v1.ExportAssetsRequest.Builder;
 import com.google.cloud.asset.v1.ExportAssetsResponse;
 import com.google.cloud.asset.v1.GcsDestination;
 import com.google.cloud.asset.v1.OutputConfig;
 import com.google.cloud.asset.v1.ProjectName;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
+import java.util.Arrays;
 
 public class ExportAssetsExample {
 
   // Use the default project Id.
   private static final String projectId = ServiceOptions.getDefaultProjectId();
 
-  // Export assets for a project.
-  // @param exportPath where the results will be exported to.
-  public static void exportAssets(String exportPath, ContentType contentType)
+  /**
+   * Export assets for a project.
+   * 
+   * @param exportPath where the results will be exported to
+   * @param contentType determines the schema for the table
+   * @param assetTypes a list of asset types to export. if empty, export all.
+   */
+  public static void exportAssets(String exportPath, ContentType contentType, String[] assetTypes)
       throws IOException, IllegalArgumentException, InterruptedException, ExecutionException {
     try (AssetServiceClient client = AssetServiceClient.create()) {
       ProjectName parent = ProjectName.of(projectId);
@@ -45,12 +52,12 @@ public class ExportAssetsExample {
           OutputConfig.newBuilder()
               .setGcsDestination(GcsDestination.newBuilder().setUri(exportPath).build())
               .build();
-      ExportAssetsRequest request =
-          ExportAssetsRequest.newBuilder()
-              .setParent(parent.toString())
-              .setOutputConfig(outputConfig)
-              .setContentType(contentType)
-              .build();
+      Builder exportAssetsRequestBuilder = ExportAssetsRequest.newBuilder()
+          .setParent(parent.toString()).setContentType(contentType).setOutputConfig(outputConfig);
+      if (assetTypes.length > 0) {
+        exportAssetsRequestBuilder.addAllAssetTypes(Arrays.asList(assetTypes));
+      }
+      ExportAssetsRequest request = exportAssetsRequestBuilder.build();              
       ExportAssetsResponse response = client.exportAssetsAsync(request).get();
       System.out.println(response);
     }

--- a/asset/src/main/java/com/example/asset/ExportAssetsExample.java
+++ b/asset/src/main/java/com/example/asset/ExportAssetsExample.java
@@ -29,8 +29,8 @@ import com.google.cloud.asset.v1.GcsDestination;
 import com.google.cloud.asset.v1.OutputConfig;
 import com.google.cloud.asset.v1.ProjectName;
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
 import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
 
 public class ExportAssetsExample {
 
@@ -39,7 +39,7 @@ public class ExportAssetsExample {
 
   /**
    * Export assets for a project.
-   * 
+
    * @param exportPath where the results will be exported to
    * @param contentType determines the schema for the table
    * @param assetTypes a list of asset types to export. if empty, export all.

--- a/asset/src/test/java/com/example/asset/QuickStartIT.java
+++ b/asset/src/test/java/com/example/asset/QuickStartIT.java
@@ -51,14 +51,12 @@ public class QuickStartIT {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
   
   private static final String bucketName = "java-docs-samples-testing";
-  private static final String path = UUID.randomUUID().toString();
-  private String datasetName;
   private ByteArrayOutputStream bout;
   private PrintStream out;
   private PrintStream originalPrintStream;
   private BigQuery bigquery;
 
-  private static final void deleteObjects() {
+  private static final void deleteObjects(String path) {
     Storage storage = StorageOptions.getDefaultInstance().getService();
     for (BlobInfo info :
         storage
@@ -86,42 +84,49 @@ public class QuickStartIT {
     // restores print statements in the original method
     System.out.flush();
     System.setOut(originalPrintStream);
-    deleteObjects();
   }
 
   @Test
   public void testExportAssetExample() throws Exception {
-    String assetDumpPath = String.format("gs://%s/%s/my-assets-dump.txt", bucketName, path);
-    ExportAssetsExample.exportAssets(assetDumpPath, ContentType.RESOURCE);
-    String got = bout.toString();
-    assertThat(got).contains(String.format("uri: \"%s\"", assetDumpPath));
+    String path = UUID.randomUUID().toString();
+    try {
+      String assetDumpPath = String.format("gs://%s/%s/my-assets-dump.txt", bucketName, path);
+      ExportAssetsExample.exportAssets(assetDumpPath, ContentType.RESOURCE);
+      String got = bout.toString();
+      assertThat(got).contains(String.format("uri: \"%s\"", assetDumpPath));
+    }
+    finally {
+      deleteObjects(path); 
+    }
   }
 
   @Test
   public void testExportAssetBigqueryPerTypeExample() throws Exception {
+    String datasetName = RemoteBigQueryHelper.generateDatasetName();    
     try {
-      String dataset = getDataset();
+      String dataset = getDataset(datasetName);
       String table = "java_test_per_type";
       ExportAssetsBigqueryExample.exportBigQuery(dataset, table, ContentType.RESOURCE,
           /*perType*/ true);
       String got = bout.toString();
       assertThat(got).contains(String.format("dataset: \"%s\"", dataset));
     } finally {
-      deleteDataset();
+      deleteDataset(datasetName);
     }
   }
 
   @Test
   public void testExportAssetBigqueryExample() throws Exception {
+    String datasetName = RemoteBigQueryHelper.generateDatasetName();    
     try {
-      String dataset = getDataset();
-      String table = "java_test";
-      ExportAssetsBigqueryExample.exportBigQuery(dataset, table, ContentType.RESOURCE,
-          /*perType*/ false);
-      String got = bout.toString();
-      assertThat(got).contains(String.format("dataset: \"%s\"", dataset));
+    String dataset = getDataset(datasetName);
+    String table = "java_test";
+    ExportAssetsBigqueryExample.exportBigQuery(
+        dataset, table, ContentType.RESOURCE, /*perType*/ false);
+    String got = bout.toString();
+    assertThat(got).contains(String.format("dataset: \"%s\"", dataset));
     } finally {
-      deleteDataset();
+      deleteDataset(datasetName);
     }
   }
 
@@ -135,15 +140,13 @@ public class QuickStartIT {
     }
   }
 
-  protected String getDataset() throws BigQueryException {
-    datasetName = RemoteBigQueryHelper.generateDatasetName();
+  protected String getDataset(String datasetName) throws BigQueryException {
     bigquery.create(DatasetInfo.newBuilder(datasetName).build());
-
     return String.format(
       "projects/%s/datasets/%s", bigquery.getOptions().getProjectId(), datasetName);
   }
 
-  protected void deleteDataset() {
+  protected void deleteDataset(String datasetName) {
     DatasetId datasetId = DatasetId.of(bigquery.getOptions().getProjectId(), datasetName);
     bigquery.delete(datasetId, DatasetDeleteOption.deleteContents());
   }

--- a/asset/src/test/java/com/example/asset/QuickStartIT.java
+++ b/asset/src/test/java/com/example/asset/QuickStartIT.java
@@ -96,8 +96,7 @@ public class QuickStartIT {
       ExportAssetsExample.exportAssets(assetDumpPath, ContentType.RESOURCE, assetTypes);
       String got = bout.toString();
       assertThat(got).contains(String.format("uri: \"%s\"", assetDumpPath));
-    }
-    finally {
+    } finally {
       deleteObjects(path); 
     }
   }

--- a/asset/src/test/java/com/example/asset/QuickStartIT.java
+++ b/asset/src/test/java/com/example/asset/QuickStartIT.java
@@ -134,8 +134,10 @@ public class QuickStartIT {
     if (bigquery.getDataset(datasetName) == null) {
       bigquery.create(DatasetInfo.newBuilder(datasetName).build());
     }
-    return String.format(
+    String dataset = String.format(
       "projects/%s/datasets/%s", ServiceOptions.getDefaultProjectId(), datasetName);
+    System.out.println(dataset);
+    return dataset;
 
   }
 }

--- a/asset/src/test/java/com/example/asset/QuickStartIT.java
+++ b/asset/src/test/java/com/example/asset/QuickStartIT.java
@@ -22,6 +22,7 @@ import com.google.cloud.ServiceOptions;
 import com.google.cloud.asset.v1.ContentType;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQuery.DatasetDeleteOption;
+import com.google.cloud.bigquery.DatasetInfo.Builder;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.bigquery.DatasetId;
@@ -131,13 +132,7 @@ public class QuickStartIT {
   }
 
   protected String getDataset() throws BigQueryException {
-    if (bigquery.getDataset(datasetName) == null) {
-      bigquery.create(DatasetInfo.newBuilder(datasetName).build());
-    }
-    String dataset = String.format(
-      "projects/%s/datasets/%s", ServiceOptions.getDefaultProjectId(), datasetName);
-    System.out.println(dataset);
-    return dataset;
-
+    bigquery.create(DatasetInfo.newBuilder(datasetName).build());
+    return String.format("projects/%s/datasets/%s", ServiceOptions.getDefaultProjectId(), datasetName);
   }
 }

--- a/asset/src/test/java/com/example/asset/QuickStartIT.java
+++ b/asset/src/test/java/com/example/asset/QuickStartIT.java
@@ -51,6 +51,8 @@ public class QuickStartIT {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
   
   private static final String bucketName = "java-docs-samples-testing";
+  private static final String[] assetTypes = { "compute.googleapis.com/Disk" };
+
   private ByteArrayOutputStream bout;
   private PrintStream out;
   private PrintStream originalPrintStream;
@@ -91,7 +93,7 @@ public class QuickStartIT {
     String path = UUID.randomUUID().toString();
     try {
       String assetDumpPath = String.format("gs://%s/%s/my-assets-dump.txt", bucketName, path);
-      ExportAssetsExample.exportAssets(assetDumpPath, ContentType.RESOURCE);
+      ExportAssetsExample.exportAssets(assetDumpPath, ContentType.RESOURCE, assetTypes);
       String got = bout.toString();
       assertThat(got).contains(String.format("uri: \"%s\"", assetDumpPath));
     }
@@ -106,7 +108,7 @@ public class QuickStartIT {
     try {
       String dataset = getDataset(datasetName);
       String table = "java_test_per_type";
-      ExportAssetsBigqueryExample.exportBigQuery(dataset, table, ContentType.RESOURCE,
+      ExportAssetsBigqueryExample.exportBigQuery(dataset, table, ContentType.RESOURCE, assetTypes,
           /*perType*/ true);
       String got = bout.toString();
       assertThat(got).contains(String.format("dataset: \"%s\"", dataset));
@@ -119,12 +121,13 @@ public class QuickStartIT {
   public void testExportAssetBigqueryExample() throws Exception {
     String datasetName = RemoteBigQueryHelper.generateDatasetName();    
     try {
-    String dataset = getDataset(datasetName);
-    String table = "java_test";
-    ExportAssetsBigqueryExample.exportBigQuery(
-        dataset, table, ContentType.RESOURCE, /*perType*/ false);
-    String got = bout.toString();
-    assertThat(got).contains(String.format("dataset: \"%s\"", dataset));
+      String dataset = getDataset(datasetName);
+      String table = "java_test";
+      String[] assetTypes = { "compute.googleapis.com/Disk" };
+      ExportAssetsBigqueryExample.exportBigQuery(
+          dataset, table, ContentType.RESOURCE, assetTypes, /*perType*/ false);
+      String got = bout.toString();
+      assertThat(got).contains(String.format("dataset: \"%s\"", dataset));
     } finally {
       deleteDataset(datasetName);
     }

--- a/asset/src/test/java/com/example/asset/QuickStartIT.java
+++ b/asset/src/test/java/com/example/asset/QuickStartIT.java
@@ -22,7 +22,6 @@ import com.google.cloud.ServiceOptions;
 import com.google.cloud.asset.v1.ContentType;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQuery.DatasetDeleteOption;
-import com.google.cloud.bigquery.DatasetInfo.Builder;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.bigquery.DatasetId;

--- a/asset/src/test/java/com/example/asset/QuickStartIT.java
+++ b/asset/src/test/java/com/example/asset/QuickStartIT.java
@@ -18,13 +18,11 @@ package com.example.asset;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.cloud.ServiceOptions;
 import com.google.cloud.asset.v1.ContentType;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQuery.DatasetDeleteOption;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.BigQueryOptions;
-import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.DatasetInfo;
 import com.google.cloud.bigquery.testing.RemoteBigQueryHelper;
@@ -135,7 +133,7 @@ public class QuickStartIT {
     bigquery.create(DatasetInfo.newBuilder(datasetName).build());
 
     return String.format(
-      "projects/%s/datasets/%s", ServiceOptions.getDefaultProjectId(), datasetName);
+      "projects/%s/datasets/%s", bigquery.getOptions().getProjectId(), datasetName);
   }
 
   protected void deleteDataset() {

--- a/asset/src/test/java/com/example/asset/QuickStartIT.java
+++ b/asset/src/test/java/com/example/asset/QuickStartIT.java
@@ -52,7 +52,7 @@ public class QuickStartIT {
   
   private static final String bucketName = "java-docs-samples-testing";
   private static final String path = UUID.randomUUID().toString();
-  private static final String datasetName = RemoteBigQueryHelper.generateDatasetName();
+  private String datasetName;
   private ByteArrayOutputStream bout;
   private PrintStream out;
   private PrintStream originalPrintStream;
@@ -87,7 +87,6 @@ public class QuickStartIT {
     System.out.flush();
     System.setOut(originalPrintStream);
     deleteObjects();
-    deleteDataset();
   }
 
   @Test
@@ -100,22 +99,30 @@ public class QuickStartIT {
 
   @Test
   public void testExportAssetBigqueryPerTypeExample() throws Exception {
-    String dataset = getDataset();
-    String table = "java_test_per_type";
-    ExportAssetsBigqueryExample.exportBigQuery(
-        dataset, table, ContentType.RESOURCE, /*perType*/ true);
-    String got = bout.toString();
-    assertThat(got).contains(String.format("dataset: \"%s\"", dataset));
+    try {
+      String dataset = getDataset();
+      String table = "java_test_per_type";
+      ExportAssetsBigqueryExample.exportBigQuery(dataset, table, ContentType.RESOURCE,
+          /*perType*/ true);
+      String got = bout.toString();
+      assertThat(got).contains(String.format("dataset: \"%s\"", dataset));
+    } finally {
+      deleteDataset();
+    }
   }
 
   @Test
   public void testExportAssetBigqueryExample() throws Exception {
-    String dataset = getDataset();
-    String table = "java_test";
-    ExportAssetsBigqueryExample.exportBigQuery(
-        dataset, table, ContentType.RESOURCE, /*perType*/ false);
-    String got = bout.toString();
-    assertThat(got).contains(String.format("dataset: \"%s\"", dataset));
+    try {
+      String dataset = getDataset();
+      String table = "java_test";
+      ExportAssetsBigqueryExample.exportBigQuery(dataset, table, ContentType.RESOURCE,
+          /*perType*/ false);
+      String got = bout.toString();
+      assertThat(got).contains(String.format("dataset: \"%s\"", dataset));
+    } finally {
+      deleteDataset();
+    }
   }
 
   @Test
@@ -129,7 +136,7 @@ public class QuickStartIT {
   }
 
   protected String getDataset() throws BigQueryException {
-    deleteDataset();
+    datasetName = RemoteBigQueryHelper.generateDatasetName();
     bigquery.create(DatasetInfo.newBuilder(datasetName).build());
 
     return String.format(

--- a/asset/src/test/java/com/example/asset/QuickStartIT.java
+++ b/asset/src/test/java/com/example/asset/QuickStartIT.java
@@ -24,6 +24,7 @@ import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQuery.DatasetDeleteOption;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.DatasetInfo;
 import com.google.cloud.bigquery.testing.RemoteBigQueryHelper;
@@ -88,8 +89,7 @@ public class QuickStartIT {
     System.out.flush();
     System.setOut(originalPrintStream);
     deleteObjects();
-    DatasetId datasetId = DatasetId.of(bigquery.getOptions().getProjectId(), datasetName);
-    bigquery.delete(datasetId, DatasetDeleteOption.deleteContents());
+    deleteDataset();
   }
 
   @Test
@@ -131,7 +131,17 @@ public class QuickStartIT {
   }
 
   protected String getDataset() throws BigQueryException {
+    deleteDataset();
     bigquery.create(DatasetInfo.newBuilder(datasetName).build());
-    return String.format("projects/%s/datasets/%s", ServiceOptions.getDefaultProjectId(), datasetName);
+
+    return String.format(
+      "projects/%s/datasets/%s", ServiceOptions.getDefaultProjectId(), datasetName);
   }
+
+  protected void deleteDataset() {
+    DatasetId datasetId = DatasetId.of(bigquery.getOptions().getProjectId(), datasetName);
+    bigquery.delete(datasetId, DatasetDeleteOption.deleteContents());
+  }
+
+
 }


### PR DESCRIPTION
#7446 has continued to flake after retries were added.  The following updates were made in this PR:

- Tests will use a different Dataset ID or GCS path each retry. Whenever a timeout flake occurred, retries immediately failed with an `INVALID_ARGUMENT` exception. I believe that was because the resources were still in use. 
- A new, optional sample parameter for exporting specific asset types was introduced. This should hopefully reduce the export time, and therefore reduce the chance of timeouts. The tests now only export the Disk asset type.

Fixes #7446
Fixes #7456
Fixes #7476  