### PR TITLE
[DLP] Update an existing job trigger

### DIFF
--- a/dlp/snippets/src/main/java/dlp/snippets/TriggersPatch.java
+++ b/dlp/snippets/src/main/java/dlp/snippets/TriggersPatch.java
@@ -41,10 +41,11 @@ public class TriggersPatch {
     patchTrigger(projectId, jobTriggerName);
   }
 
+  // Uses the Data Loss Prevention API to update an existing job trigger.
   public static void patchTrigger(String projectId, String jobTriggerName) throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
-    //
+    // the "close" method on the client to safely clean up any remaining background resources.
     try (DlpServiceClient dlpServiceClient = DlpServiceClient.create()) {
 
       // Specify the type of info the inspection will look for.
@@ -56,7 +57,6 @@ public class TriggersPatch {
               .setMinLikelihood(Likelihood.LIKELY)
               .build();
 
-      // Configure the inspection job we want the service to perform.
       InspectJobConfig inspectJobConfig = InspectJobConfig.newBuilder()
               .setInspectConfig(inspectConfig)
               .build();
@@ -65,19 +65,21 @@ public class TriggersPatch {
               .setInspectJob(inspectJobConfig)
               .build();
 
+      // Specify fields of the jobTrigger resource to be updated when the job trigger is modified.
+      // Refer https://protobuf.dev/reference/protobuf/google.protobuf/#field-mask for constructing the field mask paths.
       FieldMask fieldMask = FieldMask.newBuilder()
               .addPaths("inspect_job.inspect_config.info_types")
               .addPaths("inspect_job.inspect_config.min_likelihood")
               .build();
 
-      // Combine configurations into a request for the service.
+      // Update the job trigger with the new configuration.
       UpdateJobTriggerRequest updateJobTriggerRequest = UpdateJobTriggerRequest.newBuilder()
               .setName(JobTriggerName.of(projectId, jobTriggerName).toString())
               .setJobTrigger(jobTrigger)
               .setUpdateMask(fieldMask)
               .build();
 
-      // Send the scan request and process the response
+      // Call the API to update the job trigger.
       JobTrigger updatedJobTrigger = dlpServiceClient.updateJobTrigger(updateJobTriggerRequest);
 
       System.out.println("Job Trigger Name: " + updatedJobTrigger.getName());

--- a/dlp/snippets/src/main/java/dlp/snippets/TriggersPatch.java
+++ b/dlp/snippets/src/main/java/dlp/snippets/TriggersPatch.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dlp.snippets;
+
+// [START dlp_update_trigger]
+
+import com.google.cloud.dlp.v2.DlpServiceClient;
+import com.google.privacy.dlp.v2.InfoType;
+import com.google.privacy.dlp.v2.InspectConfig;
+import com.google.privacy.dlp.v2.InspectJobConfig;
+import com.google.privacy.dlp.v2.JobTrigger;
+import com.google.privacy.dlp.v2.JobTriggerName;
+import com.google.privacy.dlp.v2.Likelihood;
+import com.google.privacy.dlp.v2.UpdateJobTriggerRequest;
+import com.google.protobuf.FieldMask;
+import java.io.IOException;
+
+public class TriggersPatch {
+
+  public static void main(String[] args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+
+    // The Google Cloud project id to use as a parent resource.
+    String projectId = "your-project-id";
+    String jobTriggerName = "your-job-trigger-name";
+    patchTrigger(projectId, jobTriggerName);
+  }
+
+  public static void patchTrigger(String projectId, String jobTriggerName) throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    //
+    try (DlpServiceClient dlpServiceClient = DlpServiceClient.create()) {
+
+      // Specify the type of info the inspection will look for.
+      // See https://cloud.google.com/dlp/docs/infotypes-reference for complete list of info types
+      InfoType infoType = InfoType.newBuilder().setName("PERSON_NAME").build();
+
+      InspectConfig inspectConfig = InspectConfig.newBuilder()
+              .addInfoTypes(infoType)
+              .setMinLikelihood(Likelihood.LIKELY)
+              .build();
+
+      // Configure the inspection job we want the service to perform.
+      InspectJobConfig inspectJobConfig = InspectJobConfig.newBuilder()
+              .setInspectConfig(inspectConfig)
+              .build();
+
+      JobTrigger jobTrigger = JobTrigger.newBuilder()
+              .setInspectJob(inspectJobConfig)
+              .build();
+
+      FieldMask fieldMask = FieldMask.newBuilder()
+              .addPaths("inspect_job.inspect_config.info_types")
+              .addPaths("inspect_job.inspect_config.min_likelihood")
+              .build();
+
+      // Combine configurations into a request for the service.
+      UpdateJobTriggerRequest updateJobTriggerRequest = UpdateJobTriggerRequest.newBuilder()
+              .setName(JobTriggerName.of(projectId, jobTriggerName).toString())
+              .setJobTrigger(jobTrigger)
+              .setUpdateMask(fieldMask)
+              .build();
+
+      // Send the scan request and process the response
+      JobTrigger updatedJobTrigger = dlpServiceClient.updateJobTrigger(updateJobTriggerRequest);
+
+      System.out.println("Updated Trigger: " + updatedJobTrigger);
+    }
+  }
+}
+
+// [END dlp_update_trigger]

--- a/dlp/snippets/src/main/java/dlp/snippets/TriggersPatch.java
+++ b/dlp/snippets/src/main/java/dlp/snippets/TriggersPatch.java
@@ -36,6 +36,7 @@ public class TriggersPatch {
 
     // The Google Cloud project id to use as a parent resource.
     String projectId = "your-project-id";
+    // The name of the job trigger to be updated.
     String jobTriggerName = "your-job-trigger-name";
     patchTrigger(projectId, jobTriggerName);
   }
@@ -79,7 +80,13 @@ public class TriggersPatch {
       // Send the scan request and process the response
       JobTrigger updatedJobTrigger = dlpServiceClient.updateJobTrigger(updateJobTriggerRequest);
 
-      System.out.println("Updated Trigger: " + updatedJobTrigger);
+      System.out.println("Job Trigger Name: " + updatedJobTrigger.getName());
+      System.out.println(
+          "InfoType updated: "
+              + updatedJobTrigger.getInspectJob().getInspectConfig().getInfoTypes(0).getName());
+      System.out.println(
+          "Likelihood updated: "
+              + updatedJobTrigger.getInspectJob().getInspectConfig().getMinLikelihood());
     }
   }
 }

