### PR TITLE
feat(aiplatform): add code sample to update an image using text prompts

### DIFF
--- a/aiplatform/src/main/java/aiplatform/PredictImageFromImageAndTextSample.java
+++ b/aiplatform/src/main/java/aiplatform/PredictImageFromImageAndTextSample.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package aiplatform;
+
+// [START aiplatform_sdk_text_image_embedding]
+
+import com.google.cloud.aiplatform.v1beta1.EndpointName;
+import com.google.cloud.aiplatform.v1beta1.PredictResponse;
+import com.google.cloud.aiplatform.v1beta1.PredictionServiceClient;
+import com.google.cloud.aiplatform.v1beta1.PredictionServiceSettings;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Value;
+import com.google.protobuf.util.JsonFormat;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+public class PredictImageFromImageAndTextSample {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace this variable before running the sample.
+    String project = "YOUR_PROJECT_ID";
+    String textPrompt = "YOUR_TEXT_PROMPT";
+    String baseImagePath = "YOUR_BASE_IMAGE_PATH";
+
+    // Learn how to use text prompts to update an image:
+    // https://cloud.google.com/vertex-ai/docs/generative-ai/image/edit-images
+    String parameters = "{\n" + "  \"sampleCount\": 1\n" + "}";
+    String location = "us-central1";
+    String publisher = "google";
+    String model = "multimodalembedding@001";
+
+    predictImageFromImageAndText(
+        project, location, publisher, model, textPrompt, baseImagePath, parameters);
+  }
+
+  // Update images using text prompts
+  public static void predictImageFromImageAndText(
+      String project,
+      String location,
+      String publisher,
+      String model,
+      String textPrompt,
+      String baseImagePath,
+      String parameters)
+      throws IOException {
+    final String endpoint = String.format("%s-aiplatform.googleapis.com:443", location);
+    final PredictionServiceSettings predictionServiceSettings =
+        PredictionServiceSettings.newBuilder().setEndpoint(endpoint).build();
+
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    try (PredictionServiceClient predictionServiceClient =
+        PredictionServiceClient.create(predictionServiceSettings)) {
+      final EndpointName endpointName =
+          EndpointName.ofProjectLocationPublisherModelName(project, location, publisher, model);
+
+      // Convert the image to Base64
+      byte[] imageData = Base64.getEncoder().encode(Files.readAllBytes(Paths.get(baseImagePath)));
+      String encodedImage = new String(imageData, StandardCharsets.UTF_8);
+      String instance =
+          "{\"text\": \""
+              + textPrompt
+              + "\",\n"
+              + "\"image\": { \"bytesBase64Encoded\": \""
+              + encodedImage
+              + "\" }\n"
+              + "} \n";
+      Value instanceValue = stringToValue(instance);
+      List<Value> instances = new ArrayList<>();
+      instances.add(instanceValue);
+
+      Value parameterValue = stringToValue(parameters);
+
+      PredictResponse predictResponse =
+          predictionServiceClient.predict(endpointName, instances, parameterValue);
+      System.out.println("Predict Response");
+      System.out.println(predictResponse);
+      for (Value prediction : predictResponse.getPredictionsList()) {
+        System.out.format("\tPrediction: %s\n", prediction);
+      }
+    }
+  }
+
+  // Convert a Json string to a protobuf.Value
+  static Value stringToValue(String value) throws InvalidProtocolBufferException {
+    Value.Builder builder = Value.newBuilder();
+    JsonFormat.parser().merge(value, builder);
+    return builder.build();
+  }
+}
+// [END aiplatform_sdk_text_image_embedding]

--- a/aiplatform/src/test/java/aiplatform/PredictImageFromImageAndTextSampleTest.java
+++ b/aiplatform/src/test/java/aiplatform/PredictImageFromImageAndTextSampleTest.java
@@ -23,6 +23,8 @@ import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -39,7 +41,11 @@ public class PredictImageFromImageAndTextSampleTest {
   private static final String MODEL = "multimodalembedding@001";
   private static final String BASE_IMAGE_PATH = "resources/image_flower_daisy.jpg";
   private static final String TEXT_PROMPT = "an impressionist painting";
-  private static final String PARAMETERS = "{\n" + "  \"sampleCount\": 1\n" + "}";
+  private static final Map<String, Object> PARAMETERS = new HashMap<String, Object>();
+
+  static {
+    PARAMETERS.put("sampleCount", 1);
+  }
 
   private ByteArrayOutputStream bout;
   private PrintStream originalPrintStream;

--- a/aiplatform/src/test/java/aiplatform/PredictImageFromImageAndTextSampleTest.java
+++ b/aiplatform/src/test/java/aiplatform/PredictImageFromImageAndTextSampleTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package aiplatform;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class PredictImageFromImageAndTextSampleTest {
+
+  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
+
+  private static final String PROJECT = System.getenv("UCAIP_PROJECT_ID");
+  private static final String PUBLISHER = "google";
+  private static final String LOCATION = "us-central1";
+  private static final String MODEL = "multimodalembedding@001";
+  private static final String BASE_IMAGE_PATH = "resources/image_flower_daisy.jpg";
+  private static final String TEXT_PROMPT = "an impressionist painting";
+  private static final String PARAMETERS = "{\n" + "  \"sampleCount\": 1\n" + "}";
+
+  private ByteArrayOutputStream bout;
+  private PrintStream originalPrintStream;
+
+  private static void requireEnvVar(String varName) {
+    String errorMessage =
+        String.format("Environment variable '%s' is required to perform these tests.", varName);
+    assertNotNull(errorMessage, System.getenv(varName));
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+    requireEnvVar("UCAIP_PROJECT_ID");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    PrintStream out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    System.out.flush();
+    System.setOut(originalPrintStream);
+  }
+
+  @Test
+  public void testPredictImageFromImageAndText() throws IOException {
+    // Act
+    PredictImageFromImageAndTextSample.predictImageFromImageAndText(
+        PROJECT, LOCATION, PUBLISHER, MODEL, TEXT_PROMPT, BASE_IMAGE_PATH, PARAMETERS);
+
+    // Assert
+    String got = bout.toString();
+    assertThat(got).contains("Predict Response");
+  }
+}


### PR DESCRIPTION
## Description

Fixes b/288242440
Add code sample to demo how to edit an image using text prompts using image models
Docs: https://cloud.google.com/vertex-ai/docs/generative-ai/image/edit-images

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
