### PR TITLE
fix: cleanup storage deprecations

### DIFF
--- a/storage/cloud-client/README.md
+++ b/storage/cloud-client/README.md
@@ -1,9 +1,7 @@
 # Getting Started with Cloud Storage and the Google Cloud Client libraries
 
-<a
-href="https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=storage/cloud-client/README.md">
-<img alt="Open in Cloud Shell" src
-="http://gstatic.com/cloudssh/images/open-btn.png"></a>
+<a href="https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=storage/cloud-client/README.md">
+<img alt="Open in Cloud Shell" src="http://gstatic.com/cloudssh/images/open-btn.png"></a>
 
 [Google Cloud Storage][storage]  is unified object storage for developers and
 enterprises, from live data serving to data analytics/ML to data archival. These

--- a/storage/cloud-client/README.md
+++ b/storage/cloud-client/README.md
@@ -1,11 +1,13 @@
 # Getting Started with Cloud Storage and the Google Cloud Client libraries
 
-<a href="https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=storage/cloud-client/README.md">
-<img alt="Open in Cloud Shell" src ="http://gstatic.com/cloudssh/images/open-btn.png"></a>
+<a
+href="https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=storage/cloud-client/README.md">
+<img alt="Open in Cloud Shell" src
+="http://gstatic.com/cloudssh/images/open-btn.png"></a>
 
-[Google Cloud Storage][storage]  is unified object storage for developers and enterprises, from live
-data serving to data analytics/ML to data archival.
-These sample Java applications demonstrate how to access the Cloud Storage API using
+[Google Cloud Storage][storage]  is unified object storage for developers and
+enterprises, from live data serving to data analytics/ML to data archival. These
+sample Java applications demonstrate how to access the Cloud Storage API using
 the [Google Cloud Client Library for Java][google-cloud-java].
 
 [storage]: https://cloud.google.com/storage/
