### PR TITLE
chore: migrate org.joda.time to java.time (JSR310)

### DIFF
--- a/appengine-java11-bundled-services/datastore/pom.xml
+++ b/appengine-java11-bundled-services/datastore/pom.xml
@@ -88,12 +88,6 @@
       <artifactId>guava</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.12.2</version>
-    </dependency>
-
     <!-- Test Dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/appengine-java17-bundled-services/datastore/pom.xml
+++ b/appengine-java17-bundled-services/datastore/pom.xml
@@ -88,12 +88,6 @@
       <artifactId>guava</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.12.2</version>
-    </dependency>
-
     <!-- Test Dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/appengine-java8/datastore/pom.xml
+++ b/appengine-java8/datastore/pom.xml
@@ -86,12 +86,6 @@
       <artifactId>guava</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.12.2</version>
-    </dependency>
-
     <!-- Test Dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/appengine-java8/datastore/src/main/java/com/example/appengine/AbstractGuestbook.java
+++ b/appengine-java8/datastore/src/main/java/com/example/appengine/AbstractGuestbook.java
@@ -48,10 +48,8 @@ abstract class AbstractGuestbook {
    * Appends a new greeting to the guestbook and returns the {@link Entity} that was created.
    **/
   public Greeting appendGreeting(String content) {
-    Greeting greeting =
-        Greeting.create(
-            createGreeting(datastore, userService.getCurrentUser(), clock.now().toDate(), content));
-    return greeting;
+    return Greeting.create(
+        createGreeting(datastore, userService.getCurrentUser(), Date.from(clock.now()), content));
   }
 
   /**

--- a/appengine-java8/datastore/src/main/java/com/example/appengine/Greeting.java
+++ b/appengine-java8/datastore/src/main/java/com/example/appengine/Greeting.java
@@ -19,16 +19,16 @@ package com.example.appengine;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.users.User;
 import com.google.auto.value.AutoValue;
+import java.time.Instant;
 import java.util.Date;
 import javax.annotation.Nullable;
-import org.joda.time.Instant;
 
 @AutoValue
 public abstract class Greeting {
 
   static Greeting create(Entity entity) {
     User user = (User) entity.getProperty("user");
-    Instant date = new Instant((Date) entity.getProperty("date"));
+    Instant date = ((Date) entity.getProperty("date")).toInstant();
     String content = (String) entity.getProperty("content");
     return new AutoValue_Greeting(user, date, content);
   }

--- a/appengine-java8/datastore/src/main/java/com/example/time/Clock.java
+++ b/appengine-java8/datastore/src/main/java/com/example/time/Clock.java
@@ -16,12 +16,12 @@
 
 package com.example.time;
 
-import org.joda.time.Instant;
+import java.time.Instant;
 
 /**
  * Provides the current value of "now." To preserve testability, avoid all other libraries that
  * access the system clock (whether {@linkplain System#currentTimeMillis directly} or {@linkplain
- * org.joda.time.DateTime#DateTime() indirectly}).
+ * java.time.Instant#now() indirectly}).
  *
  * <p>In production, use the {@link SystemClock} implementation to return the "real" system time. In
  * tests, either use {@link com.example.time.testing.FakeClock}, or get an instance from a mocking

--- a/appengine-java8/datastore/src/main/java/com/example/time/SystemClock.java
+++ b/appengine-java8/datastore/src/main/java/com/example/time/SystemClock.java
@@ -16,7 +16,7 @@
 
 package com.example.time;
 
-import org.joda.time.Instant;
+import java.time.Instant;
 
 /**
  * Clock implementation that returns the "real" system time.
@@ -34,6 +34,6 @@ public class SystemClock implements Clock {
 
   @Override
   public Instant now() {
-    return new Instant();
+    return Instant.now();
   }
 }

--- a/appengine-java8/datastore/src/main/java/com/example/time/testing/FakeClock.java
+++ b/appengine-java8/datastore/src/main/java/com/example/time/testing/FakeClock.java
@@ -18,9 +18,8 @@ package com.example.time.testing;
 
 import com.example.time.Clock;
 import java.util.concurrent.atomic.AtomicLong;
-import org.joda.time.Instant;
-import org.joda.time.ReadableDuration;
-import org.joda.time.ReadableInstant;
+import java.time.Instant;
+import java.time.Duration;
 
 /**
  * A Clock that returns a fixed Instant value as the current clock time. The fixed Instant is
@@ -35,7 +34,7 @@ import org.joda.time.ReadableInstant;
  */
 public class FakeClock implements Clock {
 
-  private static final Instant DEFAULT_TIME = new Instant(1000000000L);
+  private static final Instant DEFAULT_TIME = Instant.ofEpochMilli(1000000000L);
   private final long baseTimeMs;
   private final AtomicLong fakeNowMs;
   private volatile long autoIncrementStepMs;
@@ -50,8 +49,8 @@ public class FakeClock implements Clock {
   /**
    * Creates a FakeClock instance initialized to the given time.
    */
-  public FakeClock(ReadableInstant now) {
-    baseTimeMs = now.getMillis();
+  public FakeClock(Instant now) {
+    baseTimeMs = now.toEpochMilli();
     fakeNowMs = new AtomicLong(baseTimeMs);
   }
 
@@ -60,8 +59,8 @@ public class FakeClock implements Clock {
    *
    * @return this
    */
-  public FakeClock setNow(ReadableInstant now) {
-    fakeNowMs.set(now.getMillis());
+  public FakeClock setNow(Instant now) {
+    fakeNowMs.set(now.toEpochMilli());
     return this;
   }
 
@@ -75,7 +74,7 @@ public class FakeClock implements Clock {
    * behavior of {@link #now()} is the same as this method.
    */
   public Instant peek() {
-    return new Instant(fakeNowMs.get());
+    return Instant.ofEpochMilli(fakeNowMs.get());
   }
 
   /**
@@ -95,8 +94,8 @@ public class FakeClock implements Clock {
    * @param duration the duration to increment the clock time by
    * @return this
    */
-  public FakeClock incrementTime(ReadableDuration duration) {
-    incrementTime(duration.getMillis());
+  public FakeClock incrementTime(Duration duration) {
+    incrementTime(duration.toMillis());
     return this;
   }
 
@@ -117,8 +116,8 @@ public class FakeClock implements Clock {
    * @param duration the duration to decrement the clock time by
    * @return this
    */
-  public FakeClock decrementTime(ReadableDuration duration) {
-    incrementTime(-duration.getMillis());
+  public FakeClock decrementTime(Duration duration) {
+    incrementTime(-duration.toMillis());
     return this;
   }
 
@@ -140,8 +139,8 @@ public class FakeClock implements Clock {
    * @param autoIncrementStep the new auto increment duration
    * @return this
    */
-  public FakeClock setAutoIncrementStep(ReadableDuration autoIncrementStep) {
-    setAutoIncrementStep(autoIncrementStep.getMillis());
+  public FakeClock setAutoIncrementStep(Duration autoIncrementStep) {
+    setAutoIncrementStep(autoIncrementStep.toMillis());
     return this;
   }
 
@@ -165,7 +164,7 @@ public class FakeClock implements Clock {
    * @see AtomicLong#addAndGet
    */
   protected final Instant addAndGet(long durationMs) {
-    return new Instant(fakeNowMs.addAndGet(durationMs));
+    return Instant.ofEpochMilli(fakeNowMs.addAndGet(durationMs));
   }
 
   /**
@@ -176,6 +175,6 @@ public class FakeClock implements Clock {
    * @see AtomicLong#getAndAdd
    */
   protected final Instant getAndAdd(long durationMs) {
-    return new Instant(fakeNowMs.getAndAdd(durationMs));
+    return Instant.ofEpochMilli(fakeNowMs.getAndAdd(durationMs));
   }
 }

--- a/appengine-java8/datastore/src/main/java/com/example/time/testing/FakeClock.java
+++ b/appengine-java8/datastore/src/main/java/com/example/time/testing/FakeClock.java
@@ -17,9 +17,9 @@
 package com.example.time.testing;
 
 import com.example.time.Clock;
-import java.util.concurrent.atomic.AtomicLong;
-import java.time.Instant;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * A Clock that returns a fixed Instant value as the current clock time. The fixed Instant is

--- a/appengine-java8/datastore/src/test/java/com/example/appengine/GuestbookStrongTest.java
+++ b/appengine-java8/datastore/src/test/java/com/example/appengine/GuestbookStrongTest.java
@@ -23,8 +23,8 @@ import com.example.time.testing.FakeClock;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.appengine.tools.development.testing.LocalUserServiceTestConfig;
+import java.time.Instant;
 import java.util.List;
-import org.joda.time.Instant;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,7 +37,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class GuestbookStrongTest {
 
-  private static final Instant FAKE_NOW = new Instant(1234567890L);
+  private static final Instant FAKE_NOW = Instant.ofEpochMilli(1234567890L);
   private static final String GUESTBOOK_ID = "my guestbook";
 
   // Set maximum eventual consistency.

--- a/iot/api-client/codelab/manager/pom.xml
+++ b/iot/api-client/codelab/manager/pom.xml
@@ -73,11 +73,6 @@
       <version>0.9.1</version>
     </dependency>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.12.2</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-cloudiot</artifactId>
       <version>v1-rev20230328-2.0.0</version>

--- a/iot/api-client/codelab/manager/src/main/java/com/example/cloud/iot/examples/MqttCommandsDemo.java
+++ b/iot/api-client/codelab/manager/src/main/java/com/example/cloud/iot/examples/MqttCommandsDemo.java
@@ -38,6 +38,8 @@ import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Instant;
+import java.util.Date;
 import java.util.Properties;
 import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
 import org.eclipse.paho.client.mqttv3.MqttCallback;
@@ -46,7 +48,6 @@ import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
-import org.joda.time.DateTime;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -60,14 +61,14 @@ public class MqttCommandsDemo {
   /** Create a Cloud IoT Core JWT for the given project id, signed with the given RSA key. */
   private static String createJwtRsa(String projectId, String privateKeyFile)
       throws NoSuchAlgorithmException, IOException, InvalidKeySpecException {
-    DateTime now = new DateTime();
+    Instant now = Instant.now();
     // Create a JWT to authenticate this device. The device will be disconnected after the token
     // expires, and will have to reconnect with a new token. The audience field should always be set
     // to the GCP project id.
     JwtBuilder jwtBuilder =
         Jwts.builder()
-            .setIssuedAt(now.toDate())
-            .setExpiration(now.plusMinutes(20).toDate())
+            .setIssuedAt(Date.from(now))
+            .setExpiration(Date.from(now.plusSeconds(20 * 60)))
             .setAudience(projectId);
 
     byte[] keyBytes = Files.readAllBytes(Paths.get(privateKeyFile));
@@ -80,15 +81,15 @@ public class MqttCommandsDemo {
   /** Create a Cloud IoT Core JWT for the given project id, signed with the given ES key. */
   private static String createJwtEs(String projectId, String privateKeyFile)
       throws NoSuchAlgorithmException, IOException, InvalidKeySpecException {
-    DateTime now = new DateTime();
+    Instant now = Instant.now();
     // Create a JWT to authenticate this device. The device will be disconnected after the token
     // expires, and will have to reconnect with a new token. The audience field should always be set
     // to the GCP project id.
     JwtBuilder jwtBuilder =
         Jwts.builder()
-            .setIssuedAt(now.toDate())
-            .setExpiration(now.plusMinutes(20).toDate())
-            .setAudience(projectId);
+          .setIssuedAt(Date.from(now))
+          .setExpiration(Date.from(now.plusSeconds(20 * 60)))
+          .setAudience(projectId);
 
     byte[] keyBytes = Files.readAllBytes(Paths.get(privateKeyFile));
     PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(keyBytes);
@@ -233,7 +234,6 @@ public class MqttCommandsDemo {
     // to authorize the device.
     connectOptions.setUserName("unused");
 
-    DateTime iat = new DateTime();
     if (algorithm.equals("RS256")) {
       connectOptions.setPassword(createJwtRsa(projectId, privateKeyFile).toCharArray());
     } else if (algorithm.equals("ES256")) {

--- a/iot/api-client/end-to-end-example/pom.xml
+++ b/iot/api-client/end-to-end-example/pom.xml
@@ -64,11 +64,6 @@
       <version>0.9.1</version>
     </dependency>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.12.2</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-cloudiot</artifactId>
       <version>v1-rev20230328-2.0.0</version>

--- a/iot/api-client/end-to-end-example/src/main/java/com/example/cloud/iot/endtoend/CloudiotPubsubExampleMqttDevice.java
+++ b/iot/api-client/end-to-end-example/src/main/java/com/example/cloud/iot/endtoend/CloudiotPubsubExampleMqttDevice.java
@@ -23,6 +23,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.KeyFactory;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Instant;
+import java.util.Date;
 import java.util.Properties;
 import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
 import org.eclipse.paho.client.mqttv3.MqttCallback;
@@ -31,7 +33,6 @@ import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
-import org.joda.time.DateTime;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -72,14 +73,14 @@ public class CloudiotPubsubExampleMqttDevice {
 
   /** Create a RSA-based JWT for the given project id, signed with the given private key. */
   private static String createJwtRsa(String projectId, String privateKeyFile) throws Exception {
-    DateTime now = new DateTime();
+    Instant now = Instant.now();
     // Create a JWT to authenticate this device. The device will be disconnected after the token
     // expires, and will have to reconnect with a new token. The audience field should always be set
     // to the GCP project id.
     JwtBuilder jwtBuilder =
         Jwts.builder()
-            .setIssuedAt(now.toDate())
-            .setExpiration(now.plusMinutes(20).toDate())
+            .setIssuedAt(Date.from(now))
+            .setExpiration(Date.from(now.plusSeconds(60 * 20)))
             .setAudience(projectId);
 
     byte[] keyBytes = Files.readAllBytes(Paths.get(privateKeyFile));
@@ -91,15 +92,15 @@ public class CloudiotPubsubExampleMqttDevice {
 
   /** Create an ES-based JWT for the given project id, signed with the given private key. */
   private static String createJwtEs(String projectId, String privateKeyFile) throws Exception {
-    DateTime now = new DateTime();
+    Instant now = Instant.now();
     // Create a JWT to authenticate this device. The device will be disconnected after the token
     // expires, and will have to reconnect with a new token. The audience field should always be set
     // to the GCP project id.
     JwtBuilder jwtBuilder =
         Jwts.builder()
-            .setIssuedAt(now.toDate())
-            .setExpiration(now.plusMinutes(20).toDate())
-            .setAudience(projectId);
+          .setIssuedAt(Date.from(now))
+          .setExpiration(Date.from(now.plusSeconds(60 * 20)))
+          .setAudience(projectId);
 
     byte[] keyBytes = Files.readAllBytes(Paths.get(privateKeyFile));
     PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(keyBytes);

--- a/iot/api-client/manager/pom.xml
+++ b/iot/api-client/manager/pom.xml
@@ -68,11 +68,6 @@
       <version>0.9.1</version>
     </dependency>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.12.2</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-cloudiot</artifactId>
       <version>v1-rev20230328-2.0.0</version>

--- a/iot/api-client/manager/src/main/java/com/example/cloud/iot/examples/HttpExample.java
+++ b/iot/api-client/manager/src/main/java/com/example/cloud/iot/examples/HttpExample.java
@@ -43,8 +43,9 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.KeyFactory;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Instant;
+import java.util.Date;
 import java.util.Base64;
-import org.joda.time.DateTime;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -69,14 +70,14 @@ public class HttpExample {
   // [START iot_http_jwt]
   /** Create a RSA-based JWT for the given project id, signed with the given private key. */
   private static String createJwtRsa(String projectId, String privateKeyFile) throws Exception {
-    DateTime now = new DateTime();
+    Instant now = Instant.now();
     // Create a JWT to authenticate this device. The device will be disconnected after the token
     // expires, and will have to reconnect with a new token. The audience field should always be set
     // to the GCP project id.
     JwtBuilder jwtBuilder =
         Jwts.builder()
-            .setIssuedAt(now.toDate())
-            .setExpiration(now.plusMinutes(20).toDate())
+            .setIssuedAt(Date.from(now))
+            .setExpiration(Date.from(now.plusSeconds(20 * 60)))
             .setAudience(projectId);
 
     byte[] keyBytes = Files.readAllBytes(Paths.get(privateKeyFile));
@@ -88,15 +89,15 @@ public class HttpExample {
 
   /** Create an ES-based JWT for the given project id, signed with the given private key. */
   private static String createJwtEs(String projectId, String privateKeyFile) throws Exception {
-    DateTime now = new DateTime();
+    Instant now = Instant.now();
     // Create a JWT to authenticate this device. The device will be disconnected after the token
     // expires, and will have to reconnect with a new token. The audience field should always be set
     // to the GCP project id.
     JwtBuilder jwtBuilder =
         Jwts.builder()
-            .setIssuedAt(now.toDate())
-            .setExpiration(now.plusMinutes(20).toDate())
-            .setAudience(projectId);
+          .setIssuedAt(Date.from(now))
+          .setExpiration(Date.from(now.plusSeconds(20 * 60)))
+          .setAudience(projectId);
 
     byte[] keyBytes = Files.readAllBytes(Paths.get(privateKeyFile));
     PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(keyBytes);
@@ -153,10 +154,10 @@ public class HttpExample {
     HttpResponse res = req.execute();
     System.out.println(res.getStatusCode());
     System.out.println(res.getStatusMessage());
-    InputStream in = res.getContent();
-
-    System.out
-        .println(CharStreams.toString(new InputStreamReader(in, StandardCharsets.UTF_8.name())));
+    try (InputStream in = res.getContent()) {
+      System.out
+          .println(CharStreams.toString(new InputStreamReader(in, StandardCharsets.UTF_8.name())));
+    }
   }
   // [END iot_http_getconfig]
 
@@ -246,7 +247,7 @@ public class HttpExample {
 
     // Create the corresponding JWT depending on the selected algorithm.
     String token;
-    DateTime iat = new DateTime();
+    Instant iat = Instant.now();
     if ("RS256".equals(options.algorithm)) {
       token = createJwtRsa(options.projectId, options.privateKeyFile);
     } else if ("ES256".equals(options.algorithm)) {
@@ -277,10 +278,10 @@ public class HttpExample {
           options.messageType, i, options.numMessages, payload);
 
       // Refresh the authentication token if the token has expired.
-      long secsSinceRefresh = ((new DateTime()).getMillis() - iat.getMillis()) / 1000;
+      long secsSinceRefresh = (Instant.now().toEpochMilli() - iat.toEpochMilli()) / 1000;
       if (secsSinceRefresh > (options.tokenExpMins * MINUTES_PER_HOUR)) {
         System.out.format("\tRefreshing token after: %d seconds%n", secsSinceRefresh);
-        iat = new DateTime();
+        iat = Instant.now();
 
         if ("RS256".equals(options.algorithm)) {
           token = createJwtRsa(options.projectId, options.privateKeyFile);

--- a/iot/api-client/manager/src/main/java/com/example/cloud/iot/examples/HttpExample.java
+++ b/iot/api-client/manager/src/main/java/com/example/cloud/iot/examples/HttpExample.java
@@ -44,8 +44,8 @@ import java.nio.file.Paths;
 import java.security.KeyFactory;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.time.Instant;
-import java.util.Date;
 import java.util.Base64;
+import java.util.Date;
 import org.json.JSONException;
 import org.json.JSONObject;
 

--- a/iot/api-client/manager/src/main/java/com/example/cloud/iot/examples/MqttExample.java
+++ b/iot/api-client/manager/src/main/java/com/example/cloud/iot/examples/MqttExample.java
@@ -30,6 +30,8 @@ import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Instant;
+import java.util.Date;
 import java.util.Properties;
 import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
 import org.eclipse.paho.client.mqttv3.MqttCallback;
@@ -38,7 +40,6 @@ import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
-import org.joda.time.DateTime;
 
 // [END iot_mqtt_includes]
 
@@ -75,14 +76,14 @@ public class MqttExample {
   /** Create a Cloud IoT Core JWT for the given project id, signed with the given RSA key. */
   private static String createJwtRsa(String projectId, String privateKeyFile)
       throws NoSuchAlgorithmException, IOException, InvalidKeySpecException {
-    DateTime now = new DateTime();
+    Instant now = Instant.now();
     // Create a JWT to authenticate this device. The device will be disconnected after the token
     // expires, and will have to reconnect with a new token. The audience field should always be set
     // to the GCP project id.
     JwtBuilder jwtBuilder =
         Jwts.builder()
-            .setIssuedAt(now.toDate())
-            .setExpiration(now.plusMinutes(20).toDate())
+            .setIssuedAt(Date.from(now))
+            .setExpiration(Date.from(now.plusSeconds(20 * 60)))
             .setAudience(projectId);
 
     byte[] keyBytes = Files.readAllBytes(Paths.get(privateKeyFile));
@@ -96,15 +97,15 @@ public class MqttExample {
   /** Create a Cloud IoT Core JWT for the given project id, signed with the given ES key. */
   private static String createJwtEs(String projectId, String privateKeyFile)
       throws NoSuchAlgorithmException, IOException, InvalidKeySpecException {
-    DateTime now = new DateTime();
+    Instant now = Instant.now();
     // Create a JWT to authenticate this device. The device will be disconnected after the token
     // expires, and will have to reconnect with a new token. The audience field should always be set
     // to the GCP project id.
     JwtBuilder jwtBuilder =
-        Jwts.builder()
-            .setIssuedAt(now.toDate())
-            .setExpiration(now.plusMinutes(20).toDate())
-            .setAudience(projectId);
+      Jwts.builder()
+        .setIssuedAt(Date.from(now))
+        .setExpiration(Date.from(now.plusSeconds(20 * 60)))
+        .setAudience(projectId);
 
     byte[] keyBytes = Files.readAllBytes(Paths.get(privateKeyFile));
     PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(keyBytes);
@@ -167,52 +168,53 @@ public class MqttExample {
     System.out.println(String.format("%s", mqttClientId));
 
     // Create a client, and connect to the Google MQTT bridge.
-    MqttClient client = new MqttClient(mqttServerAddress, mqttClientId, new MemoryPersistence());
+    try (MqttClient client =
+        new MqttClient(mqttServerAddress, mqttClientId, new MemoryPersistence())) {
+      // Both connect and publish operations may fail. If they do, allow retries but with an
+      // exponential backoff time period.
+      long initialConnectIntervalMillis = 500L;
+      long maxConnectIntervalMillis = 6000L;
+      long maxConnectRetryTimeElapsedMillis = 900000L;
+      float intervalMultiplier = 1.5f;
 
-    // Both connect and publish operations may fail. If they do, allow retries but with an
-    // exponential backoff time period.
-    long initialConnectIntervalMillis = 500L;
-    long maxConnectIntervalMillis = 6000L;
-    long maxConnectRetryTimeElapsedMillis = 900000L;
-    float intervalMultiplier = 1.5f;
+      long retryIntervalMs = initialConnectIntervalMillis;
+      long totalRetryTimeMs = 0;
 
-    long retryIntervalMs = initialConnectIntervalMillis;
-    long totalRetryTimeMs = 0;
+      while (totalRetryTimeMs < maxConnectRetryTimeElapsedMillis && !client.isConnected()) {
+        try {
+          client.connect(connectOptions);
+        } catch (MqttException e) {
+          int reason = e.getReasonCode();
 
-    while ((totalRetryTimeMs < maxConnectRetryTimeElapsedMillis) && !client.isConnected()) {
-      try {
-        client.connect(connectOptions);
-      } catch (MqttException e) {
-        int reason = e.getReasonCode();
-
-        // If the connection is lost or if the server cannot be connected, allow retries, but with
-        // exponential backoff.
-        System.out.println("An error occurred: " + e.getMessage());
-        if (reason == MqttException.REASON_CODE_CONNECTION_LOST
-            || reason == MqttException.REASON_CODE_SERVER_CONNECT_ERROR) {
-          System.out.println("Retrying in " + retryIntervalMs / 1000.0 + " seconds.");
-          Thread.sleep(retryIntervalMs);
-          totalRetryTimeMs += retryIntervalMs;
-          retryIntervalMs *= intervalMultiplier;
-          if (retryIntervalMs > maxConnectIntervalMillis) {
-            retryIntervalMs = maxConnectIntervalMillis;
+          // If the connection is lost or if the server cannot be connected, allow retries, but with
+          // exponential backoff.
+          System.out.println("An error occurred: " + e.getMessage());
+          if (reason == MqttException.REASON_CODE_CONNECTION_LOST
+              || reason == MqttException.REASON_CODE_SERVER_CONNECT_ERROR) {
+            System.out.println("Retrying in " + retryIntervalMs / 1000.0 + " seconds.");
+            Thread.sleep(retryIntervalMs);
+            totalRetryTimeMs += retryIntervalMs;
+            retryIntervalMs *= intervalMultiplier;
+            if (retryIntervalMs > maxConnectIntervalMillis) {
+              retryIntervalMs = maxConnectIntervalMillis;
+            }
+          } else {
+            throw e;
           }
-        } else {
-          throw e;
         }
       }
+
+      attachCallback(client, gatewayId);
+
+      // The topic gateways receive error updates on. QoS must be 0.
+      String errorTopic = String.format("/devices/%s/errors", gatewayId);
+      System.out.println(String.format("Listening on %s", errorTopic));
+
+      client.subscribe(errorTopic, 0);
+
+      return client;
+      // [END iot_gateway_start_mqtt]
     }
-
-    attachCallback(client, gatewayId);
-
-    // The topic gateways receive error updates on. QoS must be 0.
-    String errorTopic = String.format("/devices/%s/errors", gatewayId);
-    System.out.println(String.format("Listening on %s", errorTopic));
-
-    client.subscribe(errorTopic, 0);
-
-    return client;
-    // [END iot_gateway_start_mqtt]
   }
 
   protected static void sendDataFromDevice(
@@ -349,7 +351,7 @@ public class MqttExample {
     // to authorize the device.
     connectOptions.setUserName("unused");
 
-    DateTime iat = new DateTime();
+    Instant iat = Instant.now();
     if ("RS256".equals(options.algorithm)) {
       connectOptions.setPassword(
           createJwtRsa(options.projectId, options.privateKeyFile).toCharArray());
@@ -375,7 +377,7 @@ public class MqttExample {
     long retryIntervalMs = initialConnectIntervalMillis;
     long totalRetryTimeMs = 0;
 
-    while ((totalRetryTimeMs < maxConnectRetryTimeElapsedMillis) && !client.isConnected()) {
+    while (totalRetryTimeMs < maxConnectRetryTimeElapsedMillis && !client.isConnected()) {
       try {
         client.connect(connectOptions);
       } catch (MqttException e) {
@@ -418,10 +420,10 @@ public class MqttExample {
 
       // Refresh the connection credentials before the JWT expires.
       // [START iot_mqtt_jwt_refresh]
-      long secsSinceRefresh = ((new DateTime()).getMillis() - iat.getMillis()) / 1000;
+      long secsSinceRefresh = (Instant.now().toEpochMilli() - iat.toEpochMilli()) / 1000;
       if (secsSinceRefresh > (options.tokenExpMins * MINUTES_PER_HOUR)) {
         System.out.format("\tRefreshing token after: %d seconds%n", secsSinceRefresh);
-        iat = new DateTime();
+        iat = Instant.now();
         if ("RS256".equals(options.algorithm)) {
           connectOptions.setPassword(
               createJwtRsa(options.projectId, options.privateKeyFile).toCharArray());

--- a/iot/api-client/manager/src/main/java/com/example/cloud/iot/examples/MqttExample.java
+++ b/iot/api-client/manager/src/main/java/com/example/cloud/iot/examples/MqttExample.java
@@ -102,10 +102,10 @@ public class MqttExample {
     // expires, and will have to reconnect with a new token. The audience field should always be set
     // to the GCP project id.
     JwtBuilder jwtBuilder =
-      Jwts.builder()
-        .setIssuedAt(Date.from(now))
-        .setExpiration(Date.from(now.plusSeconds(20 * 60)))
-        .setAudience(projectId);
+        Jwts.builder()
+            .setIssuedAt(Date.from(now))
+            .setExpiration(Date.from(now.plusSeconds(20 * 60)))
+            .setAudience(projectId);
 
     byte[] keyBytes = Files.readAllBytes(Paths.get(privateKeyFile));
     PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(keyBytes);

--- a/trace/pom.xml
+++ b/trace/pom.xml
@@ -65,11 +65,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.12.2</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-core</artifactId>
     </dependency>

--- a/trace/src/main/java/com/example/trace/TraceSample.java
+++ b/trace/src/main/java/com/example/trace/TraceSample.java
@@ -25,8 +25,8 @@ import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
 import io.opencensus.trace.samplers.Samplers;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Date;
-import org.joda.time.DateTime;
 
 public class TraceSample {
 
@@ -77,7 +77,7 @@ public class TraceSample {
 
   // [START trace_setup_java_create_and_register_with_token]
   public static void createAndRegisterWithToken(String accessToken) throws IOException {
-    Date expirationTime = DateTime.now().plusSeconds(60).toDate();
+    Date expirationTime = Date.from(Instant.now().plusSeconds(60));
 
     GoogleCredentials credentials =
         GoogleCredentials.create(new AccessToken(accessToken, expirationTime));


### PR DESCRIPTION
Migrate from the Joda time library to the standard java.time classes introduced in Java 8. 

More info: https://blog.joda.org/2014/11/converting-from-joda-time-to-javatime.html