### PR TITLE
chore: combine io.quarkus dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -58,6 +58,12 @@
     },
     {
       "packagePatterns": [
+        "^io.quarkus:"
+      ],
+      "groupName": "Quarkus packages"
+    },
+    {
+      "packagePatterns": [
         "^io.vertx:"
       ],
       "groupName": "Vertx packages"


### PR DESCRIPTION
Reduces PRs and keeps versions consistent. See #8367 and #8368 