### PR TITLE
fix(monitoring): refactor a few monitoring ITs

### DIFF
--- a/monitoring/v3/src/main/java/com/example/monitoring/CreateAlertPolicy.java
+++ b/monitoring/v3/src/main/java/com/example/monitoring/CreateAlertPolicy.java
@@ -36,7 +36,7 @@ public class CreateAlertPolicy {
     createAlertPolicy(projectId, alertPolicyName);
   }
 
-  public static void createAlertPolicy(String projectId, String alertPolicyName)
+  public static AlertPolicy createAlertPolicy(String projectId, String alertPolicyName)
       throws ApiException, IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests.
@@ -95,6 +95,7 @@ public class CreateAlertPolicy {
       // Create an alert policy
       AlertPolicy actualAlertPolicy = alertPolicyServiceClient.createAlertPolicy(name, alertPolicy);
       System.out.format("alert policy created:%s", actualAlertPolicy.getName());
+      return actualAlertPolicy;
     }
   }
 }

--- a/monitoring/v3/src/main/java/com/example/monitoring/DeleteNotificationChannel.java
+++ b/monitoring/v3/src/main/java/com/example/monitoring/DeleteNotificationChannel.java
@@ -31,7 +31,7 @@ public class DeleteNotificationChannel {
     String projectId = System.getProperty("projectId");
     try (NotificationChannelServiceClient client = NotificationChannelServiceClient.create()) {
       NotificationChannelName name = NotificationChannelName.of(projectId, channelName);
-      client.deleteNotificationChannel(name, false);
+      client.deleteNotificationChannel(channelName, false);
       System.out.println("Deleted notification channel " + channelName);
     }
   }

--- a/monitoring/v3/src/main/java/com/example/monitoring/DeleteNotificationChannel.java
+++ b/monitoring/v3/src/main/java/com/example/monitoring/DeleteNotificationChannel.java
@@ -31,7 +31,7 @@ public class DeleteNotificationChannel {
     String projectId = System.getProperty("projectId");
     try (NotificationChannelServiceClient client = NotificationChannelServiceClient.create()) {
       NotificationChannelName name = NotificationChannelName.of(projectId, channelName);
-      client.deleteNotificationChannel(channelName, false);
+      client.deleteNotificationChannel(name, false);
       System.out.println("Deleted notification channel " + channelName);
     }
   }

--- a/monitoring/v3/src/test/java/com/example/monitoring/AlertIT.java
+++ b/monitoring/v3/src/test/java/com/example/monitoring/AlertIT.java
@@ -16,24 +16,27 @@
 
 package com.example.monitoring;
 
+import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.google.cloud.testing.junit4.MultipleAttemptsRule;
-import com.google.common.base.Strings;
+import com.google.cloud.monitoring.v3.NotificationChannelServiceClient;
 import com.google.common.io.Files;
+import com.google.monitoring.v3.AlertPolicy;
+import com.google.monitoring.v3.NotificationChannel;
+import com.google.monitoring.v3.ProjectName;
 import io.grpc.StatusRuntimeException;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
-import java.util.regex.Matcher;
+import java.util.UUID;
 import java.util.regex.Pattern;
 import org.junit.After;
