### PR TITLE
fix: Add missing product region tags for Cloud CDN snippets

### DIFF
--- a/cdn/signed-urls/src/main/java/com/google/cdn/SignedUrls.java
+++ b/cdn/signed-urls/src/main/java/com/google/cdn/SignedUrls.java
@@ -33,6 +33,7 @@ import javax.crypto.spec.SecretKeySpec;
 public class SignedUrls {
 
   // [START signUrl]
+  // [START cloudcdn_sign_url]
   /**
    * Creates a signed URL for a Cloud CDN endpoint with the given key
    * URL must start with http:// or https://, and must contain a forward
@@ -73,6 +74,7 @@ public class SignedUrls {
     mac.init(key);
     return  Base64.getUrlEncoder().encodeToString(mac.doFinal(input.getBytes()));
   }
+  // [END cloudcdn_sign_url]
   // [END signUrl]
 
   public static void main(String[] args) throws Exception {


### PR DESCRIPTION
Cloud CDN Snippets are missing product's specific region tags. In this PR, we are only adding region tags. No code changes. For more details, refer to [b/264905390](b/264905390).

Fixes #issue

> It's a good idea to open an issue first for discussion.

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] API's need to be enabled to test (tell us)
- [ ] Environment Variables need to be set (ask us to set them)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] Please **merge** this PR for me once it is approved.
