### PR TITLE
chore(cleanup): retire media translate samples

### DIFF
--- a/mediatranslation/README.md
+++ b/mediatranslation/README.md
@@ -1,50 +1,6 @@
-[//]: # "This README.md file is auto-generated, all changes to this file will be lost."
-[//]: # "To regenerate it, use `python -m synthtool`."
-<img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
+# Media Translation API deprication
 
-# [Cloud Media Translation: Java Samples](https://github.com/GoogleCloudPlatform/java-docs-samples/mediatranslation)
+Media Translation API is [deprecated] and will no longer be available on Google Cloud after July 1, 2024.
+All API code samples under this folder are no longer maintained and will be removed after July 1, 2024.
 
-[![Open in Cloud Shell][shell_img]][shell_link]
-
-
-
-## Table of Contents
-
-* [Build the sample](#build-the-sample)
-* [Samples](#samples)
-
-
-## Build the sample
-
-Install [Maven](http://maven.apache.org/).
-
-Build your project with:
-
-```
-mvn clean package -DskipTests
-```
-
-## Samples
-
-Please follow the [Set Up Your Project](https://cloud.google.com/media-translation/docs/getting-started#set_up_your_project)
-steps in the Quickstart doc to create a project and enable the Google Cloud
-Media Translation API. Following those steps, make sure that you
-[Set Up a Service Account](https://cloud.google.com/media-translation/docs/common/auth#set_up_a_service_account),
-and export the following environment variable:
-
-```
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/your-project-credentials.json
-```
-
-After you have authorized, you can translate media.
-
-
-## Run
-Run all tests:
-```
-mvn clean verify
-```
-
-[shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
-[shell_link]: https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=mediatranslation/README.md
-[product-docs]: https://cloud.google.com/mediatranslation/docs/
+[deprecated]: https://cloud.google.com/translate/media/docs/deprecations

--- a/mediatranslation/src/test/java/com/example/mediatranslation/TranslateFromFileTest.java
+++ b/mediatranslation/src/test/java/com/example/mediatranslation/TranslateFromFileTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -44,7 +45,9 @@ public class TranslateFromFileTest {
     bout.reset();
   }
 
+  // Test is ignored because code sample it is testing is deprecated
   @Test
+  @Ignore
   public void testTranslateFromFile() throws IOException {
     // Call translateFromFile to print out the translated output.
     TranslateFromFile.translateFromFile("resources/audio.raw");


### PR DESCRIPTION
### Description

Updates README file with the deprecation notice.
Marks all tests to be ignored.

Fixes #8393 
