### PR TITLE
chore: add CODEOWNERS for DLP samples

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -79,6 +79,7 @@ video @GoogleCloudPlatform/dee-data-ai @GoogleCloudPlatform/java-samples-reviewe
 vision @GoogleCloudPlatform/dee-data-ai @GoogleCloudPlatform/java-samples-reviewers @yoshi-approver
 
 # Self-service
+dlp @GoogleCloudPlatform/googleapis-dlp @GoogleCloudPlatform/java-samples-reviewers @yoshi-approver
 healthcare @noerog @GoogleCloudPlatform/java-samples-reviewers @yoshi-approver
 iot @GoogleCloudPlatform/api-iot @GoogleCloudPlatform/java-samples-reviewers @yoshi-approver
 media @GoogleCloudPlatform/cloud-media-team @GoogleCloudPlatform/java-samples-reviewers @yoshi-approver


### PR DESCRIPTION
DLP is self-service. Added the product team and java reviewers to CODEOWNERS.

b/269596305