### PR TITLE
chore: add deprecation notice for iot samples

### DIFF
--- a/iot/README.md
+++ b/iot/README.md
@@ -1,0 +1,7 @@
+# Deprecation Notice
+
+* <h3>Google Cloud IoT Core will be <a href="https://cloud.google.com/iot/docs/release-notes">retired as of August 16, 2023</a>.</h3>
+
+* <h3>Hence, the samples in this directory are archived and are no more maintained.</h3>
+
+* <h3>If you are customer with an assigned Google Cloud account team, contact your account team for more information.</h3>


### PR DESCRIPTION
#### Description
- Cloud IoT Core will be deprecated on Aug 16 2023
- The Core team has no specific commitment to the samples anymore
- Hence, adding an archived note to the samples directory

#### Related issues:
- https://github.com/GoogleCloudPlatform/java-docs-samples/issues/7833 tracks the eventual removal of the samples.