### PR TITLE
feat: migrating java-bigqueryconnection snippet

### DIFF
--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -80,7 +80,8 @@ if [[ "$SCRIPT_DEBUG" != "true" ]]; then
     "java-cts-v4-samples-secrets.txt" \
     "java-cloud-sql-samples-secrets.txt" \
     "java-iam-samples-secrets.txt" \
-    "java-scc-samples-secrets.txt")
+    "java-scc-samples-secrets.txt" \
+    "java-bigqueryconnection-samples-secrets.txt")
 
     # create secret dir
     mkdir -p "${KOKORO_GFILE_DIR}/secrets"

--- a/bigquery/bigqueryconnection/snippets/pom.xml
+++ b/bigquery/bigqueryconnection/snippets/pom.xml
@@ -1,0 +1,60 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>bigqueryconnection-snippets</artifactId>
+  <packaging>jar</packaging>
+  <name>Google Cloud BigQuery Connections Snippets</name>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.2.0</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.18.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigqueryconnection</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.1.3</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/bigquery/bigqueryconnection/snippets/pom.xml
+++ b/bigquery/bigqueryconnection/snippets/pom.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.google.cloud</groupId>
+  <groupId>com.example.bigquery</groupId>
   <artifactId>bigqueryconnection-snippets</artifactId>
   <packaging>jar</packaging>
   <name>Google Cloud BigQuery Connections Snippets</name>

--- a/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/CreateAwsConnection.java
+++ b/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/CreateAwsConnection.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigqueryconnection;
+
+// [START bigqueryconnection_create_aws_connection]
+import com.google.cloud.bigquery.connection.v1.AwsAccessRole;
+import com.google.cloud.bigquery.connection.v1.AwsProperties;
+import com.google.cloud.bigquery.connection.v1.Connection;
+import com.google.cloud.bigquery.connection.v1.CreateConnectionRequest;
+import com.google.cloud.bigquery.connection.v1.LocationName;
+import com.google.cloud.bigqueryconnection.v1.ConnectionServiceClient;
+import java.io.IOException;
+
+// Sample to create aws connection
+public class CreateAwsConnection {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    // Example of location: aws-us-east-1
+    String location = "MY_LOCATION";
+    String connectionId = "MY_CONNECTION_ID";
+    // Example of role id: arn:aws:iam::accountId:role/myrole
+    String iamRoleId = "MY_AWS_ROLE_ID";
+    AwsAccessRole role = AwsAccessRole.newBuilder().setIamRoleId(iamRoleId).build();
+    AwsProperties awsProperties = AwsProperties.newBuilder().setAccessRole(role).build();
+    Connection connection = Connection.newBuilder().setAws(awsProperties).build();
+    createAwsConnection(projectId, location, connectionId, connection);
+  }
+
+  public static void createAwsConnection(
+      String projectId, String location, String connectionId, Connection connection)
+      throws IOException {
+    try (ConnectionServiceClient client = ConnectionServiceClient.create()) {
+      LocationName parent = LocationName.of(projectId, location);
+      CreateConnectionRequest request =
+          CreateConnectionRequest.newBuilder()
+              .setParent(parent.toString())
+              .setConnection(connection)
+              .setConnectionId(connectionId)
+              .build();
+      Connection response = client.createConnection(request);
+      AwsAccessRole role = response.getAws().getAccessRole();
+      System.out.println(
+          "Aws connection created successfully : Aws userId :"
+              + role.getIamRoleId()
+              + " Aws externalId :"
+              + role.getIdentity());
+    }
+  }
+}
+// [END bigqueryconnection_create_aws_connection]

--- a/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/CreateAwsConnection.java
+++ b/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/CreateAwsConnection.java
@@ -42,7 +42,7 @@ public class CreateAwsConnection {
     createAwsConnection(projectId, location, connectionId, connection);
   }
 