@@ -17,13 +19,13 @@ Install [Maven](http://maven.apache.org/).
 
 Build your project with:
 
-	mvn clean package -DskipTests
+ mvn clean package -DskipTests
 
 You can then run a given `ClassName` via:
 
-	mvn exec:java -Dexec.mainClass=com.example.storage.ClassName \
-	    -DpropertyName=propertyValue \
-		-Dexec.args="any arguments to the app"
+ mvn exec:java -Dexec.mainClass=com.example.storage.ClassName \
+     -DpropertyName=propertyValue \
+  -Dexec.args="any arguments to the app"
 
 ### Creating a new bucket (using the quickstart sample)
 

--- a/storage/cloud-client/pom.xml
+++ b/storage/cloud-client/pom.xml
@@ -35,11 +35,23 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.11.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>2.18.0</version>
+      <version>2.20.2</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/storage/s3-sdk/README.md
+++ b/storage/s3-sdk/README.md
@@ -1,8 +1,8 @@
 # Using Google Cloud Storage (GCS) with the S3 SDK
 
-[Google Cloud Storage][1] features APIs that allows developers to store and access arbitrarily-large
-objects. The [GCS XML API][5] provides support for AWS S3 API users that use S3 SDKs.
-Learn more about [Migrating to GCS][6].
+[Google Cloud Storage][1] features APIs that allows developers to store and
+access arbitrarily-large objects. The [GCS XML API][5] provides support for AWS
+S3 API users that use S3 SDKs. Learn more about [Migrating to GCS][6].
 
 ## Prerequisites
 
@@ -12,47 +12,53 @@ Install [Maven](http://maven.apache.org/).
 
 1. Clone this repo.
 
-   ```
+   ```sh
    git clone https://github.com/GoogleCloudPlatform/java-docs-samples.git
    ```
 
 1. Change into this directory:
 
-   ```
+   ```sh
    cd java-docs-samples/storage/s3-sdk
    ```
 
 1. Build this project from this directory:
 
-   ```
+   ```sh
    mvn package
    ```
 
-1. Get your [Interoperable Storage Access Keys][3] and set the following environment variables:
+1. Get your [Interoperable Storage Access Keys][3] and set the following
+   environment variables:
 
 ## Test Sample
 
-1. Provide a service account which can be used to generate HMAC Key for the scope of the tests
-   
+1. Provide a service account which can be used to generate HMAC Key for the
+   scope of the tests
+
    * GOOGLE_APPLICATION_CREDENTIALS=[PATH_TO_SERVICE_ACCOUNT_JSON]
 
-1. Set the following environment variable with the default project for Interoperable Storage Access Keys.
+1. Set the following environment variable with the default project for
+   Interoperable Storage Access Keys.
 
    * GOOGLE_CLOUD_PROJECT_S3_SDK_BUCKET_NAME=[GOOGLE_PROJECT_ID]
 
 1. Run test using the following Maven command:
 
-   ```
+   ```sh
    mvn verify
    ```
 
 ## Products
+
 - [Google Cloud Storage][2]
 
 ## Language
+
 - [Java][2]
 
 ## Dependencies
+
 - [AWS S3 Java SDK][4]
 
 [1]: https://cloud.google.com/storage

--- a/storage/s3-sdk/pom.xml
+++ b/storage/s3-sdk/pom.xml
@@ -29,6 +29,18 @@
     <version>1.2.0</version>
   </parent>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.11.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -38,7 +50,7 @@
    <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
-      <version>1.12.379</version>
+      <version>1.12.435</version>
     </dependency>
     <!-- Test Dependencies -->
     <dependency>
@@ -48,21 +60,9 @@
       <version>4.13.2</version>
     </dependency>
     <dependency>
-      <groupId>com.google.truth</groupId>
-      <artifactId>truth</artifactId>
-      <version>1.1.3</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>2.18.0</version>
+      <version>2.20.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/storage/s3-sdk/src/test/java/storage/s3sdk/ListGcsBucketsTest.java
+++ b/storage/s3-sdk/src/test/java/storage/s3sdk/ListGcsBucketsTest.java
@@ -16,11 +16,10 @@
 
 package storage.s3sdk;
 
-import static org.junit.Assert.assertThat;
-
 import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import com.google.cloud.testing.junit4.StdOutCaptureRule;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,6 +40,6 @@ public class ListGcsBucketsTest {
   public void testListBucket() {
     ListGcsBuckets.listGcsBuckets(hmacKey.getAccessKeyId(), hmacKey.getAccessSecretKey());
     String output = stdOut.getCapturedOutputAsUtf8String();
-    assertThat(output, CoreMatchers.containsString("Buckets:"));
+    MatcherAssert.assertThat(output, CoreMatchers.containsString("Buckets:"));
   }
 }

--- a/storage/s3-sdk/src/test/java/storage/s3sdk/ListGcsObjectsTest.java
+++ b/storage/s3-sdk/src/test/java/storage/s3sdk/ListGcsObjectsTest.java
@@ -16,12 +16,11 @@
 
 package storage.s3sdk;
 
-import static org.junit.Assert.assertThat;
-
 import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import com.google.cloud.testing.junit4.StdOutCaptureRule;
 import java.util.Optional;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,6 +46,6 @@ public class ListGcsObjectsTest {
         hmacKey.getAccessSecretKey(),
         Optional.ofNullable(BUCKET).orElse(hmacKey.getProjectId()));
     String output = stdOut.getCapturedOutputAsUtf8String();
-    assertThat(output, CoreMatchers.containsString("Objects:"));
+    MatcherAssert.assertThat(output, CoreMatchers.containsString("Objects:"));
   }
 }

