### PR TITLE
fix: migrate GAE samples to thymeleaf 3.1

### DIFF
--- a/appengine-java11/gaeinfo/pom.xml
+++ b/appengine-java11/gaeinfo/pom.xml
@@ -73,7 +73,7 @@ Copyright 2019 Google LLC
     <dependency>
       <groupId>org.thymeleaf</groupId>
       <artifactId>thymeleaf</artifactId>
-      <version>3.0.14.RELEASE</version>
+      <version>3.1.1.RELEASE</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/appengine-java11/gaeinfo/src/main/java/com/example/appengine/standard/GaeInfoServlet.java
+++ b/appengine-java11/gaeinfo/src/main/java/com/example/appengine/standard/GaeInfoServlet.java
@@ -35,7 +35,8 @@ import okhttp3.Request;
 import okhttp3.Response;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.WebContext;
-import org.thymeleaf.templateresolver.ServletContextTemplateResolver;
+import org.thymeleaf.templateresolver.WebApplicationTemplateResolver;
+import org.thymeleaf.web.servlet.JavaxServletWebApplication;
 
 @SuppressWarnings({"serial"})
 @WebServlet(
@@ -66,6 +67,7 @@ public class GaeInfoServlet extends HttpServlet {
   private final String metadata = "http://metadata.google.internal";
 
   private TemplateEngine templateEngine;
+  private JavaxServletWebApplication application;
 
   // Use OkHttp from Square as it's quite easy to use for simple fetches.
   private final OkHttpClient ok =
@@ -76,7 +78,6 @@ public class GaeInfoServlet extends HttpServlet {
 
   // Setup to pretty print returned json
   private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
-  private final JsonParser jp = new JsonParser();
 
   // Fetch Metadata
   String fetchMetadata(String key) throws IOException {
@@ -101,15 +102,16 @@ public class GaeInfoServlet extends HttpServlet {
 
     Response response = ok.newCall(request).execute();
 
-    // Convert json to prety json
-    return gson.toJson(jp.parse(response.body().string()));
+    // Convert json to pretty json
+    return gson.toJson(JsonParser.parseString(response.body().string()));
   }
 
   @Override
   public void init() {
     // Setup ThymeLeaf
-    ServletContextTemplateResolver templateResolver =
-        new ServletContextTemplateResolver(this.getServletContext());
+    application = JavaxServletWebApplication.buildApplication(this.getServletContext());
+    WebApplicationTemplateResolver templateResolver =
+        new WebApplicationTemplateResolver(application);
 
     templateResolver.setPrefix("/WEB-INF/templates/");
     templateResolver.setSuffix(".html");
@@ -126,7 +128,8 @@ public class GaeInfoServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
     String key;
-    WebContext ctx = new WebContext(req, resp, getServletContext(), req.getLocale());
+    WebContext ctx = new WebContext(application.buildExchange(req, resp));
+    ctx.setLocale(req.getLocale());
 
     resp.setContentType("text/html");
 
@@ -149,7 +152,7 @@ public class GaeInfoServlet extends HttpServlet {
 
     Properties properties = System.getProperties();
     m = new TreeMap<>();
-    for (Enumeration e = properties.propertyNames(); e.hasMoreElements(); ) {
+    for (Enumeration<?> e = properties.propertyNames(); e.hasMoreElements(); ) {
       key = (String) e.nextElement();
       m.put(key, (String) properties.get(key));
     }
@@ -168,10 +171,10 @@ public class GaeInfoServlet extends HttpServlet {
 
     ctx.setVariable("sam", m.descendingMap());
 
-    // Recursivly get all info about service accounts -- Note tokens are leftout by default.
+    // Recursively get all info about service accounts -- Note tokens are leftout by default.
     ctx.setVariable(
         "rsa", fetchJsonMetadata("/computeMetadata/v1/instance/service-accounts/?recursive=true"));
-    // Recursivly get all data on Metadata server.
+    // Recursively get all data on Metadata server.
     ctx.setVariable("ram", fetchJsonMetadata("/?recursive=true"));
 
     templateEngine.process("index", ctx, resp.getWriter());

--- a/appengine-java8/gaeinfo/pom.xml
+++ b/appengine-java8/gaeinfo/pom.xml
@@ -68,7 +68,7 @@ Copyright 2017 Google Inc.
     <dependency>
       <groupId>org.thymeleaf</groupId>
       <artifactId>thymeleaf</artifactId>
-      <version>3.0.14.RELEASE</version>
+      <version>3.1.1.RELEASE</version>
     </dependency>
 
   </dependencies>

--- a/appengine-java8/gaeinfo/src/main/java/com/example/appengine/standard/GaeInfoServlet.java
+++ b/appengine-java8/gaeinfo/src/main/java/com/example/appengine/standard/GaeInfoServlet.java
@@ -39,7 +39,8 @@ import okhttp3.Request;
 import okhttp3.Response;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.WebContext;
-import org.thymeleaf.templateresolver.ServletContextTemplateResolver;
+import org.thymeleaf.templateresolver.WebApplicationTemplateResolver;
+import org.thymeleaf.web.servlet.JavaxServletWebApplication;
 
 // [START example]
 @SuppressWarnings({"serial"})
@@ -73,6 +74,7 @@ public class GaeInfoServlet extends HttpServlet {
   private final String metadata = "http://metadata.google.internal";
 
   private TemplateEngine templateEngine;
+  private JavaxServletWebApplication application;
 
   // Use OkHttp from Square as it's quite easy to use for simple fetches.
   private final OkHttpClient ok =
@@ -83,7 +85,6 @@ public class GaeInfoServlet extends HttpServlet {
 
   // Setup to pretty print returned json
   private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
-  private final JsonParser jp = new JsonParser();
 
   // Fetch Metadata
   String fetchMetadata(String key) throws IOException {
@@ -109,14 +110,15 @@ public class GaeInfoServlet extends HttpServlet {
     Response response = ok.newCall(request).execute();
 
     // Convert json to prety json
-    return gson.toJson(jp.parse(response.body().string()));
+    return gson.toJson(JsonParser.parseString(response.body().string()));
   }
 
   @Override
   public void init() {
     // Setup ThymeLeaf
-    ServletContextTemplateResolver templateResolver =
-        new ServletContextTemplateResolver(this.getServletContext());
+    application = JavaxServletWebApplication.buildApplication(this.getServletContext());
+    WebApplicationTemplateResolver templateResolver =
+        new WebApplicationTemplateResolver(application);
 
     templateResolver.setPrefix("/WEB-INF/templates/");
     templateResolver.setSuffix(".html");
@@ -134,7 +136,8 @@ public class GaeInfoServlet extends HttpServlet {
   public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
     String key = "";
     final AppIdentityService appIdentity = AppIdentityServiceFactory.getAppIdentityService();
-    WebContext ctx = new WebContext(req, resp, getServletContext(), req.getLocale());
+    WebContext ctx = new WebContext(application.buildExchange(req, resp));
+    ctx.setLocale(req.getLocale());
 
     resp.setContentType("text/html");
 
@@ -183,7 +186,7 @@ public class GaeInfoServlet extends HttpServlet {
 
     Properties properties = System.getProperties();
     m = new TreeMap<>();
-    for (Enumeration e = properties.propertyNames(); e.hasMoreElements(); ) {
+    for (Enumeration<?> e = properties.propertyNames(); e.hasMoreElements(); ) {
       key = (String) e.nextElement();
       m.put(key, (String) properties.get(key));
     }
@@ -210,11 +213,11 @@ public class GaeInfoServlet extends HttpServlet {
       }
       ctx.setVariable("sam", m.descendingMap());
 
-      // Recursivly get all info about service accounts -- Note tokens are leftout by default.
+      // Recursively get all info about service accounts -- Note tokens are leftout by default.
       ctx.setVariable(
           "rsa",
           fetchJsonMetadata("/computeMetadata/v1/instance/service-accounts/?recursive=true"));
-      // Recursivly get all data on Metadata server.
+      // Recursively get all data on Metadata server.
       ctx.setVariable("ram", fetchJsonMetadata("/?recursive=true"));
     }
 

--- a/appengine-java8/metadata/pom.xml
+++ b/appengine-java8/metadata/pom.xml
@@ -63,7 +63,7 @@ Copyright 2017 Google Inc.
     <dependency>
       <groupId>org.thymeleaf</groupId>
       <artifactId>thymeleaf</artifactId>
-      <version>3.0.14.RELEASE</version>
+      <version>3.1.1.RELEASE</version>
     </dependency>
 
   </dependencies>

--- a/appengine-java8/metadata/src/main/java/com/example/appengine/standard/MetadataServlet.java
+++ b/appengine-java8/metadata/src/main/java/com/example/appengine/standard/MetadataServlet.java
@@ -31,7 +31,8 @@ import okhttp3.Request;
 import okhttp3.Response;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.WebContext;
-import org.thymeleaf.templateresolver.ServletContextTemplateResolver;
+import org.thymeleaf.templateresolver.WebApplicationTemplateResolver;
+import org.thymeleaf.web.servlet.JavaxServletWebApplication;
 
 
 // [START example]
@@ -63,6 +64,7 @@ public class MetadataServlet extends HttpServlet {
 
   private final String metadata = "http://metadata.google.internal";
   private TemplateEngine templateEngine;
+  private JavaxServletWebApplication application;
 
   // Use OkHttp from Square as it's quite easy to use for simple fetches.
   private final OkHttpClient ok = new OkHttpClient.Builder()
@@ -74,7 +76,6 @@ public class MetadataServlet extends HttpServlet {
   private final Gson gson = new GsonBuilder()
       .setPrettyPrinting()
       .create();
-  private final JsonParser jp = new JsonParser();
 
   // Fetch Metadata
   String fetchMetadata(String key) throws IOException {
@@ -98,14 +99,15 @@ public class MetadataServlet extends HttpServlet {
     Response response = ok.newCall(request).execute();
 
     // Convert json to prety json
-    return gson.toJson(jp.parse(response.body().string()));
+    return gson.toJson(JsonParser.parseString(response.body().string()));
   }
 
   @Override
   public void init() {
     // Setup ThymeLeaf
-    ServletContextTemplateResolver templateResolver =
-        new ServletContextTemplateResolver(this.getServletContext());
+    application = JavaxServletWebApplication.buildApplication(this.getServletContext());
+    WebApplicationTemplateResolver templateResolver =
+        new WebApplicationTemplateResolver(application);
 
     templateResolver.setPrefix("/WEB-INF/templates/");
     templateResolver.setSuffix(".html");
@@ -122,7 +124,8 @@ public class MetadataServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
     String defaultServiceAccount = "";
-    WebContext ctx = new WebContext(req, resp, getServletContext(), req.getLocale());
+    WebContext ctx = new WebContext(application.buildExchange(req, resp));
+    ctx.setLocale(req.getLocale());
 
     resp.setContentType("text/html");
 

--- a/flexible/gaeinfo/pom.xml
+++ b/flexible/gaeinfo/pom.xml
@@ -65,7 +65,7 @@ Copyright 2017 Google Inc.
     <dependency>
       <groupId>org.thymeleaf</groupId>
       <artifactId>thymeleaf</artifactId>
-      <version>3.0.14.RELEASE</version>
+      <version>3.1.1.RELEASE</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
Migrated GAE samples using Thyme to 3.1. (Migration guide in section 2 [here](https://www.thymeleaf.org/doc/articles/thymeleaf31whatsnew.html)).

This includes the dependency updates in #7634 plus the necessary code changes.

Samples were manually tested.  Deprecated usage of JsonParser was updated, too.