### PR TITLE
fixit: add sample for cloudcdn sign cookie

### DIFF
--- a/cdn/signed-urls/src/main/java/com/google/cdn/SignedCookies.java
+++ b/cdn/signed-urls/src/main/java/com/google/cdn/SignedCookies.java
@@ -16,6 +16,7 @@
 
 package com.google.cdn;
 
+// [START cloudcdn_sign_cookie]
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -100,3 +101,4 @@ public class SignedCookies {
         .encodeToString(mac.doFinal(input.getBytes(StandardCharsets.UTF_8)));
   }
 }
+// [END cloudcdn_sign_cookie]

--- a/cdn/signed-urls/src/test/java/com/google/cdn/SignedCookiesTest.java
+++ b/cdn/signed-urls/src/test/java/com/google/cdn/SignedCookiesTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cdn;
+
+import static com.google.cdn.SignedCookies.signCookie;
+import static org.junit.Assert.*;
+
+import java.util.Base64;
+import java.util.Date;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SignedCookiesTest {
+
+  private static long TIMESTAMP = 1518135754;
+  private static Date EXPIRATION = new Date(TIMESTAMP * 1000);
+  private static byte[] KEY_BYTES = Base64.getUrlDecoder().decode("aaaaaaaaaaaaaaaaaaaaaa==");
+  private static String KEY_NAME = "my-key";
+  private static String URL_PREFIX = "https://media.example.com/videos/";
+
+  private static String INVALID_URL_PREFIX_1 = "www.media.example.com/videos/";
+  private static String INVALID_URL_PREFIX_2 = "https://media.example.com/videos/?foo";
+
+  @Test
+  public void testUrlPathSignedWithPrefix() throws Exception {
+    String result = signCookie(URL_PREFIX, KEY_BYTES, KEY_NAME, EXPIRATION);
+    final String expected = "Cloud-CDN-Cookie=URLPrefix=aHR0cHM6Ly9tZWRpYS5leGFtcGxlLmNvbS92aWRlb3Mv:Expires=1518135754:KeyName=my-key:Signature=c2oZduDcTH36_bCbO-hEoaLc_5o=";
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void testUrlPathSignedWithPrefixInvalidPrefix() throws Exception {
+    assertThrows(IllegalArgumentException.class,
+        () -> {
+          signCookie(INVALID_URL_PREFIX_1, KEY_BYTES, KEY_NAME, EXPIRATION);
+        });
+    assertThrows(IllegalArgumentException.class,
+        () -> {
+          signCookie(INVALID_URL_PREFIX_2, KEY_BYTES, KEY_NAME, EXPIRATION);
+        });
+  }
+}


### PR DESCRIPTION
add sample for cloudcdn_sign_cookie as part of fixit.
Doc page: https://cloud.google.com/cdn/docs/using-signed-cookies#programmatically_creating_signed_cookies

I've created this sample class under the existing `cdn/signed-urls` module for now. IMO these samples are closely related and an extra module just for this `sign_cookie` sample seems redundant. However, that makes the module name/artifact id inaccurate. I am inclined to update it to "signed-urls-and-cookies" instead of "signed-urls". And then this will also need change in code snippet widgets on md page for these 2 samples:
- cloudcdn_sign_url
- cloudcdn_sign_url_prefix (in progress in #8103)

Let me know which you prefer, to modify existing module name or create new one?