### PR TITLE
feat: text prompt sample for Vertex LLMs

### DIFF
--- a/aiplatform/src/main/java/aiplatform/PredictTextPromptSample.java
+++ b/aiplatform/src/main/java/aiplatform/PredictTextPromptSample.java
@@ -40,7 +40,7 @@ public class PredictTextPromptSample {
     String parameters =
         "{\n"
             + "  \"temperature\": 0.2,\n"
-            + "  \"maxDecodeSteps\": 256,\n"
+            + "  \"maxOutputTokens\": 256,\n"
             + "  \"topP\": 0.95,\n"
             + "  \"topK\": 40\n"
             + "}";
@@ -52,7 +52,8 @@ public class PredictTextPromptSample {
     predictTextPrompt(instance, parameters, project, location, publisher, model);
   }
 
-  static void predictTextPrompt(
+  // Get a text prompt from a supported text model
+  public static void predictTextPrompt(
       String instance,
       String parameters,
       String project,

--- a/aiplatform/src/main/java/aiplatform/PredictTextPromptSample.java
+++ b/aiplatform/src/main/java/aiplatform/PredictTextPromptSample.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package aiplatform;
+
+// [START aiplatform_sdk_ideation]
+
+import com.google.cloud.aiplatform.v1beta1.EndpointName;
+import com.google.cloud.aiplatform.v1beta1.PredictResponse;
+import com.google.cloud.aiplatform.v1beta1.PredictionServiceClient;
+import com.google.cloud.aiplatform.v1beta1.PredictionServiceSettings;
+import com.google.protobuf.Value;
+import com.google.protobuf.util.JsonFormat;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+// Test a text prompt with a supported large language model
+public class PredictTextPromptSample {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    // Creating text prompts for supported large language models are available on:
+    // https://cloud.google.com/vertex-ai/docs/generative-ai/text/text-overview
+    String instance =
+        "{ \"prompt\": " + "\"Give me ten interview questions for the role of program manager.\"}";
+    String parameters =
+        "{\n"
+            + "  \"temperature\": 0.2,\n"
+            + "  \"maxDecodeSteps\": 256,\n"
+            + "  \"topP\": 0.95,\n"
+            + "  \"topK\": 40\n"
+            + "}";
+    String project = "YOUR_PROJECT_ID";
+    String location = "us-central1";
+    String publisher = "google";
+    String model = "text-bison@001";
+
+    predictTextPrompt(instance, parameters, project, location, publisher, model);
+  }
+
+  static void predictTextPrompt(
+      String instance,
+      String parameters,
+      String project,
+      String location,
+      String publisher,
+      String model)
+      throws IOException {
+    String endpoint = String.format("%s-aiplatform.googleapis.com:443", location);
+    PredictionServiceSettings predictionServiceSettings =
+        PredictionServiceSettings.newBuilder().setEndpoint(endpoint).build();
+
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    try (PredictionServiceClient predictionServiceClient =
+        PredictionServiceClient.create(predictionServiceSettings)) {
+      final EndpointName endpointName =
+          EndpointName.ofProjectLocationPublisherModelName(project, location, publisher, model);
+
+      // Initialize client that will be used to send requests. This client only needs to be created
+      // once, and can be reused for multiple requests.
+      Value.Builder instanceValue = Value.newBuilder();
+      JsonFormat.parser().merge(instance, instanceValue);
+      List<Value> instances = new ArrayList<>();
+      instances.add(instanceValue.build());
+
+      // Use Value.Builder to convert instance to a dynamically typed value that can be
+      // processed by the service.
+      Value.Builder parameterValueBuilder = Value.newBuilder();
+      JsonFormat.parser().merge(parameters, parameterValueBuilder);
+      Value parameterValue = parameterValueBuilder.build();
+
+      PredictResponse predictResponse =
+          predictionServiceClient.predict(endpointName, instances, parameterValue);
+      System.out.println("Predict Response");
+      System.out.println(predictResponse);
+    }
+  }
+}
+// [END aiplatform_sdk_ideation]

--- a/aiplatform/src/main/java/aiplatform/PredictTextPromptSample.java
+++ b/aiplatform/src/main/java/aiplatform/PredictTextPromptSample.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-// Test a text prompt with a supported large language model
 public class PredictTextPromptSample {
 
   public static void main(String[] args) throws IOException {

--- a/aiplatform/src/main/java/aiplatform/PredictTextPromptSample.java
+++ b/aiplatform/src/main/java/aiplatform/PredictTextPromptSample.java
@@ -33,7 +33,7 @@ public class PredictTextPromptSample {
 
   public static void main(String[] args) throws IOException {
     // TODO(developer): Replace these variables before running the sample.
-    // Creating text prompts for supported large language models are available on:
+    // Details of designing text prompts for supported large language models:
     // https://cloud.google.com/vertex-ai/docs/generative-ai/text/text-overview
     String instance =
         "{ \"prompt\": " + "\"Give me ten interview questions for the role of program manager.\"}";

--- a/aiplatform/src/test/java/aiplatform/PredictTextPromptSampleTest.java
+++ b/aiplatform/src/test/java/aiplatform/PredictTextPromptSampleTest.java
@@ -19,15 +19,19 @@ package aiplatform;
 import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.TestCase.assertNotNull;
 
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class PredictTextPromptSampleTest {
+
+  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
 
   private static final String PROJECT = System.getenv("UCAIP_PROJECT_ID");
   private static final String INSTANCE =

--- a/aiplatform/src/test/java/aiplatform/PredictTextPromptSampleTest.java
+++ b/aiplatform/src/test/java/aiplatform/PredictTextPromptSampleTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package aiplatform;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class PredictTextPromptSampleTest {
+
+  private static final String PROJECT = System.getenv("UCAIP_PROJECT_ID");
+  private static final String INSTANCE =
+      "{ \"prompt\": " + "\"Give me ten interview questions for the role of program manager.\"}";
+  private static final String PARAMETERS =
+      "{\n"
+          + "  \"temperature\": 0.2,\n"
+          + "  \"maxDecodeSteps\": 256,\n"
+          + "  \"topP\": 0.95,\n"
+          + "  \"topK\": 40\n"
+          + "}";
+  private static final String PUBLISHER = "google";
+  private static final String LOCATION = "us-central1";
+  private static final String MODEL = "text-bison@001";
+
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static void requireEnvVar(String varName) {
+    String errorMessage =
+        String.format("Environment variable '%s' is required to perform these tests.", varName);
+    assertNotNull(errorMessage, System.getenv(varName));
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+    requireEnvVar("UCAIP_PROJECT_ID");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    System.out.flush();
+    System.setOut(originalPrintStream);
+  }
+
+  @Test
+  public void testPredictTextPrompt() throws IOException {
+    // Act
+    PredictTextPromptSample.predictTextPrompt(
+        INSTANCE, PARAMETERS, PROJECT, LOCATION, PUBLISHER, MODEL);
+
+    // Assert
+    String got = bout.toString();
+    assertThat(got).contains("Predict Response");
+  }
+}

--- a/aiplatform/src/test/java/aiplatform/PredictTextPromptSampleTest.java
+++ b/aiplatform/src/test/java/aiplatform/PredictTextPromptSampleTest.java
@@ -35,7 +35,7 @@ public class PredictTextPromptSampleTest {
   private static final String PARAMETERS =
       "{\n"
           + "  \"temperature\": 0.2,\n"
-          + "  \"maxDecodeSteps\": 256,\n"
+          + "  \"maxOutputTokens\": 256,\n"
           + "  \"topP\": 0.95,\n"
           + "  \"topK\": 40\n"
           + "}";


### PR DESCRIPTION
## Description

Fixes b/281562687

Add a text prompt sample for Vertex LLMs.

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
