### PR TITLE
fix: use recommended HmacSHA256 algorithm.

### DIFF
--- a/cdn/signed-urls/src/main/java/com/google/cdn/SignedUrls.java
+++ b/cdn/signed-urls/src/main/java/com/google/cdn/SignedUrls.java
@@ -66,7 +66,7 @@ public class SignedUrls {
   public static String getSignature(byte[] privateKey, String input)
       throws InvalidKeyException, NoSuchAlgorithmException {
 
-    final String algorithm = "HmacSHA1";
+    final String algorithm = "HmacSHA256";
     final int offset = 0;
     Key key = new SecretKeySpec(privateKey, offset, privateKey.length, algorithm);
     Mac mac = Mac.getInstance(algorithm);

--- a/cdn/signed-urls/src/test/java/com/google/cdn/SignedUrlsTest.java
+++ b/cdn/signed-urls/src/test/java/com/google/cdn/SignedUrlsTest.java
@@ -41,22 +41,22 @@ public class SignedUrlsTest {
   @Test
   public void testUrlPath() throws Exception {
     String result = signUrl(BASE_URL + "foo", KEY_BYTES, KEY_NAME, EXPIRATION);
-    final String expected = "https://www.example.com/foo?Expires=1518135754&KeyName=my-key&Signature=vUfG4yv47dyns1j9e_OI6_5meuA=";
-    assertEquals(result, expected);
+    final String expected = "https://www.example.com/foo?Expires=1518135754&KeyName=my-key&Signature=lwLX4Vs5nAyKSc-AdJ7KzwCo3jBOmxV0Wxao8TRZsjE=";
+    assertEquals(expected, result);
   }
 
   @Test
   public void testUrlParams() throws Exception {
     String result = signUrl(BASE_URL + "?param=true", KEY_BYTES, KEY_NAME, EXPIRATION);
-    final String expected = "https://www.example.com/?param=true&Expires=1518135754&KeyName=my-key&Signature=6TijW8OMX3gcMI5Kqs8ESiPY97c=";
-    assertEquals(result, expected);
+    final String expected = "https://www.example.com/?param=true&Expires=1518135754&KeyName=my-key&Signature=01iXNEFfnf4gIoQSerxC7gjTlGv24NV7_Ungxr_MNFI=";
+    assertEquals(expected, result);
   }
 
 
   @Test
   public void testStandard() throws Exception {
     String result = signUrl(BASE_URL, KEY_BYTES, KEY_NAME, EXPIRATION);
-    final String expected = "https://www.example.com/?Expires=1518135754&KeyName=my-key&Signature=4D0AbT4y0O7ZCzCUcAtPOJDkl2g=";
-    assertEquals(result, expected);
+    final String expected = "https://www.example.com/?Expires=1518135754&KeyName=my-key&Signature=wTub7cBBwT_6tYugpzp8A5xW6flFn0l9YrUioxadDN0=";
+    assertEquals(expected, result);
   }
 }


### PR DESCRIPTION
This is a followup from fixit: #8136, #8103

Update this sister sample to also use HMAC-SHA256, which is the [recommended](https://cloud.google.com/kms/docs/algorithms#algorithm_recommendations) algorithm.