### PR TITLE
test: Increased the featurestore tests timeout

### DIFF
--- a/aiplatform/src/main/java/aiplatform/CreateFeaturestoreFixedNodesSample.java
+++ b/aiplatform/src/main/java/aiplatform/CreateFeaturestoreFixedNodesSample.java
@@ -64,26 +64,30 @@ public class CreateFeaturestoreFixedNodesSample {
       int timeout)
       throws IOException, InterruptedException, ExecutionException, TimeoutException {
 
-    OperationTimedPollAlgorithm operationTimedPollAlgorithm = OperationTimedPollAlgorithm.create(
-        RetrySettings.newBuilder()
-            .setInitialRetryDelay(Duration.ofMillis(5000L))
-            .setRetryDelayMultiplier(1.5)
-            .setMaxRetryDelay(Duration.ofMillis(45000L))
-            .setInitialRpcTimeout(Duration.ZERO)
-            .setRpcTimeoutMultiplier(1.0)
-            .setMaxRpcTimeout(Duration.ZERO)
-            .setTotalTimeout(Duration.ofSeconds(timeout))
-            .build());
+    OperationTimedPollAlgorithm operationTimedPollAlgorithm =
+        OperationTimedPollAlgorithm.create(
+            RetrySettings.newBuilder()
+                .setInitialRetryDelay(Duration.ofMillis(5000L))
+                .setRetryDelayMultiplier(1.5)
+                .setMaxRetryDelay(Duration.ofMillis(45000L))
+                .setInitialRpcTimeout(Duration.ZERO)
+                .setRpcTimeoutMultiplier(1.0)
+                .setMaxRpcTimeout(Duration.ZERO)
+                .setTotalTimeout(Duration.ofSeconds(timeout))
+                .build());
 
-    FeaturestoreServiceStubSettings.Builder featurestoreServiceStubSettingsBuilder = FeaturestoreServiceStubSettings.newBuilder();
+    FeaturestoreServiceStubSettings.Builder featurestoreServiceStubSettingsBuilder =
+        FeaturestoreServiceStubSettings.newBuilder();
 
-    featurestoreServiceStubSettingsBuilder.createFeaturestoreOperationSettings()
+    featurestoreServiceStubSettingsBuilder
+        .createFeaturestoreOperationSettings()
         .setPollingAlgorithm(operationTimedPollAlgorithm);
-    FeaturestoreServiceStubSettings featureStoreStubSettings = featurestoreServiceStubSettingsBuilder.build();
-    FeaturestoreServiceSettings featurestoreServiceSettings = FeaturestoreServiceSettings.create(
-        featureStoreStubSettings);
-    featurestoreServiceSettings = featurestoreServiceSettings.toBuilder().setEndpoint(endpoint)
-        .build();
+    FeaturestoreServiceStubSettings featureStoreStubSettings =
+        featurestoreServiceStubSettingsBuilder.build();
+    FeaturestoreServiceSettings featurestoreServiceSettings =
+        FeaturestoreServiceSettings.create(featureStoreStubSettings);
+    featurestoreServiceSettings =
+        featurestoreServiceSettings.toBuilder().setEndpoint(endpoint).build();
 
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call

--- a/aiplatform/src/test/java/aiplatform/FeaturestoreSamplesTest.java
+++ b/aiplatform/src/test/java/aiplatform/FeaturestoreSamplesTest.java
@@ -49,7 +49,7 @@ public class FeaturestoreSamplesTest {
   private static final boolean USE_FORCE = true;
   private static final String LOCATION = "us-central1";
   private static final String ENDPOINT = "us-central1-aiplatform.googleapis.com:443";
-  private static final int TIMEOUT = 900;
+  private static final int TIMEOUT = 1800;
   private ByteArrayOutputStream bout;
   private PrintStream out;
   private PrintStream originalPrintStream;
@@ -79,13 +79,9 @@ public class FeaturestoreSamplesTest {
   public void tearDown()
       throws InterruptedException, ExecutionException, IOException, TimeoutException {
 
-    try {
-      // Delete the featurestore
-      DeleteFeaturestoreSample.deleteFeaturestoreSample(PROJECT_ID, featurestoreId, USE_FORCE,
-          LOCATION, ENDPOINT, TIMEOUT);
-    } catch (NullPointerException npe) {
-      return;
-    }
+    // Delete the featurestore
+    DeleteFeaturestoreSample.deleteFeaturestoreSample(PROJECT_ID, featurestoreId, USE_FORCE,
+        LOCATION, ENDPOINT, TIMEOUT);
 
     // Assert
     String deleteFeaturestoreResponse = bout.toString();

--- a/aiplatform/src/test/java/aiplatform/FeaturestoreSamplesTest.java
+++ b/aiplatform/src/test/java/aiplatform/FeaturestoreSamplesTest.java
@@ -90,7 +90,6 @@ public class FeaturestoreSamplesTest {
     System.setOut(originalPrintStream);
   }
 
-  @Ignore
   @Test
   public void testCreateFeaturestoreSample()
       throws IOException, InterruptedException, ExecutionException, TimeoutException {


### PR DESCRIPTION
Fixes #7679

1. Increased the featurestore tests timeout from 900 to 1800 seconds. This is to handle the intermittent timeouts in featurestore tests. 
2. Removed the temporary fix for #[7682](https://github.com/GoogleCloudPlatform/java-docs-samples/pull/7682) 

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] Please **merge** this PR for me once it is approved.
