### PR TITLE
chore: group Bigtable dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,12 @@
       "groupName": "AppEngine packages"
     },
     {
+      "packagePatterns": [
+        "^com.google.cloud.bigtable:"
+      ],
+      "groupName": "Bigtable packages"
+    },    
+    {
       "matchPackagePrefixes": [ "com.google" ],
       "allowedVersions": "!/.+-sp\\.[0-9]+$/"
     },


### PR DESCRIPTION
Grouping Bigtable updates to reduce clutter and ensure consistency. This covers 4 currently open updates, all on 2.8.1.