### PR TITLE
Use 'else if' to avoid re-classifying an interaction.

### DIFF
--- a/recaptcha_enterprise/demosite/src/main/java/app/MainController.java
+++ b/recaptcha_enterprise/demosite/src/main/java/app/MainController.java
@@ -380,13 +380,13 @@ public class MainController {
     }
 
     // Classify the action as BAD if the returned recaptcha action doesn't match the expected.
-    if (!assessmentResponse.getTokenProperties().getAction().equals(recaptchaAction)) {
+    else if (!assessmentResponse.getTokenProperties().getAction().equals(recaptchaAction)) {
       reason = Error.ACTION_MISMATCH.getErrorMessage();
       label = Label.BAD.getLabel();
     }
 
     // Classify the action as BAD if the returned score is less than or equal to the threshold set.
-    if (assessmentResponse.getRiskAnalysis().getScore() <= SAMPLE_THRESHOLD_SCORE) {
+    else if (assessmentResponse.getRiskAnalysis().getScore() <= SAMPLE_THRESHOLD_SCORE) {
       reason = Error.SCORE_LESS_THAN_THRESHOLD.getErrorMessage();
       label = Label.BAD.getLabel();
     }


### PR DESCRIPTION
The previous code showed the SCORE_LESS_THAN_THRESHOLD message for invalid tokens.

This matches Javascript and Python samples