### PR TITLE
test: Improve error-handling for batch bucket integration test

### DIFF
--- a/batch/snippets/src/test/java/BatchBucketIT.java
+++ b/batch/snippets/src/test/java/BatchBucketIT.java
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+// http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,6 +30,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.MissingResourceException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -121,8 +122,8 @@ public class BatchBucketIT {
   }
 
   @Test
-  public void testBucketJob()
-      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+  public void testBucketJob() throws IOException, ExecutionException, InterruptedException,
+      MissingResourceException, TimeoutException {
     CreateWithMountedBucket.createScriptJobWithBucket(PROJECT_ID, REGION, SCRIPT_JOB_NAME,
         BUCKET_NAME);
     Job job = Util.getJob(PROJECT_ID, REGION, SCRIPT_JOB_NAME);
@@ -139,7 +140,11 @@ public class BatchBucketIT {
     Bucket bucket = storage.get(BUCKET_NAME);
     for (int i = 0; i < 4; i++) {
       fileContentTemplate = String.format("Hello world from task %s.\n", i);
-      Blob blob = bucket.get(String.format(fileNameTemplate, i));
+      String fileName = String.format(fileNameTemplate, i);
+      Blob blob = bucket.get(fileName);
+      if (blob == null)
+        throw new MissingResourceException("Cannot find file in bucket.", Blob.class.getName(),
+            fileName);
       String content = new String(blob.getContent(), StandardCharsets.UTF_8);
       assertThat(fileContentTemplate).matches(content);
     }


### PR DESCRIPTION
Instead of throwing an NPE when a file is not found in the bucket, this test now handles the error and throws a detailed exception.