-import org.junit.Assert;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -42,36 +45,75 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class AlertIT {
-  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(5);
-  private static String testPolicyName = "My Uptime Check Policy";
-  private static String policyFileName = "target/policyBackup.json";
-  private static Pattern policyNameRegex =
-      Pattern.compile(
-          "alertPolicies/(?<alertid>.*)(?s).*notificationChannels/(?<channel>[a-zA-Z0-9]*)");
+  private static String alertPolicyName;
+  private static String alertPolicyId;
+  private static String notificationChannelName;
+  private static String notificationChannelId;
+  private static final String suffix = UUID.randomUUID().toString().substring(0, 8);
+  private static final String testPolicyName = "test-policy" + suffix;
+  private static final String policyFileName = "target/policyBackup.json";
+  private static final String projectId = requireEnvVar();
   private ByteArrayOutputStream bout;
   private final PrintStream originalOut = System.out;
 
+  private static String requireEnvVar() {
+    String value = System.getenv("GOOGLE_CLOUD_PROJECT");
+    assertNotNull(
+        "Environment variable " + "GOOGLE_CLOUD_PROJECT" + " is required to perform these tests.",
+        System.getenv("GOOGLE_CLOUD_PROJECT"));
+    return value;
+  }
+
+  @BeforeClass
+  public static void setupClass() throws IOException {
+    // Create a test notification channel. Clean up not required because the channel
+    // gets removed in `testReplaceChannels()`.
+    try (NotificationChannelServiceClient client = NotificationChannelServiceClient.create()) {
+      NotificationChannel notificationChannel =
+          NotificationChannel.newBuilder()
+              .setType("email")
+              .putLabels("email_address", "java-docs-samples-testing@google.com")
+              .build();
+      NotificationChannel channel =
+          client.createNotificationChannel(ProjectName.of(projectId), notificationChannel);
+      notificationChannelName = channel.getName();
+      notificationChannelId =
+          notificationChannelName.substring(notificationChannelName.lastIndexOf("/") + 1);
+    }
+
+    // Create a test alert policy.
+    AlertPolicy alertPolicy = CreateAlertPolicy.createAlertPolicy(projectId, testPolicyName);
+    alertPolicyName = alertPolicy.getName();
+    alertPolicyId = alertPolicyName.substring(alertPolicyName.lastIndexOf('/') + 1);
+  }
+
   @Before
-  public void setUp() {
+  public void setUp() throws IOException {
     bout = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(bout));
+    PrintStream out = new PrintStream(bout);
+    System.setOut(out);
   }
 
   @After
-  public void tearDown() {
+  public void tearDown() throws IOException {
     System.setOut(originalOut);
     bout.reset();
   }
 
+  @AfterClass
+  public static void tearDownClass() throws IOException {
+    DeleteAlertPolicy.deleteAlertPolicy(alertPolicyName);
+  }
+
   @Test
   public void testListPolicies() throws IOException {
-    AlertSample.main(new String[] {"list"});
+    AlertSample.main("list");
     assertTrue(bout.toString().contains(testPolicyName));
   }
 
   @Test
   public void testBackupPolicies() throws IOException {
-    AlertSample.main(new String[] {"backup", "-j", policyFileName});
+    AlertSample.main("backup", "-j", policyFileName);
     File backupFile = new File(policyFileName);
     assertTrue(backupFile.exists());
     String fileContents = String.join("\n", Files.readLines(backupFile, StandardCharsets.UTF_8));
@@ -81,19 +123,13 @@ public class AlertIT {
   // TODO(b/78293034): Complete restore backup test when parse/unparse issue is figured out.
   @Test
   @Ignore
-  public void testRestoreBackup() throws IOException {}
+  public void testRestoreBackup() {}
 
   @Test
   public void testReplaceChannels() throws IOException {
-    // Get a test policy name for the project.
-    AlertSample.main(new String[] {"list"});
-    Matcher matcher = policyNameRegex.matcher(bout.toString());
-    assertTrue(matcher.find());
-    String alertId = matcher.group("alertid");
-    String channel = matcher.group("channel");
-    Assert.assertFalse(Strings.isNullOrEmpty(alertId));
-    AlertSample.main(new String[] {"replace-channels", "-a", alertId, "-c", channel});
-    Pattern resultPattern = Pattern.compile("(?s).*Updated .*/alertPolicies/" + alertId);
+    AlertSample.main(
+        new String[] {"replace-channels", "-a", alertPolicyId, "-c", notificationChannelId});
+    Pattern resultPattern = Pattern.compile("(?s).*Updated .*" + alertPolicyId);
     assertTrue(resultPattern.matcher(bout.toString()).find());
   }
 

--- a/monitoring/v3/src/test/java/com/example/monitoring/AlertIT.java
+++ b/monitoring/v3/src/test/java/com/example/monitoring/AlertIT.java
@@ -126,8 +126,7 @@ public class AlertIT {
 
   @Test
   public void testReplaceChannels() throws IOException {
-    AlertSample.main(
-        "replace-channels", "-a", alertPolicyId, "-c", notificationChannelId);
+    AlertSample.main("replace-channels", "-a", alertPolicyId, "-c", notificationChannelId);
     Pattern resultPattern = Pattern.compile("(?s).*Updated .*" + alertPolicyId);
     assertTrue(resultPattern.matcher(bout.toString()).find());
   }
@@ -146,20 +145,16 @@ public class AlertIT {
     while (retry) {
       try {
         if (isEnabled) {
-          AlertSample.main(
-              "disable", "-d", "display_name=\"" + testPolicyName + "\"");
+          AlertSample.main("disable", "-d", "display_name=\"" + testPolicyName + "\"");
           assertTrue(bout.toString().contains("disabled"));
 
-          AlertSample.main(
-              "enable", "-d", "display_name=\"" + testPolicyName + "\"");
+          AlertSample.main("enable", "-d", "display_name=\"" + testPolicyName + "\"");
           assertTrue(bout.toString().contains("enabled"));
         } else {
-          AlertSample.main(
-              "enable", "-d", "display_name=\"" + testPolicyName + "\"");
+          AlertSample.main("enable", "-d", "display_name=\"" + testPolicyName + "\"");
           assertTrue(bout.toString().contains("enabled"));
 
-          AlertSample.main(
-              "disable", "-d", "display_name=\"" + testPolicyName + "\"");
+          AlertSample.main("disable", "-d", "display_name=\"" + testPolicyName + "\"");
           assertTrue(bout.toString().contains("disabled"));
         }
         retry = false;

--- a/monitoring/v3/src/test/java/com/example/monitoring/AlertIT.java
+++ b/monitoring/v3/src/test/java/com/example/monitoring/AlertIT.java
@@ -47,7 +47,6 @@ import org.junit.runners.JUnit4;
 public class AlertIT {
   private static String alertPolicyName;
   private static String alertPolicyId;
-  private static String notificationChannelName;
   private static String notificationChannelId;
   private static final String suffix = UUID.randomUUID().toString().substring(0, 8);
   private static final String testPolicyName = "test-policy" + suffix;
@@ -76,7 +75,7 @@ public class AlertIT {
               .build();
       NotificationChannel channel =
           client.createNotificationChannel(ProjectName.of(projectId), notificationChannel);
-      notificationChannelName = channel.getName();
+      String notificationChannelName = channel.getName();
       notificationChannelId =
           notificationChannelName.substring(notificationChannelName.lastIndexOf("/") + 1);
     }
@@ -128,14 +127,14 @@ public class AlertIT {
   @Test
   public void testReplaceChannels() throws IOException {
     AlertSample.main(
-        new String[] {"replace-channels", "-a", alertPolicyId, "-c", notificationChannelId});
+        "replace-channels", "-a", alertPolicyId, "-c", notificationChannelId);
     Pattern resultPattern = Pattern.compile("(?s).*Updated .*" + alertPolicyId);
     assertTrue(resultPattern.matcher(bout.toString()).find());
   }
 
   @Test
   public void testDisableEnablePolicies() throws IOException, InterruptedException {
-    AlertSample.main(new String[] {"enable", "-d", "display_name=\"" + testPolicyName + "\""});
+    AlertSample.main("enable", "-d", "display_name=\"" + testPolicyName + "\"");
 
     // check the current state of policy to make sure
     // not to enable the policy that is already enabled.
@@ -143,31 +142,31 @@ public class AlertIT {
     int maxAttempts = 10;
     int attempt = 0;
     int factor = 1;
-    Boolean retry = true;
+    boolean retry = true;
     while (retry) {
       try {
         if (isEnabled) {
           AlertSample.main(
-              new String[] {"disable", "-d", "display_name=\"" + testPolicyName + "\""});
+              "disable", "-d", "display_name=\"" + testPolicyName + "\"");
           assertTrue(bout.toString().contains("disabled"));
 
           AlertSample.main(
-              new String[] {"enable", "-d", "display_name=\"" + testPolicyName + "\""});
+              "enable", "-d", "display_name=\"" + testPolicyName + "\"");
           assertTrue(bout.toString().contains("enabled"));
         } else {
           AlertSample.main(
-              new String[] {"enable", "-d", "display_name=\"" + testPolicyName + "\""});
+              "enable", "-d", "display_name=\"" + testPolicyName + "\"");
           assertTrue(bout.toString().contains("enabled"));
 
           AlertSample.main(
-              new String[] {"disable", "-d", "display_name=\"" + testPolicyName + "\""});
+              "disable", "-d", "display_name=\"" + testPolicyName + "\"");
           assertTrue(bout.toString().contains("disabled"));
         }
         retry = false;
       } catch (StatusRuntimeException e) {
-        System.out.println("Error: " + e.toString());
+        System.out.println("Error: " + e);
         System.out.println("Retrying...");
-        Thread.sleep(2300 * factor);
+        Thread.sleep(2300L * factor);
         attempt += 1;
         factor += 1;
         if (attempt >= maxAttempts) {

--- a/monitoring/v3/src/test/java/com/example/monitoring/AlertIT.java
+++ b/monitoring/v3/src/test/java/com/example/monitoring/AlertIT.java
@@ -66,7 +66,7 @@ public class AlertIT {
   @Test
   public void testListPolicies() throws IOException {
     AlertSample.main(new String[] {"list"});
-    assertTrue(bout.toString().contains("My Uptime Check Policy"));
+    assertTrue(bout.toString().contains(testPolicyName));
   }
 
   @Test
@@ -75,7 +75,7 @@ public class AlertIT {
     File backupFile = new File(policyFileName);
     assertTrue(backupFile.exists());
     String fileContents = String.join("\n", Files.readLines(backupFile, StandardCharsets.UTF_8));
-    assertTrue(fileContents.contains("My Uptime Check Policy"));
+    assertTrue(fileContents.contains(testPolicyName));
   }
 
   // TODO(b/78293034): Complete restore backup test when parse/unparse issue is figured out.
@@ -99,7 +99,7 @@ public class AlertIT {
 
   @Test
   public void testDisableEnablePolicies() throws IOException, InterruptedException {
-    AlertSample.main(new String[] {"enable", "-d", "display_name=\""+testPolicyName+"\""});
+    AlertSample.main(new String[] {"enable", "-d", "display_name=\"" + testPolicyName + "\""});
 
     // check the current state of policy to make sure
     // not to enable the policy that is already enabled.
@@ -111,16 +111,20 @@ public class AlertIT {
     while (retry) {
       try {
         if (isEnabled) {
-          AlertSample.main(new String[] {"disable", "-d", "display_name=\""+testPolicyName+"\""});
+          AlertSample.main(
+              new String[] {"disable", "-d", "display_name=\"" + testPolicyName + "\""});
           assertTrue(bout.toString().contains("disabled"));
 
-          AlertSample.main(new String[] {"enable", "-d", "display_name=\""+testPolicyName+"\""});
+          AlertSample.main(
+              new String[] {"enable", "-d", "display_name=\"" + testPolicyName + "\""});
           assertTrue(bout.toString().contains("enabled"));
         } else {
-          AlertSample.main(new String[] {"enable", "-d", "display_name=\""+testPolicyName+"\""});
+          AlertSample.main(
+              new String[] {"enable", "-d", "display_name=\"" + testPolicyName + "\""});
           assertTrue(bout.toString().contains("enabled"));
 
-          AlertSample.main(new String[] {"disable", "-d", "display_name=\""+testPolicyName+"\""});
+          AlertSample.main(
+              new String[] {"disable", "-d", "display_name=\"" + testPolicyName + "\""});
           assertTrue(bout.toString().contains("disabled"));
         }
         retry = false;

--- a/monitoring/v3/src/test/java/com/example/monitoring/AlertIT.java
+++ b/monitoring/v3/src/test/java/com/example/monitoring/AlertIT.java
@@ -43,7 +43,7 @@ import org.junit.runners.JUnit4;
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class AlertIT {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(5);
-  private static String testPolicyName = "test-policy";
+  private static String testPolicyName = "My Uptime Check Policy";
   private static String policyFileName = "target/policyBackup.json";
   private static Pattern policyNameRegex =
       Pattern.compile(
@@ -66,7 +66,7 @@ public class AlertIT {
   @Test
   public void testListPolicies() throws IOException {
     AlertSample.main(new String[] {"list"});
-    assertTrue(bout.toString().contains(testPolicyName));
+    assertTrue(bout.toString().contains("My Uptime Check Policy"));
   }
 
   @Test
@@ -75,7 +75,7 @@ public class AlertIT {
     File backupFile = new File(policyFileName);
     assertTrue(backupFile.exists());
     String fileContents = String.join("\n", Files.readLines(backupFile, StandardCharsets.UTF_8));
-    assertTrue(fileContents.contains("test-policy"));
+    assertTrue(fileContents.contains("My Uptime Check Policy"));
   }
 
   // TODO(b/78293034): Complete restore backup test when parse/unparse issue is figured out.
@@ -99,7 +99,7 @@ public class AlertIT {
 
   @Test
   public void testDisableEnablePolicies() throws IOException, InterruptedException {
-    AlertSample.main(new String[] {"enable", "-d", "display_name='test-policy'"});
+    AlertSample.main(new String[] {"enable", "-d", "display_name=\""+testPolicyName+"\""});
 
     // check the current state of policy to make sure
     // not to enable the policy that is already enabled.
@@ -111,16 +111,16 @@ public class AlertIT {
     while (retry) {
       try {
         if (isEnabled) {
-          AlertSample.main(new String[] {"disable", "-d", "display_name='test-policy'"});
+          AlertSample.main(new String[] {"disable", "-d", "display_name=\""+testPolicyName+"\""});
           assertTrue(bout.toString().contains("disabled"));
 
-          AlertSample.main(new String[] {"enable", "-d", "display_name='test-policy'"});
+          AlertSample.main(new String[] {"enable", "-d", "display_name=\""+testPolicyName+"\""});
           assertTrue(bout.toString().contains("enabled"));
         } else {
-          AlertSample.main(new String[] {"enable", "-d", "display_name='test-policy'"});
+          AlertSample.main(new String[] {"enable", "-d", "display_name=\""+testPolicyName+"\""});
           assertTrue(bout.toString().contains("enabled"));
 
-          AlertSample.main(new String[] {"disable", "-d", "display_name='test-policy'"});
+          AlertSample.main(new String[] {"disable", "-d", "display_name=\""+testPolicyName+"\""});
           assertTrue(bout.toString().contains("disabled"));
         }
         retry = false;

--- a/monitoring/v3/src/test/java/com/example/monitoring/DeleteNotificationChannelIT.java
+++ b/monitoring/v3/src/test/java/com/example/monitoring/DeleteNotificationChannelIT.java
@@ -19,16 +19,15 @@ package com.example.monitoring;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.cloud.monitoring.v3.NotificationChannelServiceClient;
-import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import com.google.monitoring.v3.NotificationChannel;
 import com.google.monitoring.v3.ProjectName;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -37,14 +36,11 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class DeleteNotificationChannelIT {
-  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(5);
-
   private ByteArrayOutputStream bout;
-  private PrintStream out;
   private static final String LEGACY_PROJECT_ENV_NAME = "GCLOUD_PROJECT";
   private static final String PROJECT_ENV_NAME = "GOOGLE_CLOUD_PROJECT";
-  private static String NOTIFICATION_CHANNEL_NAME = "channelname";
-  private static NotificationChannel NOTIFICATION_CHANNEL;
+  private static final String suffix = UUID.randomUUID().toString().substring(0, 8);
+  private static String NOTIFICATION_CHANNEL_NAME = "channelname" + suffix;
   private PrintStream originalPrintStream;
 
   private static String getProjectId() {
@@ -60,7 +56,7 @@ public class DeleteNotificationChannelIT {
   public static void setupClass() throws IOException {
     try (NotificationChannelServiceClient client = NotificationChannelServiceClient.create()) {
       String projectId = getProjectId();
-      NOTIFICATION_CHANNEL =
+      NotificationChannel NOTIFICATION_CHANNEL =
           NotificationChannel.newBuilder()
               .setType("email")
               .putLabels("email_address", "java-docs-samples-testing@google.com")
@@ -74,7 +70,7 @@ public class DeleteNotificationChannelIT {
   @Before
   public void setUp() {
     bout = new ByteArrayOutputStream();
-    out = new PrintStream(bout);
+    PrintStream out = new PrintStream(bout);
     originalPrintStream = System.out;
     System.setOut(out);
     System.setProperty("projectId", DeleteNotificationChannelIT.getProjectId());

--- a/monitoring/v3/src/test/java/com/example/monitoring/DeleteNotificationChannelIT.java
+++ b/monitoring/v3/src/test/java/com/example/monitoring/DeleteNotificationChannelIT.java
@@ -56,13 +56,13 @@ public class DeleteNotificationChannelIT {
   public static void setupClass() throws IOException {
     try (NotificationChannelServiceClient client = NotificationChannelServiceClient.create()) {
       String projectId = getProjectId();
-      NotificationChannel NOTIFICATION_CHANNEL =
+      NotificationChannel notificationChannel =
           NotificationChannel.newBuilder()
               .setType("email")
               .putLabels("email_address", "java-docs-samples-testing@google.com")
               .build();
       NotificationChannel channel =
-          client.createNotificationChannel(ProjectName.of(projectId), NOTIFICATION_CHANNEL);
+          client.createNotificationChannel(ProjectName.of(projectId), notificationChannel);
       NOTIFICATION_CHANNEL_NAME = channel.getName();
     }
   }

--- a/monitoring/v3/src/test/java/com/example/monitoring/ListAlertPolicyIT.java
+++ b/monitoring/v3/src/test/java/com/example/monitoring/ListAlertPolicyIT.java
@@ -19,41 +19,41 @@ package com.example.monitoring;
 import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.TestCase.assertNotNull;
 
-import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
 
 /** Tests for list an alert policy sample. */
 public class ListAlertPolicyIT {
-  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(5);
-  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  private static final String PROJECT_ID = requireEnvVar();
   private ByteArrayOutputStream bout;
-  private PrintStream out;
   private PrintStream originalPrintStream;
+  private static final String suffix = UUID.randomUUID().toString().substring(0, 8);
+  private static final String testPolicyName = "test-policy" + suffix;
 
-  private static String requireEnvVar(String varName) {
-    String value = System.getenv(varName);
+  private static String requireEnvVar() {
+    String value = System.getenv("GOOGLE_CLOUD_PROJECT");
     assertNotNull(
-        "Environment variable " + varName + " is required to perform these tests.",
-        System.getenv(varName));
+        "Environment variable " + "GOOGLE_CLOUD_PROJECT" + " is required to perform these tests.",
+        System.getenv("GOOGLE_CLOUD_PROJECT"));
     return value;
   }
 
   @BeforeClass
-  public static void checkRequirements() {
-    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  public static void checkRequirements() throws IOException {
+    requireEnvVar();
+    CreateAlertPolicy.createAlertPolicy(PROJECT_ID, testPolicyName);
   }
 
   @Before
   public void setUp() {
     bout = new ByteArrayOutputStream();
-    out = new PrintStream(bout);
+    PrintStream out = new PrintStream(bout);
     originalPrintStream = System.out;
     System.setOut(out);
   }


### PR DESCRIPTION
fixes #7916
fixes #7915
fixes #7914
fixes #7913
fixes #7912

i see other badly written tests in this /monitoring directory that will need a larger scale rewrite
- inconsistent use of resource id versus resource names
- not all samples have tests
- unnecessary ITs for each sample, with this type of admin ops, ITs can be combined into a single IT
- repeated use of functions like `requireEnvVar` in each IT and can be extracted instead
- the `java-pubsub` samples repo have some really good examples that can be ref'ed

for now, i've done a few things while being aware that there's a 500 hard limit on alerting policies per google cloud project. these include:
- create test resources for each IT run (of the ITs i touched) and clean them up 
- use consistent naming for resource ids versus names
- rewrite create resource sample to return resource type, where we can extract resource names, rather than using a list method