### PR TITLE
fix: address tictactoe test failure

### DIFF
--- a/appengine-java8/firebase-tictactoe/src/test/java/com/example/appengine/firetactoe/TicTacToeServletTest.java
+++ b/appengine-java8/firebase-tictactoe/src/test/java/com/example/appengine/firetactoe/TicTacToeServletTest.java
@@ -183,13 +183,13 @@ public class TicTacToeServletTest {
 
     verify(mockHttpTransport, atLeastOnce()).buildRequest(eq("PATCH"),
         ArgumentMatchers.matches(FIREBASE_DB_URL + "/channels/[\\w-]+.json$"));
-    verify(requestDispatcher).forward(mockRequest, mockResponse);
-    verify(mockRequest).setAttribute(eq("token"), anyString());
-    verify(mockRequest).setAttribute("game_key", game.id);
-    verify(mockRequest).setAttribute("me", USER_ID);
-    verify(mockRequest).setAttribute("channel_id", USER_ID + game.id);
-    verify(mockRequest).setAttribute(eq("initial_message"), anyString());
-    verify(mockRequest).setAttribute(eq("game_link"), anyString());
+    verify(requestDispatcher, atLeastOnce()).forward(mockRequest, mockResponse);
+    verify(mockRequest, atLeastOnce()).setAttribute(eq("token"), anyString());
+    verify(mockRequest, atLeastOnce()).setAttribute("game_key", game.id);
+    verify(mockRequest, atLeastOnce()).setAttribute("me", USER_ID);
+    verify(mockRequest, atLeastOnce()).setAttribute("channel_id", USER_ID + game.id);
+    verify(mockRequest, atLeastOnce()).setAttribute(eq("initial_message"), anyString());
+    verify(mockRequest, atLeastOnce()).setAttribute(eq("game_link"), anyString());
   }
 
   @Test

--- a/appengine-java8/firebase-tictactoe/src/test/java/com/example/appengine/firetactoe/TicTacToeServletTest.java
+++ b/appengine-java8/firebase-tictactoe/src/test/java/com/example/appengine/firetactoe/TicTacToeServletTest.java
@@ -18,6 +18,7 @@ package com.example.appengine.firetactoe;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -180,7 +181,7 @@ public class TicTacToeServletTest {
     assertThat(game).isNotNull();
     assertThat(game.userX).isEqualTo(USER_ID);
 
-    verify(mockHttpTransport, times(1)).buildRequest(eq("PATCH"),
+    verify(mockHttpTransport, atLeastOnce()).buildRequest(eq("PATCH"),
         ArgumentMatchers.matches(FIREBASE_DB_URL + "/channels/[\\w-]+.json$"));
     verify(requestDispatcher).forward(mockRequest, mockResponse);
     verify(mockRequest).setAttribute(eq("token"), anyString());


### PR DESCRIPTION
New retry logic in #8253 is working, but a subsequent assert needs to be updated. This PR updates the assert to check that the method was called at least once, rather than only once.

Error:
```
Wanted 1 time:
-> at com.example.appengine.firetactoe.TicTacToeServletTest.doGetNoGameKey(TicTacToeServletTest.java:183)
But was 2 times:
-> at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:889)
-> at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:889)
	at com.example.appengine.firetactoe.TicTacToeServletTest.doGetNoGameKey(TicTacToeServletTest.java:183)
```