### PR TITLE
fix: update batch region to address quota alerts

### DIFF
--- a/batch/snippets/src/main/java/com/example/batch/CreateWithScriptNoMounting.java
+++ b/batch/snippets/src/main/java/com/example/batch/CreateWithScriptNoMounting.java
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START batch_create_script_job]
+package com.example.batch;
 
+// [START batch_create_script_job]
 import com.google.cloud.batch.v1.AllocationPolicy;
 import com.google.cloud.batch.v1.AllocationPolicy.InstancePolicy;
 import com.google.cloud.batch.v1.AllocationPolicy.InstancePolicyOrTemplate;

--- a/batch/snippets/src/main/java/com/example/batch/CreateWithTemplate.java
+++ b/batch/snippets/src/main/java/com/example/batch/CreateWithTemplate.java
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START batch_create_container_job]
+package com.example.batch;
 
+// [START batch_create_job_with_template]
 import com.google.cloud.batch.v1.AllocationPolicy;
-import com.google.cloud.batch.v1.AllocationPolicy.InstancePolicy;
 import com.google.cloud.batch.v1.AllocationPolicy.InstancePolicyOrTemplate;
 import com.google.cloud.batch.v1.BatchServiceClient;
 import com.google.cloud.batch.v1.ComputeResource;
@@ -24,7 +24,7 @@ import com.google.cloud.batch.v1.Job;
 import com.google.cloud.batch.v1.LogsPolicy;
 import com.google.cloud.batch.v1.LogsPolicy.Destination;
 import com.google.cloud.batch.v1.Runnable;
-import com.google.cloud.batch.v1.Runnable.Container;
+import com.google.cloud.batch.v1.Runnable.Script;
 import com.google.cloud.batch.v1.TaskGroup;
 import com.google.cloud.batch.v1.TaskSpec;
 import com.google.protobuf.Duration;
