### PR TITLE
chore: Adding self-service DLP team to labels and blunderbuss

### DIFF
--- a/.github/auto-label.yaml
+++ b/.github/auto-label.yaml
@@ -69,3 +69,4 @@ path:
     vision: "vision"
     webrisk: "webrisk"
     workflows: "workflows"
+    dlp: "dlp"

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -26,6 +26,10 @@ assign_issues_by:
   - 'api: spanner'
   to:
   - ansh0l
+- labels:
+  - 'api: dlp'
+  to:
+  - GoogleCloudPlatform/googleapis-dlp
   
 assign_prs:
   - GoogleCloudPlatform/java-samples-reviewers
@@ -51,5 +55,7 @@ assign_prs_by:
   - 'api: cloudsql'
   to:
   - GoogleCloudPlatform/infra-db-dpes
-
-
+- labels:
+  - 'api: dlp'
+  to:
+  - GoogleCloudPlatform/googleapis-dlp


### PR DESCRIPTION
Adding self-service DLP team to labels and blunderbuss