### PR TITLE
fix: flaky test in compute sample: WindowsOs Image

### DIFF
--- a/compute/cloud-client/src/main/java/compute/windows/osimage/CreateImage.java
+++ b/compute/cloud-client/src/main/java/compute/windows/osimage/CreateImage.java
@@ -111,7 +111,7 @@ public class CreateImage {
           .setImageResource(image)
           .build();
 
-      Operation response = imagesClient.insertAsync(insertImageRequest).get(3, TimeUnit.MINUTES);
+      Operation response = imagesClient.insertAsync(insertImageRequest).get(5, TimeUnit.MINUTES);
 
       if (response.hasError()) {
         System.out.println("Image creation failed ! ! " + response);

--- a/compute/cloud-client/src/test/java/compute/windows/osimage/WindowsOsImageIT.java
+++ b/compute/cloud-client/src/test/java/compute/windows/osimage/WindowsOsImageIT.java
@@ -24,6 +24,7 @@ import com.google.cloud.compute.v1.Instance;
 import com.google.cloud.compute.v1.InstancesClient;
 import com.google.cloud.compute.v1.NetworkInterface;
 import com.google.cloud.compute.v1.Operation;
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import compute.DeleteInstance;
 import compute.Util;
 import java.io.ByteArrayOutputStream;
@@ -51,10 +52,15 @@ public class WindowsOsImageIT {
 
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
   private static final String ZONE = "us-central1-a";
+  private static final int MAX_ATTEMPT_COUNT = 3;
+  private static final int INITIAL_BACKOFF_MILLIS = 300000; // 5 minutes
   private static String INSTANCE_NAME;
   private static String DISK_NAME;
   private static String IMAGE_NAME;
   @Rule
+  public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(
+      MAX_ATTEMPT_COUNT,
+      INITIAL_BACKOFF_MILLIS);
   private ByteArrayOutputStream stdOut;
 
   // Check if the required environment variables are set.


### PR DESCRIPTION
Fixes #7686 #7688 

Both the issues are flaky. Hence, increased timeout for the operations and added MultipleAttemptsRule.