### PR TITLE
fix: address quota warnings for privateca

### DIFF
--- a/privateca/snippets/README.md
+++ b/privateca/snippets/README.md
@@ -1,12 +1,16 @@
 # Google Cloud Private Certificate Authority Service
 
 <a href="https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=privateca/snippets/README.md">
-<img alt="Open in Cloud Shell" src ="http://gstatic.com/cloudssh/images/open-btn.png"></a>
+<img alt="Open in Cloud Shell" src="http://gstatic.com/cloudssh/images/open-btn.png"></a>
 
-Google [Cloud Private Certificate Authority Service](https://cloud.google.com/certificate-authority-service) is a highly available, scalable Google Cloud service that enables you to simplify, automate, and customize the deployment, management, and security of private certificate authorities (CA).
+Google [Cloud Private Certificate Authority
+Service](https://cloud.google.com/certificate-authority-service) is a highly
+available, scalable Google Cloud service that enables you to simplify, automate,
+and customize the deployment, management, and security of private certificate
+authorities (CA).
 
-These sample Java applications demonstrate how to access the Cloud CA API using the
-Google Java API Client Libraries.
+These sample Java applications demonstrate how to access the Cloud CA API using
+the Google Java API Client Libraries.
 
 ## Prerequisites
 
@@ -16,25 +20,34 @@ Set up a Google Cloud project with billing enabled.
 
 ### Enable the API
 
-You must [enable the Google Private Certificate Authority Service API](https://console.cloud.google.com/flows/enableapi?apiid=privateca.googleapis.com) for your project in order to use these samples.
+You must [enable the Google Private Certificate Authority Service
+API](https://console.cloud.google.com/flows/enableapi?apiid=privateca.googleapis.com)
+for your project in order to use these samples.
 
 ### Service account
 
-A service account with private key credentials is required to create signed bearer tokens.
-Create a [service account](https://console.cloud.google.com/iam-admin/serviceaccounts/create) and download the credentials file as JSON.
+A service account with private key credentials is required to create signed
+bearer tokens. Create a [service
+account](https://console.cloud.google.com/iam-admin/serviceaccounts/create) and
+download the credentials file as JSON.
 
 ### Set Environment Variables
 
-You must set your project ID and service account credentials in order to run the tests.
+You must set your project ID and service account credentials in order to run the
+tests.
 
-```
-$ export GOOGLE_CLOUD_PROJECT="<google-project-id-here>"
-$ export GOOGLE_APPLICATION_CREDENTIALS="<path-to-service-account-credentials-file>"
+```sh
+export GOOGLE_CLOUD_PROJECT="<google-project-id-here>"
+export GOOGLE_APPLICATION_CREDENTIALS="<path-to-service-account-credentials-file>"
 ```
 
 ### Grant Permissions
 
-You must ensure that the [user account or service account](https://cloud.google.com/iam/docs/service-accounts#differences_between_a_service_account_and_a_user_account) you used to authorize your gcloud session has the proper permissions to edit Private CA resources for your project. In the Cloud Console under IAM, add the following roles to the project whose service account you're using to test:
+You must ensure that the [user account or service
+account](https://cloud.google.com/iam/docs/service-accounts#differences_between_a_service_account_and_a_user_account)
+you used to authorize your gcloud session has the proper permissions to edit
+Private CA resources for your project. In the Cloud Console under IAM, add the
+following roles to the project whose service account you're using to test:
 
 * Cloud CA Service Admin
 * Cloud CA Service Certificate Requester
@@ -44,32 +57,40 @@ You must ensure that the [user account or service account](https://cloud.google.
 * Cloud CA Service Operation Manager  
 * Cloud CA Service Auditor
 
-More information can be found in the [Google Private Certificate Authority Service Docs](https://cloud.google.com/certificate-authority-service/docs/reference/permissions-and-roles).
-
+More information can be found in the [Google Private Certificate Authority
+Service
+Docs](https://cloud.google.com/certificate-authority-service/docs/reference/permissions-and-roles).
 
 ## Build and Run
 
 The following instructions will help you prepare your development environment.
 
-1. Download and install the [Java Development Kit (JDK)](https://www.oracle.com/java/technologies/javase-downloads.html). 
-   Verify that the [JAVA_HOME](https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/envvars001.html) environment variable is set and points to your JDK installation.
+1. Download and install the [Java Development Kit
+   (JDK)](https://www.oracle.com/java/technologies/javase-downloads.html).
+   Verify that the
+   [JAVA_HOME](https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/envvars001.html)
+   environment variable is set and points to your JDK installation.
 
+1. Download and install [Apache Maven](http://maven.apache.org/download.cgi) by
+   following the [Maven installation
+   guide](http://maven.apache.org/install.html) for your specific operating
+   system.
 
-2. Download and install [Apache Maven](http://maven.apache.org/download.cgi) by following the [Maven installation guide](http://maven.apache.org/install.html) for your specific operating system.
+1. Clone the GoogleCloudPlatform/java-docs-samples repository.
 
-
-3. Clone the GoogleCloudPlatform/java-docs-samples repository.
-```
+```sh
 git clone https://github.com/GoogleCloudPlatform/java-docs-samples.git
 ```
 
-4. Navigate to the sample code directory.
+1. Navigate to the sample code directory.
 
-```
+```sh
 cd privateca/snippets
 ```
 
-5. Run the **SnippetsIT** test file present under the test folder.
+1. Run the **SnippetsIT** test file present under the test folder.
 
-### Crypto frameworks 
-[Bouncy Castle](https://www.bouncycastle.org/documentation.html) cryptographic framework is used as a part of testing.
+### Crypto frameworks
+
+[Bouncy Castle](https://www.bouncycastle.org/documentation.html) cryptographic
+framework is used as a part of testing.

--- a/privateca/snippets/src/test/java/privateca/SnippetsIT.java
+++ b/privateca/snippets/src/test/java/privateca/SnippetsIT.java
@@ -77,7 +77,6 @@ public class SnippetsIT {
 
   private static final int MAX_ATTEMPT_COUNT = 3;
   private static final int INITIAL_BACKOFF_MILLIS = 300000; // 5 minutes
-
   @Rule
   public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(
       MAX_ATTEMPT_COUNT,

--- a/privateca/snippets/src/test/java/privateca/SnippetsIT.java
+++ b/privateca/snippets/src/test/java/privateca/SnippetsIT.java
@@ -97,8 +97,7 @@ public class SnippetsIT {
     reqEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
     reqEnvVar("GOOGLE_CLOUD_PROJECT");
 
-
-    LOCATION = Util.getRegion();    
+    LOCATION = Util.getRegion();
     CA_poolId = "ca-pool-" + UUID.randomUUID();
     CA_poolId_DELETE = "ca-pool-" + UUID.randomUUID();
     CA_NAME = "ca-name-" + UUID.randomUUID();

--- a/privateca/snippets/src/test/java/privateca/SnippetsIT.java
+++ b/privateca/snippets/src/test/java/privateca/SnippetsIT.java
@@ -18,6 +18,7 @@ package privateca;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+
 import com.google.cloud.monitoring.v3.AlertPolicyServiceClient;
 import com.google.cloud.security.privateca.v1.CaPool.IssuancePolicy;
 import com.google.cloud.security.privateca.v1.CaPoolName;
@@ -355,9 +356,9 @@ public class SnippetsIT {
     MonitorCertificateAuthority.createCaMonitoringPolicy(PROJECT_ID);
     assertThat(stdOut.toString()).contains(monitoringPolicyCreated);
 
-    Pattern pattern = Pattern.compile(monitoringPolicyCreated + "(\\w+)\\b");
+    Pattern pattern = Pattern.compile(monitoringPolicyCreated + "(.*)");
     Matcher matcher = pattern.matcher(stdOut.toString());
-    assertThat(matcher.find()).isTrue();    
+    assertThat(matcher.find()).isTrue();
     ALERT_POLICY_NAME = matcher.group(1);
   }
 

--- a/privateca/snippets/src/test/java/privateca/Util.java
+++ b/privateca/snippets/src/test/java/privateca/Util.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -130,25 +131,13 @@ public abstract class Util {
   }
 
   /**
-   * @return region (e.g. "us-west1") that is selected based on the Java version. This
-   * distributes the testing workload across regions to avoid exceeding quotas.
+   * @return a region (e.g. "us-west1") that is randomly selected from uswest-* regions.
+   * This distributes the testing workload across regions to avoid exceeding quotas.
    */
   public static String getRegion() {
-    String regionPrefix = "us-west";  // 4 available us-west regions
-    String javaVersion = System.getProperty("java.version");
-    String majorVersion = javaVersion.split("\\.")[0];
-
-    String regionSuffix;
-    if ("8".equals(majorVersion)) {
-      regionSuffix = "1";
-    } else if ("11".equals(majorVersion)) {
-      regionSuffix = "2";
-    } else if ("17".equals(majorVersion)) {
-      regionSuffix = "3";
-    } else {
-      regionSuffix = "4";
-    }
-
-    return regionPrefix + regionSuffix;
+    String regionPrefix = "us-west";
+    int numRegions = 4;  // 4 available us-west regions
+    int selectedRegion = ThreadLocalRandom.current().nextInt(1, numRegions + 1);
+    return regionPrefix + String.valueOf(selectedRegion);
   }
 }

--- a/privateca/snippets/src/test/java/privateca/Util.java
+++ b/privateca/snippets/src/test/java/privateca/Util.java
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeoutException;
 public abstract class Util {
 
   private static final int DELETION_THRESHOLD_TIME_HOURS = 24;
-  
+
   // Delete Ca pools which starts with the given prefixToDelete.
   public static void cleanUpCaPool(String projectId,
       String location)
@@ -137,7 +137,7 @@ public abstract class Util {
     String regionPrefix = "us-west";  // 4 available us-west regions
     String javaVersion = System.getProperty("java.version");
     String majorVersion = javaVersion.split("\\.")[0];
-    
+
     String regionSuffix;
     if ("8".equals(majorVersion)) {
       regionSuffix = "1";
@@ -148,6 +148,7 @@ public abstract class Util {
     } else {
       regionSuffix = "4";
     }
+
     return regionPrefix + regionSuffix;
   }
 }

--- a/privateca/snippets/src/test/java/privateca/Util.java
+++ b/privateca/snippets/src/test/java/privateca/Util.java
@@ -34,10 +34,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-public class Util {
+public abstract class Util {
 
   private static final int DELETION_THRESHOLD_TIME_HOURS = 24;
-
+  
   // Delete Ca pools which starts with the given prefixToDelete.
   public static void cleanUpCaPool(String projectId,
       String location)
@@ -127,5 +127,27 @@ public class Util {
     Instant instant = Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanos());
     return instant
         .isBefore(Instant.now().minus(DELETION_THRESHOLD_TIME_HOURS, ChronoUnit.HOURS));
+  }
+
+  /**
+   * @return region (e.g. "us-west1") that is selected based on the Java version. This
+   * distributes the testing workload across regions to avoid exceeding quotas.
+   */
+  public static String getRegion() {
+    String regionPrefix = "us-west";  // 4 available us-west regions
+    String javaVersion = System.getProperty("java.version");
+    String majorVersion = javaVersion.split("\\.")[0];
+    
+    String regionSuffix;
+    if ("8".equals(majorVersion)) {
+      regionSuffix = "1";
+    } else if ("11".equals(majorVersion)) {
+      regionSuffix = "2";
+    } else if ("17".equals(majorVersion)) {
+      regionSuffix = "3";
+    } else {
+      regionSuffix = "4";
+    }
+    return regionPrefix + regionSuffix;
   }
 }


### PR DESCRIPTION
The `privateca` tests regularly hit a create certificate quota limit. This PR adds a utility function which enables distributing the tests across multiple regions to reduce the pressure on quota.

It also fixes existing Java warnings, and lints the README.