-  public static void createAwsConnection(
+  static void createAwsConnection(
       String projectId, String location, String connectionId, Connection connection)
       throws IOException {
     try (ConnectionServiceClient client = ConnectionServiceClient.create()) {

--- a/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/CreateConnection.java
+++ b/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/CreateConnection.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigqueryconnection;
+
+// [START bigqueryconnection_create_connection]
+import com.google.cloud.bigquery.connection.v1.CloudSqlCredential;
+import com.google.cloud.bigquery.connection.v1.CloudSqlProperties;
+import com.google.cloud.bigquery.connection.v1.Connection;
+import com.google.cloud.bigquery.connection.v1.CreateConnectionRequest;
+import com.google.cloud.bigquery.connection.v1.LocationName;
+import com.google.cloud.bigqueryconnection.v1.ConnectionServiceClient;
+import java.io.IOException;
+
+// Sample to create a connection with cloud MySql database
+public class CreateConnection {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    String location = "MY_LOCATION";
+    String connectionId = "MY_CONNECTION_ID";
+    String database = "MY_DATABASE";
+    String instance = "MY_INSTANCE";
+    String instanceLocation = "MY_INSTANCE_LOCATION";
+    String username = "MY_USERNAME";
+    String password = "MY_PASSWORD";
+    String instanceId = String.format("%s:%s:%s", projectId, instanceLocation, instance);
+    CloudSqlCredential cloudSqlCredential =
+        CloudSqlCredential.newBuilder().setUsername(username).setPassword(password).build();
+    CloudSqlProperties cloudSqlProperties =
+        CloudSqlProperties.newBuilder()
+            .setType(CloudSqlProperties.DatabaseType.MYSQL)
+            .setDatabase(database)
+            .setInstanceId(instanceId)
+            .setCredential(cloudSqlCredential)
+            .build();
+    Connection connection = Connection.newBuilder().setCloudSql(cloudSqlProperties).build();
+    createConnection(projectId, location, connectionId, connection);
+  }
+
+  public static void createConnection(
+      String projectId, String location, String connectionId, Connection connection)
+      throws IOException {
+    try (ConnectionServiceClient client = ConnectionServiceClient.create()) {
+      LocationName parent = LocationName.of(projectId, location);
+      CreateConnectionRequest request =
+          CreateConnectionRequest.newBuilder()
+              .setParent(parent.toString())
+              .setConnection(connection)
+              .setConnectionId(connectionId)
+              .build();
+      Connection response = client.createConnection(request);
+      System.out.println("Connection created successfully :" + response.getName());
+    }
+  }
+}
+// [END bigqueryconnection_create_connection]

--- a/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/CreateConnection.java
+++ b/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/CreateConnection.java
@@ -52,7 +52,7 @@ public class CreateConnection {
     createConnection(projectId, location, connectionId, connection);
   }
 
-  public static void createConnection(
+  static void createConnection(
       String projectId, String location, String connectionId, Connection connection)
       throws IOException {
     try (ConnectionServiceClient client = ConnectionServiceClient.create()) {

--- a/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/DeleteConnection.java
+++ b/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/DeleteConnection.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigqueryconnection;
+
+// [START bigqueryconnection_delete_connection]
+import com.google.cloud.bigquery.connection.v1.ConnectionName;
+import com.google.cloud.bigquery.connection.v1.DeleteConnectionRequest;
+import com.google.cloud.bigqueryconnection.v1.ConnectionServiceClient;
+import java.io.IOException;
+
+// Sample to delete a connection
+public class DeleteConnection {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    String location = "MY_LOCATION";
+    String connectionName = "MY_CONNECTION_NAME";
+    deleteConnection(projectId, location, connectionName);
+  }
+
+  public static void deleteConnection(String projectId, String location, String connectionName)
+      throws IOException {
+    try (ConnectionServiceClient client = ConnectionServiceClient.create()) {
+      ConnectionName name = ConnectionName.of(projectId, location, connectionName);
+      DeleteConnectionRequest request =
+          DeleteConnectionRequest.newBuilder().setName(name.toString()).build();
+      client.deleteConnection(request);
+      System.out.println("Connection deleted successfully");
+    }
+  }
+}
+// [END bigqueryconnection_delete_connection]

--- a/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/DeleteConnection.java
+++ b/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/DeleteConnection.java
@@ -33,7 +33,7 @@ public class DeleteConnection {
     deleteConnection(projectId, location, connectionName);
   }
 
-  public static void deleteConnection(String projectId, String location, String connectionName)
+  static void deleteConnection(String projectId, String location, String connectionName)
       throws IOException {
     try (ConnectionServiceClient client = ConnectionServiceClient.create()) {
       ConnectionName name = ConnectionName.of(projectId, location, connectionName);

--- a/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/GetConnection.java
+++ b/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/GetConnection.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigqueryconnection;
+
+// [START bigqueryconnection_get_connection]
+import com.google.cloud.bigquery.connection.v1.Connection;
+import com.google.cloud.bigquery.connection.v1.ConnectionName;
+import com.google.cloud.bigquery.connection.v1.GetConnectionRequest;
+import com.google.cloud.bigqueryconnection.v1.ConnectionServiceClient;
+import java.io.IOException;
+
+// Sample to get connection
+public class GetConnection {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    String location = "MY_LOCATION";
+    String connectionId = "MY_CONNECTION_ID";
+    getConnection(projectId, location, connectionId);
+  }
+
+  public static void getConnection(String projectId, String location, String connectionId)
+      throws IOException {
+    try (ConnectionServiceClient client = ConnectionServiceClient.create()) {
+      ConnectionName name = ConnectionName.of(projectId, location, connectionId);
+      GetConnectionRequest request =
+          GetConnectionRequest.newBuilder().setName(name.toString()).build();
+      Connection response = client.getConnection(request);
+      System.out.println("Connection info retrieved successfully :" + response.getName());
+    }
+  }
+}
+// [END bigqueryconnection_get_connection]

--- a/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/GetConnection.java
+++ b/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/GetConnection.java
@@ -34,7 +34,7 @@ public class GetConnection {
     getConnection(projectId, location, connectionId);
   }
 
-  public static void getConnection(String projectId, String location, String connectionId)
+  static void getConnection(String projectId, String location, String connectionId)
       throws IOException {
     try (ConnectionServiceClient client = ConnectionServiceClient.create()) {
       ConnectionName name = ConnectionName.of(projectId, location, connectionId);

--- a/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/ListConnections.java
+++ b/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/ListConnections.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigqueryconnection;
+
+// [START bigqueryconnection_list_connections]
+import com.google.cloud.bigquery.connection.v1.ListConnectionsRequest;
+import com.google.cloud.bigquery.connection.v1.LocationName;
+import com.google.cloud.bigqueryconnection.v1.ConnectionServiceClient;
+import java.io.IOException;
+
+// Sample to get list of connections
+public class ListConnections {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    String location = "MY_LOCATION";
+    listConnections(projectId, location);
+  }
+
+  public static void listConnections(String projectId, String location) throws IOException {
+    try (ConnectionServiceClient client = ConnectionServiceClient.create()) {
+      LocationName parent = LocationName.of(projectId, location);
+      int pageSize = 10;
+      ListConnectionsRequest request =
+          ListConnectionsRequest.newBuilder()
+              .setParent(parent.toString())
+              .setPageSize(pageSize)
+              .build();
+      client
+          .listConnections(request)
+          .iterateAll()
+          .forEach(con -> System.out.println("Connection Id :" + con.getName()));
+    }
+  }
+}
+// [END bigqueryconnection_list_connections]

--- a/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/ListConnections.java
+++ b/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/ListConnections.java
@@ -32,7 +32,7 @@ public class ListConnections {
     listConnections(projectId, location);
   }
 
-  public static void listConnections(String projectId, String location) throws IOException {
+  static void listConnections(String projectId, String location) throws IOException {
     try (ConnectionServiceClient client = ConnectionServiceClient.create()) {
       LocationName parent = LocationName.of(projectId, location);
       int pageSize = 10;

--- a/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/QuickstartSample.java
+++ b/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/QuickstartSample.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigqueryconnection;
+
+// [START bigqueryconnection_quickstart]
+import com.google.cloud.bigquery.connection.v1.ListConnectionsRequest;
+import com.google.cloud.bigquery.connection.v1.LocationName;
+import com.google.cloud.bigqueryconnection.v1.ConnectionServiceClient;
+import java.io.IOException;
+
+// Sample to demonstrates basic usage of the BigQuery connection API.
+public class QuickstartSample {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    String location = "MY_LOCATION";
+    listConnections(projectId, location);
+  }
+
+  public static void listConnections(String projectId, String location) throws IOException {
+    try (ConnectionServiceClient connectionServiceClient = ConnectionServiceClient.create()) {
+      LocationName parent = LocationName.of(projectId, location);
+      int pageSize = 10;
+      ListConnectionsRequest request =
+          ListConnectionsRequest.newBuilder()
+              .setParent(parent.toString())
+              .setPageSize(pageSize)
+              .build();
+      ConnectionServiceClient.ListConnectionsPagedResponse response =
+          connectionServiceClient.listConnections(request);
+
+      // Print the results.
+      System.out.println("List of connections:");
+      response
+          .iterateAll()
+          .forEach(connection -> System.out.println("Connection Name: " + connection.getName()));
+    }
+  }
+}
+// [END bigqueryconnection_quickstart]

--- a/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/QuickstartSample.java
+++ b/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/QuickstartSample.java
@@ -32,7 +32,7 @@ public class QuickstartSample {
     listConnections(projectId, location);
   }
 
-  public static void listConnections(String projectId, String location) throws IOException {
+  static void listConnections(String projectId, String location) throws IOException {
     try (ConnectionServiceClient connectionServiceClient = ConnectionServiceClient.create()) {
       LocationName parent = LocationName.of(projectId, location);
       int pageSize = 10;

--- a/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/ShareConnection.java
+++ b/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/ShareConnection.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigqueryconnection;
+
+// [START bigqueryconnection_share_connection]
+import com.google.api.resourcenames.ResourceName;
+import com.google.cloud.bigquery.connection.v1.ConnectionName;
+import com.google.cloud.bigqueryconnection.v1.ConnectionServiceClient;
+import com.google.iam.v1.Binding;
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.SetIamPolicyRequest;
+import java.io.IOException;
+
+// Sample to share connections
+public class ShareConnection {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    String location = "MY_LOCATION";
+    String connectionId = "MY_CONNECTION_ID";
+    shareConnection(projectId, location, connectionId);
+  }
+
+  public static void shareConnection(String projectId, String location, String connectionId)
+      throws IOException {
+    try (ConnectionServiceClient client = ConnectionServiceClient.create()) {
+      ResourceName resource = ConnectionName.of(projectId, location, connectionId);
+      Binding binding =
+          Binding.newBuilder()
+              .addMembers("group:example-analyst-group@google.com")
+              .setRole("roles/bigquery.connectionUser")
+              .build();
+      Policy policy = Policy.newBuilder().addBindings(binding).build();
+      SetIamPolicyRequest request =
+          SetIamPolicyRequest.newBuilder()
+              .setResource(resource.toString())
+              .setPolicy(policy)
+              .build();
+      client.setIamPolicy(request);
+      System.out.println("Connection shared successfully");
+    }
+  }
+}
+// [END bigqueryconnection_share_connection]

--- a/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/ShareConnection.java
+++ b/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/ShareConnection.java
@@ -36,7 +36,7 @@ public class ShareConnection {
     shareConnection(projectId, location, connectionId);
   }
 
-  public static void shareConnection(String projectId, String location, String connectionId)
+  static void shareConnection(String projectId, String location, String connectionId)
       throws IOException {
     try (ConnectionServiceClient client = ConnectionServiceClient.create()) {
       ResourceName resource = ConnectionName.of(projectId, location, connectionId);

--- a/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/UpdateConnection.java
+++ b/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/UpdateConnection.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigqueryconnection;
+
+// [START bigqueryconnection_update_connection]
+import com.google.cloud.bigquery.connection.v1.Connection;
+import com.google.cloud.bigquery.connection.v1.ConnectionName;
+import com.google.cloud.bigquery.connection.v1.UpdateConnectionRequest;
+import com.google.cloud.bigqueryconnection.v1.ConnectionServiceClient;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.util.FieldMaskUtil;
+import java.io.IOException;
+
+// Sample to update connection
+public class UpdateConnection {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    String location = "MY_LOCATION";
+    String connectionId = "MY_CONNECTION_ID";
+    String description = "MY_DESCRIPTION";
+    Connection connection = Connection.newBuilder().setDescription(description).build();
+    updateConnection(projectId, location, connectionId, connection);
+  }
+
+  public static void updateConnection(
+      String projectId, String location, String connectionId, Connection connection)
+      throws IOException {
+    try (ConnectionServiceClient client = ConnectionServiceClient.create()) {
+      ConnectionName name = ConnectionName.of(projectId, location, connectionId);
+      FieldMask updateMask = FieldMaskUtil.fromString("description");
+      UpdateConnectionRequest request =
+          UpdateConnectionRequest.newBuilder()
+              .setName(name.toString())
+              .setConnection(connection)
+              .setUpdateMask(updateMask)
+              .build();
+      Connection response = client.updateConnection(request);
+      System.out.println("Connection updated successfully :" + response.getDescription());
+    }
+  }
+}
+// [END bigqueryconnection_update_connection]

--- a/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/UpdateConnection.java
+++ b/bigquery/bigqueryconnection/snippets/src/main/java/com/example/bigqueryconnection/UpdateConnection.java
@@ -38,7 +38,7 @@ public class UpdateConnection {
     updateConnection(projectId, location, connectionId, connection);
   }
 
-  public static void updateConnection(
+  static void updateConnection(
       String projectId, String location, String connectionId, Connection connection)
       throws IOException {
     try (ConnectionServiceClient client = ConnectionServiceClient.create()) {

--- a/bigquery/bigqueryconnection/snippets/src/test/java/com/example/bigqueryconnection/CreateAwsConnectionIT.java
+++ b/bigquery/bigqueryconnection/snippets/src/test/java/com/example/bigqueryconnection/CreateAwsConnectionIT.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigqueryconnection;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.connection.v1.AwsAccessRole;
+import com.google.cloud.bigquery.connection.v1.AwsProperties;
+import com.google.cloud.bigquery.connection.v1.Connection;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CreateAwsConnectionIT {
+
+  private static final Logger LOG = Logger.getLogger(CreateAwsConnectionIT.class.getName());
+  private static final String LOCATION = "aws-us-east-1";
+  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  private static final String AWS_ACCOUNT_ID = requireEnvVar("AWS_ACCOUNT_ID");
+  private static final String AWS_ROLE_ID = requireEnvVar("AWS_ROLE_ID");
+
+  private String connectionId;
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+    requireEnvVar("AWS_ACCOUNT_ID");
+    requireEnvVar("AWS_ROLE_ID");
+  }
+
+  @Before
+  public void setUp() {
+    connectionId = "CREATE_AWS_CONNECTION_TEST_" + UUID.randomUUID().toString().substring(0, 8);
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    // Clean up
+    DeleteConnection.deleteConnection(PROJECT_ID, LOCATION, connectionId);
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testCreateAwsConnection() throws IOException {
+    String iamRoleId = String.format("arn:aws:iam::%s:role/%s", AWS_ACCOUNT_ID, AWS_ROLE_ID);
+    AwsAccessRole awsRole = AwsAccessRole.newBuilder().setIamRoleId(iamRoleId).build();
+    AwsProperties awsProperties = AwsProperties.newBuilder().setAccessRole(awsRole).build();
+    Connection connection = Connection.newBuilder().setAws(awsProperties).build();
+    CreateAwsConnection.createAwsConnection(PROJECT_ID, LOCATION, connectionId, connection);
+    assertThat(bout.toString()).contains("Aws connection created successfully :");
+  }
+}

--- a/bigquery/bigqueryconnection/snippets/src/test/java/com/example/bigqueryconnection/CreateConnectionIT.java
+++ b/bigquery/bigqueryconnection/snippets/src/test/java/com/example/bigqueryconnection/CreateConnectionIT.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigqueryconnection;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.connection.v1.CloudSqlCredential;
+import com.google.cloud.bigquery.connection.v1.CloudSqlProperties;
+import com.google.cloud.bigquery.connection.v1.Connection;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CreateConnectionIT {
+
+  private static final Logger LOG = Logger.getLogger(CreateConnectionIT.class.getName());
+  private static final String LOCATION = "US";
+  private static final String REGION = "us-central1";
+  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  private static final String MY_SQL_DATABASE = requireEnvVar("MY_SQL_DATABASE");
+  private static final String MY_SQL_INSTANCE = requireEnvVar("MY_SQL_INSTANCE");
+  private static final String DB_USER = requireEnvVar("DB_USER");
+  private static final String DB_PWD = requireEnvVar("DB_PWD");
+
+  private String connectionId;
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+    requireEnvVar("MY_SQL_DATABASE");
+    requireEnvVar("MY_SQL_INSTANCE");
+    requireEnvVar("DB_USER");
+    requireEnvVar("DB_PWD");
+  }
+
+  @Before
+  public void setUp() {
+    connectionId = "CREATE_CONNECTION_TEST_" + UUID.randomUUID().toString().substring(0, 8);
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    // Clean up
+    DeleteConnection.deleteConnection(PROJECT_ID, LOCATION, connectionId);
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testCreateConnection() throws IOException {
+    String instanceId = String.format("%s:%s:%s", PROJECT_ID, REGION, MY_SQL_INSTANCE);
+    CloudSqlCredential cloudSqlCredential =
+        CloudSqlCredential.newBuilder().setUsername(DB_USER).setPassword(DB_PWD).build();
+    CloudSqlProperties cloudSqlProperties =
+        CloudSqlProperties.newBuilder()
+            .setType(CloudSqlProperties.DatabaseType.MYSQL)
+            .setDatabase(MY_SQL_DATABASE)
+            .setInstanceId(instanceId)
+            .setCredential(cloudSqlCredential)
+            .build();
+    Connection connection =
+        Connection.newBuilder()
+            .setFriendlyName(connectionId)
+            .setCloudSql(cloudSqlProperties)
+            .build();
+    CreateConnection.createConnection(PROJECT_ID, LOCATION, connectionId, connection);
+    assertThat(bout.toString()).contains("Connection created successfully :");
+  }
+}

--- a/bigquery/bigqueryconnection/snippets/src/test/java/com/example/bigqueryconnection/DeleteConnectionIT.java
+++ b/bigquery/bigqueryconnection/snippets/src/test/java/com/example/bigqueryconnection/DeleteConnectionIT.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigqueryconnection;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.connection.v1.CloudSqlCredential;
+import com.google.cloud.bigquery.connection.v1.CloudSqlProperties;
+import com.google.cloud.bigquery.connection.v1.Connection;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DeleteConnectionIT {
+
+  private static final Logger LOG = Logger.getLogger(DeleteConnectionIT.class.getName());
+  private static final String LOCATION = "US";
+  private static final String REGION = "us-central1";
+  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  private static final String MY_SQL_DATABASE = requireEnvVar("MY_SQL_DATABASE");
+  private static final String MY_SQL_INSTANCE = requireEnvVar("MY_SQL_INSTANCE");
+  private static final String DB_USER = requireEnvVar("DB_USER");
+  private static final String DB_PWD = requireEnvVar("DB_PWD");
+
+  private String connectionId;
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+    requireEnvVar("MY_SQL_DATABASE");
+    requireEnvVar("MY_SQL_INSTANCE");
+    requireEnvVar("DB_USER");
+    requireEnvVar("DB_PWD");
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+    // create a temporary connection
+    connectionId = "DELETE_CONNECTION_TEST_" + UUID.randomUUID().toString().substring(0, 8);
+    String instanceId = String.format("%s:%s:%s", PROJECT_ID, REGION, MY_SQL_INSTANCE);
+    CloudSqlCredential cloudSqlCredential =
+        CloudSqlCredential.newBuilder().setUsername(DB_USER).setPassword(DB_PWD).build();
+    CloudSqlProperties cloudSqlProperties =
+        CloudSqlProperties.newBuilder()
+            .setType(CloudSqlProperties.DatabaseType.MYSQL)
+            .setDatabase(MY_SQL_DATABASE)
+            .setInstanceId(instanceId)
+            .setCredential(cloudSqlCredential)
+            .build();
+    Connection connection = Connection.newBuilder().setCloudSql(cloudSqlProperties).build();
+    CreateConnection.createConnection(PROJECT_ID, LOCATION, connectionId, connection);
+  }
+
+  @After
+  public void tearDown() {
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testDeleteConnection() throws IOException {
+    DeleteConnection.deleteConnection(PROJECT_ID, LOCATION, connectionId);
+    assertThat(bout.toString()).contains("Connection deleted successfully");
+  }
+}

--- a/bigquery/bigqueryconnection/snippets/src/test/java/com/example/bigqueryconnection/GetConnectionIT.java
+++ b/bigquery/bigqueryconnection/snippets/src/test/java/com/example/bigqueryconnection/GetConnectionIT.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigqueryconnection;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.connection.v1.CloudSqlCredential;
+import com.google.cloud.bigquery.connection.v1.CloudSqlProperties;
+import com.google.cloud.bigquery.connection.v1.Connection;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class GetConnectionIT {
+
+  private static final Logger LOG = Logger.getLogger(GetConnectionIT.class.getName());
+  private static final String LOCATION = "US";
+  private static final String REGION = "us-central1";
+  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  private static final String MY_SQL_DATABASE = requireEnvVar("MY_SQL_DATABASE");
+  private static final String MY_SQL_INSTANCE = requireEnvVar("MY_SQL_INSTANCE");
+  private static final String DB_USER = requireEnvVar("DB_USER");
+  private static final String DB_PWD = requireEnvVar("DB_PWD");
+
+  private String connectionId;
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+    requireEnvVar("MY_SQL_DATABASE");
+    requireEnvVar("MY_SQL_INSTANCE");
+    requireEnvVar("DB_USER");
+    requireEnvVar("DB_PWD");
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+    // create a temporary connection
+    connectionId = "GET_CONNECTION_TEST_" + UUID.randomUUID().toString().substring(0, 8);
+    String instanceId = String.format("%s:%s:%s", PROJECT_ID, REGION, MY_SQL_INSTANCE);
+    CloudSqlCredential cloudSqlCredential =
+        CloudSqlCredential.newBuilder().setUsername(DB_USER).setPassword(DB_PWD).build();
+    CloudSqlProperties cloudSqlProperties =
+        CloudSqlProperties.newBuilder()
+            .setType(CloudSqlProperties.DatabaseType.MYSQL)
+            .setDatabase(MY_SQL_DATABASE)
+            .setInstanceId(instanceId)
+            .setCredential(cloudSqlCredential)
+            .build();
+    Connection connection = Connection.newBuilder().setCloudSql(cloudSqlProperties).build();
+    CreateConnection.createConnection(PROJECT_ID, LOCATION, connectionId, connection);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    // Clean up
+    DeleteConnection.deleteConnection(PROJECT_ID, LOCATION, connectionId);
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testGetConnection() throws IOException {
+    GetConnection.getConnection(PROJECT_ID, LOCATION, connectionId);
+    assertThat(bout.toString()).contains("Connection info retrieved successfully :");
+  }
+}

--- a/bigquery/bigqueryconnection/snippets/src/test/java/com/example/bigqueryconnection/ListConnectionsIT.java
+++ b/bigquery/bigqueryconnection/snippets/src/test/java/com/example/bigqueryconnection/ListConnectionsIT.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigqueryconnection;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+import com.google.cloud.bigquery.connection.v1.CloudSqlCredential;
+import com.google.cloud.bigquery.connection.v1.CloudSqlProperties;
+import com.google.cloud.bigquery.connection.v1.Connection;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ListConnectionsIT {
+
+  private static final Logger LOG = Logger.getLogger(ListConnectionsIT.class.getName());
+  private static final String LOCATION = "US";
+  private static final String REGION = "us-central1";
+  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  private static final String MY_SQL_DATABASE = requireEnvVar("MY_SQL_DATABASE");
+  private static final String MY_SQL_INSTANCE = requireEnvVar("MY_SQL_INSTANCE");
+  private static final String DB_USER = requireEnvVar("DB_USER");
+  private static final String DB_PWD = requireEnvVar("DB_PWD");
+
+  private String connectionId;
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+    requireEnvVar("MY_SQL_DATABASE");
+    requireEnvVar("MY_SQL_INSTANCE");
+    requireEnvVar("DB_USER");
+    requireEnvVar("DB_PWD");
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+    // create a temporary connection
+    connectionId = "LIST_CONNECTIONS_TEST_" + UUID.randomUUID().toString().substring(0, 8);
+    String instanceId = String.format("%s:%s:%s", PROJECT_ID, REGION, MY_SQL_INSTANCE);
+    CloudSqlCredential cloudSqlCredential =
+        CloudSqlCredential.newBuilder().setUsername(DB_USER).setPassword(DB_PWD).build();
+    CloudSqlProperties cloudSqlProperties =
+        CloudSqlProperties.newBuilder()
+            .setType(CloudSqlProperties.DatabaseType.MYSQL)
+            .setDatabase(MY_SQL_DATABASE)
+            .setInstanceId(instanceId)
+            .setCredential(cloudSqlCredential)
+            .build();
+    Connection connection = Connection.newBuilder().setCloudSql(cloudSqlProperties).build();
+    CreateConnection.createConnection(PROJECT_ID, LOCATION, connectionId, connection);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    // Clean up
+    DeleteConnection.deleteConnection(PROJECT_ID, LOCATION, connectionId);
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testListConnections() throws IOException {
+    ListConnections.listConnections(PROJECT_ID, LOCATION);
+    assertThat(bout.toString()).contains("Connection Id :");
+  }
+}

--- a/bigquery/bigqueryconnection/snippets/src/test/java/com/example/bigqueryconnection/QuickstartSampleIT.java
+++ b/bigquery/bigqueryconnection/snippets/src/test/java/com/example/bigqueryconnection/QuickstartSampleIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigqueryconnection;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class QuickstartSampleIT {
+
+  private static final Logger LOG = Logger.getLogger(QuickstartSampleIT.class.getName());
+  private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testQuickstart() throws IOException {
+    QuickstartSample.listConnections(PROJECT_ID, "US");
+    assertThat(bout.toString()).contains("List of connections:");
+  }
+}

--- a/bigquery/bigqueryconnection/snippets/src/test/java/com/example/bigqueryconnection/ShareConnectionIT.java
+++ b/bigquery/bigqueryconnection/snippets/src/test/java/com/example/bigqueryconnection/ShareConnectionIT.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigqueryconnection;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.connection.v1.CloudSqlCredential;
+import com.google.cloud.bigquery.connection.v1.CloudSqlProperties;
+import com.google.cloud.bigquery.connection.v1.Connection;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ShareConnectionIT {
+
+  private static final Logger LOG = Logger.getLogger(ShareConnectionIT.class.getName());
+  private static final String LOCATION = "US";
+  private static final String REGION = "us-central1";
+  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  private static final String MY_SQL_DATABASE = requireEnvVar("MY_SQL_DATABASE");
+  private static final String MY_SQL_INSTANCE = requireEnvVar("MY_SQL_INSTANCE");
+  private static final String DB_USER = requireEnvVar("DB_USER");
+  private static final String DB_PWD = requireEnvVar("DB_PWD");
+
+  private String connectionId;
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+    requireEnvVar("MY_SQL_DATABASE");
+    requireEnvVar("MY_SQL_INSTANCE");
+    requireEnvVar("DB_USER");
+    requireEnvVar("DB_PWD");
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+    // create a temporary connection
+    connectionId = "SHARE_CONNECTION_TEST_" + UUID.randomUUID().toString().substring(0, 8);
+    String instanceId = String.format("%s:%s:%s", PROJECT_ID, REGION, MY_SQL_INSTANCE);
+    CloudSqlCredential cloudSqlCredential =
+        CloudSqlCredential.newBuilder().setUsername(DB_USER).setPassword(DB_PWD).build();
+    CloudSqlProperties cloudSqlProperties =
+        CloudSqlProperties.newBuilder()
+            .setType(CloudSqlProperties.DatabaseType.MYSQL)
+            .setDatabase(MY_SQL_DATABASE)
+            .setInstanceId(instanceId)
+            .setCredential(cloudSqlCredential)
+            .build();
+    Connection connection = Connection.newBuilder().setCloudSql(cloudSqlProperties).build();
+    CreateConnection.createConnection(PROJECT_ID, LOCATION, connectionId, connection);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    // Clean up
+    DeleteConnection.deleteConnection(PROJECT_ID, LOCATION, connectionId);
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testShareConnection() throws IOException {
+    ShareConnection.shareConnection(PROJECT_ID, LOCATION, connectionId);
+    assertThat(bout.toString()).contains("Connection shared successfully");
+  }
+}

--- a/bigquery/bigqueryconnection/snippets/src/test/java/com/example/bigqueryconnection/UpdateConnectionIT.java
+++ b/bigquery/bigqueryconnection/snippets/src/test/java/com/example/bigqueryconnection/UpdateConnectionIT.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigqueryconnection;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.connection.v1.CloudSqlCredential;
+import com.google.cloud.bigquery.connection.v1.CloudSqlProperties;
+import com.google.cloud.bigquery.connection.v1.Connection;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class UpdateConnectionIT {
+
+  private static final Logger LOG = Logger.getLogger(UpdateConnectionIT.class.getName());
+  private static final String LOCATION = "US";
+  private static final String REGION = "us-central1";
+  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  private static final String MY_SQL_DATABASE = requireEnvVar("MY_SQL_DATABASE");
+  private static final String MY_SQL_INSTANCE = requireEnvVar("MY_SQL_INSTANCE");
+  private static final String DB_USER = requireEnvVar("DB_USER");
+  private static final String DB_PWD = requireEnvVar("DB_PWD");
+
+  private String connectionId;
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+    requireEnvVar("MY_SQL_DATABASE");
+    requireEnvVar("MY_SQL_INSTANCE");
+    requireEnvVar("DB_USER");
+    requireEnvVar("DB_PWD");
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+    // create a temporary connection
+    connectionId = "UPDATE_CONNECTION_TEST_" + UUID.randomUUID().toString().substring(0, 8);
+    String instanceId = String.format("%s:%s:%s", PROJECT_ID, REGION, MY_SQL_INSTANCE);
+    CloudSqlCredential cloudSqlCredential =
+        CloudSqlCredential.newBuilder().setUsername(DB_USER).setPassword(DB_PWD).build();
+    CloudSqlProperties cloudSqlProperties =
+        CloudSqlProperties.newBuilder()
+            .setType(CloudSqlProperties.DatabaseType.MYSQL)
+            .setDatabase(MY_SQL_DATABASE)
+            .setInstanceId(instanceId)
+            .setCredential(cloudSqlCredential)
+            .build();
+    Connection connection = Connection.newBuilder().setCloudSql(cloudSqlProperties).build();
+    CreateConnection.createConnection(PROJECT_ID, LOCATION, connectionId, connection);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    // Clean up
+    DeleteConnection.deleteConnection(PROJECT_ID, LOCATION, connectionId);
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testUpdateConnection() throws IOException {
+    String description = "MY_DESCRIPTION";
+    Connection connection = Connection.newBuilder().setDescription(description).build();
+    UpdateConnection.updateConnection(PROJECT_ID, LOCATION, connectionId, connection);
+    assertThat(bout.toString()).contains("Connection updated successfully :");
+  }
+}


### PR DESCRIPTION
Migrating the snippet from googleapis/java-bigqueryconnection https://github.com/googleapis/java-bigqueryconnection/tree/8e1577003242eb019fb07be51fc7b874613e9d3b/samples/snippets

These tests ran fine in https://source.cloud.google.com/results/invocations/bef3f8f1-575b-49e6-979c-cf69c91505f4/targets (May)


## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [x] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [x] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
