### PR TITLE
fixit: create new Java sample for aiplatform_create_custom_job_sample

### DIFF
--- a/aiplatform/src/main/java/aiplatform/CreateCustomJobSample.java
+++ b/aiplatform/src/main/java/aiplatform/CreateCustomJobSample.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package aiplatform;
+
+// [START aiplatform_create_custom_job_sample]
+import com.google.cloud.aiplatform.v1.AcceleratorType;
+import com.google.cloud.aiplatform.v1.ContainerSpec;
+import com.google.cloud.aiplatform.v1.CustomJob;
+import com.google.cloud.aiplatform.v1.CustomJobSpec;
+import com.google.cloud.aiplatform.v1.JobServiceClient;
+import com.google.cloud.aiplatform.v1.JobServiceSettings;
+import com.google.cloud.aiplatform.v1.LocationName;
+import com.google.cloud.aiplatform.v1.MachineSpec;
+import com.google.cloud.aiplatform.v1.WorkerPoolSpec;
+import java.io.IOException;
+
+public class CreateCustomJobSample {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String project = "PROJECT";
+    String displayName = "DISPLAY_NAME";
+    String containerImageUri = "CONTAINER_IMAGE_URI";
+    createCustomJobSample(project, displayName, containerImageUri);
+  }
+
+  static void createCustomJobSample(String project, String displayName, String containerImageUri)
+      throws IOException {
+    JobServiceSettings settings =
+        JobServiceSettings.newBuilder()
+            .setEndpoint("us-central1-aiplatform.googleapis.com:443")
+            .build();
+    String location = "us-central1";
+
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (JobServiceClient client = JobServiceClient.create(settings)) {
+      MachineSpec machineSpec =
+          MachineSpec.newBuilder()
+              .setMachineType("n1-standard-4")
+              .setAcceleratorType(AcceleratorType.NVIDIA_TESLA_K80)
+              .setAcceleratorCount(1)
+              .build();
+
+      ContainerSpec containerSpec =
+          ContainerSpec.newBuilder().setImageUri(containerImageUri).build();
+
+      WorkerPoolSpec workerPoolSpec =
+          WorkerPoolSpec.newBuilder()
+              .setMachineSpec(machineSpec)
+              .setReplicaCount(1)
+              .setContainerSpec(containerSpec)
+              .build();
+
+      CustomJobSpec customJobSpecJobSpec =
+          CustomJobSpec.newBuilder().addWorkerPoolSpecs(workerPoolSpec).build();
+
+      CustomJob customJob =
+          CustomJob.newBuilder()
+              .setDisplayName(displayName)
+              .setJobSpec(customJobSpecJobSpec)
+              .build();
+      LocationName parent = LocationName.of(project, location);
+      CustomJob response = client.createCustomJob(parent, customJob);
+      System.out.format("response: %s\n", response);
+      System.out.format("Name: %s\n", response.getName());
+    }
+  }
+}
+
+// [END aiplatform_create_custom_job_sample]

--- a/aiplatform/src/main/java/aiplatform/CreateCustomJobSample.java
+++ b/aiplatform/src/main/java/aiplatform/CreateCustomJobSample.java
@@ -17,6 +17,7 @@
 package aiplatform;
 
 // [START aiplatform_create_custom_job_sample]
+
 import com.google.cloud.aiplatform.v1.AcceleratorType;
 import com.google.cloud.aiplatform.v1.ContainerSpec;
 import com.google.cloud.aiplatform.v1.CustomJob;
@@ -28,12 +29,18 @@ import com.google.cloud.aiplatform.v1.MachineSpec;
 import com.google.cloud.aiplatform.v1.WorkerPoolSpec;
 import java.io.IOException;
 
