### PR TITLE
chore: group SLF4J dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -57,6 +57,13 @@
       "groupName": "Jetty packages"
     },
     {
+      "packagePatterns": [
+        "^org.slf4j:"
+      ],
+      "groupName": "SLF4J packages"
+    },    
+    
+    {
       "packageNames": [
         "javax.servlet:javax.servlet-api"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -62,7 +62,6 @@
       ],
       "groupName": "SLF4J packages"
     },    
-    
     {
       "packageNames": [
         "javax.servlet:javax.servlet-api"


### PR DESCRIPTION
This will group 3+ SLF4J dependency updates that have a matching version number.