### PR TITLE
fix(healthcare-api): clean up de-identified dataset after tests

### DIFF
--- a/healthcare/v1/src/test/java/snippets/healthcare/DatasetTests.java
+++ b/healthcare/v1/src/test/java/snippets/healthcare/DatasetTests.java
@@ -67,10 +67,17 @@ public class DatasetTests {
 
   @AfterClass
   public static void deleteTempItems() throws IOException {
+    // Delete the destination dataset created during de-identification.
     try {
       DatasetDelete.datasetDelete(destinationDatasetName);
     } catch (GoogleJsonResponseException ex) {
-      // Destination dataset already deleted, continue.
+      if (ex.getStatusCode() == 404) {
+        System.out.println("Destination dataset already deleted, continue.");
+      } else {
+        System.out.println(
+            "Error during deleteTempItems while deleting de-identified destination dataset: \n"
+                + ex.toString());
+      }
     }
   }
 
@@ -94,7 +101,11 @@ public class DatasetTests {
     try {
       DatasetDelete.datasetDelete(datasetName);
     } catch (GoogleJsonResponseException ex) {
-      // Dataset already deleted, continue.
+      if (ex.getStatusCode() == 404) {
+        System.out.println("Dataset already deleted, continue.");
+      } else {
+        System.out.println("Error during tearDown while deleting dataset: \n" + ex.toString());
+      }
     }
     bout.reset();
   }
@@ -102,8 +113,8 @@ public class DatasetTests {
   @Test
   public void test_DatasetCreateDelete() throws IOException {
     String newName = "new-dataset";
-    String newFullName =
-        String.format("projects/%s/locations/%s/datasets/%s", PROJECT_ID, REGION_ID, newName);
+    String newFullName = String.format(
+        "projects/%s/locations/%s/datasets/%s", PROJECT_ID, REGION_ID, newName);
     try {
       DatasetDelete.datasetDelete(newFullName);
     } catch (GoogleJsonResponseException gjre) {

--- a/healthcare/v1/src/test/java/snippets/healthcare/DatasetTests.java
+++ b/healthcare/v1/src/test/java/snippets/healthcare/DatasetTests.java
@@ -67,7 +67,11 @@ public class DatasetTests {
 
   @AfterClass
   public static void deleteTempItems() throws IOException {
-    DatasetDelete.datasetDelete(destinationDatasetName);
+    try {
+      DatasetDelete.datasetDelete(destinationDatasetName);
+    } catch (GoogleJsonResponseException ex) {
+      // Destination dataset already deleted, continue.
+    }
   }
 
   @Before

--- a/healthcare/v1/src/test/java/snippets/healthcare/DatasetTests.java
+++ b/healthcare/v1/src/test/java/snippets/healthcare/DatasetTests.java
@@ -27,6 +27,7 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -47,6 +48,7 @@ public class DatasetTests {
   private static final String REGION_ID = "us-central1";
 
   private static String datasetName;
+  private static String destinationDatasetName;
 
   private final PrintStream originalOut = System.out;
   private ByteArrayOutputStream bout;
@@ -63,6 +65,11 @@ public class DatasetTests {
     requireEnvVar("GOOGLE_CLOUD_PROJECT");
   }
 
+  @AfterClass
+  public static void deleteTempItems() throws IOException {
+    DatasetDelete.datasetDelete(destinationDatasetName);
+  }
+
   @Before
   public void beforeTest() throws IOException {
     bout = new ByteArrayOutputStream();
@@ -71,7 +78,6 @@ public class DatasetTests {
     String datasetId = "dataset-" + UUID.randomUUID().toString().replaceAll("-", "_");
     String parentName = String.format("projects/%s/locations/%s", PROJECT_ID, REGION_ID);
     datasetName = String.format("%s/datasets/%s", parentName, datasetId);
-
     DatasetCreate.datasetCreate(PROJECT_ID, REGION_ID, datasetId);
 
     bout = new ByteArrayOutputStream();
@@ -136,7 +142,8 @@ public class DatasetTests {
 
   @Test
   public void test_DatasetDeidentify() throws IOException {
-    DatasetDeIdentify.datasetDeIdentify(datasetName, datasetName + "-died");
+    destinationDatasetName = String.format(datasetName + "deid");
+    DatasetDeIdentify.datasetDeIdentify(datasetName, destinationDatasetName);
 
     String output = bout.toString();
     assertThat(output, containsString("De-identified Dataset created."));

--- a/healthcare/v1/src/test/java/snippets/healthcare/DatasetTests.java
+++ b/healthcare/v1/src/test/java/snippets/healthcare/DatasetTests.java
@@ -71,12 +71,9 @@ public class DatasetTests {
     try {
       DatasetDelete.datasetDelete(destinationDatasetName);
     } catch (GoogleJsonResponseException ex) {
-      if (ex.getStatusCode() == 404) {
-        System.out.println("Destination dataset already deleted, continue.");
-      } else {
-        System.out.println(
-            "Error during deleteTempItems while deleting de-identified destination dataset: \n"
-                + ex.toString());
+      // If 404, dataset was already deleted.
+      if (ex.getStatusCode() != 404) {
+        throw ex;
       }
     }
   }
@@ -101,10 +98,9 @@ public class DatasetTests {
     try {
       DatasetDelete.datasetDelete(datasetName);
     } catch (GoogleJsonResponseException ex) {
-      if (ex.getStatusCode() == 404) {
-        System.out.println("Dataset already deleted, continue.");
-      } else {
-        System.out.println("Error during tearDown while deleting dataset: \n" + ex.toString());
+      // If 404, dataset was already deleted.
+      if (ex.getStatusCode() != 404) {
+        throw ex;
       }
     }
     bout.reset();


### PR DESCRIPTION
Fixes de-identified datasets created during tests not being deleted.

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [X] `pom.xml` parent set to latest `shared-configuration`
- [X] **Tests** pass:   `mvn clean verify` **required**
- [X] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [X] Please **merge** this PR for me once it is approved.
