### PR TITLE
Bring your own connector - samples for Dataplex customers

### DIFF
--- a/datacatalog/snippets/pom.xml
+++ b/datacatalog/snippets/pom.xml
@@ -30,7 +30,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>26.1.2</version>
+        <version>26.11.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -44,6 +44,10 @@
     </dependency>
     <!-- [END data_catalog_install_with_bom] -->
 
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-storage</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
@@ -60,6 +64,11 @@
       <artifactId>truth</artifactId>
       <version>1.1.3</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.2.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/datacatalog/snippets/src/main/java/com/example/datacatalog/CreateCustomConnector.java
+++ b/datacatalog/snippets/src/main/java/com/example/datacatalog/CreateCustomConnector.java
@@ -1,0 +1,226 @@
+package com.example.datacatalog;
+
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.cloud.datacatalog.v1.ColumnSchema;
+import com.google.cloud.datacatalog.v1.DataCatalogClient;
+import com.google.cloud.datacatalog.v1.DumpItem;
+import com.google.cloud.datacatalog.v1.Entry;
+import com.google.cloud.datacatalog.v1.EntryType;
+import com.google.cloud.datacatalog.v1.ImportEntriesMetadata;
+import com.google.cloud.datacatalog.v1.ImportEntriesRequest;
+import com.google.cloud.datacatalog.v1.ImportEntriesResponse;
+import com.google.cloud.datacatalog.v1.Schema;
+import com.google.cloud.datacatalog.v1.SystemTimestamps;
+import com.google.cloud.datacatalog.v1.Tag;
+import com.google.cloud.datacatalog.v1.TagField;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.datacatalog.v1.TaggedEntry;
+import com.google.common.collect.ImmutableList;
+import com.google.longrunning.Operation;
+import com.google.longrunning.OperationsClient;
+import com.google.protobuf.util.Timestamps;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.Date;
+
+// Sample to create a custom connector. A production-ready connector does the following:
+// 1. Fetches metadata from a source system (for example, from an RDBMS).
+// 2. Creates Dataplex metadata objects (Entries, Tags) based on the fetched data.
+// 3. Writes them to Google Cloud Storage bucket
+// 4. Calls ImportEntries() API of the Dataplex Catalog to initiate import process.
+
+public class CreateCustomConnector {
+
+  public static void main(String[] args)
+      throws IOException, ExecutionException, InterruptedException {
+    // TODO(developer): Replace these variables before running the sample.
+    // String projectId = "my-project";
+    // String entryGroupId = "onprem_entry_group";
+    // String gcsBucketName = "my_gcs_bucket";
+    // String storageProjectId = "my-storage-project"; // can be the same as projectId where metadata will be stored; but does not have to be.
+
+    String projectId = "qc-cloudsql-connector-devproj";
+    String entryGroupId = "github_sample_eg";
+    String gcsBucketName = "qc_public_sample_test";
+    String storageProjectId = "qc-cloudsql-connector-devproj";
+
+    // Use any available Dataplex Catalog region.
+    String location = "us-central1";
+
+    /* Use Spark context if you would like to run a connector on GCP as a Dataplex task.
+    At the end of the application, stop the context.
+    JavaSparkContext ctx = new JavaSparkContext(new SparkConf());
+    < rest of the connector code.. >
+    ctx.stop();
+    */
+
+    importEntriesViaCustomConnector(location, projectId, entryGroupId, storageProjectId, gcsBucketName);
+
+
+  }
+
+  public static void importEntriesViaCustomConnector(String location, String projectId, String entryGroupId, String storageProjectId, String gcsBucketName)
+      throws IOException, ExecutionException, InterruptedException {
+
+    // Showing how to fetch metadata from a source system is out of the scope of this sample. Comments in the method below provide some hints though.
+    fetchMetadataFromSourceSystem();
+
+    // Translate fetched metadata into Dataplex Entry format.
+    DumpItem dumpItem = prepareDumpItem();
+
+    // Write metadata in Dataplex format to an existing Google Cloud Storage bucket.
+    writeMetadataToGscBucket(dumpItem, storageProjectId, gcsBucketName);
+
+    // Call DataplexCatalog ImportEntries() API to import the dump.
+    importEntriesToCatalog(projectId, location, entryGroupId, gcsBucketName);
+
+  }
+
+  private static void fetchMetadataFromSourceSystem() {
+    /* Here is a general approach on example of MySQL database:
+
+    String mySqlUrl = getArg("mysql_url", args);
+    String mySqlUsername = getArg("mysql_username", args);
+    String mySqlPassword = getArg("mysql_password", args); // don't really do this, use [Secret Manager](https://cloud.google.com/secret-manager) to keep the password safe
+
+    Class.forName ("com.mysql.jdbc.Driver").newInstance ();
+    Connection conn = DriverManager.getConnection (mySqlUrl, mySqlUsername, mySqlPassword);
+    PreparedStatement ps = conn.prepareStatement(
+        "SELECT table_schema, table_name, create_time, update_time FROM information_schema.tables");
+    ResultSet rs = ps.executeQuery();
+      while (rs.next()) {
+
+      // add Entry basing on ResultSet to some buffer
+      // ...
+    }
+      rs.close();
+      conn.close();
+
+     */
+  }
+
+  private static DumpItem prepareDumpItem() {
+    // Prepare Dataplex Entry based on metadata fetched form the source system.
+
+    Schema schema = Schema.newBuilder()
+        .addColumns(ColumnSchema.newBuilder().setColumn("ID").setType("LONGINT"))
+        .addColumns(ColumnSchema.newBuilder().setColumn("NAME").setType("VARCHAR(20)"))
+        .build();
+    SystemTimestamps timestamps = SystemTimestamps.newBuilder()
+        .setCreateTime(Timestamps.fromDate(new Date()))
+        .setUpdateTime(Timestamps.fromDate(new Date()))
+        .build();
+    Entry entry = Entry.newBuilder()
+        .setFullyQualifiedName("my_system:my_db.my_table")
+        .setUserSpecifiedSystem("My database system")
+        .setType(EntryType.TABLE)
+        .setSourceSystemTimestamps(timestamps)
+        .setDisplayName("My database table")
+        .setSchema(schema)
+        .build();
+
+    // If some metadata is not easily modelled by Dataplex Entries, use Tags to ingest it.
+    Tag tag1 = Tag.newBuilder()
+        .setTemplate("projects/myproject/locations/us-central1/tagTemplates/existingTemplate")
+        .putFields("field", TagField.newBuilder().setStringValue("tag1_value").build())
+        .build();
+    Tag tag2 = Tag.newBuilder()
+        .setTemplate("projects/myproject/locations/us-central1/tagTemplates/otherExistingTemplate")
+        .putFields("field", TagField.newBuilder().setStringValue("tag2_value").build())
+        .setColumn("column")
+        .build();
+
+    // Tags that should be deleted from the Dataplex
+    Tag absentTag = Tag.newBuilder()
+        .setTemplate("projects/myproject/locations/us-central1/tagTemplates/existingTemplate")
+        .setColumn("column2")
+        .build();
+
+    // Build a container for the metadata
+    return DumpItem.newBuilder()
+        .setTaggedEntry(
+            TaggedEntry.newBuilder()
+                // Add an entry
+                .setV1Entry(entry)
+                // Add tags to be created / updated
+                .addAllPresentTags(ImmutableList.of(tag1, tag2))
+                // Add tags to be deleted
+                .addAllAbsentTags(ImmutableList.of(absentTag))
+                .build())
+        .build();
+  }
+
+  private static void writeMetadataToGscBucket(DumpItem dumpItem, String storageProjectId, String gcsBucketName)
+      throws IOException {
+    // Use Google Cloud Storage API to write metadata dump.
+    // When you write real production load, you would want to shard the dump into multiple files for faster processing.
+    // Contents of all the files within specified bucket will be ingested.
+    Storage storage = StorageOptions.newBuilder().setProjectId(storageProjectId).build().getService();
+
+    /* Dump files should use standard protobuf binary wire format to store Entries in file.
+
+    Alternatively, the entire byte[] containing the wire encoding of delimited DumpItems in a single dump file can be Mime Base64 encoded. To indicate files where that is the case, please change the extension of the file from .wire to .txt.
+    Note, that whole file needs to be encoded at once, instead of each DumpItem being encoded separately, and concatenated.
+    For example:
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    dumpItem1.writeDelimitedTo(baos);
+    dumpItem2.writeDelimitedTo(baos);
+    byte[] protobufWireFormatBytes = baos.toByteArray();
+    String base64EncodedStr = Base64.getMimeEncoder().encodeToString(protobufWireFormatBytes);
+     */
+    String gcsPath = "gs://" + gcsBucketName + "/output/" + "output_0001.wire";
+    BlobId blobId = BlobId.fromGsUtilUri(gcsPath);
+    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
+
+    ByteArrayOutputStream encodedEntries = new ByteArrayOutputStream();
+    // DumpItems must be delimited, so that when system reads the file, it can tell them apart.
+    // For instance, in java you can use the writeDelimitedTo method.
+    dumpItem.writeDelimitedTo(encodedEntries);
+    storage.create(blobInfo, encodedEntries.toByteArray());
+  }
+
+  private static void importEntriesToCatalog(String projectId, String location, String entryGroupName, String gcsBucketName)
+      throws ExecutionException, InterruptedException, IOException {
+
+
+
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (DataCatalogClient dataCatalogClient = DataCatalogClient.create()) {
+
+      // Specify which EntryGroup the entries should be ingested to.
+      String parent = String.format(
+          "projects/%s/locations/%s/entryGroups/%s", projectId, location, entryGroupName);
+
+      // Specify valid path to the dump stored in Google Cloud Storage
+      String pathToDump = "gs://" + gcsBucketName + "/";
+
+      // Send ImportEntries request to the Dataplex Catalog. ImportEntries is an async procedure, and it returns a long-running operation that a client can query.
+      OperationFuture<ImportEntriesResponse, ImportEntriesMetadata> importEntriesFuture =
+          dataCatalogClient.importEntriesAsync(ImportEntriesRequest.newBuilder()
+              .setParent(parent)
+              .setGcsBucketPath(pathToDump)
+              .build());
+
+      // Get a name of the long-running operation.
+      String operationName = importEntriesFuture.getName();
+
+      // Get an operation client to be able to query an operation.
+      OperationsClient operationsClient = dataCatalogClient.getOperationsClient();
+
+      // Query an operation to learn about the state of import.
+      Operation longRunningOperation = operationsClient.getOperation(operationName);
+      ImportEntriesMetadata importEntriesMetadata = ImportEntriesMetadata.parseFrom(longRunningOperation.getMetadata().getValue());
+
+      System.out.printf("Long-running operation is created with name: %s \n", operationName);
+      System.out.printf("Long-running operation metadata details: %s", importEntriesMetadata);
+
+    }
+  }
+}

