### PR TITLE
fix(compute): fix flaky issues in firewall and cmt

### DIFF
--- a/compute/cloud-client/src/test/java/compute/FirewallIT.java
+++ b/compute/cloud-client/src/test/java/compute/FirewallIT.java
@@ -123,10 +123,9 @@ public class FirewallIT {
     try {
       compute.ListFirewallRules.listFirewallRules(PROJECT_ID);
       assertThat(stdOut.toString()).contains(FIREWALL_RULE_CREATE);
-    } catch (NotFoundException e) {
-      System.out.println("Rule already deleted! ");
-    } catch (InvalidArgumentException | NullPointerException e) {
-      System.out.println("Rule is not ready (probably being deleted).");
+    } catch (AssertionError e) {
+      // Catches assertion error.
+      System.out.println("Rule already deleted or being deleted.");
     }
     // Clear system output to not affect other tests.
     // Refrain from setting out to null.

--- a/compute/cloud-client/src/test/java/compute/FirewallIT.java
+++ b/compute/cloud-client/src/test/java/compute/FirewallIT.java
@@ -26,6 +26,7 @@ import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -122,10 +123,11 @@ public class FirewallIT {
     System.setOut(new PrintStream(stdOut));
     try {
       compute.ListFirewallRules.listFirewallRules(PROJECT_ID);
-      assertThat(stdOut.toString()).contains(FIREWALL_RULE_CREATE);
-    } catch (AssertionError e) {
-      // Catches assertion error.
-      System.out.println("Rule already deleted or being deleted.");
+      if (!stdOut.toString().contains(FIREWALL_RULE_CREATE)) {
+        throw new NoSuchElementException("Rule already deleted or being deleted.");
+      }
+    } catch (NoSuchElementException e) {
+      System.out.println(e.getMessage());
     }
     // Clear system output to not affect other tests.
     // Refrain from setting out to null.

--- a/compute/cloud-client/src/test/java/compute/InstanceOperationsIT.java
+++ b/compute/cloud-client/src/test/java/compute/InstanceOperationsIT.java
@@ -18,6 +18,7 @@ package compute;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static compute.Util.getZone;
 
 import com.google.cloud.compute.v1.Instance;
 import com.google.cloud.compute.v1.Instance.Status;
@@ -71,7 +72,7 @@ public class InstanceOperationsIT {
     requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
     requireEnvVar("GOOGLE_CLOUD_PROJECT");
 
-    ZONE = "us-central1-a";
+    ZONE = getZone();
     MACHINE_NAME = "my-new-test-instance" + UUID.randomUUID();
     MACHINE_NAME_ENCRYPTED = "encrypted-test-instance" + UUID.randomUUID();
     DISK_NAME = "test-clone-disk-enc-" + UUID.randomUUID();

--- a/compute/cloud-client/src/test/java/compute/InstanceTemplatesIT.java
+++ b/compute/cloud-client/src/test/java/compute/InstanceTemplatesIT.java
@@ -18,6 +18,7 @@ package compute;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static compute.Util.getZone;
 
 import com.google.cloud.compute.v1.Instance;
 import com.google.cloud.compute.v1.InstancesClient;
@@ -43,8 +44,8 @@ import org.junit.runners.JUnit4;
 public class InstanceTemplatesIT {
 
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
-  private static final String DEFAULT_REGION = "us-central1";
-  private static final String DEFAULT_ZONE = DEFAULT_REGION + "-a";
+  private static final String DEFAULT_ZONE = getZone();
+  private static final String DEFAULT_REGION = DEFAULT_ZONE.substring(0, DEFAULT_ZONE.length()-1);
   private static String TEMPLATE_NAME;
   private static String TEMPLATE_NAME_WITH_DISK;
   private static String TEMPLATE_NAME_FROM_INSTANCE;

--- a/compute/cloud-client/src/test/java/compute/InstanceTemplatesIT.java
+++ b/compute/cloud-client/src/test/java/compute/InstanceTemplatesIT.java
@@ -45,7 +45,7 @@ public class InstanceTemplatesIT {
 
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
   private static final String DEFAULT_ZONE = getZone();
-  private static final String DEFAULT_REGION = DEFAULT_ZONE.substring(0, DEFAULT_ZONE.length()-1);
+  private static final String DEFAULT_REGION = DEFAULT_ZONE.substring(0, DEFAULT_ZONE.length() - 1);
   private static String TEMPLATE_NAME;
   private static String TEMPLATE_NAME_WITH_DISK;
   private static String TEMPLATE_NAME_FROM_INSTANCE;

--- a/compute/cloud-client/src/test/java/compute/InstanceTemplatesIT.java
+++ b/compute/cloud-client/src/test/java/compute/InstanceTemplatesIT.java
@@ -45,7 +45,7 @@ public class InstanceTemplatesIT {
 
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
   private static final String DEFAULT_ZONE = getZone();
-  private static final String DEFAULT_REGION = DEFAULT_ZONE.substring(0, DEFAULT_ZONE.length() - 1);
+  private static final String DEFAULT_REGION = DEFAULT_ZONE.substring(0, DEFAULT_ZONE.length() - 2);
   private static String TEMPLATE_NAME;
   private static String TEMPLATE_NAME_WITH_DISK;
   private static String TEMPLATE_NAME_FROM_INSTANCE;

--- a/compute/cloud-client/src/test/java/compute/InstancesAdvancedIT.java
+++ b/compute/cloud-client/src/test/java/compute/InstancesAdvancedIT.java
@@ -92,7 +92,8 @@ public class InstancesAdvancedIT {
     MACHINE_NAME_SUBNETWORK = "test-instance-subnet-" + uuid;
     MACHINE_NAME_EXISTING_DISK = "test-instance-exis" + uuid;
     NETWORK_NAME = "global/networks/default";
-    SUBNETWORK_NAME = "regions/us-central1/subnetworks/default";
+    SUBNETWORK_NAME = String.format("regions/%s/subnetworks/default",
+        ZONE.substring(0, ZONE.length() - 2));
 
     TEST_DISK = createSourceDisk();
     TEST_SNAPSHOT = createSnapshot(TEST_DISK);

--- a/compute/cloud-client/src/test/java/compute/InstancesAdvancedIT.java
+++ b/compute/cloud-client/src/test/java/compute/InstancesAdvancedIT.java
@@ -17,6 +17,7 @@
 package compute;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static compute.Util.getZone;
 
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.cloud.compute.v1.Disk;
@@ -82,7 +83,7 @@ public class InstancesAdvancedIT {
     requireEnvVar("GOOGLE_CLOUD_PROJECT");
 
     UUID uuid = UUID.randomUUID();
-    ZONE = "us-central1-a";
+    ZONE = getZone();
     MACHINE_NAME_PUBLIC_IMAGE = "test-instance-pub-" + uuid;
     MACHINE_NAME_CUSTOM_IMAGE = "test-instance-cust-" + uuid;
     MACHINE_NAME_ADDITIONAL_DISK = "test-instance-add-" + uuid;

--- a/compute/cloud-client/src/test/java/compute/SnippetsIT.java
+++ b/compute/cloud-client/src/test/java/compute/SnippetsIT.java
@@ -18,6 +18,7 @@ package compute;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static compute.Util.getZone;
 
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.cloud.compute.v1.AttachedDisk;
@@ -82,7 +83,7 @@ public class SnippetsIT {
     requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
     requireEnvVar("GOOGLE_CLOUD_PROJECT");
 
-    ZONE = "us-central1-a";
+    ZONE = getZone();
     MACHINE_NAME = "my-new-test-instance" + UUID.randomUUID();
     MACHINE_NAME_LIST_INSTANCE = "my-new-test-instance" + UUID.randomUUID();
     MACHINE_NAME_WAIT_FOR_OP = "my-new-test-instance" + UUID.randomUUID();

--- a/compute/cloud-client/src/test/java/compute/Util.java
+++ b/compute/cloud-client/src/test/java/compute/Util.java
@@ -53,14 +53,8 @@ public abstract class Util {
   static {
     ZONES = new String[]{
         "us-central1-a",
-        "us-central1-b",
-        "us-central1-c",
         "us-west1-a",
-        "us-west1-b",
-        "us-west1-c",
         "asia-south1-a",
-        "asia-south1-b",
-        "asia-south1-c"
     };
   }
 

--- a/compute/cloud-client/src/test/java/compute/Util.java
+++ b/compute/cloud-client/src/test/java/compute/Util.java
@@ -51,16 +51,16 @@ public abstract class Util {
   private static final String[] ZONES;
 
   static {
-    ZONES = new String[] {
-      "us-central1-a",
-      "us-central1-b",
-      "us-central1-c",
-      "us-west1-a",
-      "us-west1-b",
-      "us-west1-c",
-      "asia-south1-a",
-      "asia-south1-b",
-      "asia-south1-c"
+    ZONES = new String[]{
+        "us-central1-a",
+        "us-central1-b",
+        "us-central1-c",
+        "us-west1-a",
+        "us-west1-b",
+        "us-west1-c",
+        "asia-south1-a",
+        "asia-south1-b",
+        "asia-south1-c"
     };
   }
 
@@ -174,7 +174,7 @@ public abstract class Util {
       return regionDisksClient.get(projectId, region, diskName);
     }
   }
-  
+
   // Returns a random zone.
   public static String getZone() {
     return ZONES[new Random().nextInt(ZONES.length)];

--- a/compute/cloud-client/src/test/java/compute/Util.java
+++ b/compute/cloud-client/src/test/java/compute/Util.java
@@ -37,16 +37,32 @@ import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Map.Entry;
+import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.IntStream;
 
-public class Util {
+public abstract class Util {
   // Cleans existing test resources if any.
   // If the project contains too many instances, use "filter" when listing resources
   // and delete the listed resources based on the timestamp.
 
   private static final int DELETION_THRESHOLD_TIME_HOURS = 24;
+  private static final String[] ZONES;
+
+  static {
+    ZONES = new String[] {
+      "us-central1-a",
+      "us-central1-b",
+      "us-central1-c",
+      "us-west1-a",
+      "us-west1-b",
+      "us-west1-c",
+      "asia-south1-a",
+      "asia-south1-b",
+      "asia-south1-c"
+    };
+  }
 
   // Delete templates which starts with the given prefixToDelete and
   // has creation timestamp >24 hours.
@@ -157,6 +173,11 @@ public class Util {
     try (RegionDisksClient regionDisksClient = RegionDisksClient.create()) {
       return regionDisksClient.get(projectId, region, diskName);
     }
+  }
+  
+  // Returns a random zone.
+  public static String getZone() {
+    return ZONES[new Random().nextInt(ZONES.length)];
   }
 
 }

--- a/compute/cloud-client/src/test/java/compute/customhostname/CustomHostnameInstanceIT.java
+++ b/compute/cloud-client/src/test/java/compute/customhostname/CustomHostnameInstanceIT.java
@@ -18,6 +18,7 @@ package compute.customhostname;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static compute.Util.getZone;
 
 import compute.DeleteInstance;
 import java.io.ByteArrayOutputStream;
@@ -62,7 +63,7 @@ public class CustomHostnameInstanceIT {
     requireEnvVar("GOOGLE_CLOUD_PROJECT");
 
     INSTANCE_NAME = "my-custom-hostname-test-instance" + UUID.randomUUID().toString().split("-")[0];
-    ZONE = "us-central1-a";
+    ZONE = getZone();
     CUSTOM_HOSTNAME = "host.domain.com";
 
     // Create Instance with a custom hostname.

--- a/compute/cloud-client/src/test/java/compute/custommachinetype/CustomMachineTypeIT.java
+++ b/compute/cloud-client/src/test/java/compute/custommachinetype/CustomMachineTypeIT.java
@@ -18,6 +18,7 @@ package compute.custommachinetype;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static compute.Util.getZone;
 
 import com.google.cloud.compute.v1.Instance;
 import com.google.cloud.compute.v1.InstancesClient;
@@ -47,7 +48,7 @@ import org.junit.runners.JUnit4;
 public class CustomMachineTypeIT {
 
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
-  private static final String ZONE = "us-central1-a";
+  private static final String ZONE = getZone();
   private static final String CUSTOM_MACHINE_TYPE = String.format(
       "zones/%s/machineTypes/n2-custom-8-10240", ZONE);
 

--- a/compute/cloud-client/src/test/java/compute/custommachinetype/HelperIT.java
+++ b/compute/cloud-client/src/test/java/compute/custommachinetype/HelperIT.java
@@ -18,6 +18,7 @@ package compute.custommachinetype;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static compute.Util.getZone;
 
 import compute.custommachinetype.HelperClass.CpuSeries;
 import compute.custommachinetype.HelperClass.CustomMachineType;
@@ -38,7 +39,7 @@ import org.junit.jupiter.api.Test;
 public class HelperIT {
 
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
-  private static final String ZONE = "us-central1-a";
+  private static final String ZONE = getZone();
 
   private ByteArrayOutputStream stdOut;
 

--- a/compute/cloud-client/src/test/java/compute/deleteprotection/DeleteProtectionIT.java
+++ b/compute/cloud-client/src/test/java/compute/deleteprotection/DeleteProtectionIT.java
@@ -18,6 +18,7 @@ package compute.deleteprotection;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static compute.Util.getZone;
 
 import compute.DeleteInstance;
 import compute.Util;
@@ -43,7 +44,7 @@ import org.junit.runners.JUnit4;
 public class DeleteProtectionIT {
 
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
-  private static final String ZONE = "us-central1-a";
+  private static final String ZONE = getZone();
   private static String INSTANCE_NAME;
 
   private ByteArrayOutputStream stdOut;

--- a/compute/cloud-client/src/test/java/compute/disks/DisksFromSourceIT.java
+++ b/compute/cloud-client/src/test/java/compute/disks/DisksFromSourceIT.java
@@ -91,7 +91,7 @@ public class DisksFromSourceIT {
     requireEnvVar("GOOGLE_CLOUD_PROJECT");
 
     ZONE = getZone();
-    REGION = ZONE.substring(0, ZONE.length() - 1);
+    REGION = ZONE.substring(0, ZONE.length() - 2);
     KMS_KEYRING_NAME = "compute-test-keyring";
     KMS_KEY_NAME = "compute-test-key";
 

--- a/compute/cloud-client/src/test/java/compute/disks/DisksFromSourceIT.java
+++ b/compute/cloud-client/src/test/java/compute/disks/DisksFromSourceIT.java
@@ -18,6 +18,7 @@ package compute.disks;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static compute.Util.getZone;
 
 import com.google.cloud.compute.v1.CreateSnapshotDiskRequest;
 import com.google.cloud.compute.v1.Disk;
@@ -89,8 +90,8 @@ public class DisksFromSourceIT {
     // requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
     requireEnvVar("GOOGLE_CLOUD_PROJECT");
 
-    ZONE = "us-central1-a";
-    REGION = "us-central1";
+    ZONE = getZone();
+    REGION = ZONE.substring(0, ZONE.length()-1);
     KMS_KEYRING_NAME = "compute-test-keyring";
     KMS_KEY_NAME = "compute-test-key";
 

--- a/compute/cloud-client/src/test/java/compute/disks/DisksFromSourceIT.java
+++ b/compute/cloud-client/src/test/java/compute/disks/DisksFromSourceIT.java
@@ -91,7 +91,7 @@ public class DisksFromSourceIT {
     requireEnvVar("GOOGLE_CLOUD_PROJECT");
 
     ZONE = getZone();
-    REGION = ZONE.substring(0, ZONE.length()-1);
+    REGION = ZONE.substring(0, ZONE.length() - 1);
     KMS_KEYRING_NAME = "compute-test-keyring";
     KMS_KEY_NAME = "compute-test-key";
 

--- a/compute/cloud-client/src/test/java/compute/disks/DisksIT.java
+++ b/compute/cloud-client/src/test/java/compute/disks/DisksIT.java
@@ -94,7 +94,7 @@ public class DisksIT {
     requireEnvVar("GOOGLE_CLOUD_PROJECT");
 
     ZONE = getZone();
-    REGION = ZONE.substring(0, ZONE.length() - 1);
+    REGION = ZONE.substring(0, ZONE.length() - 2);
     String uuid = UUID.randomUUID().toString().split("-")[0];
     INSTANCE_NAME = "test-disks-" + uuid;
     DISK_NAME = "gcloud-test-disk-" + uuid;

--- a/compute/cloud-client/src/test/java/compute/disks/DisksIT.java
+++ b/compute/cloud-client/src/test/java/compute/disks/DisksIT.java
@@ -94,7 +94,7 @@ public class DisksIT {
     requireEnvVar("GOOGLE_CLOUD_PROJECT");
 
     ZONE = getZone();
-    REGION = ZONE.substring(0, ZONE.length()-1);
+    REGION = ZONE.substring(0, ZONE.length() - 1);
     String uuid = UUID.randomUUID().toString().split("-")[0];
     INSTANCE_NAME = "test-disks-" + uuid;
     DISK_NAME = "gcloud-test-disk-" + uuid;

--- a/compute/cloud-client/src/test/java/compute/disks/DisksIT.java
+++ b/compute/cloud-client/src/test/java/compute/disks/DisksIT.java
@@ -18,6 +18,7 @@ package compute.disks;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static compute.Util.getZone;
 
 import com.google.cloud.compute.v1.AttachedDisk;
 import com.google.cloud.compute.v1.AttachedDiskInitializeParams;
@@ -92,8 +93,8 @@ public class DisksIT {
     requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
     requireEnvVar("GOOGLE_CLOUD_PROJECT");
 
-    ZONE = "us-central1-a";
-    REGION = "us-central1";
+    ZONE = getZone();
+    REGION = ZONE.substring(0, ZONE.length()-1);
     String uuid = UUID.randomUUID().toString().split("-")[0];
     INSTANCE_NAME = "test-disks-" + uuid;
     DISK_NAME = "gcloud-test-disk-" + uuid;

--- a/compute/cloud-client/src/test/java/compute/disks/SnapshotsIT.java
+++ b/compute/cloud-client/src/test/java/compute/disks/SnapshotsIT.java
@@ -76,7 +76,7 @@ public class SnapshotsIT {
     requireEnvVar("GOOGLE_CLOUD_PROJECT");
 
     ZONE = getZone();
-    LOCATION = ZONE.substring(0, ZONE.length() - 1);
+    LOCATION = ZONE.substring(0, ZONE.length() - 2);
     String uuid = UUID.randomUUID().toString().split("-")[0];
     DISK_NAME = "gcloud-test-disk-" + uuid;
     REGIONAL_DISK_NAME = "gcloud-regional-test-disk-" + uuid;

--- a/compute/cloud-client/src/test/java/compute/disks/SnapshotsIT.java
+++ b/compute/cloud-client/src/test/java/compute/disks/SnapshotsIT.java
@@ -154,8 +154,8 @@ public class SnapshotsIT {
           .setName(diskName)
           .addAllReplicaZones(
               List.of(
-                  String.format("projects/%s/zones/europe-central2-a", projectId),
-                  String.format("projects/%s/zones/europe-central2-b", projectId))
+                  String.format("projects/%s/zones/%s", projectId, LOCATION + "-b"),
+                  String.format("projects/%s/zones/%s", projectId, LOCATION + "-c"))
           )
           .build();
 

--- a/compute/cloud-client/src/test/java/compute/disks/SnapshotsIT.java
+++ b/compute/cloud-client/src/test/java/compute/disks/SnapshotsIT.java
@@ -18,6 +18,7 @@ package compute.disks;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static compute.Util.getZone;
 
 import com.google.cloud.compute.v1.Disk;
 import com.google.cloud.compute.v1.DisksClient;
@@ -74,8 +75,8 @@ public class SnapshotsIT {
     requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
     requireEnvVar("GOOGLE_CLOUD_PROJECT");
 
-    ZONE = "europe-central2-b";
-    LOCATION = "europe-central2";
+    ZONE = getZone();
+    LOCATION = ZONE.substring(0, ZONE.length()-1);
     String uuid = UUID.randomUUID().toString().split("-")[0];
     DISK_NAME = "gcloud-test-disk-" + uuid;
     REGIONAL_DISK_NAME = "gcloud-regional-test-disk-" + uuid;

--- a/compute/cloud-client/src/test/java/compute/disks/SnapshotsIT.java
+++ b/compute/cloud-client/src/test/java/compute/disks/SnapshotsIT.java
@@ -76,7 +76,7 @@ public class SnapshotsIT {
     requireEnvVar("GOOGLE_CLOUD_PROJECT");
 
     ZONE = getZone();
-    LOCATION = ZONE.substring(0, ZONE.length()-1);
+    LOCATION = ZONE.substring(0, ZONE.length() - 1);
     String uuid = UUID.randomUUID().toString().split("-")[0];
     DISK_NAME = "gcloud-test-disk-" + uuid;
     REGIONAL_DISK_NAME = "gcloud-regional-test-disk-" + uuid;

--- a/compute/cloud-client/src/test/java/compute/preemptible/PreemptibleIT.java
+++ b/compute/cloud-client/src/test/java/compute/preemptible/PreemptibleIT.java
@@ -18,6 +18,7 @@ package compute.preemptible;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static compute.Util.getZone;
 
 import com.google.cloud.compute.v1.Operation;
 import com.google.cloud.compute.v1.ZoneOperationsClient.ListPagedResponse;
@@ -44,7 +45,7 @@ import org.junit.runners.JUnit4;
 public class PreemptibleIT {
 
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
-  private static final String ZONE = "us-central1-a";
+  private static final String ZONE = getZone();
   private static String INSTANCE_NAME;
 
   private ByteArrayOutputStream stdOut;

--- a/compute/cloud-client/src/test/java/compute/windows/osimage/WindowsOsImageIT.java
+++ b/compute/cloud-client/src/test/java/compute/windows/osimage/WindowsOsImageIT.java
@@ -16,6 +16,7 @@ package compute.windows.osimage;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static compute.Util.getZone;
 
 import com.google.cloud.compute.v1.AttachedDisk;
 import com.google.cloud.compute.v1.AttachedDiskInitializeParams;
@@ -51,7 +52,7 @@ import org.junit.runners.JUnit4;
 public class WindowsOsImageIT {
 
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
-  private static final String ZONE = "us-central1-a";
+  private static final String ZONE = getZone();
   private static final int MAX_ATTEMPT_COUNT = 3;
   private static final int INITIAL_BACKOFF_MILLIS = 120000; // 2 minutes
   private static String INSTANCE_NAME;

--- a/compute/cloud-client/src/test/java/compute/windows/windowsinstances/CreatingManagingWindowsInstancesIT.java
+++ b/compute/cloud-client/src/test/java/compute/windows/windowsinstances/CreatingManagingWindowsInstancesIT.java
@@ -76,7 +76,8 @@ public class CreatingManagingWindowsInstancesIT {
     INSTANCE_NAME_INTERNAL = "windows-test-instance-internal-" + uuid;
     FIREWALL_RULE_NAME = "windows-test-firewall-" + uuid;
     NETWORK_NAME = "global/networks/default";
-    SUBNETWORK_NAME = "regions/us-central1/subnetworks/default";
+    SUBNETWORK_NAME = String.format("regions/%s/subnetworks/default",
+        ZONE.substring(0, ZONE.length() - 2));
     ROUTE_NAME = "windows-test-route-" + uuid;
 
     stdOut.close();

--- a/compute/cloud-client/src/test/java/compute/windows/windowsinstances/CreatingManagingWindowsInstancesIT.java
+++ b/compute/cloud-client/src/test/java/compute/windows/windowsinstances/CreatingManagingWindowsInstancesIT.java
@@ -16,6 +16,7 @@ package compute.windows.windowsinstances;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static compute.Util.getZone;
 
 import com.google.cloud.compute.v1.RoutesClient;
 import compute.DeleteFirewallRule;
@@ -41,7 +42,7 @@ import org.junit.runners.JUnit4;
 public class CreatingManagingWindowsInstancesIT {
 
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
-  private static final String ZONE = "us-central1-b";
+  private static final String ZONE = getZone();
   private static String INSTANCE_NAME_EXTERNAL;
   private static String INSTANCE_NAME_INTERNAL;
   private static String FIREWALL_RULE_NAME;


### PR DESCRIPTION
## Description

Fixes #8319 and #8384

1. Caught `Assertion Error` in FirewallsIT: Firewall rules are deleted by GCEEnforcer hence leading to flaky assertion.
2. Created a Util method to return random zones for tests. This avoids quota issues.
