### PR TITLE
test: avoid referencing veneer in HBase tests

### DIFF
--- a/bigtable/hbase/snippets/src/main/java/com/example/bigtable/Filters.java
+++ b/bigtable/hbase/snippets/src/main/java/com/example/bigtable/Filters.java
@@ -18,10 +18,6 @@ package com.example.bigtable;
 
 // [START bigtable_filters_print_hbase]
 
-import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
-
-import com.google.api.gax.rpc.ServerStream;
-import com.google.bigtable.v2.ColumnRange;
 import com.google.cloud.bigtable.hbase.BigtableConfiguration;
 import java.io.IOException;
 import java.time.Instant;
@@ -43,13 +39,10 @@ import org.apache.hadoop.hbase.filter.FamilyFilter;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.FilterList;
 import org.apache.hadoop.hbase.filter.FilterList.Operator;
-import org.apache.hadoop.hbase.filter.PageFilter;
-import org.apache.hadoop.hbase.filter.PrefixFilter;
 import org.apache.hadoop.hbase.filter.QualifierFilter;
 import org.apache.hadoop.hbase.filter.RandomRowFilter;
 import org.apache.hadoop.hbase.filter.RegexStringComparator;
 import org.apache.hadoop.hbase.filter.RowFilter;
-import org.apache.hadoop.hbase.filter.SingleColumnValueFilter;
 import org.apache.hadoop.hbase.filter.SkipFilter;
 import org.apache.hadoop.hbase.filter.ValueFilter;
 import org.apache.hadoop.hbase.util.Bytes;

--- a/bigtable/hbase/snippets/src/test/java/com/example/bigtable/FiltersTest.java
+++ b/bigtable/hbase/snippets/src/test/java/com/example/bigtable/FiltersTest.java
@@ -20,17 +20,21 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertNotNull;
 
 import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
