### PR TITLE
fix: gce machine type name for auto-deletion

### DIFF
--- a/compute/cloud-client/src/test/java/compute/custommachinetype/CustomMachineTypeIT.java
+++ b/compute/cloud-client/src/test/java/compute/custommachinetype/CustomMachineTypeIT.java
@@ -89,7 +89,7 @@ public class CustomMachineTypeIT {
     Util.cleanUpExistingInstances("cmt-test-", PROJECT_ID, ZONE);
 
     String randomUUID = UUID.randomUUID().toString().split("-")[0];
-    CUSTOM_MACHINE_TYPE_INSTANCE = "cmt-test" + randomUUID;
+    CUSTOM_MACHINE_TYPE_INSTANCE = "cmt-test-" + randomUUID;
     CUSTOM_MACHINE_TYPE_INSTANCE_WITH_HELPER = "cmt-test-with-helper" + randomUUID;
     CUSTOM_MACHINE_TYPE_INSTANCE_WITH_SHARED_CORE = "cmt-test-shared-core" + randomUUID;
     CUSTOM_MACHINE_TYPE_INSTANCE_WITHOUT_HELPER = "cmt-test-without-helper" + randomUUID;


### PR DESCRIPTION
Fix: b/269415403

Custom Machine type instances were not being cleaned up because of a typo in one of the instance names.