### PR TITLE
feat(aiplatform): add tune model sample for Vertex LLMs

### DIFF
--- a/aiplatform/src/main/java/aiplatform/CreatePipelineJobModelTuningSample.java
+++ b/aiplatform/src/main/java/aiplatform/CreatePipelineJobModelTuningSample.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package aiplatform;
+
+// [START aiplatform_sdk_tuning]
+import com.google.cloud.aiplatform.v1beta1.CreatePipelineJobRequest;
+import com.google.cloud.aiplatform.v1beta1.LocationName;
+import com.google.cloud.aiplatform.v1beta1.PipelineJob;
+import com.google.cloud.aiplatform.v1beta1.PipelineJob.RuntimeConfig;
+import com.google.cloud.aiplatform.v1beta1.PipelineServiceClient;
+import com.google.cloud.aiplatform.v1beta1.PipelineServiceSettings;
+import com.google.protobuf.Value;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CreatePipelineJobModelTuningSample {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String project = "PROJECT";
+    String location =
+        "europe-west4"; // Model tuning is only supported in europe-west4 for Public Preview
+    String pipelineJobDisplayName = "PIPELINE_JOB_DISPLAY_NAME";
+    String modelDisplayName = "MODEL_DISPLAY_NAME";
+    String outputDir = "OUTPUT_DIR";
+    String datasetUri = "DATASET_URI";
+    int trainingSteps = 100;
+
+    createPipelineJobModelTuningSample(
+        project,
+        location,
+        pipelineJobDisplayName,
+        modelDisplayName,
+        outputDir,
+        datasetUri,
+        trainingSteps);
+  }
+
+  // Create a model tuning job
+  public static void createPipelineJobModelTuningSample(
+      String project,
+      String location,
+      String pipelineJobDisplayName,
+      String modelDisplayName,
+      String outputDir,
+      String datasetUri,
+      int trainingSteps)
+      throws IOException {
+    final String endpoint = String.format("%s-aiplatform.googleapis.com:443", location);
+    PipelineServiceSettings pipelineServiceSettings =
+        PipelineServiceSettings.newBuilder().setEndpoint(endpoint).build();
+
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    try (PipelineServiceClient client = PipelineServiceClient.create(pipelineServiceSettings)) {
+      Map<String, Value> parameterValues = new HashMap<>();
+      parameterValues.put("project", stringToValue(project));
+      parameterValues.put("model_display_name", stringToValue(modelDisplayName));
+      parameterValues.put("dataset_uri", stringToValue(datasetUri));
+      parameterValues.put(
+          "location",
+          stringToValue(
+              "us-central1")); // Deployment is only supported in us-central1 for Public Preview
+      parameterValues.put("large_model_reference", stringToValue("text-bison@001"));
+      parameterValues.put("train_steps", numberToValue(trainingSteps));
+
+      RuntimeConfig runtimeConfig =
+          RuntimeConfig.newBuilder()
+              .setGcsOutputDirectory(outputDir)
+              .putAllParameterValues(parameterValues)
+              .build();
+
+      PipelineJob pipelineJob =
+          PipelineJob.newBuilder()
+              .setTemplateUri(
+                  "https://us-kfp.pkg.dev/ml-pipeline/large-language-model-pipelines/tune-large-model/v1.0.0")
+              .setDisplayName(pipelineJobDisplayName)
+              .setRuntimeConfig(runtimeConfig)
+              .build();
+
+      LocationName parent = LocationName.of(project, location);
+      CreatePipelineJobRequest request =
+          CreatePipelineJobRequest.newBuilder()
+              .setParent(parent.toString())
+              .setPipelineJob(pipelineJob)
+              .build();
+
+      PipelineJob response = client.createPipelineJob(request);
+      System.out.format("response: %s\n", response);
+      System.out.format("Name: %s\n", response.getName());
+    }
+  }
+
+  static Value stringToValue(String str) {
+    return Value.newBuilder().setStringValue(str).build();
+  }
+
+  static Value numberToValue(int n) {
+    return Value.newBuilder().setNumberValue(n).build();
+  }
+}
+
+// [END aiplatform_sdk_tuning]

