### PR TITLE
[DLP] Implementation of stored infotype creation

### DIFF
--- a/dlp/snippets/src/main/java/dlp/snippets/CreateStoredInfoType.java
+++ b/dlp/snippets/src/main/java/dlp/snippets/CreateStoredInfoType.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dlp.snippets;
+
+// [START dlp_create_stored_infotype]
+
+import com.google.cloud.dlp.v2.DlpServiceClient;
+import com.google.privacy.dlp.v2.CloudStorageFileSet;
+import com.google.privacy.dlp.v2.CloudStoragePath;
+import com.google.privacy.dlp.v2.CreateStoredInfoTypeRequest;
+import com.google.privacy.dlp.v2.LargeCustomDictionaryConfig;
+import com.google.privacy.dlp.v2.LocationName;
+import com.google.privacy.dlp.v2.StoredInfoType;
+import com.google.privacy.dlp.v2.StoredInfoTypeConfig;
+import java.io.IOException;
+
+public class CreateStoredInfoType {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+
+    //The Google Cloud project id to use as a parent resource.
+    String projectId = "bdp-2059-is-31084";
+    // Specify the file in GCS bucket to be used as a term list.
+    String gcsPath = "gs://" + "your-bucket-name" + "path/to/file.txt";
+    // The path to the location in a GCS bucket to store the created dictionary.
+    String outputPath = "gs://" + "your-bucket-name" + "path/to/directory";
+    createStoredInfoType(projectId, gcsPath, outputPath);
+  }
+
+  public static void createStoredInfoType(String projectId, String gcsPath, String outputPath)
+      throws IOException {
+    try (DlpServiceClient dlp = DlpServiceClient.create()) {
+
+      // Optionally set a display name and a description.
+      String displayName = "Java Test";
+      String description = "Dictionary of GitHub usernames used in commits";
+
+      CloudStoragePath cloudStoragePath =
+          CloudStoragePath.newBuilder()
+              .setPath(outputPath)
+              .build();
+
+      CloudStorageFileSet cloudStorageFileSet = CloudStorageFileSet.newBuilder()
+              .setUrl(gcsPath)
+              .build();
+
+      LargeCustomDictionaryConfig largeCustomDictionaryConfig =
+          LargeCustomDictionaryConfig.newBuilder()
+              .setOutputPath(cloudStoragePath)
+              .setCloudStorageFileSet(cloudStorageFileSet)
+              .build();
+
+      StoredInfoTypeConfig storedInfoTypeConfig = StoredInfoTypeConfig.newBuilder()
+              .setDisplayName(displayName)
+              .setDescription(description)
+              .setLargeCustomDictionary(largeCustomDictionaryConfig)
+              .build();
+
+      // Combine configurations into a request for the service.
+      CreateStoredInfoTypeRequest createStoredInfoType = CreateStoredInfoTypeRequest.newBuilder()
+              .setParent(LocationName.of(projectId, "global").toString())
+              .setConfig(storedInfoTypeConfig)
+              .setStoredInfoTypeId("test-new")
+              .build();
+
+      // Send the request and receive response from the service.
+      StoredInfoType response = dlp.createStoredInfoType(createStoredInfoType);
+
+      // Print the results.
+      System.out.println("Created Stored InfoType: " + response);
+    }
+  }
+}
+
+// [END dlp_create_stored_infotype]

--- a/dlp/snippets/src/main/java/dlp/snippets/CreateStoredInfoType.java
+++ b/dlp/snippets/src/main/java/dlp/snippets/CreateStoredInfoType.java
@@ -42,6 +42,7 @@ public class CreateStoredInfoType {
     createStoredInfoType(projectId, outputPath);
   }
 
