### PR TITLE
feat: add secretmanager sample for ConsumeEventNotification

### DIFF
--- a/secretmanager/pom.xml
+++ b/secretmanager/pom.xml
@@ -61,6 +61,13 @@
       <artifactId>protobuf-java-util</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.26</version>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>
@@ -75,4 +82,26 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.10.1</version>
+        <configuration>
+          <source>11</source> <!-- depending on your project -->
+          <target>11</target> <!-- depending on your project -->
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>1.18.26</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/secretmanager/src/main/java/secretmanager/ConsumeEventNotification.java
+++ b/secretmanager/src/main/java/secretmanager/ConsumeEventNotification.java
@@ -13,6 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
 package secretmanager;
 
 // [START secretmanager_consume_event_notification]
@@ -82,12 +83,12 @@ public class ConsumeEventNotification {
 
     @Override
     public String toString() {
-      return "PubSubMessage{" +
-          "data='" + data + '\'' +
-          ", attributes=" + attributes +
-          ", messageId='" + messageId + '\'' +
-          ", publishTime='" + publishTime + '\'' +
-          '}';
+      return "PubSubMessage{"
+          + "data='" + data + '\''
+          + ", attributes=" + attributes
+          + ", messageId='" + messageId + '\''
+          + ", publishTime='" + publishTime + '\''
+          + '}';
     }
   }
 }

--- a/secretmanager/src/main/java/secretmanager/ConsumeEventNotification.java
+++ b/secretmanager/src/main/java/secretmanager/ConsumeEventNotification.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright 2023 Google LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package secretmanager;
+
+// [START secretmanager_consume_event_notification]
+
+import java.util.Base64;
+import java.util.Map;
+import java.util.logging.Logger;
+
+// Demonstrates how to consume and process a Pub/Sub notification from Secret Manager.Triggered
+// from a message on a Cloud Pub/Sub topic.
+// Ideally the class should implement a background function that accepts a PubSub message.
+// public class ConsumeEventNotification implements BackgroundFunction<PubSubMessage> { }
+public class ConsumeEventNotification {
+
+  // You can configure the logs to print the message in Cloud Logging.
+  private static final Logger logger = Logger.getLogger(ConsumeEventNotification.class.getName());
+
+  // Accepts a message from a PubSub topic and writes it to logger.
+  public static String accept(PubSubMessage message) {
+    String eventType = message.attributes.get("eventType");
+    String secretId = message.attributes.get("secretId");
+    String data = new String(Base64.getDecoder().decode(message.data));
+    String log = String.format("Received %s for %s. New metadata: %s", eventType, secretId, data);
+    logger.info(log);
+    return log;
+  }
+
+  // Event payload. Mock of the actual PubSub message.
+  public static class PubSubMessage {
+
+    byte[] data;
+    Map<String, String> attributes;
+    String messageId;
+    String publishTime;
+
+    public byte[] getData() {
+      return data;
+    }
+
+    public void setData(byte[] data) {
+      this.data = data;
+    }
+
+    public Map<String, String> getAttributes() {
+      return attributes;
+    }
+
+    public void setAttributes(Map<String, String> attributes) {
+      this.attributes = attributes;
+    }
+
+    public String getMessageId() {
+      return messageId;
+    }
+
+    public void setMessageId(String messageId) {
+      this.messageId = messageId;
+    }
+
+    public String getPublishTime() {
+      return publishTime;
+    }
+
+    public void setPublishTime(String publishTime) {
+      this.publishTime = publishTime;
+    }
+
+    @Override
+    public String toString() {
+      return "PubSubMessage{" +
+          "data='" + data + '\'' +
+          ", attributes=" + attributes +
+          ", messageId='" + messageId + '\'' +
+          ", publishTime='" + publishTime + '\'' +
+          '}';
+    }
+  }
+}
+// [END secretmanager_consume_event_notification]

--- a/secretmanager/src/main/java/secretmanager/ConsumeEventNotification.java
+++ b/secretmanager/src/main/java/secretmanager/ConsumeEventNotification.java
@@ -21,6 +21,7 @@ package secretmanager;
 import java.util.Base64;
 import java.util.Map;
 import java.util.logging.Logger;
+import lombok.Data;
 
 // Demonstrates how to consume and process a Pub/Sub notification from Secret Manager.Triggered
 // from a message on a Cloud Pub/Sub topic.
@@ -42,54 +43,14 @@ public class ConsumeEventNotification {
   }
 
   // Event payload. Mock of the actual PubSub message.
+  @Data
   public static class PubSubMessage {
 
     byte[] data;
     Map<String, String> attributes;
     String messageId;
     String publishTime;
-
-    public byte[] getData() {
-      return data;
-    }
-
-    public void setData(byte[] data) {
-      this.data = data;
-    }
-
-    public Map<String, String> getAttributes() {
-      return attributes;
-    }
-
-    public void setAttributes(Map<String, String> attributes) {
-      this.attributes = attributes;
-    }
-
-    public String getMessageId() {
-      return messageId;
-    }
-
-    public void setMessageId(String messageId) {
-      this.messageId = messageId;
-    }
-
-    public String getPublishTime() {
-      return publishTime;
-    }
-
-    public void setPublishTime(String publishTime) {
-      this.publishTime = publishTime;
-    }
-
-    @Override
-    public String toString() {
-      return "PubSubMessage{"
-          + "data='" + data + '\''
-          + ", attributes=" + attributes
-          + ", messageId='" + messageId + '\''
-          + ", publishTime='" + publishTime + '\''
-          + '}';
-    }
+    String orderingKey;
   }
 }
 // [END secretmanager_consume_event_notification]


### PR DESCRIPTION
## Description

Bug: b/281694482 
Doc update: cl/533479206

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