@@ -33,7 +33,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-public class CreateWithContainerNoMounting {
+public class CreateWithTemplate {
 
   public static void main(String[] args)
       throws IOException, ExecutionException, InterruptedException, TimeoutException {
@@ -49,12 +49,19 @@ public class CreateWithContainerNoMounting {
     // It needs to be unique for each project and region pair.
     String jobName = "JOB_NAME";
 
-    createContainerJob(projectId, region, jobName);
+    // A link to an existing Instance Template. Acceptable formats:
+    //   * "projects/{projectId}/global/instanceTemplates/{templateName}"
+    //   * "{templateName}" - if the template is defined in the same project
+    //   as used to create the Job.
+    String templateLink = "TEMPLATE_LINK";
+
+    createWithTemplate(projectId, region, jobName, templateLink);
   }
 
-  // This method shows how to create a sample Batch Job that will run a simple command inside a
-  // container on Cloud Compute instances.
-  public static void createContainerJob(String projectId, String region, String jobName)
+  // This method shows how to create a sample Batch Job that will run
+  // a simple command on Cloud Compute instances created using a provided Template.
+  public static void createWithTemplate(String projectId, String region, String jobName,
+      String templateLink)
       throws IOException, ExecutionException, InterruptedException, TimeoutException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
@@ -65,14 +72,15 @@ public class CreateWithContainerNoMounting {
       // Define what will be done as part of the job.
       Runnable runnable =
           Runnable.newBuilder()
-              .setContainer(
-                  Container.newBuilder()
-                      .setImageUri("gcr.io/google-containers/busybox")
-                      .setEntrypoint("/bin/sh")
-                      .addCommands("-c")
-                      .addCommands(
+              .setScript(
+                  Script.newBuilder()
+                      .setText(
                           "echo Hello world! This is task ${BATCH_TASK_INDEX}. "
                               + "This job has a total of ${BATCH_TASK_COUNT} tasks.")
+                      // You can also run a script from a file. Just remember, that needs to be a
+                      // script that's already on the VM that will be running the job.
+                      // Using setText() and setPath() is mutually exclusive.
+                      // .setPath("/tmp/test.sh")
                       .build())
               .build();
 
@@ -99,14 +107,12 @@ public class CreateWithContainerNoMounting {
       TaskGroup taskGroup = TaskGroup.newBuilder().setTaskCount(4).setTaskSpec(task).build();
 
       // Policies are used to define on what kind of virtual machines the tasks will run on.
-      // In this case, we tell the system to use "e2-standard-4" machine type.
-      // Read more about machine types here: https://cloud.google.com/compute/docs/machine-types
-      InstancePolicy instancePolicy =
-          InstancePolicy.newBuilder().setMachineType("e2-standard-4").build();
-
+      // In this case, we tell the system to use an instance template that defines all the
+      // required parameters.
       AllocationPolicy allocationPolicy =
           AllocationPolicy.newBuilder()
-              .addInstances(InstancePolicyOrTemplate.newBuilder().setPolicy(instancePolicy).build())
+              .addInstances(
+                  InstancePolicyOrTemplate.newBuilder().setInstanceTemplate(templateLink).build())
               .build();
 
       Job job =
@@ -114,7 +120,7 @@ public class CreateWithContainerNoMounting {
               .addTaskGroups(taskGroup)
               .setAllocationPolicy(allocationPolicy)
               .putLabels("env", "testing")
-              .putLabels("type", "container")
+              .putLabels("type", "script")
               // We use Cloud Logging as it's an out of the box available option.
               .setLogsPolicy(
                   LogsPolicy.newBuilder().setDestination(Destination.CLOUD_LOGGING).build())
@@ -138,4 +144,4 @@ public class CreateWithContainerNoMounting {
     }
   }
 }
-// [END batch_create_container_job]
+// [END batch_create_job_with_template]

--- a/batch/snippets/src/main/java/com/example/batch/DeleteJob.java
+++ b/batch/snippets/src/main/java/com/example/batch/DeleteJob.java
@@ -12,49 +12,47 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START batch_get_task]
+package com.example.batch;
 
+// [START batch_delete_job]
 import com.google.cloud.batch.v1.BatchServiceClient;
-import com.google.cloud.batch.v1.Task;
-import com.google.cloud.batch.v1.TaskName;
 import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
-public class GetTask {
+public class DeleteJob {
 
-  public static void main(String[] args) throws IOException {
+  public static void main(String[] args)
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
     // TODO(developer): Replace these variables before running the sample.
     // Project ID or project number of the Cloud project you want to use.
     String projectId = "YOUR_PROJECT_ID";
+
     // Name of the region hosts the job.
     String region = "europe-central2";
-    // The name of the job you want to retrieve information about.
-    String jobName = "JOB_NAME";
-    // The name of the group that owns the task you want to check. Usually it's `group0`.
-    String groupName = "group0";
-    // Number of the task you want to look up.
-    int taskNumber = 0;
 
-    getTask(projectId, region, jobName, groupName, taskNumber);
+    // The name of the job that you want to delete.
+    String jobName = "JOB_NAME";
+
+    deleteJob(projectId, region, jobName);
   }
 
-  // Retrieve information about a Task.
-  public static void getTask(String projectId, String region, String jobName, String groupName,
-      int taskNumber) throws IOException {
+  // Triggers the deletion of a Job.
+  public static void deleteJob(String projectId, String region, String jobName)
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the `batchServiceClient.close()` method on the client to safely
     // clean up any remaining background resources.
     try (BatchServiceClient batchServiceClient = BatchServiceClient.create()) {
 
-      Task task = batchServiceClient.getTask(TaskName.newBuilder()
-          .setProject(projectId)
-          .setLocation(region)
-          .setJob(jobName)
-          .setTaskGroup(groupName)
-          .setTask(String.valueOf(taskNumber))
-          .build());
-      System.out.printf("Retrieved task information: %s", task.getName());
+      // Construct the parent path of the job.
+      String name = String.format("projects/%s/locations/%s/jobs/%s", projectId, region, jobName);
+
+      batchServiceClient.deleteJobAsync(name).get(5, TimeUnit.MINUTES);
+      System.out.printf("Delete the job: %s", jobName);
     }
   }
 }
-// [END batch_get_task]
+// [END batch_delete_job]

--- a/batch/snippets/src/main/java/com/example/batch/GetJob.java
+++ b/batch/snippets/src/main/java/com/example/batch/GetJob.java
@@ -12,18 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START batch_delete_job]
+package com.example.batch;
 
+// [START batch_get_job]
 import com.google.cloud.batch.v1.BatchServiceClient;
+import com.google.cloud.batch.v1.Job;
+import com.google.cloud.batch.v1.JobName;
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
-public class DeleteJob {
+public class GetJob {
 
-  public static void main(String[] args)
-      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+  public static void main(String[] args) throws IOException {
     // TODO(developer): Replace these variables before running the sample.
     // Project ID or project number of the Cloud project you want to use.
     String projectId = "YOUR_PROJECT_ID";
@@ -31,27 +30,30 @@ public class DeleteJob {
     // Name of the region hosts the job.
     String region = "europe-central2";
 
-    // The name of the job that you want to delete.
+    // The name of the job you want to retrieve information about.
     String jobName = "JOB_NAME";
 
-    deleteJob(projectId, region, jobName);
+    getJob(projectId, region, jobName);
   }
 
-  // Triggers the deletion of a Job.
-  public static void deleteJob(String projectId, String region, String jobName)
-      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+  // Retrieve information about a Batch Job.
+  public static void getJob(String projectId, String region, String jobName) throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the `batchServiceClient.close()` method on the client to safely
     // clean up any remaining background resources.
     try (BatchServiceClient batchServiceClient = BatchServiceClient.create()) {
 
-      // Construct the parent path of the job.
-      String name = String.format("projects/%s/locations/%s/jobs/%s", projectId, region, jobName);
+      Job job =
+          batchServiceClient.getJob(
+              JobName.newBuilder()
+                  .setProject(projectId)
+                  .setLocation(region)
+                  .setJob(jobName)
+                  .build());
 
-      batchServiceClient.deleteJobAsync(name).get(5, TimeUnit.MINUTES);
-      System.out.printf("Delete the job: %s", jobName);
+      System.out.printf("Retrieved the job: %s ", job.getName());
     }
   }
 }
-// [END batch_delete_job]
+// [END batch_get_job]

--- a/batch/snippets/src/main/java/com/example/batch/GetTask.java
+++ b/batch/snippets/src/main/java/com/example/batch/GetTask.java
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START batch_list_tasks]
+package com.example.batch;
 
+// [START batch_get_task]
 import com.google.cloud.batch.v1.BatchServiceClient;
 import com.google.cloud.batch.v1.Task;
+import com.google.cloud.batch.v1.TaskName;
 import java.io.IOException;
 
-public class ListTasks {
+public class GetTask {
 
   public static void main(String[] args) throws IOException {
     // TODO(developer): Replace these variables before running the sample.
@@ -26,29 +28,34 @@ public class ListTasks {
     String projectId = "YOUR_PROJECT_ID";
     // Name of the region hosts the job.
     String region = "europe-central2";
-    // Name of the job which tasks you want to list.
+    // The name of the job you want to retrieve information about.
     String jobName = "JOB_NAME";
-    // Name of the group of tasks. Usually it's `group0`.
+    // The name of the group that owns the task you want to check. Usually it's `group0`.
     String groupName = "group0";
+    // Number of the task you want to look up.
+    int taskNumber = 0;
 
-    listTasks(projectId, region, jobName, groupName);
+    getTask(projectId, region, jobName, groupName, taskNumber);
   }
 
-  // Get a list of all jobs defined in given region.
-  public static void listTasks(String projectId, String region, String jobName, String groupName)
-      throws IOException {
+  // Retrieve information about a Task.
+  public static void getTask(String projectId, String region, String jobName, String groupName,
+      int taskNumber) throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the `batchServiceClient.close()` method on the client to safely
     // clean up any remaining background resources.
     try (BatchServiceClient batchServiceClient = BatchServiceClient.create()) {
 
-      String parent = String.format("projects/%s/locations/%s/jobs/%s/taskGroups/%s", projectId,
-          region, jobName, groupName);
-      for (Task task : batchServiceClient.listTasks(parent).iterateAll()) {
-        System.out.println(task.getName());
-      }
+      Task task = batchServiceClient.getTask(TaskName.newBuilder()
+          .setProject(projectId)
+          .setLocation(region)
+          .setJob(jobName)
+          .setTaskGroup(groupName)
+          .setTask(String.valueOf(taskNumber))
+          .build());
+      System.out.printf("Retrieved task information: %s", task.getName());
     }
   }
 }
-// [END batch_list_tasks]
+// [END batch_get_task]

--- a/batch/snippets/src/main/java/com/example/batch/ListJobs.java
+++ b/batch/snippets/src/main/java/com/example/batch/ListJobs.java
@@ -12,44 +12,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START batch_job_logs]
+package com.example.batch;
 
+// [START batch_list_jobs]
+import com.google.cloud.batch.v1.BatchServiceClient;
 import com.google.cloud.batch.v1.Job;
-import com.google.cloud.logging.v2.LoggingClient;
-import com.google.logging.v2.ListLogEntriesRequest;
-import com.google.logging.v2.LogEntry;
 import java.io.IOException;
 
-public class ReadJobLogs {
+public class ListJobs {
 
   public static void main(String[] args) throws IOException {
     // TODO(developer): Replace these variables before running the sample.
-    // Project ID or project number of the Cloud project hosting the job.
+    // Project ID or project number of the Cloud project you want to use.
     String projectId = "YOUR_PROJECT_ID";
 
-    // The job which logs you want to print.
-    Job job = Job.newBuilder().build();
+    // Name of the region hosting the jobs.
+    String region = "europe-central2";
 
-    readJobLogs(projectId, job);
+    listJobs(projectId, region);
   }
 
-  // Prints the log messages created by given job.
-  public static void readJobLogs(String projectId, Job job) throws IOException {
+  // Get a list of all jobs defined in given region.
+  public static void listJobs(String projectId, String region) throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
-    // the `loggingClient.close()` method on the client to safely
+    // the `batchServiceClient.close()` method on the client to safely
     // clean up any remaining background resources.
-    try (LoggingClient loggingClient = LoggingClient.create()) {
+    try (BatchServiceClient batchServiceClient = BatchServiceClient.create()) {
 
-      ListLogEntriesRequest request = ListLogEntriesRequest.newBuilder()
-          .addResourceNames(String.format("projects/%s", projectId))
-          .setFilter(String.format("labels.job_uid=%s", job.getUid()))
-          .build();
+      // Construct the parent path of the job.
+      String parent = String.format("projects/%s/locations/%s", projectId, region);
 
-      for (LogEntry logEntry : loggingClient.listLogEntries(request).iterateAll()) {
-        System.out.println(logEntry.getTextPayload());
+      for (Job job : batchServiceClient.listJobs(parent).iterateAll()) {
+        System.out.println(job.getName());
       }
+      System.out.println("Listed all batch jobs.");
     }
   }
 }
-// [END batch_job_logs]
+// [END batch_list_jobs]

--- a/batch/snippets/src/main/java/com/example/batch/ListTasks.java
+++ b/batch/snippets/src/main/java/com/example/batch/ListTasks.java
@@ -12,47 +12,44 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START batch_get_job]
+package com.example.batch;
 
+// [START batch_list_tasks]
 import com.google.cloud.batch.v1.BatchServiceClient;
-import com.google.cloud.batch.v1.Job;
-import com.google.cloud.batch.v1.JobName;
+import com.google.cloud.batch.v1.Task;
 import java.io.IOException;
 
-public class GetJob {
+public class ListTasks {
 
   public static void main(String[] args) throws IOException {
     // TODO(developer): Replace these variables before running the sample.
     // Project ID or project number of the Cloud project you want to use.
     String projectId = "YOUR_PROJECT_ID";
-
     // Name of the region hosts the job.
     String region = "europe-central2";
-
-    // The name of the job you want to retrieve information about.
+    // Name of the job which tasks you want to list.
     String jobName = "JOB_NAME";
+    // Name of the group of tasks. Usually it's `group0`.
+    String groupName = "group0";
 
-    getJob(projectId, region, jobName);
+    listTasks(projectId, region, jobName, groupName);
   }
 
-  // Retrieve information about a Batch Job.
-  public static void getJob(String projectId, String region, String jobName) throws IOException {
+  // Get a list of all jobs defined in given region.
+  public static void listTasks(String projectId, String region, String jobName, String groupName)
+      throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the `batchServiceClient.close()` method on the client to safely
     // clean up any remaining background resources.
     try (BatchServiceClient batchServiceClient = BatchServiceClient.create()) {
 
-      Job job =
-          batchServiceClient.getJob(
-              JobName.newBuilder()
-                  .setProject(projectId)
-                  .setLocation(region)
-                  .setJob(jobName)
-                  .build());
-
-      System.out.printf("Retrieved the job: %s ", job.getName());
+      String parent = String.format("projects/%s/locations/%s/jobs/%s/taskGroups/%s", projectId,
+          region, jobName, groupName);
+      for (Task task : batchServiceClient.listTasks(parent).iterateAll()) {
+        System.out.println(task.getName());
+      }
     }
   }
 }
-// [END batch_get_job]
+// [END batch_list_tasks]

--- a/batch/snippets/src/main/java/com/example/batch/ReadJobLogs.java
+++ b/batch/snippets/src/main/java/com/example/batch/ReadJobLogs.java
@@ -12,41 +12,45 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START batch_list_jobs]
+package com.example.batch;
 
-import com.google.cloud.batch.v1.BatchServiceClient;
+// [START batch_job_logs]
 import com.google.cloud.batch.v1.Job;
+import com.google.cloud.logging.v2.LoggingClient;
+import com.google.logging.v2.ListLogEntriesRequest;
+import com.google.logging.v2.LogEntry;
 import java.io.IOException;
 
-public class ListJobs {
+public class ReadJobLogs {
 
   public static void main(String[] args) throws IOException {
     // TODO(developer): Replace these variables before running the sample.
-    // Project ID or project number of the Cloud project you want to use.
+    // Project ID or project number of the Cloud project hosting the job.
     String projectId = "YOUR_PROJECT_ID";
 
-    // Name of the region hosting the jobs.
-    String region = "europe-central2";
+    // The job which logs you want to print.
+    Job job = Job.newBuilder().build();
 
-    listJobs(projectId, region);
+    readJobLogs(projectId, job);
   }
 
-  // Get a list of all jobs defined in given region.
-  public static void listJobs(String projectId, String region) throws IOException {
+  // Prints the log messages created by given job.
+  public static void readJobLogs(String projectId, Job job) throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
-    // the `batchServiceClient.close()` method on the client to safely
+    // the `loggingClient.close()` method on the client to safely
     // clean up any remaining background resources.
-    try (BatchServiceClient batchServiceClient = BatchServiceClient.create()) {
+    try (LoggingClient loggingClient = LoggingClient.create()) {
 
-      // Construct the parent path of the job.
-      String parent = String.format("projects/%s/locations/%s", projectId, region);
+      ListLogEntriesRequest request = ListLogEntriesRequest.newBuilder()
+          .addResourceNames(String.format("projects/%s", projectId))
+          .setFilter(String.format("labels.job_uid=%s", job.getUid()))
+          .build();
 
-      for (Job job : batchServiceClient.listJobs(parent).iterateAll()) {
-        System.out.println(job.getName());
+      for (LogEntry logEntry : loggingClient.listLogEntries(request).iterateAll()) {
+        System.out.println(logEntry.getTextPayload());
       }
-      System.out.println("Listed all batch jobs.");
     }
   }
 }
-// [END batch_list_jobs]
+// [END batch_job_logs]

--- a/batch/snippets/src/test/java/com/example/batch/BatchBasicIT.java
+++ b/batch/snippets/src/test/java/com/example/batch/BatchBasicIT.java
@@ -16,6 +16,7 @@ package com.example.batch;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+
 import com.google.cloud.batch.v1.BatchServiceClient;
 import com.google.cloud.batch.v1.Job;
 import com.google.cloud.batch.v1.JobName;

--- a/batch/snippets/src/test/java/com/example/batch/BatchBasicIT.java
+++ b/batch/snippets/src/test/java/com/example/batch/BatchBasicIT.java
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+package com.example.batch;
+
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
-
 import com.google.cloud.batch.v1.BatchServiceClient;
 import com.google.cloud.batch.v1.Job;
 import com.google.cloud.batch.v1.JobName;
@@ -39,7 +40,7 @@ import org.junit.runners.JUnit4;
 public class BatchBasicIT {
 
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
-  private static final String REGION = "europe-north1";
+  private static final String REGION = "us-central1";
   private static final int MAX_ATTEMPT_COUNT = 3;
   private static final int INITIAL_BACKOFF_MILLIS = 120000; // 2 minutes
   private static String SCRIPT_JOB_NAME;
@@ -62,49 +63,51 @@ public class BatchBasicIT {
   @BeforeClass
   public static void setUp()
       throws IOException, InterruptedException, ExecutionException, TimeoutException {
-    final PrintStream out = System.out;
-    ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(stdOut));
-    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
-    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+    try (PrintStream out = System.out) {
+      ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
+      System.setOut(new PrintStream(stdOut));
+      requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+      requireEnvVar("GOOGLE_CLOUD_PROJECT");
 
-    String uuid = String.valueOf(UUID.randomUUID());
-    SCRIPT_JOB_NAME = "test-job-script-" + uuid;
-    CONTAINER_JOB_NAME = "test-job-container-" + uuid;
+      String uuid = String.valueOf(UUID.randomUUID());
+      SCRIPT_JOB_NAME = "test-job-script-" + uuid;
+      CONTAINER_JOB_NAME = "test-job-container-" + uuid;
 
-    CreateWithContainerNoMounting.createContainerJob(PROJECT_ID, REGION, CONTAINER_JOB_NAME);
-    assertThat(stdOut.toString())
-        .contains(
-            "Successfully created the job: "
-                + String.format(
-                "projects/%s/locations/%s/jobs/%s", PROJECT_ID, REGION, CONTAINER_JOB_NAME));
-    CreateWithScriptNoMounting.createScriptJob(PROJECT_ID, REGION, SCRIPT_JOB_NAME);
-    assertThat(stdOut.toString())
-        .contains(
-            "Successfully created the job: "
-                + String.format(
-                "projects/%s/locations/%s/jobs/%s", PROJECT_ID, REGION, SCRIPT_JOB_NAME));
-    TimeUnit.SECONDS.sleep(10);
+      CreateWithContainerNoMounting.createContainerJob(PROJECT_ID, REGION, CONTAINER_JOB_NAME);
+      assertThat(stdOut.toString())
+          .contains(
+              "Successfully created the job: "
+                  + String.format(
+                  "projects/%s/locations/%s/jobs/%s", PROJECT_ID, REGION, CONTAINER_JOB_NAME));
+      CreateWithScriptNoMounting.createScriptJob(PROJECT_ID, REGION, SCRIPT_JOB_NAME);
+      assertThat(stdOut.toString())
+          .contains(
+              "Successfully created the job: "
+                  + String.format(
+                  "projects/%s/locations/%s/jobs/%s", PROJECT_ID, REGION, SCRIPT_JOB_NAME));
+      TimeUnit.SECONDS.sleep(10);
 
-    Util.waitForJobCompletion(Util.getJob(PROJECT_ID, REGION, CONTAINER_JOB_NAME));
-    Util.waitForJobCompletion(Util.getJob(PROJECT_ID, REGION, SCRIPT_JOB_NAME));
+      Util.waitForJobCompletion(Util.getJob(PROJECT_ID, REGION, CONTAINER_JOB_NAME));
+      Util.waitForJobCompletion(Util.getJob(PROJECT_ID, REGION, SCRIPT_JOB_NAME));
 
-    stdOut.close();
-    System.setOut(out);
+      stdOut.close();
+      System.setOut(out);
+    }
   }
 
   @AfterClass
   public static void cleanup()
       throws IOException, InterruptedException, ExecutionException, TimeoutException {
-    final PrintStream out = System.out;
-    ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(stdOut));
+    try (PrintStream out = System.out) {
+      ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
+      System.setOut(new PrintStream(stdOut));
 
-    DeleteJob.deleteJob(PROJECT_ID, REGION, CONTAINER_JOB_NAME);
-    DeleteJob.deleteJob(PROJECT_ID, REGION, SCRIPT_JOB_NAME);
+      DeleteJob.deleteJob(PROJECT_ID, REGION, CONTAINER_JOB_NAME);
+      DeleteJob.deleteJob(PROJECT_ID, REGION, SCRIPT_JOB_NAME);
 
-    stdOut.close();
-    System.setOut(out);
+      stdOut.close();
+      System.setOut(out);
+    }
   }
 
   @Before
@@ -160,5 +163,4 @@ public class BatchBasicIT {
       assertThat(stdOut.toString()).contains(goal);
     }
   }
-
 }

--- a/batch/snippets/src/test/java/com/example/batch/BatchBucketIT.java
+++ b/batch/snippets/src/test/java/com/example/batch/BatchBucketIT.java
@@ -16,6 +16,7 @@ package com.example.batch;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+
 import com.google.cloud.batch.v1.Job;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;

--- a/batch/snippets/src/test/java/com/example/batch/BatchTemplateIT.java
+++ b/batch/snippets/src/test/java/com/example/batch/BatchTemplateIT.java
@@ -16,6 +16,7 @@ package com.example.batch;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+
 import com.google.cloud.compute.v1.AccessConfig;
 import com.google.cloud.compute.v1.AccessConfig.NetworkTier;
 import com.google.cloud.compute.v1.AttachedDisk;
@@ -85,8 +86,8 @@ public class BatchTemplateIT {
 
       // Get project number from project id.
       try (ProjectsClient projectsClient = ProjectsClient.create()) {
-        PROJECT_NUMBER = projectsClient.getProject(String.format("projects/%s", PROJECT_ID)).getName()
-            .split("/")[1];
+        PROJECT_NUMBER = projectsClient.getProject(String.format("projects/%s", PROJECT_ID))
+            .getName().split("/")[1];
       }
       String uuid = String.valueOf(UUID.randomUUID());
       SCRIPT_JOB_NAME = "test-job-template-" + uuid;

--- a/batch/snippets/src/test/java/com/example/batch/Util.java
+++ b/batch/snippets/src/test/java/com/example/batch/Util.java
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+package com.example.batch;
+
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.cloud.batch.v1.BatchServiceClient;


### PR DESCRIPTION
Change region to `us-central1` to address CPU quota alerts.

Also, addressed code warnings that added `com.example.batch` package and disposed of resources.