### PR TITLE
test: handle flaky timeout in GAE task test

### DIFF
--- a/unittests/src/test/java/com/google/appengine/samples/DeferredTaskTest.java
+++ b/unittests/src/test/java/com/google/appengine/samples/DeferredTaskTest.java
@@ -1,17 +1,17 @@
 /*
  * Copyright 2015 Google Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.google.appengine.samples;

--- a/unittests/src/test/java/com/google/appengine/samples/DeferredTaskTest.java
+++ b/unittests/src/test/java/com/google/appengine/samples/DeferredTaskTest.java
@@ -83,7 +83,6 @@ public class DeferredTaskTest {
   }
 
   @After
-  @SuppressWarnings("finally")
   public void tearDown() throws TestTimedOutException {
     MyTask.taskRan = false;
     requestReset();
@@ -92,19 +91,19 @@ public class DeferredTaskTest {
     } catch (/*TestTimedOutException*/ Throwable ex) {
       // Ignoring, flaky test, sometimes we do timeout.
       Logger.getLogger(DeferredTaskTest.class.getName()).log(Level.SEVERE, null, ex);
-    } finally {
-      // tearDown() times out non-deterministically, and the exception can't be caught.
-      // testTaskGetsRun() now expects the exception. Since the expected parameter
-      // can't be optional, the exception is intentionally thrown when tearDown() is successful.
-      throw new TestTimedOutException(0, TimeUnit.MINUTES);
     }
   }
 
   @Test(expected = TestTimedOutException.class)
-  public void testTaskGetsRun() throws InterruptedException {
+  public void testTaskGetsRun() throws InterruptedException, TestTimedOutException {
     QueueFactory.getDefaultQueue().add(TaskOptions.Builder.withPayload(new MyTask()));
     assertTrue(requestAwait());
     assertTrue(MyTask.taskRan);
+
+    // tearDown() times out non-deterministically, and the exception can't be caught.
+    // testTaskGetsRun() now expects the exception. Since the expected parameter
+    // can't be optional, the exception is intentionally thrown when tearDown() is successful.
+    throw new TestTimedOutException(0, TimeUnit.MINUTES);
   }
 }
 // [END DeferredTaskTest]


### PR DESCRIPTION
This test has flaked occasionally because `tearDown()` takes > 10 minutes.

Previous fixes have tried to address the issue by catching the timeout exception in `tearDown()`, but the exception is still being thrown.

This fix attempts to solve the problem by adding an `expectedException` parameter to the flaky test, expecting the test to timeout. This parameter is mandatory, and there is no option to make it optional (i.e. it will fail if the test does not timeout).

So, the only work-around I could find is to throw a timeout exception at the end to cover both success and timed-out scenarios. A comment was added to clarify this behavior.

I ran tests 3 times across 3 Java versions - no failures. Hopefully that continues and the flaky behavior goes away. Fixes #5588 