--- a/aiplatform/src/test/java/aiplatform/CreatePipelineJobModelTuningSampleTest.java
+++ b/aiplatform/src/test/java/aiplatform/CreatePipelineJobModelTuningSampleTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package aiplatform;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.cloud.aiplatform.v1beta1.DeleteOperationMetadata;
+import com.google.cloud.aiplatform.v1beta1.PipelineServiceClient;
+import com.google.cloud.aiplatform.v1beta1.PipelineServiceSettings;
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
+import com.google.protobuf.Empty;
+import io.grpc.StatusRuntimeException;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class CreatePipelineJobModelTuningSampleTest {
+  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
+
+  private static final String PROJECT = System.getenv("UCAIP_PROJECT_ID");
+  private static final String LOCATION = "europe-west4";
+  private static final String OUTPUT_DIR =
+      "gs://ucaip-samples-europe-west4/training_pipeline_output";
+  private static final String DATASET_URI =
+      "gs://cloud-samples-data/ai-platform/generative_ai/headline_classification.jsonl";
+  private static final int TRAINING_STEPS = 100;
+  private String pipelineJobName;
+  private ByteArrayOutputStream bout;
+  private PrintStream originalPrintStream;
+
+  private static void requireEnvVar(String varName) {
+    String errorMessage =
+        String.format("Environment variable '%s' is required to perform these tests.", varName);
+    assertNotNull(errorMessage, System.getenv(varName));
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+    requireEnvVar("UCAIP_PROJECT_ID");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    PrintStream out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown()
+      throws IOException, InterruptedException, TimeoutException, ExecutionException {
+    final String endpoint = String.format("%s-aiplatform.googleapis.com:443", LOCATION);
+    PipelineServiceSettings pipelineServiceSettings =
+        PipelineServiceSettings.newBuilder().setEndpoint(endpoint).build();
+
+    try (PipelineServiceClient pipelineServiceClient =
+        PipelineServiceClient.create(pipelineServiceSettings)) {
+      // Cancel the PipelineJob
+      pipelineServiceClient.cancelPipelineJob(pipelineJobName);
+      TimeUnit.MINUTES.sleep(2);
+
+      // Delete the PipelineJob
+      int retryCount = 3;
+      while (retryCount > 0) {
+        retryCount--;
+        try {
+          OperationFuture<Empty, DeleteOperationMetadata> operationFuture =
+              pipelineServiceClient.deletePipelineJobAsync(pipelineJobName);
+          operationFuture.get(300, TimeUnit.SECONDS);
+
+          // if delete operation is successful, break out of the loop and continue
+          break;
+        } catch (StatusRuntimeException e) {
+          // wait for another 1 minute, then retry
+          System.out.println("Retrying (due to unfinished cancellation operation)...");
+          TimeUnit.MINUTES.sleep(1);
+        } catch (Exception otherExceptions) {
+          // other exception, let them throw
+          throw otherExceptions;
+        }
+      }
+    }
+
+    System.out.flush();
+    System.setOut(originalPrintStream);
+  }
+
+  @Test
+  public void createTrainingPipelineModelTuningSample() throws IOException {
+    final String pipelineJobDisplayName =
+        String.format(
+            "temp_create_pipeline_job_test_%s",
+            UUID.randomUUID().toString().replaceAll("-", "_").substring(0, 26));
+
+    final String modelDisplayName =
+        String.format(
+            "temp_create_pipeline_job_model_test_%s",
+            UUID.randomUUID().toString().replaceAll("-", "_").substring(0, 26));
+
+    // Act
+    CreatePipelineJobModelTuningSample.createPipelineJobModelTuningSample(
+        PROJECT,
+        LOCATION,
+        pipelineJobDisplayName,
+        modelDisplayName,
+        OUTPUT_DIR,
+        DATASET_URI,
+        TRAINING_STEPS);
+
+    // Assert
+    String got = bout.toString();
+    assertThat(got).contains(pipelineJobDisplayName);
+    pipelineJobName = got.split("Name: ")[1].split("\n")[0];
+  }
+}


### PR DESCRIPTION
## Description

Fixes b281562687

Add a tune model sample for Vertex LLMs.
Public doc: https://cloud.google.com/vertex-ai/docs/generative-ai/models/tune-models

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