--- a/datacatalog/snippets/src/main/java/com/example/datacatalog/CreateCustomConnector.java
+++ b/datacatalog/snippets/src/main/java/com/example/datacatalog/CreateCustomConnector.java
@@ -247,8 +247,8 @@ public class CreateCustomConnector {
       ImportEntriesMetadata importEntriesMetadata = ImportEntriesMetadata.parseFrom(
           longRunningOperation.getMetadata().getValue());
 
-      System.out.printf("Long-running operation is created with name: %s \n", operationName);
-      System.out.printf("Long-running operation metadata details: %s", importEntriesMetadata);
+      System.out.println("Long-running operation is created with name: " + operationName);
+      System.out.printf("Long-running operation metadata details: " +  importEntriesMetadata);
 
     }
   }

--- a/datacatalog/snippets/src/main/java/com/example/datacatalog/CreateCustomConnector.java
+++ b/datacatalog/snippets/src/main/java/com/example/datacatalog/CreateCustomConnector.java
@@ -1,5 +1,7 @@
 package com.example.datacatalog;
 
+// [START data_catalog_custom_connector]
+
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.cloud.datacatalog.v1.ColumnSchema;
 import com.google.cloud.datacatalog.v1.DataCatalogClient;
@@ -27,6 +29,7 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.Date;
 
