### PR TITLE
chore: update region tags on session-handling sample

### DIFF
--- a/session-handling/src/main/java/com/example/gettingstarted/actions/HelloWorldServlet.java
+++ b/session-handling/src/main/java/com/example/gettingstarted/actions/HelloWorldServlet.java
@@ -15,7 +15,7 @@
 
 package com.example.gettingstarted.actions;
 
-// [START session_handling_servlet]
+// [START cloudrun_session_handling_servlet]
 
 import java.io.IOException;
 import java.util.Random;
@@ -58,4 +58,4 @@ public class HelloWorldServlet extends HttpServlet {
     resp.getWriter().write(String.format("%d views for %s", views, greeting));
   }
 }
-// [END session_handling_servlet]
+// [END cloudrun_session_handling_servlet]

--- a/session-handling/src/main/java/com/example/gettingstarted/util/FirestoreSessionFilter.java
+++ b/session-handling/src/main/java/com/example/gettingstarted/util/FirestoreSessionFilter.java
@@ -55,7 +55,7 @@ public class FirestoreSessionFilter implements Filter {
   private static Firestore firestore;
   private static CollectionReference sessions;
 
-  // [START sessions_handling_init]
+  // [START firestore_sessions_handling_init]
   @Override
   public void init(FilterConfig config) throws ServletException {
     // Initialize local copy of datastore session variables.
@@ -77,9 +77,9 @@ public class FirestoreSessionFilter implements Filter {
       throw new ServletException("Exception initializing FirestoreSessionFilter.", e);
     }
   }
-  // [END sessions_handling_init]
+  // [END firestore_sessions_handling_init]
 
-  // [START sessions_handling_filter]
+  // [START firestore_sessions_handling_filter]
   @Override
   public void doFilter(ServletRequest servletReq, ServletResponse servletResp, FilterChain chain)
       throws IOException, ServletException {
@@ -129,7 +129,7 @@ public class FirestoreSessionFilter implements Filter {
     logger.info("Saving data to " + sessionId + " with views: " + session.getAttribute("views"));
     firestore.runTransaction((ob) -> sessions.document(sessionId).set(sessionMap));
   }
-  // [END sessions_handling_filter]
+  // [END firestore_sessions_handling_filter]
 
   private String getCookieValue(HttpServletRequest req, String cookieName) {
     Cookie[] cookies = req.getCookies();
@@ -143,7 +143,7 @@ public class FirestoreSessionFilter implements Filter {
     return "";
   }
 
-  // [START sessions_load_session_variables]
+  // [START firestore_sessions_load_session_variables]
 
   /**
    * Take an HttpServletRequest, and copy all of the current session variables over to it
@@ -171,5 +171,5 @@ public class FirestoreSessionFilter implements Filter {
             })
         .get();
   }
-  // [END sessions_load_session_variables]
+  // [END firestore_sessions_load_session_variables]
 }


### PR DESCRIPTION
This sample is currently not associated with a product, but it used in this [tutorial](https://cloud.google.com/java/getting-started/session-handling-with-firestore): "This tutorial shows how to handle sessions on [Cloud Run](https://cloud.google.com/run).

Will create a matching doc CL. Once that is approved, we can remove the "Do not merge" label and merge both the PR and CL.