+  // Creates a custom stored info type that contains GitHub usernames used in commits.
   public static void createStoredInfoType(String projectId, String outputPath)
       throws IOException {
     try (DlpServiceClient dlp = DlpServiceClient.create()) {
@@ -50,17 +51,20 @@ public class CreateStoredInfoType {
       String displayName = "GitHub usernames";
       String description = "Dictionary of GitHub usernames used in commits";
 
+      // The output path where the custom dictionary containing the GitHub usernames will be stored.
       CloudStoragePath cloudStoragePath =
           CloudStoragePath.newBuilder()
               .setPath(outputPath)
               .build();
 
+      // The reference to the table containing the GitHub usernames.
       BigQueryTable table = BigQueryTable.newBuilder()
               .setProjectId("bigquery-public-data")
               .setTableId("github_nested")
               .setDatasetId("samples")
               .build();
 
+      // The reference to the BigQuery field that contains the GitHub usernames.
       BigQueryField bigQueryField = BigQueryField.newBuilder()
               .setTable(table)
               .setField(FieldId.newBuilder().setName("actor").build())

--- a/dlp/snippets/src/test/java/dlp/snippets/InfoTypesTests.java
+++ b/dlp/snippets/src/test/java/dlp/snippets/InfoTypesTests.java
@@ -47,7 +47,8 @@ public class InfoTypesTests extends TestBase {
     String output = bout.toString();
     String storedInfoTypeId = output.split("Created Stored InfoType: ")[1].split("\n")[0];
     assertThat(output).contains("Created Stored InfoType: ");
-    assertThat(output).contains("storedInfoTypes");
+    assertThat(storedInfoTypeId)
+        .contains(String.format("projects/" + PROJECT_ID + "/locations/global/storedInfoTypes/"));
     try (DlpServiceClient dlp = DlpServiceClient.create()) {
       dlp.deleteStoredInfoType(storedInfoTypeId);
     }

--- a/dlp/snippets/src/test/java/dlp/snippets/InfoTypesTests.java
+++ b/dlp/snippets/src/test/java/dlp/snippets/InfoTypesTests.java
@@ -19,6 +19,7 @@ package dlp.snippets;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import java.io.IOException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -37,5 +38,13 @@ public class InfoTypesTests extends TestBase {
     String output = bout.toString();
     assertThat(output).contains("Name");
     assertThat(output).contains("Display name");
+  }
+
+  @Test
+  public void testCreateStoredInfoType() throws IOException {
+    String outputPath = "gs://dlp-crest-test/java-custom-dictionary";
+    CreateStoredInfoType.createStoredInfoType(PROJECT_ID, GCS_PATH, outputPath);
+    String output = bout.toString();
+    assertThat(output).contains("Created Stored InfoType: ");
   }
 }

--- a/dlp/snippets/src/test/java/dlp/snippets/InfoTypesTests.java
+++ b/dlp/snippets/src/test/java/dlp/snippets/InfoTypesTests.java
@@ -18,6 +18,7 @@ package dlp.snippets;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.cloud.dlp.v2.DlpServiceClient;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import org.junit.Test;
@@ -42,9 +43,13 @@ public class InfoTypesTests extends TestBase {
 
   @Test
   public void testCreateStoredInfoType() throws IOException {
-    String outputPath = "gs://dlp-crest-test/java-custom-dictionary";
-    CreateStoredInfoType.createStoredInfoType(PROJECT_ID, GCS_PATH, outputPath);
+    CreateStoredInfoType.createStoredInfoType(PROJECT_ID, GCS_PATH);
     String output = bout.toString();
+    String storedInfoTypeId = output.split("Created Stored InfoType: ")[1].split("\n")[0];
     assertThat(output).contains("Created Stored InfoType: ");
+    assertThat(output).contains("storedInfoTypes");
+    try (DlpServiceClient dlp = DlpServiceClient.create()) {
+      dlp.deleteStoredInfoType(storedInfoTypeId);
+    }
   }
 }


### PR DESCRIPTION
[Create a stored Infotype](https://cloud.google.com/dlp/docs/creating-stored-infotypes#create-storedinfotye)

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [X] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [X] **Tests** pass:   `mvn clean verify` **required**
- [X] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [X] Please **merge** this PR for me once it is approved