--- a/storage/xml-api/cmdline-sample/README.md
+++ b/storage/xml-api/cmdline-sample/README.md
@@ -1,7 +1,10 @@
-This is the sample used in the [Cloud Storage Java documentation](https://cloud.google.com/storage/docs/xml-api-java-samples).
+This is the sample used in the [Cloud Storage Java
+documentation](https://cloud.google.com/storage/docs/xml-api-java-samples).
 
-<a href="https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=storage/xml-api/cmdline-sample/README.md">
-<img alt="Open in Cloud Shell" src ="http://gstatic.com/cloudssh/images/open-btn.png"></a>
+<a
+href="https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=storage/xml-api/cmdline-sample/README.md">
+<img alt="Open in Cloud Shell" src
+="http://gstatic.com/cloudssh/images/open-btn.png"></a>
 
 Using the Command Line Sample
 ==============================================================
@@ -9,29 +12,38 @@ Using the Command Line Sample
 Browse Online
 --------------
 
-The main file is [StorageSample.java](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/storage/xml-api/cmdline-sample/src/main/java/StorageSample.java).
-
+The main file is
+[StorageSample.java](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/storage/xml-api/cmdline-sample/src/main/java/StorageSample.java).
 
 Setup
 -----
 
-* [Create](https://cloud.google.com/storage/docs/cloud-console#_creatingbuckets) a Google Cloud Storage bucket
-* This module uses [Application Default Credentials](https://developers.google.com/accounts/docs/application-default-credentials). If you are running it outside of [Google Compute Engine](https://cloud.google.com/compute/), you'll need to
-    * Download the json private key for a [Service Account](https://cloud.google.com/storage/docs/authentication#service_accounts) and have it available.
-    * Set an environment variable: `export GOOGLE_APPLICATION_CREDENTIALS=path/to/your-key.json`
-* You must also be able to work with [GitHub](https://help.github.com/articles/set-up-git) repositories.
+* [Create](https://cloud.google.com/storage/docs/cloud-console#_creatingbuckets)
+  a Google Cloud Storage bucket
+* This module uses [Application Default
+  Credentials](https://developers.google.com/accounts/docs/application-default-credentials).
+  If you are running it outside of [Google Compute
+  Engine](https://cloud.google.com/compute/), you'll need to
+  * Download the json private key for a [Service
+    Account](https://cloud.google.com/storage/docs/authentication#service_accounts)
+    and have it available.
+  * Set an environment variable: `export
+    GOOGLE_APPLICATION_CREDENTIALS=path/to/your-key.json`
+* You must also be able to work with
+  [GitHub](https://help.github.com/articles/set-up-git) repositories.
 * Clone repository.
 
         git clone https://github.com/GoogleCloudPlatform/java-docs-samples.git
-
 
 Command-line Instructions
 -------------------------
 
 * **Prerequisites:**
-    * Install the latest version of [Java](https://java.com) and [Maven](https://maven.apache.org/download.html).
-    * Set the environment variable: `export GOOGLE_APPLICATION_CREDENTIALS=your-key-filename.json`
-    * You may need to set your `JAVA_HOME`.
+  * Install the latest version of [Java](https://java.com) and
+    [Maven](https://maven.apache.org/download.html).
+  * Set the environment variable: `export
+    GOOGLE_APPLICATION_CREDENTIALS=your-key-filename.json`
+  * You may need to set your `JAVA_HOME`.
 
 ```bash
 cd java-docs-samples/storage/xml-api/cmdline-sample
@@ -43,33 +55,39 @@ mvn -q exec:java -Dexec.args="your-bucket-name"
 To enable logging of HTTP requests and responses (highly recommended when
 developing), please take a look at logging.properties.
 
-
 Eclipse Instructions
 --------------------
 
 * **Prerequisites:**
-    * Install [Eclipse](http://www.eclipse.org/downloads/), the [Maven plugin](http://eclipse.org/m2e/), and optionally the [GitHub plugin](http://eclipse.github.com/).
+  * Install [Eclipse](http://www.eclipse.org/downloads/), the [Maven
+    plugin](http://eclipse.org/m2e/), and optionally the [GitHub
+    plugin](http://eclipse.github.com/).
 
 * Set up Eclipse Preferences
 
-    * Window > Preferences... (or on Mac, Eclipse > Preferences...)
-    * Select Maven
+  * Window > Preferences... (or on Mac, Eclipse > Preferences...)
+  * Select Maven
 
-        * check on "Download Artifact Sources"
-        * check on "Download Artifact JavaDoc"
+    * check on "Download Artifact Sources"
+    * check on "Download Artifact JavaDoc"
 
 * Create a new project using `storage/xml-api/cmdline-sample`
 
-    * Create a new Java Project.
-    * Choose the **Location** of the project to be the location of `cmdline-sample`
-    * Select the project and **Convert to Maven Project** to add Maven Dependencies.
-    * Click on Run > Run configurations
-        * Navigate to your **Java Application**'s configuration section
-        * In the **Arguments** tab, add the name of the bucket you created above as a **Program argument**
-        * In the **Environment** tab, create a variable `GOOGLE_APPLICATION_CREDENTIALS` and set it to the path to your json private key file.
+  * Create a new Java Project.
+  * Choose the **Location** of the project to be the location of
+    `cmdline-sample`
+  * Select the project and **Convert to Maven Project** to add Maven
+    Dependencies.
+  * Click on Run > Run configurations
+    * Navigate to your **Java Application**'s configuration section
+    * In the **Arguments** tab, add the name of the bucket you created above as
+      a **Program argument**
+    * In the **Environment** tab, create a variable
+      `GOOGLE_APPLICATION_CREDENTIALS` and set it to the path to your json
+      private key file.
 
 * Run
 
-    * Right-click on project
-    * Run As > Java Application
-    * If asked, type "StorageSample" and click OK
+  * Right-click on project
+  * Run As > Java Application
+  * If asked, type "StorageSample" and click OK

--- a/storage/xml-api/cmdline-sample/pom.xml
+++ b/storage/xml-api/cmdline-sample/pom.xml
@@ -30,12 +30,24 @@
   </parent>
 
   <properties>
-    <project.http.version>1.42.3</project.http.version>
+    <project.http.version>1.43.1</project.http.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <codehaus-exec-maven-plugin>1.6.0</codehaus-exec-maven-plugin>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.11.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <plugins>
@@ -57,7 +69,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <source>7</source>
           <target>7</target>
@@ -68,38 +80,21 @@
   </build>
   <dependencies>
     <dependency>
-      <groupId>com.google.apis</groupId>
-      <artifactId>google-api-services-storage</artifactId>
-      <version>v1-rev20220705-2.0.0</version>
-      <exclusions>
-        <exclusion> <!-- exclude an old version of Guava -->
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava-jdk5</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.google.auth</groupId>
-      <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.15.0</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-jackson2</artifactId>
       <version>${project.http.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>31.1-jre</version>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <version>1.16.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+      <version>2.2.0</version>
     </dependency>
     <!-- Test Dependencies -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>

--- a/storage/xml-api/serviceaccount-appengine-sample/README.md
+++ b/storage/xml-api/serviceaccount-appengine-sample/README.md
@@ -4,21 +4,25 @@ Using the Service Account App Engine Sample
 Browse Online
 -------------
 
-The main code file is [StorageSample.java](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/storage/xml-api/serviceaccount-appengine-sample/src/main/java/StorageServiceAccountSample.java).
+The main code file is
+[StorageSample.java](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/storage/xml-api/serviceaccount-appengine-sample/src/main/java/StorageServiceAccountSample.java).
 
 Add Your App Engine Service Account Name to the Project Team
 ------------------------------------------------------------
 
-See the instructions at https://developers.google.com/storage/docs/xml-api-java-samples
-for getting your App Engine Service Account Name and adding it to your project team.
+See the instructions at
+<https://developers.google.com/storage/docs/xml-api-java-samples> for getting
+your App Engine Service Account Name and adding it to your project team.
 
 Checkout Instructions
 ---------------------
 
-**Prerequisites:** install the latest version of [Java](https://java.com) and [Maven](https://maven.apache.org/download.html). You may need to set your `JAVA_HOME`.
+**Prerequisites:** install the latest version of [Java](https://java.com) and
+[Maven](https://maven.apache.org/download.html). You may need to set your
+`JAVA_HOME`.
 
 You must also be able to work with a GitHub repository (see e.g.,
-https://help.github.com/articles/set-up-git).
+<https://help.github.com/articles/set-up-git>).
 
     cd [someDirectory]
     git clone https://github.com/GoogleCloudPlatform/java-docs-samples.git
@@ -37,16 +41,21 @@ To run your application locally on a development server:
 
 To deploy your application to appspot.com:
 
-If this is the first time you are deploying your application to appspot.com, you will to perform the following steps first.
+If this is the first time you are deploying your application to appspot.com, you
+will to perform the following steps first.
 
-- Go to https://appengine.google.com and create an application.
-- Edit src/main/webapp/WEB-INF/appengine-web.xml, and enter the unique application identifier (you chose it in the prior step) between the <application> tags.
+- Go to <https://appengine.google.com> and create an application.
+- Edit src/main/webapp/WEB-INF/appengine-web.xml, and enter the unique
+  application identifier (you chose it in the prior step) between the
+  <application> tags.
 
 If you've done the above, you can deploy at any time:
 
     mvn appengine:update
 
-If this is the first time you have run "update" on the project, a browser window will open prompting you to log in. Log in with the same Google account the app is registered with.
+If this is the first time you have run "update" on the project, a browser window
+will open prompting you to log in. Log in with the same Google account the app
+is registered with.
 
 Set Up a Project in Eclipse
 ---------------------------

--- a/storage/xml-api/serviceaccount-appengine-sample/pom.xml
+++ b/storage/xml-api/serviceaccount-appengine-sample/pom.xml
@@ -35,7 +35,7 @@
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <google-api-client.version>2.1.1</google-api-client.version>
+    <google-api-client.version>2.2.0</google-api-client.version>
     <webappDirectory>${project.build.directory}/${project.build.finalName}
     </webappDirectory>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -46,50 +46,56 @@
     <finalName>war</finalName>
     <outputDirectory>${webappDirectory}/WEB-INF/classes</outputDirectory>
 
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-war-plugin</artifactId>
-        <version>${maven-war-plugin-version}</version>
-        <executions>
-          <execution>
-            <phase>compile</phase>
-            <goals>
-              <goal>exploded</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <webappDirectory>${webappDirectory}</webappDirectory>
-        </configuration>
-      </plugin>
+    <configuration>
+      <lifecycleMappingMetadata>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-war-plugin</artifactId>
+              <version>${maven-war-plugin-version}</version>
+              <executions>
+                <execution>
+                  <phase>compile</phase>
+                  <goals>
+                    <goal>exploded</goal>
+                  </goals>
+                </execution>
+              </executions>
+              <configuration>
+                <webappDirectory>${webappDirectory}</webappDirectory>
+              </configuration>
+            </plugin>
 
-      <!--
+            <!--
         The actual appengine-maven-plugin. Type "mvn appengine:run" to run project,
         "mvn appengine:update" to upload to GAE.
       -->
-      <plugin>
-        <groupId>com.google.cloud.tools</groupId>
-        <artifactId>appengine-maven-plugin</artifactId>
-        <version>2.4.4</version>
-        <configuration>
-          <projectId>GCLOUD_CONFIG</projectId>
-          <version>gaeinfo</version>
-          <port>8888</port>
-        </configuration>
-      </plugin>
+            <plugin>
+              <groupId>com.google.cloud.tools</groupId>
+              <artifactId>appengine-maven-plugin</artifactId>
+              <version>2.4.4</version>
+              <configuration>
+                <projectId>GCLOUD_CONFIG</projectId>
+                <version>gaeinfo</version>
+                <port>8888</port>
+              </configuration>
+            </plugin>
 
-      <!--
+            <!--
         Upload application to the appspot automatically, during
         release:perform
       -->
-      <plugin>
-        <artifactId>maven-release-plugin</artifactId>
-        <configuration>
-          <goals>gae:deploy</goals>
-        </configuration>
-      </plugin>
-    </plugins>
+            <plugin>
+              <artifactId>maven-release-plugin</artifactId>
+              <configuration>
+                <goals>gae:deploy</goals>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </lifecycleMappingMetadata>
+    </configuration>
   </build>
   <dependencies>
 
@@ -97,7 +103,7 @@
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
-      <version>2.0.5</version>
+      <version>2.0.12</version>
     </dependency>
 
     <dependency>

--- a/storage/xml-api/serviceaccount-appengine-sample/pom.xml
+++ b/storage/xml-api/serviceaccount-appengine-sample/pom.xml
@@ -46,56 +46,52 @@
     <finalName>war</finalName>
     <outputDirectory>${webappDirectory}/WEB-INF/classes</outputDirectory>
 
-    <configuration>
-      <lifecycleMappingMetadata>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-war-plugin</artifactId>
-              <version>${maven-war-plugin-version}</version>
-              <executions>
-                <execution>
-                  <phase>compile</phase>
-                  <goals>
-                    <goal>exploded</goal>
-                  </goals>
-                </execution>
-              </executions>
-              <configuration>
-                <webappDirectory>${webappDirectory}</webappDirectory>
-              </configuration>
-            </plugin>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>${maven-war-plugin-version}</version>
+          <executions>
+            <execution>
+              <phase>compile</phase>
+              <goals>
+                <goal>exploded</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <webappDirectory>${webappDirectory}</webappDirectory>
+          </configuration>
+        </plugin>
 
-            <!--
+        <!--
         The actual appengine-maven-plugin. Type "mvn appengine:run" to run project,
         "mvn appengine:update" to upload to GAE.
       -->
-            <plugin>
-              <groupId>com.google.cloud.tools</groupId>
-              <artifactId>appengine-maven-plugin</artifactId>
-              <version>2.4.4</version>
-              <configuration>
-                <projectId>GCLOUD_CONFIG</projectId>
-                <version>gaeinfo</version>
-                <port>8888</port>
-              </configuration>
-            </plugin>
+        <plugin>
+          <groupId>com.google.cloud.tools</groupId>
+          <artifactId>appengine-maven-plugin</artifactId>
+          <version>2.4.4</version>
+          <configuration>
+            <projectId>GCLOUD_CONFIG</projectId>
+            <version>gaeinfo</version>
+            <port>8888</port>
+          </configuration>
+        </plugin>
 
-            <!--
+        <!--
         Upload application to the appspot automatically, during
         release:perform
       -->
-            <plugin>
-              <artifactId>maven-release-plugin</artifactId>
-              <configuration>
-                <goals>gae:deploy</goals>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </lifecycleMappingMetadata>
-    </configuration>
+        <plugin>
+          <artifactId>maven-release-plugin</artifactId>
+          <configuration>
+            <goals>gae:deploy</goals>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
   <dependencies>
 


### PR DESCRIPTION
Cleaned up `/storage` samples, including:
- fixing deprecation warnings
- simplifying `pom.xml` with use of libraries bom
- lint markdown (including line length)