--- a/dlp/snippets/src/test/java/dlp/snippets/TriggersTests.java
+++ b/dlp/snippets/src/test/java/dlp/snippets/TriggersTests.java
@@ -126,8 +126,19 @@ public class TriggersTests extends TestBase {
 
     JobTrigger trigger = createTrigger();
     String triggerName = trigger.getName();
-    TriggersPatch.patchTrigger(PROJECT_ID, triggerName);
+    String triggerId;
+
+    Matcher matcher = Pattern.compile("jobTriggers/").matcher(triggerName);
+    if (matcher.find()) {
+      triggerId = triggerName.substring(matcher.end());
+    } else {
+      throw new Exception("Could not extract triggerID");
+    }
+    TriggersPatch.patchTrigger(PROJECT_ID, triggerId);
     String output = bout.toString();
-    assertThat(output).contains("Updated Trigger:");
+    assertThat(output).contains("Job Trigger Name: abcd");
+    assertThat(output).contains("InfoType updated");
+    assertThat(output).contains("Likelihood updated");
+    TriggersDelete.deleteTrigger(PROJECT_ID, triggerId);
   }
 }

--- a/dlp/snippets/src/test/java/dlp/snippets/TriggersTests.java
+++ b/dlp/snippets/src/test/java/dlp/snippets/TriggersTests.java
@@ -126,14 +126,9 @@ public class TriggersTests extends TestBase {
 
     JobTrigger trigger = createTrigger();
     String triggerName = trigger.getName();
-    String triggerId;
 
-    Matcher matcher = Pattern.compile("jobTriggers/").matcher(triggerName);
-    if (matcher.find()) {
-      triggerId = triggerName.substring(matcher.end());
-    } else {
-      throw new Exception("Could not extract triggerID");
-    }
+    String[] components = triggerName.split("/");
+    String triggerId = components[components.length - 1];
     TriggersPatch.patchTrigger(PROJECT_ID, triggerId);
     String output = bout.toString();
     assertThat(output).contains("Job Trigger Name:");

--- a/dlp/snippets/src/test/java/dlp/snippets/TriggersTests.java
+++ b/dlp/snippets/src/test/java/dlp/snippets/TriggersTests.java
@@ -136,9 +136,9 @@ public class TriggersTests extends TestBase {
     }
     TriggersPatch.patchTrigger(PROJECT_ID, triggerId);
     String output = bout.toString();
-    assertThat(output).contains("Job Trigger Name: abcd");
-    assertThat(output).contains("InfoType updated");
-    assertThat(output).contains("Likelihood updated");
+    assertThat(output).contains("Job Trigger Name:");
+    assertThat(output).contains("InfoType updated:");
+    assertThat(output).contains("Likelihood updated:");
     TriggersDelete.deleteTrigger(PROJECT_ID, triggerId);
   }
 }

--- a/dlp/snippets/src/test/java/dlp/snippets/TriggersTests.java
+++ b/dlp/snippets/src/test/java/dlp/snippets/TriggersTests.java
@@ -120,4 +120,14 @@ public class TriggersTests extends TestBase {
     String output = bout.toString();
     assertThat(output).contains("Trigger deleted:");
   }
+
+  @Test
+  public void testUpdateTrigger() throws Exception {
+
+    JobTrigger trigger = createTrigger();
+    String triggerName = trigger.getName();
+    TriggersPatch.patchTrigger(PROJECT_ID, triggerName);
+    String output = bout.toString();
+    assertThat(output).contains("Updated Trigger:");
+  }
 }


### PR DESCRIPTION
Implementation of [Updating an existing job trigger](https://cloud.google.com/dlp/docs/creating-job-triggers#update_an_existing_job_trigger)

## Checklist

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [X] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [X] **Tests** pass:   `mvn clean verify` **required**
- [X] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [X] Please **merge** this PR for me once it is approved
