### PR TITLE
chore: remove versions of managed dependencies

### DIFF
--- a/appengine-java11/guestbook-cloud-firestore/pom.xml
+++ b/appengine-java11/guestbook-cloud-firestore/pom.xml
@@ -72,8 +72,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>31.1-jre</version>
-    </dependency>
+      </dependency>
 
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/appengine-java11/springboot-helloworld/pom.xml
+++ b/appengine-java11/springboot-helloworld/pom.xml
@@ -70,8 +70,7 @@
     <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-jetty</artifactId>
-        <version>2.7.10</version>
-    </dependency>
+        </dependency>
   </dependencies>
 
   <build>

--- a/appengine-java11/tasks-handler/pom.xml
+++ b/appengine-java11/tasks-handler/pom.xml
@@ -62,7 +62,6 @@ limitations under the License.
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>2.7.10</version>
       <exclusions>
         <!-- Exclude the Tomcat dependency -->
         <exclusion>
@@ -74,8 +73,7 @@ limitations under the License.
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-jetty</artifactId>
-      <version>2.7.10</version>
-    </dependency>
+      </dependency>
 
   </dependencies>
 

--- a/appengine-java11/vertx-helloworld/pom.xml
+++ b/appengine-java11/vertx-helloworld/pom.xml
@@ -74,7 +74,6 @@ limitations under the License.
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>4.3.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/appengine-java8/springboot-helloworld/pom.xml
+++ b/appengine-java8/springboot-helloworld/pom.xml
@@ -29,8 +29,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>${spring.boot.version}</version>
-            <!-- Exclude Tomcat so that it doesn't conflict w/ Jetty server -->
+      <!-- Exclude Tomcat so that it doesn't conflict w/ Jetty server -->
       <exclusions>
         <exclusion>
           <groupId>org.springframework.boot</groupId>