-import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
-import com.google.cloud.bigtable.data.v2.BigtableDataClient;
-import com.google.cloud.bigtable.data.v2.models.BulkMutation;
-import com.google.cloud.bigtable.data.v2.models.Mutation;
-import com.google.protobuf.ByteString;
+import com.google.cloud.bigtable.hbase.BigtableConfiguration;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.UUID;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.BufferedMutator;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -67,109 +71,78 @@ public class FiltersTest {
     projectId = requireEnv("GOOGLE_CLOUD_PROJECT");
     instanceId = requireEnv(INSTANCE_ENV);
 
-    try (BigtableTableAdminClient adminClient =
-        BigtableTableAdminClient.create(projectId, instanceId)) {
-      CreateTableRequest createTableRequest =
-          CreateTableRequest.of(TABLE_ID)
-              .addFamily(COLUMN_FAMILY_NAME_STATS)
-              .addFamily(COLUMN_FAMILY_NAME_DATA);
-      adminClient.createTable(createTableRequest);
+    try (Connection connection = BigtableConfiguration.connect(projectId, instanceId)) {
+      try (Admin admin = connection.getAdmin()) {
+        admin.createTable(
+            new HTableDescriptor(TableName.valueOf(TABLE_ID))
+                .addFamily(new HColumnDescriptor(COLUMN_FAMILY_NAME_STATS))
+                .addFamily(new HColumnDescriptor(COLUMN_FAMILY_NAME_DATA))
 
-      try (BigtableDataClient dataClient = BigtableDataClient.create(projectId, instanceId)) {
-        BulkMutation bulkMutation =
-            BulkMutation.create(TABLE_ID)
-                .add(
-                    "phone#4c410523#20190501",
-                    Mutation.create()
-                        .setCell(
-                            COLUMN_FAMILY_NAME_STATS,
-                            ByteString.copyFrom("connected_cell".getBytes()),
-                            TIMESTAMP_NANO,
-                            1)
-                        .setCell(
-                            COLUMN_FAMILY_NAME_STATS,
-                            ByteString.copyFrom("connected_wifi".getBytes()),
-                            TIMESTAMP_NANO,
-                            1)
-                        .setCell(
-                            COLUMN_FAMILY_NAME_STATS, "os_build", TIMESTAMP_NANO, "PQ2A.190405.003")
-                        .setCell(
-                            COLUMN_FAMILY_NAME_DATA,
-                            "data_plan_01gb",
-                            TIMESTAMP_MINUS_HR_NANO,
-                            "true")
-                        .setCell(COLUMN_FAMILY_NAME_DATA, "data_plan_01gb", TIMESTAMP_NANO, "false")
-                        .setCell(COLUMN_FAMILY_NAME_DATA, "data_plan_05gb", TIMESTAMP_NANO, "true"))
-                .add(
-                    "phone#4c410523#20190502",
-                    Mutation.create()
-                        .setCell(
-                            COLUMN_FAMILY_NAME_STATS,
-                            ByteString.copyFrom("connected_cell".getBytes()),
-                            TIMESTAMP_NANO,
-                            1)
-                        .setCell(
-                            COLUMN_FAMILY_NAME_STATS,
-                            ByteString.copyFrom("connected_wifi".getBytes()),
-                            TIMESTAMP_NANO,
-                            1)
-                        .setCell(
-                            COLUMN_FAMILY_NAME_STATS, "os_build", TIMESTAMP_NANO, "PQ2A.190405.004")
-                        .setCell(COLUMN_FAMILY_NAME_DATA, "data_plan_05gb", TIMESTAMP_NANO, "true"))
-                .add(
-                    "phone#4c410523#20190505",
-                    Mutation.create()
-                        .setCell(
-                            COLUMN_FAMILY_NAME_STATS,
-                            ByteString.copyFrom("connected_cell".getBytes()),
-                            TIMESTAMP_NANO,
-                            0)
-                        .setCell(
-                            COLUMN_FAMILY_NAME_STATS,
-                            ByteString.copyFrom("connected_wifi".getBytes()),
-                            TIMESTAMP_NANO,
-                            1)
-                        .setCell(
-                            COLUMN_FAMILY_NAME_STATS, "os_build", TIMESTAMP_NANO, "PQ2A.190406.000")
-                        .setCell(COLUMN_FAMILY_NAME_DATA, "data_plan_05gb", TIMESTAMP_NANO, "true"))
-                .add(
-                    "phone#5c10102#20190501",
-                    Mutation.create()
-                        .setCell(
-                            COLUMN_FAMILY_NAME_STATS,
-                            ByteString.copyFrom("connected_cell".getBytes()),
-                            TIMESTAMP_NANO,
-                            1)
-                        .setCell(
-                            COLUMN_FAMILY_NAME_STATS,
-                            ByteString.copyFrom("connected_wifi".getBytes()),
-                            TIMESTAMP_NANO,
-                            1)
-                        .setCell(
-                            COLUMN_FAMILY_NAME_STATS, "os_build", TIMESTAMP_NANO, "PQ2A.190401.002")
-                        .setCell(COLUMN_FAMILY_NAME_DATA, "data_plan_10gb", TIMESTAMP_NANO, "true"))
-                .add(
-                    "phone#5c10102#20190502",
-                    Mutation.create()
-                        .setCell(
-                            COLUMN_FAMILY_NAME_STATS,
-                            ByteString.copyFrom("connected_cell".getBytes()),
-                            TIMESTAMP_NANO,
-                            1)
-                        .setCell(
-                            COLUMN_FAMILY_NAME_STATS,
-                            ByteString.copyFrom("connected_wifi".getBytes()),
-                            TIMESTAMP_NANO,
-                            0)
-                        .setCell(
-                            COLUMN_FAMILY_NAME_STATS, "os_build", TIMESTAMP_NANO, "PQ2A.190406.000")
-                        .setCell(
-                            COLUMN_FAMILY_NAME_DATA, "data_plan_10gb", TIMESTAMP_NANO, "true"));
+        );
 
-        dataClient.bulkMutateRows(bulkMutation);
+        try (BufferedMutator batcher = connection.getBufferedMutator(
+            TableName.valueOf(TABLE_ID))) {
+
+          batcher.mutate(
+              new Put("phone#4c410523#20190501".getBytes())
+                  .addColumn(COLUMN_FAMILY_NAME_STATS.getBytes(), "connected_cell".getBytes(),
+                      TIMESTAMP, Bytes.toBytes(1L))
+                  .addColumn(COLUMN_FAMILY_NAME_STATS.getBytes(), "connected_wifi".getBytes(),
+                      TIMESTAMP, Bytes.toBytes(1L))
+                  .addColumn(COLUMN_FAMILY_NAME_STATS.getBytes(), "os_build".getBytes(), TIMESTAMP,
+                      Bytes.toBytes("PQ2A.190405.003"))
+                  .addColumn(COLUMN_FAMILY_NAME_DATA.getBytes(), "data_plan_01gb".getBytes(),
+                      TIMESTAMP_MINUS_HR, Bytes.toBytes("true"))
+                  .addColumn(COLUMN_FAMILY_NAME_DATA.getBytes(), "data_plan_01gb".getBytes(),
+                      TIMESTAMP, Bytes.toBytes("false"))
+                  .addColumn(COLUMN_FAMILY_NAME_DATA.getBytes(), "data_plan_05gb".getBytes(),
+                      TIMESTAMP, Bytes.toBytes("true"))
+          );
+          batcher.mutate(
+              new Put("phone#4c410523#20190502".getBytes())
+                  .addColumn(COLUMN_FAMILY_NAME_STATS.getBytes(), Bytes.toBytes("connected_cell"),
+                      TIMESTAMP, Bytes.toBytes(1L))
+                  .addColumn(COLUMN_FAMILY_NAME_STATS.getBytes(), Bytes.toBytes("connected_wifi"),
+                      TIMESTAMP, Bytes.toBytes(1L))
+                  .addColumn(COLUMN_FAMILY_NAME_STATS.getBytes(), Bytes.toBytes("os_build"),
+                      TIMESTAMP, Bytes.toBytes("PQ2A.190405.004"))
+                  .addColumn(COLUMN_FAMILY_NAME_DATA.getBytes(), Bytes.toBytes("data_plan_05gb"),
+                      TIMESTAMP, Bytes.toBytes("true")));
+          batcher.mutate(
+              new Put(Bytes.toBytes("phone#4c410523#20190505"))
+                  .addColumn(Bytes.toBytes(COLUMN_FAMILY_NAME_STATS),
+                      Bytes.toBytes("connected_cell"), TIMESTAMP, Bytes.toBytes(0L))
+                  .addColumn(Bytes.toBytes(COLUMN_FAMILY_NAME_STATS),
+                      Bytes.toBytes("connected_wifi"), TIMESTAMP, Bytes.toBytes(1))
+                  .addColumn(Bytes.toBytes(COLUMN_FAMILY_NAME_STATS), Bytes.toBytes("os_build"),
+                      TIMESTAMP, Bytes.toBytes("PQ2A.190406.000"))
+                  .addColumn(Bytes.toBytes(COLUMN_FAMILY_NAME_DATA),
+                      Bytes.toBytes("data_plan_05gb"), TIMESTAMP, Bytes.toBytes("true")));
+          batcher.mutate(
+              new Put(Bytes.toBytes("phone#5c10102#20190501"))
+                  .addColumn(Bytes.toBytes(COLUMN_FAMILY_NAME_STATS),
+                      Bytes.toBytes("connected_cell"), TIMESTAMP, Bytes.toBytes(1L))
+                  .addColumn(Bytes.toBytes(COLUMN_FAMILY_NAME_STATS),
+                      Bytes.toBytes("connected_wifi"), TIMESTAMP, Bytes.toBytes(1L))
+                  .addColumn(Bytes.toBytes(COLUMN_FAMILY_NAME_STATS), Bytes.toBytes("os_build"),
+                      TIMESTAMP, Bytes.toBytes("PQ2A.190401.002"))
+                  .addColumn(Bytes.toBytes(COLUMN_FAMILY_NAME_DATA),
+                      Bytes.toBytes("data_plan_10gb"), TIMESTAMP, Bytes.toBytes("true")));
+          batcher.mutate(
+              new Put(Bytes.toBytes("phone#5c10102#20190502"))
+                  .addColumn(Bytes.toBytes(COLUMN_FAMILY_NAME_STATS),
+                      Bytes.toBytes("connected_cell"), TIMESTAMP, Bytes.toBytes(1L))
+                  .addColumn(Bytes.toBytes(COLUMN_FAMILY_NAME_STATS),
+                      Bytes.toBytes("connected_wifi"), TIMESTAMP, Bytes.toBytes(0L))
+                  .addColumn(Bytes.toBytes(COLUMN_FAMILY_NAME_STATS), Bytes.toBytes("os_build"),
+                      TIMESTAMP, Bytes.toBytes("PQ2A.190406.000"))
+                  .addColumn(
+                      Bytes.toBytes(COLUMN_FAMILY_NAME_DATA), Bytes.toBytes("data_plan_10gb"),
+                      TIMESTAMP, Bytes.toBytes("true")));
+        }
       }
     } catch (Exception e) {
-      System.out.println("Error during beforeClass: \n" + e.toString());
+      System.out.println("Error during beforeClass: \n" + e);
       throw (e);
     }
   }

--- a/bigtable/hbase/snippets/src/test/java/com/example/bigtable/ReadsTest.java
+++ b/bigtable/hbase/snippets/src/test/java/com/example/bigtable/ReadsTest.java
@@ -19,16 +19,19 @@ package com.example.bigtable;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertNotNull;
 
-import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
-import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
-import com.google.cloud.bigtable.data.v2.BigtableDataClient;
-import com.google.cloud.bigtable.data.v2.models.BulkMutation;
-import com.google.cloud.bigtable.data.v2.models.Mutation;
-import com.google.protobuf.ByteString;
+import com.google.cloud.bigtable.hbase.BigtableConfiguration;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.UUID;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.BufferedMutator;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -44,7 +47,6 @@ public class ReadsTest {
       "mobile-time-series-" + UUID.randomUUID().toString().substring(0, 20);
   private static final String COLUMN_FAMILY_NAME = "stats_summary";
   private static final long TIMESTAMP = System.currentTimeMillis();
-  private static final long TIMESTAMP_NANO = TIMESTAMP * 1000;
 
   private static String projectId;
   private static String instanceId;
@@ -63,92 +65,107 @@ public class ReadsTest {
     projectId = requireEnv("GOOGLE_CLOUD_PROJECT");
     instanceId = requireEnv(INSTANCE_ENV);
 
-    try (BigtableTableAdminClient adminClient =
-        BigtableTableAdminClient.create(projectId, instanceId)) {
-      CreateTableRequest createTableRequest =
-          CreateTableRequest.of(TABLE_ID).addFamily(COLUMN_FAMILY_NAME);
-      adminClient.createTable(createTableRequest);
+    try (Connection connection = BigtableConfiguration.connect(projectId, instanceId);
+        Admin admin = connection.getAdmin()) {
 
-      try (BigtableDataClient dataClient = BigtableDataClient.create(projectId, instanceId)) {
-        BulkMutation bulkMutation =
-            BulkMutation.create(TABLE_ID)
-                .add(
-                    "phone#4c410523#20190501",
-                    Mutation.create()
-                        .setCell(
-                            COLUMN_FAMILY_NAME,
-                            ByteString.copyFrom("connected_cell".getBytes()),
-                            TIMESTAMP_NANO,
-                            1)
-                        .setCell(
-                            COLUMN_FAMILY_NAME,
-                            ByteString.copyFrom("connected_wifi".getBytes()),
-                            TIMESTAMP_NANO,
-                            1)
-                        .setCell(COLUMN_FAMILY_NAME, "os_build", TIMESTAMP_NANO, "PQ2A.190405.003"))
-                .add(
-                    "phone#4c410523#20190502",
-                    Mutation.create()
-                        .setCell(
-                            COLUMN_FAMILY_NAME,
-                            ByteString.copyFrom("connected_cell".getBytes()),
-                            TIMESTAMP_NANO,
-                            1)
-                        .setCell(
-                            COLUMN_FAMILY_NAME,
-                            ByteString.copyFrom("connected_wifi".getBytes()),
-                            TIMESTAMP_NANO,
-                            1)
-                        .setCell(COLUMN_FAMILY_NAME, "os_build", TIMESTAMP_NANO, "PQ2A.190405.004"))
-                .add(
-                    "phone#4c410523#20190505",
-                    Mutation.create()
-                        .setCell(
-                            COLUMN_FAMILY_NAME,
-                            ByteString.copyFrom("connected_cell".getBytes()),
-                            TIMESTAMP_NANO,
-                            0)
-                        .setCell(
-                            COLUMN_FAMILY_NAME,
-                            ByteString.copyFrom("connected_wifi".getBytes()),
-                            TIMESTAMP_NANO,
-                            1)
-                        .setCell(COLUMN_FAMILY_NAME, "os_build", TIMESTAMP_NANO, "PQ2A.190406.000"))
-                .add(
-                    "phone#5c10102#20190501",
-                    Mutation.create()
-                        .setCell(
-                            COLUMN_FAMILY_NAME,
-                            ByteString.copyFrom("connected_cell".getBytes()),
-                            TIMESTAMP_NANO,
-                            1)
-                        .setCell(
-                            COLUMN_FAMILY_NAME,
-                            ByteString.copyFrom("connected_wifi".getBytes()),
-                            TIMESTAMP_NANO,
-                            1)
-                        .setCell(COLUMN_FAMILY_NAME, "os_build", TIMESTAMP_NANO, "PQ2A.190401.002"))
-                .add(
-                    "phone#5c10102#20190502",
-                    Mutation.create()
-                        .setCell(
-                            COLUMN_FAMILY_NAME,
-                            ByteString.copyFrom("connected_cell".getBytes()),
-                            TIMESTAMP_NANO,
-                            1)
-                        .setCell(
-                            COLUMN_FAMILY_NAME,
-                            ByteString.copyFrom("connected_wifi".getBytes()),
-                            TIMESTAMP_NANO,
-                            0)
-                        .setCell(
-                            COLUMN_FAMILY_NAME, "os_build", TIMESTAMP_NANO, "PQ2A.190406.000"));
+      admin.createTable(
+          new HTableDescriptor(TableName.valueOf(TABLE_ID))
+              .addFamily(new HColumnDescriptor(COLUMN_FAMILY_NAME)));
 
-        dataClient.bulkMutateRows(bulkMutation);
+      try (BufferedMutator batcher = connection.getBufferedMutator(TableName.valueOf(TABLE_ID))) {
+        batcher.mutate(
+            new Put(Bytes.toBytes("phone#4c410523#20190501"))
+                .addColumn(
+                    COLUMN_FAMILY_NAME.getBytes(),
+                    Bytes.toBytes("connected_cell"),
+                    TIMESTAMP,
+                    Bytes.toBytes(1L))
+                .addColumn(
+                    COLUMN_FAMILY_NAME.getBytes(),
+                    Bytes.toBytes("connected_wifi"),
+                    TIMESTAMP,
+                    Bytes.toBytes(1L))
+                .addColumn(
+                    COLUMN_FAMILY_NAME.getBytes(),
+                    Bytes.toBytes("os_build"),
+                    TIMESTAMP,
+                    Bytes.toBytes("PQ2A.190405.003")));
+
+        batcher.mutate(
+            new Put(Bytes.toBytes("phone#4c410523#20190502"))
+                .addColumn(
+                    COLUMN_FAMILY_NAME.getBytes(),
+                    Bytes.toBytes("connected_cell"),
+                    TIMESTAMP,
+                    Bytes.toBytes(1L))
+                .addColumn(
+                    COLUMN_FAMILY_NAME.getBytes(),
+                    Bytes.toBytes("connected_wifi"),
+                    TIMESTAMP,
+                    Bytes.toBytes(1L))
+                .addColumn(
+                    COLUMN_FAMILY_NAME.getBytes(),
+                    Bytes.toBytes("os_build"),
+                    TIMESTAMP,
+                    Bytes.toBytes("PQ2A.190405.004")));
+
+        batcher.mutate(
+            new Put(Bytes.toBytes("phone#4c410523#20190505"))
+                .addColumn(
+                    COLUMN_FAMILY_NAME.getBytes(),
+                    Bytes.toBytes("connected_cell"),
+                    TIMESTAMP,
+                    Bytes.toBytes(0L))
+                .addColumn(
+                    COLUMN_FAMILY_NAME.getBytes(),
+                    Bytes.toBytes("connected_wifi"),
+                    TIMESTAMP,
+                    Bytes.toBytes(1L))
+                .addColumn(
+                    COLUMN_FAMILY_NAME.getBytes(),
+                    Bytes.toBytes("os_build"),
+                    TIMESTAMP,
+                    Bytes.toBytes("PQ2A.190406.000")));
+
+        batcher.mutate(
+            new Put(Bytes.toBytes("phone#5c10102#20190501"))
+                .addColumn(
+                    COLUMN_FAMILY_NAME.getBytes(),
+                    Bytes.toBytes("connected_cell"),
+                    TIMESTAMP,
+                    Bytes.toBytes(1L))
+                .addColumn(
+                    COLUMN_FAMILY_NAME.getBytes(),
+                    Bytes.toBytes("connected_wifi"),
+                    TIMESTAMP,
+                    Bytes.toBytes(1L))
+                .addColumn(
+                    COLUMN_FAMILY_NAME.getBytes(),
+                    Bytes.toBytes("os_build"),
+                    TIMESTAMP,
+                    Bytes.toBytes("PQ2A.190401.002")));
+
+        batcher.mutate(
+            new Put(Bytes.toBytes("phone#5c10102#20190502"))
+                .addColumn(
+                    COLUMN_FAMILY_NAME.getBytes(),
+                    Bytes.toBytes("connected_cell"),
+                    TIMESTAMP,
+                    Bytes.toBytes(1L))
+                .addColumn(
+                    COLUMN_FAMILY_NAME.getBytes(),
+                    Bytes.toBytes("connected_wifi"),
+                    TIMESTAMP,
+                    Bytes.toBytes(0L))
+                .addColumn(
+                    COLUMN_FAMILY_NAME.getBytes(),
+                    Bytes.toBytes("os_build"),
+                    TIMESTAMP,
+                    Bytes.toBytes("PQ2A.190406.000")));
       }
     } catch (Exception e) {
-      System.out.println("Error during beforeClass: \n" + e.toString());
-      throw (e);
+      System.out.println("Error during beforeClass: \n" + e);
+      throw e;
     }
   }
 
@@ -160,11 +177,11 @@ public class ReadsTest {
 
   @AfterClass
   public static void afterClass() throws IOException {
-    try (BigtableTableAdminClient adminClient =
-        BigtableTableAdminClient.create(projectId, instanceId)) {
-      adminClient.deleteTable(TABLE_ID);
+    try (Connection connection = BigtableConfiguration.connect(projectId, instanceId);
+        Admin admin = connection.getAdmin()) {
+      admin.deleteTable(TableName.valueOf(TABLE_ID));
     } catch (Exception e) {
-      System.out.println("Error during afterClass: \n" + e.toString());
+      System.out.println("Error during afterClass: \n" + e);
       throw (e);
     }
   }


### PR DESCRIPTION
HBase tests should stick to the public surface of the HBase adapter. The underlying veneer implementation should be an implementation detail