### PR TITLE
fix: add multiple retries to Content Warehouse sample

### DIFF
--- a/content-warehouse/src/test/java/contentwarehouse/v1/QuickStartTest.java
+++ b/content-warehouse/src/test/java/contentwarehouse/v1/QuickStartTest.java
@@ -19,6 +19,7 @@ package contentwarehouse.v1;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertNotNull;
 
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -28,14 +29,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 
 public class QuickStartTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
-  
+
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
-  private static final String LOCATION = "us"; 
-  private static final String USER_ID = "user:andrewchasin@google.com"; 
+  private static final String LOCATION = "us";
+  private static final String USER_ID = "user:andrewchasin@google.com";
 
   private ByteArrayOutputStream bout;
   private PrintStream out;

--- a/content-warehouse/src/test/java/contentwarehouse/v1/QuickStartTest.java
+++ b/content-warehouse/src/test/java/contentwarehouse/v1/QuickStartTest.java
@@ -26,9 +26,13 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 
 public class QuickStartTest {
+  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
+  
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
   private static final String LOCATION = "us"; 
   private static final String USER_ID = "user:andrewchasin@google.com"; 


### PR DESCRIPTION
## Description

Fixes #7997

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