@@ -50,20 +49,17 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
-      <version>${spring.boot.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/appengine-java8/springboot-helloworld/pom.xml
+++ b/appengine-java8/springboot-helloworld/pom.xml
@@ -29,6 +29,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+      <version>${spring.boot.version}</version>
       <!-- Exclude Tomcat so that it doesn't conflict w/ Jetty server -->
       <exclusions>
         <exclusion>
@@ -55,6 +56,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <version>${spring.boot.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -60,13 +60,11 @@ limitations under the License.
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-appengine</artifactId>
-      <version>1.15.0</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.15.0</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-apikeys</artifactId>

--- a/automl/pom.xml
+++ b/automl/pom.xml
@@ -71,6 +71,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-core</artifactId>
+      <version>2.12.0</version>
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>

--- a/automl/pom.xml
+++ b/automl/pom.xml
@@ -71,7 +71,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-core</artifactId>
-      <version>2.12.0</version>
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>

--- a/cloud-sql/mysql/client-side-encryption/pom.xml
+++ b/cloud-sql/mysql/client-side-encryption/pom.xml
@@ -62,8 +62,7 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-jackson2</artifactId>
-      <version>1.42.3</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.cloud.sql</groupId>
       <artifactId>mysql-socket-factory-connector-j-8</artifactId>

--- a/cloud-sql/postgres/client-side-encryption/pom.xml
+++ b/cloud-sql/postgres/client-side-encryption/pom.xml
@@ -62,8 +62,7 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-jackson2</artifactId>
-      <version>1.42.3</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.cloud.sql</groupId>
       <artifactId>postgres-socket-factory</artifactId>

--- a/cloud-sql/sqlserver/client-side-encryption/pom.xml
+++ b/cloud-sql/sqlserver/client-side-encryption/pom.xml
@@ -62,8 +62,7 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-jackson2</artifactId>
-      <version>1.42.3</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.cloud.sql</groupId>
       <artifactId>cloud-sql-connector-jdbc-sqlserver</artifactId>

--- a/compute/cloud-client/pom.xml
+++ b/compute/cloud-client/pom.xml
@@ -23,6 +23,7 @@
     <dependency>
       <artifactId>google-cloud-compute</artifactId>
       <groupId>com.google.cloud</groupId>
+      <version>1.18.0</version>
       </dependency>
     <dependency>
       <artifactId>google-cloud-storage</artifactId>

--- a/compute/cloud-client/pom.xml
+++ b/compute/cloud-client/pom.xml
@@ -23,8 +23,7 @@
     <dependency>
       <artifactId>google-cloud-compute</artifactId>
       <groupId>com.google.cloud</groupId>
-      <version>1.18.0</version>
-    </dependency>
+      </dependency>
     <dependency>
       <artifactId>google-cloud-storage</artifactId>
       <groupId>com.google.cloud</groupId>
@@ -36,13 +35,11 @@
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax</artifactId>
-      <version>2.23.0</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-httpjson</artifactId>
-      <version>0.108.1</version>
-    </dependency>
+      </dependency>
 
 
     <!-- Test dependencies -->

--- a/container-registry/vulnerability-notification-function/pom.xml
+++ b/container-registry/vulnerability-notification-function/pom.xml
@@ -49,8 +49,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.10.1</version>
-    </dependency>
+      </dependency>
 
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/datacatalog/snippets/pom.xml
+++ b/datacatalog/snippets/pom.xml
@@ -51,8 +51,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <version>3.21.7</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>

--- a/dialogflow/snippets/pom.xml
+++ b/dialogflow/snippets/pom.xml
@@ -47,7 +47,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-core</artifactId>
-      <version>2.12.0</version>
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>

--- a/document-ai/pom.xml
+++ b/document-ai/pom.xml
@@ -41,8 +41,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-document-ai</artifactId>
-      <version>2.14.0</version>
-    </dependency>
+      </dependency>
     <!-- [END documentai_install_with_bom] -->
     <dependency>
       <groupId>com.google.cloud</groupId>

--- a/eventarc/audit-storage/pom.xml
+++ b/eventarc/audit-storage/pom.xml
@@ -57,8 +57,7 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.12.0</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
@@ -73,7 +72,6 @@ limitations under the License.
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/eventarc/generic/pom.xml
+++ b/eventarc/generic/pom.xml
@@ -50,8 +50,7 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.12.0</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>

--- a/eventarc/pubsub/pom.xml
+++ b/eventarc/pubsub/pom.xml
@@ -57,8 +57,7 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.12.0</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
@@ -73,7 +72,6 @@ limitations under the License.
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/flexible/java-11/springboot-helloworld/pom.xml
+++ b/flexible/java-11/springboot-helloworld/pom.xml
@@ -74,12 +74,10 @@
     <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-jetty</artifactId>
-        <version>2.7.10</version>
-    </dependency>
+        </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/functions/helloworld/hello-gcs/pom.xml
+++ b/functions/helloworld/hello-gcs/pom.xml
@@ -68,7 +68,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
-      <version>31.1-jre</version>
       <scope>test</scope>
     </dependency>
 
@@ -94,8 +93,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.10.1</version>
-    </dependency>
+      </dependency>
 
     <!-- Used in ExampleSystemTest AND ExampleIntegrationTest -->
     <dependency>

--- a/functions/helloworld/hello-pubsub/pom.xml
+++ b/functions/helloworld/hello-pubsub/pom.xml
@@ -68,7 +68,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
-      <version>31.1-jre</version>
       <scope>test</scope>
     </dependency>
 
@@ -86,8 +85,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.10.1</version>
-    </dependency>
+      </dependency>
 
     <!-- Used in ExampleIntegrationTest (to make POST requests -->
     <dependency>

--- a/functions/imagemagick/pom.xml
+++ b/functions/imagemagick/pom.xml
@@ -80,7 +80,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
-      <version>31.1-jre</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/ocr/ocr-process-image/pom.xml
+++ b/functions/ocr/ocr-process-image/pom.xml
@@ -84,7 +84,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
-      <version>31.1-jre</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/ocr/ocr-save-result/pom.xml
+++ b/functions/ocr/ocr-save-result/pom.xml
@@ -84,7 +84,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
-      <version>31.1-jre</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/ocr/ocr-translate-text/pom.xml
+++ b/functions/ocr/ocr-translate-text/pom.xml
@@ -80,7 +80,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
-      <version>31.1-jre</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/pubsub/publish-message/pom.xml
+++ b/functions/pubsub/publish-message/pom.xml
@@ -77,7 +77,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
-      <version>31.1-jre</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/functions/slack/pom.xml
+++ b/functions/slack/pom.xml
@@ -60,14 +60,12 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.10.1</version>
-    </dependency>
+      </dependency>
 
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-jackson2</artifactId>
-      <version>1.42.3</version>
-    </dependency>
+      </dependency>
     
     <dependency>
       <groupId>com.google.apis</groupId>
@@ -104,7 +102,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
-      <version>31.1-jre</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/v2/hello-gcs/pom.xml
+++ b/functions/v2/hello-gcs/pom.xml
@@ -61,7 +61,6 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.10.1</version>
       <scope>compile</scope>
     </dependency>
 
@@ -80,7 +79,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
-      <version>31.1-jre</version>
       <scope>test</scope>
     </dependency>
 

--- a/functions/v2/imagemagick/pom.xml
+++ b/functions/v2/imagemagick/pom.xml
@@ -89,7 +89,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
-      <version>31.1-jre</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/v2/ocr/ocr-process-image/pom.xml
+++ b/functions/v2/ocr/ocr-process-image/pom.xml
@@ -80,8 +80,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.10.1</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloudevent-types</artifactId>
@@ -104,7 +103,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
-      <version>31.1-jre</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/v2/ocr/ocr-save-result/pom.xml
+++ b/functions/v2/ocr/ocr-save-result/pom.xml
@@ -72,8 +72,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.10.1</version>
-    </dependency>
+      </dependency>
     <!-- The following dependencies are only required for testing -->
     <dependency>
       <groupId>junit</groupId>
@@ -90,7 +89,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
-      <version>31.1-jre</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/functions/v2/ocr/ocr-translate-text/pom.xml
+++ b/functions/v2/ocr/ocr-translate-text/pom.xml
@@ -89,7 +89,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
-      <version>31.1-jre</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/healthcare/v1/pom.xml
+++ b/healthcare/v1/pom.xml
@@ -75,8 +75,7 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-jackson2</artifactId>
-      <version>1.42.3</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-healthcare</artifactId>
@@ -85,13 +84,11 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>2.0.0</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.15.0</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-core</artifactId>

--- a/iam/snippets/pom.xml
+++ b/iam/snippets/pom.xml
@@ -31,13 +31,11 @@
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.15.0</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-jackson2</artifactId>
-      <version>1.42.3</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-iam-policy</artifactId>

--- a/jobs/v4/pom.xml
+++ b/jobs/v4/pom.xml
@@ -56,7 +56,7 @@
            <groupId>com.google.http-client</groupId>
            <artifactId>google-http-client-jackson2</artifactId>
            <version>1.42.3</version>
-           </dependency>    
+        </dependency>    
         <!-- [END jobs_java_dependencies_beta] -->
 
         <!-- Test dependencies -->

--- a/jobs/v4/pom.xml
+++ b/jobs/v4/pom.xml
@@ -55,6 +55,7 @@
         <dependency>
            <groupId>com.google.http-client</groupId>
            <artifactId>google-http-client-jackson2</artifactId>
+           <version>1.42.3</version>
            </dependency>    
         <!-- [END jobs_java_dependencies_beta] -->
 

--- a/jobs/v4/pom.xml
+++ b/jobs/v4/pom.xml
@@ -55,8 +55,7 @@
         <dependency>
            <groupId>com.google.http-client</groupId>
            <artifactId>google-http-client-jackson2</artifactId>
-           <version>1.42.3</version>
-        </dependency>    
+           </dependency>    
         <!-- [END jobs_java_dependencies_beta] -->
 
         <!-- Test dependencies -->

--- a/language/analysis/pom.xml
+++ b/language/analysis/pom.xml
@@ -58,8 +58,7 @@ limitations under the License.
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>31.1-jre</version>
-    </dependency>
+      </dependency>
 
     <!-- Test Dependencies -->
     <dependency>

--- a/media/transcoder/pom.xml
+++ b/media/transcoder/pom.xml
@@ -53,8 +53,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-video-transcoder</artifactId>
-      <version>1.7.0</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-core</artifactId>
@@ -76,7 +75,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>2.18.0</version>
-    </dependency>
+      </dependency>
   </dependencies>
 </project>

--- a/monitoring/cloud-client/pom.xml
+++ b/monitoring/cloud-client/pom.xml
@@ -54,30 +54,25 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>31.1-jre</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.10.1</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <version>4.0.0-rc-2</version>
-    </dependency>
+      </dependency>
 
     <!-- FIXME: remove after client fixes depenency issue => BOM 9.0.0   -->
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-credentials</artifactId>
-      <version>1.14.0</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.15.0</version>
-    </dependency>
+      </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/monitoring/v3/pom.xml
+++ b/monitoring/v3/pom.xml
@@ -59,8 +59,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.10.1</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>

--- a/optimization/snippets/pom.xml
+++ b/optimization/snippets/pom.xml
@@ -43,8 +43,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-optimization</artifactId>
-      <version>1.11.0</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>

--- a/privateca/snippets/pom.xml
+++ b/privateca/snippets/pom.xml
@@ -52,8 +52,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-security-private-ca</artifactId>
-      <version>2.15.0</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>

--- a/privateca/snippets/pom.xml
+++ b/privateca/snippets/pom.xml
@@ -52,6 +52,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-security-private-ca</artifactId>
+      <version>2.15.0</version>
       </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>

--- a/pubsub/spring/pom.xml
+++ b/pubsub/spring/pom.xml
@@ -89,6 +89,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pubsub/spring/pom.xml
+++ b/pubsub/spring/pom.xml
@@ -89,7 +89,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pubsublite/streaming-analytics/pom.xml
+++ b/pubsublite/streaming-analytics/pom.xml
@@ -131,8 +131,7 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>2.0.1</version>
-    </dependency>
+      </dependency>
 
     <dependency>
       <groupId>com.google.apis</groupId>

--- a/recaptcha_enterprise/demosite/pom.xml
+++ b/recaptcha_enterprise/demosite/pom.xml
@@ -57,13 +57,11 @@
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
-      <version>4.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-chrome-driver</artifactId>
-      <version>4.7.0</version>
       <scope>test</scope>
     </dependency>
     <!-- end_Selenium_dependencies -->
@@ -73,7 +71,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -89,19 +86,16 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>2.7.10</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
-      <version>2.7.10</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-thymeleaf</artifactId>
-      <version>2.7.10</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>api-common</artifactId>
@@ -110,7 +104,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
-      <version>2.7.10</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/recaptcha_enterprise/snippets/src/pom.xml
+++ b/recaptcha_enterprise/snippets/src/pom.xml
@@ -72,8 +72,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>31.1-jre</version>
-    </dependency>
+      </dependency>
     <!-- Removes the dependency of driver binary file -->
     <dependency>
       <groupId>io.github.bonigarcia</groupId>

--- a/retail/interactive-tutorials/pom.xml
+++ b/retail/interactive-tutorials/pom.xml
@@ -42,8 +42,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-retail</artifactId>
-      <version>2.15.0</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -53,18 +52,15 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquery</artifactId>
-      <version>2.24.3</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>2.18.0</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.10.1</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>

--- a/run/endpoints-v2-backend/pom.xml
+++ b/run/endpoints-v2-backend/pom.xml
@@ -68,7 +68,6 @@ limitations under the License.
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/run/filesystem/pom.xml
+++ b/run/filesystem/pom.xml
@@ -65,7 +65,6 @@ limitations under the License.
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -76,7 +75,6 @@ limitations under the License.
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>4.9.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/run/helloworld/pom.xml
+++ b/run/helloworld/pom.xml
@@ -57,7 +57,6 @@ limitations under the License.
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/run/image-processing/pom.xml
+++ b/run/image-processing/pom.xml
@@ -60,8 +60,7 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.12.0</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
@@ -72,7 +71,6 @@ limitations under the License.
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.10.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -98,7 +96,6 @@ limitations under the License.
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/run/markdown-preview/editor/pom.xml
+++ b/run/markdown-preview/editor/pom.xml
@@ -54,8 +54,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>4.9.3</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
@@ -64,7 +63,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/run/markdown-preview/renderer/pom.xml
+++ b/run/markdown-preview/renderer/pom.xml
@@ -70,7 +70,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/run/pubsub/pom.xml
+++ b/run/pubsub/pom.xml
@@ -57,8 +57,7 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.12.0</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
@@ -67,7 +66,6 @@ limitations under the License.
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/security-command-center/snippets/pom.xml
+++ b/security-command-center/snippets/pom.xml
@@ -42,8 +42,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-securitycenter</artifactId>
-      <version>2.21.0</version>
-    </dependency>
+      </dependency>
 
     <dependency>
       <groupId>com.google.cloud</groupId>
@@ -59,8 +58,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <version>3.21.7</version>
-    </dependency>
+      </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/spanner/changestreams/pom.xml
+++ b/spanner/changestreams/pom.xml
@@ -54,8 +54,7 @@
       <dependency>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
-          <version>31.1-jre</version>
-      </dependency>
+          </dependency>
       <dependency>
           <groupId>org.apache.avro</groupId>
           <artifactId>avro</artifactId>

--- a/spanner/opencensus/pom.xml
+++ b/spanner/opencensus/pom.xml
@@ -42,8 +42,7 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-census</artifactId>
-      <version>1.50.2</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-impl</artifactId>
@@ -53,8 +52,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.21.12</version>
-    </dependency>
+      </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-exporter-stats-stackdriver</artifactId>
@@ -82,7 +80,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
-      <version>6.35.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/spanner/r2dbc/pom.xml
+++ b/spanner/r2dbc/pom.xml
@@ -75,7 +75,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/storage/cloud-client/pom.xml
+++ b/storage/cloud-client/pom.xml
@@ -51,8 +51,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>2.20.2</version>
-    </dependency>
+      </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/storage/s3-sdk/pom.xml
+++ b/storage/s3-sdk/pom.xml
@@ -62,7 +62,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>2.20.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/translate/pom.xml
+++ b/translate/pom.xml
@@ -62,7 +62,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-core</artifactId>
-      <version>2.12.0</version>
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>

--- a/video/pom.xml
+++ b/video/pom.xml
@@ -63,7 +63,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-core</artifactId>
-      <version>2.12.0</version>
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>

--- a/video/pom.xml
+++ b/video/pom.xml
@@ -63,6 +63,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-core</artifactId>
+      <version>2.12.0</version>
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>

--- a/vision/snippets/pom.xml
+++ b/vision/snippets/pom.xml
@@ -66,7 +66,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-core</artifactId>
-      <version>2.12.0</version>
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>

--- a/workflows/cloud-client/pom.xml
+++ b/workflows/cloud-client/pom.xml
@@ -59,8 +59,7 @@ limitations under the License.
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-workflow-executions</artifactId>
-      <version>2.13.0</version>
-    </dependency>
+      </dependency>
     <!-- [END workflows_api_quickstart_dependencies] -->
 
     <!-- Test dependencies -->


### PR DESCRIPTION
Some samples are still explicitly setting dependency versions, even though they are managed by the [libraries-bom](https://github.com/googleapis/java-cloud-bom).

This creates unnecessary dependency updates that would otherwise be managed through one update to the `libraries-bom`. It can also lead to potential conflicts between dependency versions that don't work well together.

This PR removes `<version/>` from dependencies that are already centrally managed.

Several samples were excluded due to failures, and will be revisited later:
* appengine-java8/springboot-helloworld
* automl
* compute/cloud-client
* jobs/v4
* privateca
* pubsub/spring
* video