+// Create a custom job to run machine learning training code in Vertex AI
 public class CreateCustomJobSample {
 
   public static void main(String[] args) throws IOException {
     // TODO(developer): Replace these variables before running the sample.
     String project = "PROJECT";
     String displayName = "DISPLAY_NAME";
+
+    // Vertex AI runs your training application in a Docker container image. A Docker container
+    // image is a self-contained software package that includes code and all dependencies. Learn
+    // more about preparing your training application at
+    // https://cloud.google.com/vertex-ai/docs/training/overview#prepare_your_training_application
     String containerImageUri = "CONTAINER_IMAGE_URI";
     createCustomJobSample(project, displayName, containerImageUri);
   }
@@ -47,8 +54,7 @@ public class CreateCustomJobSample {
     String location = "us-central1";
 
     // Initialize client that will be used to send requests. This client only needs to be created
-    // once, and can be reused for multiple requests. After completing all of your requests, call
-    // the "close" method on the client to safely clean up any remaining background resources.
+    // once, and can be reused for multiple requests.
     try (JobServiceClient client = JobServiceClient.create(settings)) {
       MachineSpec machineSpec =
           MachineSpec.newBuilder()

--- a/aiplatform/src/test/java/aiplatform/CreateCustomJobSampleTest.java
+++ b/aiplatform/src/test/java/aiplatform/CreateCustomJobSampleTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package aiplatform;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.aiplatform.v1beta1.JobServiceClient;
+import com.google.cloud.aiplatform.v1beta1.JobServiceSettings;
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class CreateCustomJobSampleTest {
+
+  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(5);
+
+  private static final String PROJECT = System.getenv("UCAIP_PROJECT_ID");
+  private static final String CONTAINER_IMAGE_URI =
+      "gcr.io/ucaip-sample-tests/ucaip-training-test:latest";
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+  private String customJobId;
+
+  private static void requireEnvVar(String varName) {
+    String errorMessage =
+        String.format("Environment variable '%s' is required to perform these tests.", varName);
+    assertNotNull(errorMessage, System.getenv(varName));
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+    requireEnvVar("UCAIP_PROJECT_ID");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown()
+      throws InterruptedException, ExecutionException, IOException, TimeoutException {
+    JobServiceSettings settings =
+        JobServiceSettings.newBuilder()
+            .setEndpoint("us-central1-aiplatform.googleapis.com:443")
+            .build();
+
+    try (JobServiceClient client = JobServiceClient.create(settings)) {
+      // Cancel custom job
+      String customJobName =
+          String.format("projects/%s/locations/us-central1/customJobs/%s", PROJECT, customJobId);
+      client.cancelCustomJob(customJobName);
+
+      TimeUnit.MINUTES.sleep(1);
+
+      // Delete the created job
+      client.deleteCustomJobAsync(customJobName);
+      System.out.flush();
+      System.setOut(originalPrintStream);
+    }
+  }
+
+  @Test
+  public void testCreateCustomJobSample() throws IOException {
+    String customJobDisplayName =
+        String.format(
+            "temp_custom_job_display_name_%s",
+            UUID.randomUUID().toString().replaceAll("-", "_").substring(0, 26));
+
+    CreateCustomJobSample.createCustomJobSample(PROJECT, customJobDisplayName, CONTAINER_IMAGE_URI);
+
+    String got = bout.toString();
+    assertThat(got).contains(customJobDisplayName);
+    assertThat(got).contains("response:");
+    customJobId = got.split("Name: ")[1].split("customJobs/")[1].split("\n")[0];
+  }
+}

--- a/aiplatform/src/test/java/aiplatform/CreateCustomJobSampleTest.java
+++ b/aiplatform/src/test/java/aiplatform/CreateCustomJobSampleTest.java
@@ -19,8 +19,9 @@ package aiplatform;
 import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.TestCase.assertNotNull;
 
-import com.google.cloud.aiplatform.v1beta1.JobServiceClient;
-import com.google.cloud.aiplatform.v1beta1.JobServiceSettings;
+import com.google.cloud.aiplatform.v1.CustomJobName;
+import com.google.cloud.aiplatform.v1.JobServiceClient;
+import com.google.cloud.aiplatform.v1.JobServiceSettings;
 import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -77,11 +78,11 @@ public class CreateCustomJobSampleTest {
 
     try (JobServiceClient client = JobServiceClient.create(settings)) {
       // Cancel custom job
-      String customJobName =
-          String.format("projects/%s/locations/us-central1/customJobs/%s", PROJECT, customJobId);
+      String location = "us-central1";
+      CustomJobName customJobName = CustomJobName.of(PROJECT, location, customJobId);
       client.cancelCustomJob(customJobName);
 
-      TimeUnit.MINUTES.sleep(1);
+      TimeUnit.MINUTES.sleep(2);
 
       // Delete the created job
       client.deleteCustomJobAsync(customJobName);


### PR DESCRIPTION
## Description

Fixes #281693980

Added missing Java sample for aiplatform_create_custom_job_sample

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
