### PR TITLE
fix: cleanup testMonitorCertificateAuthority() test

### DIFF
--- a/monitoring/v3/src/test/java/com/example/monitoring/ListAlertPolicyIT.java
+++ b/monitoring/v3/src/test/java/com/example/monitoring/ListAlertPolicyIT.java
@@ -19,11 +19,13 @@ package com.example.monitoring;
 import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.TestCase.assertNotNull;
 
+import com.google.monitoring.v3.AlertPolicy;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.UUID;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -33,6 +35,7 @@ public class ListAlertPolicyIT {
   private static final String PROJECT_ID = requireEnvVar();
   private ByteArrayOutputStream bout;
   private PrintStream originalPrintStream;
+  private static String policyName;
   private static final String suffix = UUID.randomUUID().toString().substring(0, 8);
   private static final String testPolicyName = "test-policy" + suffix;
 
@@ -47,7 +50,8 @@ public class ListAlertPolicyIT {
   @BeforeClass
   public static void checkRequirements() throws IOException {
     requireEnvVar();
-    CreateAlertPolicy.createAlertPolicy(PROJECT_ID, testPolicyName);
+    AlertPolicy policy = CreateAlertPolicy.createAlertPolicy(PROJECT_ID, testPolicyName);
+    policyName = policy.getName();
   }
 
   @Before
@@ -63,6 +67,11 @@ public class ListAlertPolicyIT {
     // restores print statements in the original method
     System.out.flush();
     System.setOut(originalPrintStream);
+  }
+
+  @AfterClass
+  public static void tearDownClass() throws IOException {
+    DeleteAlertPolicy.deleteAlertPolicy(policyName);
   }
 
   @Test

--- a/privateca/snippets/src/main/java/privateca/MonitorCertificateAuthority.java
+++ b/privateca/snippets/src/main/java/privateca/MonitorCertificateAuthority.java
@@ -30,6 +30,8 @@ import java.io.IOException;
 
 public class MonitorCertificateAuthority {
 
+  public static final String POLICY_NAME = "policy-name";
+
   public static void main(String[] args) throws IOException {
     // TODO(developer): Replace these variables before running the sample.
     String project = "your-project-id";
@@ -37,7 +39,7 @@ public class MonitorCertificateAuthority {
   }
 
   // Creates a monitoring policy that notifies you 30 days before a managed CA expires.
-  public static void createCaMonitoringPolicy(String project) throws IOException {
+  public static String createCaMonitoringPolicy(String project) throws IOException {
     /* Initialize client that will be used to send requests. This client only needs to be created
     once, and can be reused for multiple requests. After completing all of your requests, call
     the `client.close()` method on the client to safely
@@ -45,8 +47,6 @@ public class MonitorCertificateAuthority {
     try (AlertPolicyServiceClient client = AlertPolicyServiceClient.create();
         NotificationChannelServiceClient notificationClient =
             NotificationChannelServiceClient.create()) {
-
-      String policyName = "policy-name";
 
       /* Query which indicates the resource to monitor and the constraints.
       Here, the alert policy notifies you 30 days before a managed CA expires.
@@ -72,7 +72,7 @@ public class MonitorCertificateAuthority {
       // Set the query and notification channel.
       AlertPolicy alertPolicy =
           AlertPolicy.newBuilder()
-              .setDisplayName(policyName)
+              .setDisplayName(POLICY_NAME)
               .addConditions(
                   Condition.newBuilder()
                       .setDisplayName("ca-cert-chain-expiration")
@@ -86,6 +86,7 @@ public class MonitorCertificateAuthority {
       AlertPolicy policy = client.createAlertPolicy(ProjectName.of(project), alertPolicy);
 
       System.out.println("Monitoring policy successfully created !" + policy.getName());
+      return policy.getName();
     }
   }
 }


### PR DESCRIPTION
### Description

Performs cleanup for the `testMonitorCertificateAuthority()` by deleting an alert policy that is created by `createCaMonitoringPolicy()`.

Fixes #8320
