### PR TITLE
[DLP] Implementation of computing K Anonymity With EntityId

### DIFF
--- a/dlp/snippets/src/main/java/dlp/snippets/RiskAnalysisKAnonymityWithEntityId.java
+++ b/dlp/snippets/src/main/java/dlp/snippets/RiskAnalysisKAnonymityWithEntityId.java
@@ -48,10 +48,10 @@ public class RiskAnalysisKAnonymityWithEntityId {
 
     // TODO(developer): Replace these variables before running the sample.
     // The Google Cloud project id to use as a parent resource.
-    String projectId = "bdp-2059-is-31084";
+    String projectId = "your-project-id";
     // The BigQuery dataset id to be used and the reference table name to be inspected.
-    String datasetId = "dlp_crest_test_dataset";
-    String tableId = "test-kanony";
+    String datasetId = "your-bigquery-dataset-id";
+    String tableId = "your-bigquery-table-id";
     calculateKAnonymityWithEntityId(projectId, datasetId, tableId);
   }
 
@@ -60,17 +60,7 @@ public class RiskAnalysisKAnonymityWithEntityId {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
-    FileInputStream credentialsFile =
-        new FileInputStream(
-            "/Users/bhavika.dhanwani/Downloads/bdp-2059-is-31084-c1d4f0928c82.json");
-    GoogleCredentials credentials = GoogleCredentials.fromStream(credentialsFile);
-
-    // Configure DLP service settings with the credentials
-    DlpServiceSettings dlpSettings =
-        DlpServiceSettings.newBuilder()
-            .setCredentialsProvider(FixedCredentialsProvider.create(credentials))
-            .build();
-    try (DlpServiceClient dlpServiceClient = DlpServiceClient.create(dlpSettings)) {
+    try (DlpServiceClient dlpServiceClient = DlpServiceClient.create()) {
 
       // Specify the BigQuery table to analyze
       BigQueryTable bigQueryTable =

--- a/dlp/snippets/src/main/java/dlp/snippets/RiskAnalysisKAnonymityWithEntityId.java
+++ b/dlp/snippets/src/main/java/dlp/snippets/RiskAnalysisKAnonymityWithEntityId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ public class RiskAnalysisKAnonymityWithEntityId {
               .build();
 
       // These values represent the column names of quasi-identifiers to analyze
-      List<String> quasiIds = Arrays.asList("age", "title");
+      List<String> quasiIds = Arrays.asList("Age", "Mystery");
 
       // Configure the privacy metric to compute for re-identification risk analysis.
       List<FieldId> quasiIdFields =
@@ -90,7 +90,7 @@ public class RiskAnalysisKAnonymityWithEntityId {
               .collect(Collectors.toList());
 
       // Specify the unique identifier in the source table for the k-anonymity analysis.
-      FieldId fieldId = FieldId.newBuilder().setName("user_id").build();
+      FieldId fieldId = FieldId.newBuilder().setName("Name").build();
       EntityId entityId = EntityId.newBuilder().setField(fieldId).build();
       PrivacyMetric.KAnonymityConfig kanonymityConfig =
           PrivacyMetric.KAnonymityConfig.newBuilder()

--- a/dlp/snippets/src/main/java/dlp/snippets/RiskAnalysisKAnonymityWithEntityId.java
+++ b/dlp/snippets/src/main/java/dlp/snippets/RiskAnalysisKAnonymityWithEntityId.java
@@ -80,8 +80,8 @@ public class RiskAnalysisKAnonymityWithEntityId {
               .collect(Collectors.toList());
 
       // Specify the unique identifier in the source table for the k-anonymity analysis.
-      FieldId fieldId = FieldId.newBuilder().setName("Name").build();
-      EntityId entityId = EntityId.newBuilder().setField(fieldId).build();
+      FieldId uniqueIdField = FieldId.newBuilder().setName("Name").build();
+      EntityId entityId = EntityId.newBuilder().setField(uniqueIdField).build();
       PrivacyMetric.KAnonymityConfig kanonymityConfig =
           PrivacyMetric.KAnonymityConfig.newBuilder()
               .addAllQuasiIds(quasiIdFields)

--- a/dlp/snippets/src/main/java/dlp/snippets/RiskAnalysisKAnonymityWithEntityId.java
+++ b/dlp/snippets/src/main/java/dlp/snippets/RiskAnalysisKAnonymityWithEntityId.java
@@ -93,6 +93,8 @@ public class RiskAnalysisKAnonymityWithEntityId {
           PrivacyMetric.newBuilder().setKAnonymityConfig(kanonymityConfig).build();
 
       // Specify the bigquery table to store the findings.
+      // The "test_results" table in the given BigQuery dataset will be created if it doesn't
+      // already exist.
       BigQueryTable outputbigQueryTable =
           BigQueryTable.newBuilder()
               .setProjectId(projectId)

--- a/dlp/snippets/src/test/java/dlp/snippets/RiskAnalysisTests.java
+++ b/dlp/snippets/src/test/java/dlp/snippets/RiskAnalysisTests.java
@@ -38,6 +38,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class RiskAnalysisTests extends TestBase {
 
+  private static DlpServiceClient DLP_SERVICE_CLIENT;
+
   private UUID testRunUuid = UUID.randomUUID();
   private TopicName topicName =
       TopicName.of(PROJECT_ID, String.format("%s-%s", TOPIC_ID, testRunUuid.toString()));
@@ -58,6 +60,8 @@ public class RiskAnalysisTests extends TestBase {
 
   @Before
   public void before() throws Exception {
+
+    DLP_SERVICE_CLIENT = DlpServiceClient.create();
     // Create a new topic
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       topicAdminClient.createTopic(topicName);
@@ -101,9 +105,7 @@ public class RiskAnalysisTests extends TestBase {
         .findFirst()
         .get();
     jobName = jobName.split(":")[1].trim();
-    try (DlpServiceClient dlp = DlpServiceClient.create()) {
-      dlp.deleteDlpJob(jobName);
-    }
+    DLP_SERVICE_CLIENT.deleteDlpJob(jobName);
   }
 
   @Test
@@ -120,9 +122,7 @@ public class RiskAnalysisTests extends TestBase {
         .findFirst()
         .get();
     jobName = jobName.split(":")[1].trim();
-    try (DlpServiceClient dlp = DlpServiceClient.create()) {
-      dlp.deleteDlpJob(jobName);
-    }
+    DLP_SERVICE_CLIENT.deleteDlpJob(jobName);
   }
 
   @Test
@@ -138,9 +138,7 @@ public class RiskAnalysisTests extends TestBase {
         .findFirst()
         .get();
     jobName = jobName.split(":")[1].trim();
-    try (DlpServiceClient dlp = DlpServiceClient.create()) {
-      dlp.deleteDlpJob(jobName);
-    }
+    DLP_SERVICE_CLIENT.deleteDlpJob(jobName);
   }
 
   @Test
@@ -156,9 +154,8 @@ public class RiskAnalysisTests extends TestBase {
         .findFirst()
         .get();
     jobName = jobName.split(":")[1].trim();
-    try (DlpServiceClient dlp = DlpServiceClient.create()) {
-      dlp.deleteDlpJob(jobName);
-    }
+    DLP_SERVICE_CLIENT.deleteDlpJob(jobName);
+
   }
 
   @Test
@@ -176,8 +173,22 @@ public class RiskAnalysisTests extends TestBase {
         .findFirst()
         .get();
     jobName = jobName.split(":")[1].trim();
-    try (DlpServiceClient dlp = DlpServiceClient.create()) {
-      dlp.deleteDlpJob(jobName);
-    }
+    DLP_SERVICE_CLIENT.deleteDlpJob(jobName);
+  }
+
+  @Test
+  public void testKAnonymityWithEntityId() throws Exception {
+    RiskAnalysisKAnonymityWithEntityId.calculateKAnonymityWithEntityId(
+            PROJECT_ID, DATASET_ID, TABLE_ID);
+    String output = bout.toString();
+    assertThat(output).containsMatch("Bucket size range: \\[\\d, \\d\\]");
+    assertThat(output).contains("Quasi-ID values");
+    assertThat(output).contains("Class size: 1");
+    String jobName = Arrays.stream(output.split("\n"))
+            .filter(line -> line.contains("Job name:"))
+            .findFirst()
+            .get();
+    jobName = jobName.split(":")[1].trim();
+    DLP_SERVICE_CLIENT.deleteDlpJob(jobName);
   }
 }


### PR DESCRIPTION

Implementation of [computing K Anonymity With EntityId.](https://cloud.google.com/dlp/docs/visualizing_re-id_risk.md?g=0&l=119#step_1_calculate_k-anonymity_on_the_dataset)
## Checklist

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [X] **Tests** pass:   `mvn clean verify` **required**
- [X] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [X] Please **merge** this PR for me once it is approved
