### PR TITLE
test: add retries to aiplatform tests

### DIFF
--- a/aiplatform/src/test/java/aiplatform/CreateHyperparameterTuningJobSampleTest.java
+++ b/aiplatform/src/test/java/aiplatform/CreateHyperparameterTuningJobSampleTest.java
@@ -21,6 +21,7 @@ import static junit.framework.TestCase.assertNotNull;
 
 import com.google.cloud.aiplatform.v1beta1.JobServiceClient;
 import com.google.cloud.aiplatform.v1beta1.JobServiceSettings;
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -31,9 +32,12 @@ import java.util.concurrent.TimeoutException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class CreateHyperparameterTuningJobSampleTest {
+  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(5);
+
   private static final String PROJECT = System.getenv("UCAIP_PROJECT_ID");
   private static final String CONTAINER_IMAGE_URI =
       "gcr.io/ucaip-sample-tests/ucaip-training-test:latest";

--- a/aiplatform/src/test/java/aiplatform/CreateTrainingPipelineSampleTest.java
+++ b/aiplatform/src/test/java/aiplatform/CreateTrainingPipelineSampleTest.java
@@ -19,6 +19,7 @@ package aiplatform;
 import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.TestCase.assertNotNull;
 
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -29,12 +30,14 @@ import java.util.concurrent.TimeoutException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class CreateTrainingPipelineSampleTest {
+  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(5);
 
   private static final String PROJECT_ID = System.getenv("UCAIP_PROJECT_ID");
   private static final String DATASET_ID = "1084241610289446912";

--- a/aiplatform/src/test/java/aiplatform/CreateTrainingPipelineTextClassificationSampleTest.java
+++ b/aiplatform/src/test/java/aiplatform/CreateTrainingPipelineTextClassificationSampleTest.java
@@ -19,6 +19,7 @@ package aiplatform;
 import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.TestCase.assertNotNull;
 
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -29,12 +30,14 @@ import java.util.concurrent.TimeoutException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class CreateTrainingPipelineTextClassificationSampleTest {
+  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(5);
 
   private static final String PROJECT = System.getenv("UCAIP_PROJECT_ID");
   private static final String DATASET_ID = System.getenv("TRAINING_PIPELINE_TEXT_CLASS_DATASET_ID");

--- a/aiplatform/src/test/java/aiplatform/ImportDataVideoObjectTrackingSampleTest.java
+++ b/aiplatform/src/test/java/aiplatform/ImportDataVideoObjectTrackingSampleTest.java
@@ -27,6 +27,7 @@ import com.google.cloud.aiplatform.v1beta1.DatasetServiceClient;
 import com.google.cloud.aiplatform.v1beta1.DatasetServiceSettings;
 import com.google.cloud.aiplatform.v1beta1.DeleteOperationMetadata;
 import com.google.cloud.aiplatform.v1beta1.LocationName;
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import com.google.protobuf.Empty;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -37,9 +38,11 @@ import java.util.concurrent.TimeoutException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class ImportDataVideoObjectTrackingSampleTest {
+  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(5);
 
   private static final String PROJECT = System.getenv("UCAIP_PROJECT_ID");
   private static final String LOCATION = "us-central1";


### PR DESCRIPTION
Added retries to failing `aiplatform` tests.

This may address all of the issues. However, a couple tests might need more improvements in teardown. We can explore that later if failures reoccur.

Fixes #7544 
Fixes #7531
Fixes #7526 
Fixes #7525 