### PR TITLE
Deidentify with masking

### DIFF
--- a/dlp/snippets/src/main/java/dlp/snippets/DeIdentifyWithMasking.java
+++ b/dlp/snippets/src/main/java/dlp/snippets/DeIdentifyWithMasking.java
@@ -30,7 +30,6 @@ import com.google.privacy.dlp.v2.InfoTypeTransformations.InfoTypeTransformation;
 import com.google.privacy.dlp.v2.InspectConfig;
 import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.PrimitiveTransformation;
-import com.google.privacy.dlp.v2.ReplaceWithInfoTypeConfig;
 import java.io.IOException;
 import java.util.Arrays;
 
@@ -67,7 +66,7 @@ public class DeIdentifyWithMasking {
               .build();
       PrimitiveTransformation primitiveTransformation =
           PrimitiveTransformation.newBuilder()
-              .setReplaceWithInfoTypeConfig(ReplaceWithInfoTypeConfig.getDefaultInstance())
+              .setCharacterMaskConfig(characterMaskConfig)
               .build();
       InfoTypeTransformation infoTypeTransformation =
           InfoTypeTransformation.newBuilder()


### PR DESCRIPTION
## Description
Code sample DeidentifyWithMasking was using replacement instead of masking. Correcting PrimitiveTransformation to include CharacterMaskConfig instead of ReplaceWithInfoTypeConfig.

Fixes #7935

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [x] Please **merge** this PR for me once it is approved
