### PR TITLE
chore: update grpc dependency group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,7 +40,7 @@
     },
     {
       "packagePatterns": [
-        "^io.grpc:grpc-"
+        "io.grpc:(?:protoc-gen-)?grpc-*"
       ],
       "groupName": "gRPC packages"
     },


### PR DESCRIPTION
The GRPC dependency group currently misses [protoc-gen-grpc-java](https://mvnrepository.com/artifact/io.grpc/protoc-gen-grpc-java), which follows the same versioning scheme.