+
 // Sample to create a custom connector. A production-ready connector does the following:
 // 1. Fetches metadata from a source system (for example, from an RDBMS).
 // 2. Creates Dataplex metadata objects (Entries, Tags) based on the fetched data.
@@ -38,15 +41,11 @@ public class CreateCustomConnector {
   public static void main(String[] args)
       throws IOException, ExecutionException, InterruptedException {
     // TODO(developer): Replace these variables before running the sample.
-    // String projectId = "my-project";
-    // String entryGroupId = "onprem_entry_group";
-    // String gcsBucketName = "my_gcs_bucket";
-    // String storageProjectId = "my-storage-project"; // can be the same as projectId where metadata will be stored; but does not have to be.
+    String projectId = "my-project";
+    String entryGroupId = "onprem_entry_group";
+    String gcsBucketName = "my_gcs_bucket";
+    String storageProjectId = "my-storage-project"; // can be the same as projectId where metadata will be stored; but does not have to be.
 
-    String projectId = "qc-cloudsql-connector-devproj";
-    String entryGroupId = "github_sample_eg";
-    String gcsBucketName = "qc_public_sample_test";
-    String storageProjectId = "qc-cloudsql-connector-devproj";
 
     // Use any available Dataplex Catalog region.
     String location = "us-central1";
@@ -224,3 +223,5 @@ public class CreateCustomConnector {
     }
   }
 }
+
+// [END data_catalog_custom_connector]

--- a/datacatalog/snippets/src/main/java/com/example/datacatalog/GetImportEntriesState.java
+++ b/datacatalog/snippets/src/main/java/com/example/datacatalog/GetImportEntriesState.java
@@ -1,5 +1,7 @@
 package com.example.datacatalog;
 
+// [START data_catalog_query_import_entries_operation]
+
 import static org.awaitility.Awaitility.with;
 import static org.awaitility.pollinterval.FibonacciPollInterval.fibonacci;
 
