### PR TITLE
chore: group Cloud SQL connectors

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,12 @@
       "groupName": "Bigtable packages"
     },
     {
+      "packagePatterns": [
+        "^com.google.cloud.sql:"
+      ],
+      "groupName": "Cloud SQL connectors"
+    },
+    {
       "matchPackagePrefixes": [ "com.google" ],
       "allowedVersions": "!/.+-sp\\.[0-9]+$/"
     },


### PR DESCRIPTION
These connectors have coordinated releases. Latest is currently v1.12.0. There are 5 outstanding dependencies that this will group into 1.