### PR TITLE
feat(aiplatform): add the code sample for list the tuned models of the Vertex LLMs

### DIFF
--- a/aiplatform/src/main/java/aiplatform/ListTunedModelsSample.java
+++ b/aiplatform/src/main/java/aiplatform/ListTunedModelsSample.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * List available featurestore details. See
+ * https://cloud.google.com/vertex-ai/docs/featurestore/setup before running
+ * the code snippet
+ */
+
+package aiplatform;
+
+// [START aiplatform_sdk_list_tuned_models]
+
+import com.google.cloud.aiplatform.v1beta1.LocationName;
+import com.google.cloud.aiplatform.v1beta1.Model;
+import com.google.cloud.aiplatform.v1beta1.ListModelsRequest;
+import com.google.cloud.aiplatform.v1beta1.ModelServiceClient;
+import com.google.cloud.aiplatform.v1beta1.ModelServiceClient.ListModelsPagedResponse;
+import com.google.cloud.aiplatform.v1beta1.ModelServiceSettings;
+import java.io.IOException;
+
+public class ListTunedModelsSample {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace this variable before running the sample.
+    String project = "YOUR_PROJECT_ID";
+
+    String location = "us-central1";
+    String model = "text-bison@001";
+
+    listTunedModelsSample(project, location, model);
+  }
+
+  // List tuned models for a large language model
+  public static void listTunedModelsSample(String project, String location, String model)
+      throws IOException {
+    final String endpoint = String.format("%s-aiplatform.googleapis.com:443", location);
+    ModelServiceSettings modelServiceSettings =
+        ModelServiceSettings.newBuilder().setEndpoint(endpoint).build();
+
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    try (ModelServiceClient modelServiceClient = ModelServiceClient.create(modelServiceSettings)) {
+      final String parent = LocationName.of(project, location).toString();
+      final String filter =
+          String.format("labels.google-vertex-llm-tuning-base-model-id=%s", model);
+      ListModelsRequest request =
+          ListModelsRequest.newBuilder().setParent(parent).setFilter(filter).build();
+
+      ListModelsPagedResponse listModelsPagedResponse = modelServiceClient.listModels(request);
+      System.out.println("List Tuned Models response");
+      for (Model element : listModelsPagedResponse.iterateAll()) {
+        System.out.format("\tModel Name: %s\n", element.getName());
+        System.out.format("\tModel Display Name: %s\n", element.getDisplayName());
+      }
+    }
+  }
+}
+// [END aiplatform_sdk_list_tuned_models]

--- a/aiplatform/src/main/java/aiplatform/ListTunedModelsSample.java
+++ b/aiplatform/src/main/java/aiplatform/ListTunedModelsSample.java
@@ -23,9 +23,9 @@ package aiplatform;
 
 // [START aiplatform_sdk_list_tuned_models]
 
+import com.google.cloud.aiplatform.v1beta1.ListModelsRequest;
 import com.google.cloud.aiplatform.v1beta1.LocationName;
 import com.google.cloud.aiplatform.v1beta1.Model;
-import com.google.cloud.aiplatform.v1beta1.ListModelsRequest;
 import com.google.cloud.aiplatform.v1beta1.ModelServiceClient;
 import com.google.cloud.aiplatform.v1beta1.ModelServiceClient.ListModelsPagedResponse;
 import com.google.cloud.aiplatform.v1beta1.ModelServiceSettings;

--- a/aiplatform/src/test/java/aiplatform/ListTunedModelsSampleTest.java
+++ b/aiplatform/src/test/java/aiplatform/ListTunedModelsSampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,27 +16,29 @@
 
 package aiplatform;
 
+import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.TestCase.assertNotNull;
 
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class ListTunedModelsSampleTest {
+  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
 
-  private static final String PROJECT_ID = System.getenv("UCAIP_PROJECT_ID");
+  private static final String PROJECT = System.getenv("UCAIP_PROJECT_ID");
   private static final String LOCATION = "us-central1";
   private static final String MODEL = "text-bison@001";
-
   private ByteArrayOutputStream bout;
-  private PrintStream out;
   private PrintStream originalPrintStream;
 
   private static void requireEnvVar(String varName) {
@@ -54,7 +56,7 @@ public class ListTunedModelsSampleTest {
   @Before
   public void setUp() {
     bout = new ByteArrayOutputStream();
-    out = new PrintStream(bout);
+    PrintStream out = new PrintStream(bout);
     originalPrintStream = System.out;
     System.setOut(out);
   }
@@ -68,12 +70,10 @@ public class ListTunedModelsSampleTest {
   @Test
   public void testListTunedModelsSample() throws IOException {
     // Act
-    ListTunedModelsSample.listTunedModelsSample(
-        PROJECT_ID, LOCATION, MODEL);
+    ListTunedModelsSample.listTunedModelsSample(PROJECT, LOCATION, MODEL);
 
     // Assert
-//    String got = bout.toString();
-//    assertThat(got).contains(EVALUATION_ID);
-//    assertThat(got).contains("Model Evaluation Slice Name: ");
+    String got = bout.toString();
+    assertThat(got).contains("List Tuned Models response");
   }
 }

--- a/aiplatform/src/test/java/aiplatform/ListTunedModelsSampleTest.java
+++ b/aiplatform/src/test/java/aiplatform/ListTunedModelsSampleTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package aiplatform;
+
+import static junit.framework.TestCase.assertNotNull;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ListTunedModelsSampleTest {
+
+  private static final String PROJECT_ID = System.getenv("UCAIP_PROJECT_ID");
+  private static final String LOCATION = "us-central1";
+  private static final String MODEL = "text-bison@001";
+
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static void requireEnvVar(String varName) {
+    String errorMessage =
+        String.format("Environment variable '%s' is required to perform these tests.", varName);
+    assertNotNull(errorMessage, System.getenv(varName));
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+    requireEnvVar("UCAIP_PROJECT_ID");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    System.out.flush();
+    System.setOut(originalPrintStream);
+  }
+
+  @Test
+  public void testListTunedModelsSample() throws IOException {
+    // Act
+    ListTunedModelsSample.listTunedModelsSample(
+        PROJECT_ID, LOCATION, MODEL);
+
+    // Assert
+//    String got = bout.toString();
+//    assertThat(got).contains(EVALUATION_ID);
+//    assertThat(got).contains("Model Evaluation Slice Name: ");
+  }
+}


### PR DESCRIPTION
## Description

Fixes b281562687

Add a list tuned models sample for Vertex LLMs.
Public doc: https://cloud.google.com/vertex-ai/docs/generative-ai/models/tune-models#view_a_list_of_tuned_models

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