@@ -13,10 +15,7 @@ import com.google.cloud.datacatalog.v1.ImportEntriesResponse;
 import com.google.longrunning.Operation;
 import com.google.longrunning.OperationsClient;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.rpc.Status;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.awaitility.core.EvaluatedCondition;
@@ -31,6 +30,8 @@ public class GetImportEntriesState {
       throws IOException, ExecutionException, InterruptedException {
     // TODO(developer): Replace these variables before running the sample.
     String longRunningOperationName = "projects/my-project/locations/us-central1/operations/import_entries_abc";
+    // When ImportEntries() method of Dataplex Catalog is called, it returns a name of a long-running operation.
+    // This operation can be queried to find out the state of the import.
     queryImportEntriesState(longRunningOperationName);
   }
 
@@ -105,3 +106,5 @@ public class GetImportEntriesState {
   }
 
 }
+
+// [END data_catalog_query_import_entries_operation]

--- a/datacatalog/snippets/src/main/java/com/example/datacatalog/GetImportEntriesState.java
+++ b/datacatalog/snippets/src/main/java/com/example/datacatalog/GetImportEntriesState.java
@@ -42,7 +42,7 @@ import org.threeten.bp.Duration;
 public class GetImportEntriesState {
 
   public static void main(String[] args)
-      throws IOException, ExecutionException, InterruptedException {
+      throws IOException {
     // TODO(developer): Replace these variables before running the sample.
     String longRunningOperationName =
         "projects/my-project/locations/us-central1/operations/import_entries_abc";

--- a/datacatalog/snippets/src/main/java/com/example/datacatalog/GetImportEntriesState.java
+++ b/datacatalog/snippets/src/main/java/com/example/datacatalog/GetImportEntriesState.java
@@ -1,0 +1,107 @@
+package com.example.datacatalog;
+
+import static org.awaitility.Awaitility.with;
+import static org.awaitility.pollinterval.FibonacciPollInterval.fibonacci;
+
+import com.google.api.gax.longrunning.OperationTimedPollAlgorithm;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.cloud.datacatalog.v1.DataCatalogClient;
+import com.google.cloud.datacatalog.v1.DataCatalogSettings;
+import com.google.cloud.datacatalog.v1.ImportEntriesMetadata;
+import com.google.cloud.datacatalog.v1.ImportEntriesMetadata.ImportState;
+import com.google.cloud.datacatalog.v1.ImportEntriesResponse;
+import com.google.longrunning.Operation;
+import com.google.longrunning.OperationsClient;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.rpc.Status;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.core.EvaluatedCondition;
+import org.threeten.bp.Duration;
+
+
+// Sample to poll long-running operation for the state of entries import.
+
+public class GetImportEntriesState {
+
+  public static void main(String[] args)
+      throws IOException, ExecutionException, InterruptedException {
+    // TODO(developer): Replace these variables before running the sample.
+    String longRunningOperationName = "projects/my-project/locations/us-central1/operations/import_entries_abc";
+    queryImportEntriesState(longRunningOperationName);
+  }
+
+  public static void queryImportEntriesState(String longRunningOperationName)
+      throws IOException {
+
+    try (DataCatalogClient dataCatalogClient = createDataCatalogClient()) {
+      OperationsClient operationsClient = dataCatalogClient.getOperationsClient();
+
+      // Periodically poll long-running operation to check state of the metadata import.
+      Operation result =
+          with()
+              .pollInterval(fibonacci(TimeUnit.MINUTES))
+              .await()
+              .atMost(java.time.Duration.ofHours(1))
+              .conditionEvaluationListener(GetImportEntriesState::printCondition)
+              .until(() -> operationsClient.getOperation(longRunningOperationName),
+                  Operation::getDone);
+
+      // Interpret operation result.
+      // It might result in error.
+      if (result.hasError()) {
+        System.out.println("Import failed: " + result.getError());
+      }
+
+      // If there were no fatal errors, operation will return ImportEntriesResponse, just like normal API call would.
+      // Response contains useful statistics.
+      if (result.hasResponse()) {
+        ImportEntriesResponse response =
+            ImportEntriesResponse.parseFrom(result.getResponse().getValue());
+        System.out.println("Operation resolved in response: " + response);
+      }
+
+      // Operation metadata is also available to check. It contains a state of operation and partial errors, if any.
+      ImportEntriesMetadata importEntriesMetadata = ImportEntriesMetadata.parseFrom(
+          result.getMetadata().getValue());
+      System.out.println("Operation metadata: " + importEntriesMetadata);
+    }
+  }
+
+  private static void printCondition(EvaluatedCondition<Operation> condition) {
+    ImportState state;
+    try {
+      ImportEntriesMetadata importEntriesMetadata = ImportEntriesMetadata.parseFrom(
+          condition.getValue().getMetadata().getValue());
+      state = importEntriesMetadata.getState();
+    } catch (InvalidProtocolBufferException e) {
+      state = ImportState.UNRECOGNIZED;
+    }
+    Duration duration = Duration.ofMillis(condition.getElapsedTimeInMS());
+
+    System.out.println("Import Entries state after " + duration + ": " + state);
+
+  }
+
+  private static DataCatalogClient createDataCatalogClient() throws IOException {
+    // It’s essential to provide RetrySettings to DataCatalogClient to enable blocking wait for the import result.
+    RetrySettings retrySettings = RetrySettings.newBuilder()
+        .setInitialRetryDelay(Duration.ofSeconds(1))
+        .setRetryDelayMultiplier(1.5)
+        .setMaxRetryDelay(Duration.ofMinutes(5))
+        .setInitialRpcTimeout(Duration.ZERO)
+        .setRpcTimeoutMultiplier(1.0)
+        .setMaxRpcTimeout(Duration.ZERO)
+        .setTotalTimeout(Duration.ofHours(4)) // set total polling timeout to 4 hours
+        .build();
+    DataCatalogSettings.Builder dcSettingsBuilder = DataCatalogSettings.newBuilder();
+    dcSettingsBuilder.importEntriesOperationSettings()
+        .setPollingAlgorithm(OperationTimedPollAlgorithm.create(retrySettings));
+    dcSettingsBuilder.importEntriesSettings().setRetrySettings(retrySettings);
+    return DataCatalogClient.create(dcSettingsBuilder.build());
+  }
+
+}

--- a/datacatalog/snippets/src/main/java/com/example/datacatalog/GetImportEntriesState.java
+++ b/datacatalog/snippets/src/main/java/com/example/datacatalog/GetImportEntriesState.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.datacatalog;
 
 // [START data_catalog_query_import_entries_operation]
@@ -21,7 +37,6 @@ import java.util.concurrent.TimeUnit;
 import org.awaitility.core.EvaluatedCondition;
 import org.threeten.bp.Duration;
 
-
 // Sample to poll long-running operation for the state of entries import.
 
 public class GetImportEntriesState {
@@ -29,27 +44,24 @@ public class GetImportEntriesState {
   public static void main(String[] args)
       throws IOException, ExecutionException, InterruptedException {
     // TODO(developer): Replace these variables before running the sample.
-    String longRunningOperationName = "projects/my-project/locations/us-central1/operations/import_entries_abc";
-    // When ImportEntries() method of Dataplex Catalog is called, it returns a name of a long-running operation.
+    String longRunningOperationName =
+        "projects/my-project/locations/us-central1/operations/import_entries_abc";
+    // When ImportEntries() method of Dataplex Catalog is called,
+    // it returns a name of a long-running operation.
     // This operation can be queried to find out the state of the import.
     queryImportEntriesState(longRunningOperationName);
   }
 
-  public static void queryImportEntriesState(String longRunningOperationName)
-      throws IOException {
+  public static void queryImportEntriesState(String longRunningOperationName) throws IOException {
 
     try (DataCatalogClient dataCatalogClient = createDataCatalogClient()) {
       OperationsClient operationsClient = dataCatalogClient.getOperationsClient();
 
       // Periodically poll long-running operation to check state of the metadata import.
-      Operation result =
-          with()
-              .pollInterval(fibonacci(TimeUnit.MINUTES))
-              .await()
-              .atMost(java.time.Duration.ofHours(1))
-              .conditionEvaluationListener(GetImportEntriesState::printCondition)
-              .until(() -> operationsClient.getOperation(longRunningOperationName),
-                  Operation::getDone);
+      Operation result = with().pollInterval(fibonacci(TimeUnit.MINUTES)).await()
+          .atMost(java.time.Duration.ofHours(1))
+          .conditionEvaluationListener(GetImportEntriesState::printCondition)
+          .until(() -> operationsClient.getOperation(longRunningOperationName), Operation::getDone);
 
       // Interpret operation result.
       // It might result in error.
@@ -57,15 +69,17 @@ public class GetImportEntriesState {
         System.out.println("Import failed: " + result.getError());
       }
 
-      // If there were no fatal errors, operation will return ImportEntriesResponse, just like normal API call would.
+      // If there were no fatal errors, operation will return ImportEntriesResponse,
+      // just like normal API call would.
       // Response contains useful statistics.
       if (result.hasResponse()) {
-        ImportEntriesResponse response =
-            ImportEntriesResponse.parseFrom(result.getResponse().getValue());
+        ImportEntriesResponse response = ImportEntriesResponse.parseFrom(
+            result.getResponse().getValue());
         System.out.println("Operation resolved in response: " + response);
       }
 
-      // Operation metadata is also available to check. It contains a state of operation and partial errors, if any.
+      // Operation metadata is also available to check.
+      // It contains a state of operation and partial errors, if any.
       ImportEntriesMetadata importEntriesMetadata = ImportEntriesMetadata.parseFrom(
           result.getMetadata().getValue());
       System.out.println("Operation metadata: " + importEntriesMetadata);
@@ -88,14 +102,12 @@ public class GetImportEntriesState {
   }
 
   private static DataCatalogClient createDataCatalogClient() throws IOException {
-    // It’s essential to provide RetrySettings to DataCatalogClient to enable blocking wait for the import result.
+    // It’s essential to provide RetrySettings to DataCatalogClient
+    // to enable blocking wait for the import result.
     RetrySettings retrySettings = RetrySettings.newBuilder()
-        .setInitialRetryDelay(Duration.ofSeconds(1))
-        .setRetryDelayMultiplier(1.5)
-        .setMaxRetryDelay(Duration.ofMinutes(5))
-        .setInitialRpcTimeout(Duration.ZERO)
-        .setRpcTimeoutMultiplier(1.0)
-        .setMaxRpcTimeout(Duration.ZERO)
+        .setInitialRetryDelay(Duration.ofSeconds(1)).setRetryDelayMultiplier(1.5)
+        .setMaxRetryDelay(Duration.ofMinutes(5)).setInitialRpcTimeout(Duration.ZERO)
+        .setRpcTimeoutMultiplier(1.0).setMaxRpcTimeout(Duration.ZERO)
         .setTotalTimeout(Duration.ofHours(4)) // set total polling timeout to 4 hours
         .build();
     DataCatalogSettings.Builder dcSettingsBuilder = DataCatalogSettings.newBuilder();

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/CreateCustomConnectorIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/CreateCustomConnectorIT.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.datacatalog;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -8,12 +24,12 @@ import com.google.cloud.datacatalog.v1.DataCatalogClient;
 import com.google.cloud.datacatalog.v1.DeleteEntryGroupRequest;
 import com.google.cloud.datacatalog.v1.EntryGroupName;
 import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageClass;
 import com.google.cloud.storage.StorageOptions;
-import com.google.cloud.storage.BlobId;
 import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -29,20 +45,20 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class CreateCustomConnectorIT {
-  @Rule
-  public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
 
   private static final String ID = UUID.randomUUID().toString().substring(0, 8);
   private static final String LOCATION = "us-central1";
+  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  @Rule
+  public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
   private final Logger log = Logger.getLogger(this.getClass().getName());
+  private final Storage storageService = StorageOptions.newBuilder().setProjectId(PROJECT_ID)
+      .build().getService();
   private String entryGroup;
   private String gcsBucketName;
-  private final Storage storageService = StorageOptions.newBuilder().setProjectId(PROJECT_ID).build().getService();
   private ByteArrayOutputStream bout;
   private PrintStream out;
   private PrintStream originalPrintStream;
-
-  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
 
   private static String requireEnvVar(String varName) {
     String value = System.getenv(varName);
@@ -88,8 +104,10 @@ public class CreateCustomConnectorIT {
   }
 
   @Test
-  public void testCreateCustomConnector() throws IOException, ExecutionException, InterruptedException {
-    CreateCustomConnector.importEntriesViaCustomConnector(LOCATION,PROJECT_ID, entryGroup, PROJECT_ID, gcsBucketName);
+  public void testCreateCustomConnector()
+      throws IOException, ExecutionException, InterruptedException {
+    CreateCustomConnector.importEntriesViaCustomConnector(LOCATION, PROJECT_ID, entryGroup,
+        PROJECT_ID, gcsBucketName);
     assertThat(bout.toString()).contains("Long-running operation is created");
   }
 
@@ -98,13 +116,13 @@ public class CreateCustomConnectorIT {
     String location = "ASIA";
 
     storageService.create(
-            BucketInfo.newBuilder(bucketName)
-                .setStorageClass(storageClass)
-                .setLocation(location)
-                .build());
+        BucketInfo.newBuilder(bucketName)
+            .setStorageClass(storageClass)
+            .setLocation(location)
+            .build());
   }
 
-  private void deleteTemporaryGcsBucket (String bucketName) {
+  private void deleteTemporaryGcsBucket(String bucketName) {
     Page<Blob> blobs = storageService.list(bucketName);
     for (Blob blob : blobs.iterateAll()) {
       BlobId blobId = BlobId.of(bucketName, blob.getName());

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/CreateCustomConnectorIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/CreateCustomConnectorIT.java
@@ -1,0 +1,118 @@
+package com.example.datacatalog;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.api.gax.paging.Page;
+import com.google.cloud.datacatalog.v1.DataCatalogClient;
+import com.google.cloud.datacatalog.v1.DeleteEntryGroupRequest;
+import com.google.cloud.datacatalog.v1.EntryGroupName;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageClass;
+import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class CreateCustomConnectorIT {
+  @Rule
+  public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
+
+  private static final String ID = UUID.randomUUID().toString().substring(0, 8);
+  private static final String LOCATION = "us-central1";
+  private final Logger log = Logger.getLogger(this.getClass().getName());
+  private String entryGroup;
+  private String gcsBucketName;
+  private final Storage storageService = StorageOptions.newBuilder().setProjectId(PROJECT_ID).build().getService();
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull("Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+    entryGroup = "ENTRY_GROUP_TEST_" + ID;
+    gcsBucketName = "bucket_test_" + ID;
+    // Create temporary entry group
+    CreateEntryGroup.createEntryGroup(PROJECT_ID, LOCATION, entryGroup);
+    // Create temporary Google Cloud Storage Bucket
+    createTemporaryGcsBucket(gcsBucketName);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    // Clean up Data Catalog
+    try (DataCatalogClient dataCatalogClient = DataCatalogClient.create()) {
+      EntryGroupName name = EntryGroupName.of(PROJECT_ID, LOCATION, entryGroup);
+      DeleteEntryGroupRequest request =
+          DeleteEntryGroupRequest.newBuilder().setName(name.toString()).build();
+      dataCatalogClient.deleteEntryGroup(request);
+    }
+    // Clean up Cloud Storage
+    deleteTemporaryGcsBucket(gcsBucketName);
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    log.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testCreateCustomConnector() throws IOException, ExecutionException, InterruptedException {
+    CreateCustomConnector.importEntriesViaCustomConnector(LOCATION,PROJECT_ID, entryGroup, PROJECT_ID, gcsBucketName);
+    assertThat(bout.toString()).contains("Long-running operation is created");
+  }
+
+  private void createTemporaryGcsBucket(String bucketName) {
+    StorageClass storageClass = StorageClass.COLDLINE;
+    String location = "ASIA";
+
+    storageService.create(
+            BucketInfo.newBuilder(bucketName)
+                .setStorageClass(storageClass)
+                .setLocation(location)
+                .build());
+  }
+
+  private void deleteTemporaryGcsBucket (String bucketName) {
+    Page<Blob> blobs = storageService.list(bucketName);
+    for (Blob blob : blobs.iterateAll()) {
+      BlobId blobId = BlobId.of(bucketName, blob.getName());
+      storageService.delete(blobId);
+    }
+
+    Bucket bucket = storageService.get(gcsBucketName);
+    bucket.delete();
+  }
+}
+

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/GetImportEntriesStateIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/GetImportEntriesStateIT.java
@@ -1,0 +1,141 @@
+package com.example.datacatalog;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.api.gax.paging.Page;
+import com.google.cloud.datacatalog.v1.DataCatalogClient;
+import com.google.cloud.datacatalog.v1.DeleteEntryGroupRequest;
+import com.google.cloud.datacatalog.v1.EntryGroupName;
+import com.google.cloud.datacatalog.v1.ImportEntriesMetadata;
+import com.google.cloud.datacatalog.v1.ImportEntriesRequest;
+import com.google.cloud.datacatalog.v1.ImportEntriesResponse;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageClass;
+import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GetImportEntriesStateIT {
+  @Rule
+  public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
+
+  private static final String ID = UUID.randomUUID().toString().substring(0, 8);
+  private static final String LOCATION = "us-central1";
+  private final Logger log = Logger.getLogger(this.getClass().getName());
+  private static final String ENTRY_GROUP = "ENTRY_GROUP_TEST_" + ID;
+
+  private static final String GCS_BUCKET_NAME = "bucket_test_" + ID;
+  private String operationName;
+  private final Storage storageService = StorageOptions.newBuilder().setProjectId(PROJECT_ID).build().getService();
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull("Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() throws IOException, ExecutionException, InterruptedException {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+
+    // Create temporary entry group
+    CreateEntryGroup.createEntryGroup(PROJECT_ID, LOCATION, ENTRY_GROUP);
+    // Create temporary Google Cloud Storage Bucket
+    createTemporaryGcsBucket();
+    // Call ImportEntries and get name of a long-running operation
+    operationName = getLongRunningOperationName();
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    // Clean up Data Catalog
+    try (DataCatalogClient dataCatalogClient = DataCatalogClient.create()) {
+      EntryGroupName name = EntryGroupName.of(PROJECT_ID, LOCATION, ENTRY_GROUP);
+      DeleteEntryGroupRequest request =
+          DeleteEntryGroupRequest.newBuilder().setName(name.toString()).build();
+      dataCatalogClient.deleteEntryGroup(request);
+    }
+    // Clean up Cloud Storage
+    deleteTemporaryGcsBucket();
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    log.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testGetImportEntriesState() throws IOException {
+    GetImportEntriesState.queryImportEntriesState(operationName);
+    assertThat(bout.toString()).contains("Import Entries state");
+  }
+
+  private void createTemporaryGcsBucket() {
+    StorageClass storageClass = StorageClass.COLDLINE;
+    String location = "ASIA";
+
+    storageService.create(
+        BucketInfo.newBuilder(GCS_BUCKET_NAME)
+            .setStorageClass(storageClass)
+            .setLocation(location)
+            .build());
+  }
+
+  private void deleteTemporaryGcsBucket () {
+    Page<Blob> blobs = storageService.list(GCS_BUCKET_NAME);
+    for (Blob blob : blobs.iterateAll()) {
+      BlobId blobId = BlobId.of(GCS_BUCKET_NAME, blob.getName());
+      storageService.delete(blobId);
+    }
+
+    Bucket bucket = storageService.get(GCS_BUCKET_NAME);
+    bucket.delete();
+  }
+
+  private String getLongRunningOperationName()
+      throws IOException, ExecutionException, InterruptedException {
+    String entryGroupName = EntryGroupName.of(PROJECT_ID, LOCATION, ENTRY_GROUP).toString();
+    String gcsBucketPath = "gs://" + GCS_BUCKET_NAME;
+    try (DataCatalogClient dataCatalogClient = DataCatalogClient.create()) {
+      OperationFuture<ImportEntriesResponse, ImportEntriesMetadata> importEntriesFuture =
+          dataCatalogClient.importEntriesAsync(ImportEntriesRequest.newBuilder()
+              .setParent(entryGroupName)
+              .setGcsBucketPath(gcsBucketPath)
+              .build());
+
+      return importEntriesFuture.getName();
+    }
+  }
+}
+
+

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/GetImportEntriesStateIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/GetImportEntriesStateIT.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.datacatalog;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -12,12 +28,12 @@ import com.google.cloud.datacatalog.v1.ImportEntriesMetadata;
 import com.google.cloud.datacatalog.v1.ImportEntriesRequest;
 import com.google.cloud.datacatalog.v1.ImportEntriesResponse;
 import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageClass;
 import com.google.cloud.storage.StorageOptions;
-import com.google.cloud.storage.BlobId;
 import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -33,22 +49,21 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class GetImportEntriesStateIT {
-  @Rule
-  public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
 
   private static final String ID = UUID.randomUUID().toString().substring(0, 8);
   private static final String LOCATION = "us-central1";
-  private final Logger log = Logger.getLogger(this.getClass().getName());
   private static final String ENTRY_GROUP = "ENTRY_GROUP_TEST_" + ID;
-
   private static final String GCS_BUCKET_NAME = "bucket_test_" + ID;
+  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  @Rule
+  public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
+  private final Logger log = Logger.getLogger(this.getClass().getName());
+  private final Storage storageService = StorageOptions.newBuilder().setProjectId(PROJECT_ID)
+      .build().getService();
   private String operationName;
-  private final Storage storageService = StorageOptions.newBuilder().setProjectId(PROJECT_ID).build().getService();
   private ByteArrayOutputStream bout;
   private PrintStream out;
   private PrintStream originalPrintStream;
-
-  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
 
   private static String requireEnvVar(String varName) {
     String value = System.getenv(varName);
@@ -111,7 +126,7 @@ public class GetImportEntriesStateIT {
             .build());
   }
 
-  private void deleteTemporaryGcsBucket () {
+  private void deleteTemporaryGcsBucket() {
     Page<Blob> blobs = storageService.list(GCS_BUCKET_NAME);
     for (Blob blob : blobs.iterateAll()) {
       BlobId blobId = BlobId.of(GCS_BUCKET_NAME, blob.getName());


### PR DESCRIPTION
Add code samples demonstrating how one can build a custom connector and ingest their entries to Dataplex Catalog via our upcoming ImportEntries() API.

- [Yes ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [Yes ] `pom.xml` parent set to latest `shared-configuration`
- [No changes ] Appropriate changes to README are included in PR
- [No ] API's need to be enabled to test (tell us)
- [Maybe? ] Environment Variables need to be set (ask us to set them) -> I tested with GOOGLE_CLOUD_PROJECT to which I have access to, and it worked fine.
- [Partially ] **Tests** pass:   `mvn clean verify` **required** -> Tests that relate to my changes pass. One unrelated test fails (QuickstartIT), because apparently one needs to set up some static resources on GCP to run it. I did not do that.
- [Yes ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [Took into account ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [Yes! ] Please **merge** this PR for me once it is approved.
