### PR TITLE
Fix DLP Example DeIdentifyWithFpe to use a dummy SSN as input text.

### DIFF
--- a/dlp/snippets/src/main/java/dlp/snippets/DeIdentifyWithFpe.java
+++ b/dlp/snippets/src/main/java/dlp/snippets/DeIdentifyWithFpe.java
@@ -43,7 +43,7 @@ public class DeIdentifyWithFpe {
   public static void main(String[] args) throws Exception {
     // TODO(developer): Replace these variables before running the sample.
     String projectId = "your-project-id";
-    String textToDeIdentify = "I'm Gary and my email is gary@example.com";
+    String textToDeIdentify = "I'm Gary and my SSN is 552096781";
     String kmsKeyName =
         "projects/YOUR_PROJECT/"
             + "locations/YOUR_KEYRING_REGION/"


### PR DESCRIPTION
Currently the example uses an email address and so there is noting identified in output.
Fixed the input string to use a dummy SSN.

Testing done:
Manually tested to confirm sample works as expected. Sample output:
>Text after format-preserving encryption: I'm Gary and my SSN is SSN_TOKEN(9):003857918

Automated test already exists and uses a SSN.

Fixes #issue

> It's a good idea to open an issue first for discussion.

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] Please **merge** this PR for me once it is approved.
