### PR TITLE
chore: Update pom for latest version in discoveryengine

### DIFF
--- a/discoveryengine/pom.xml
+++ b/discoveryengine/pom.xml
@@ -30,7 +30,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>26.13.0</version>
+        <version>26.14.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -39,15 +39,12 @@
 
   <dependencies>
     <dependency>
-      <!-- TODO: version must be removed once the libraries-bom updates to new version -->
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-discoveryengine</artifactId>
-      <version>0.12.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-discoveryengine-v1beta</artifactId>
-      <version>0.12.0</version>
     </dependency>
     <!-- [END genappbuilder_install_with_bom] -->
     <dependency>


### PR DESCRIPTION
Removed explicit library versioning, no longer needed after update