### PR TITLE
cdn/signed-urls: use correct HMac algorithm

### DIFF
--- a/cdn/signed-urls/src/main/java/com/google/cdn/SignedCookies.java
+++ b/cdn/signed-urls/src/main/java/com/google/cdn/SignedCookies.java
@@ -89,7 +89,7 @@ public class SignedCookies {
   private static String getSignatureForUrl(byte[] privateKey, String input)
       throws InvalidKeyException, NoSuchAlgorithmException {
 
-    final String algorithm = "HmacSHA256";
+    final String algorithm = "HmacSHA1";
     final int offset = 0;
     Key key = new SecretKeySpec(privateKey, offset, privateKey.length, algorithm);
     Mac mac = Mac.getInstance(algorithm);

--- a/cdn/signed-urls/src/main/java/com/google/cdn/SignedUrlWithPrefix.java
+++ b/cdn/signed-urls/src/main/java/com/google/cdn/SignedUrlWithPrefix.java
@@ -94,7 +94,7 @@ public class SignedUrlWithPrefix {
   private static String getSignatureForUrl(byte[] privateKey, String input)
       throws InvalidKeyException, NoSuchAlgorithmException {
 
-    final String algorithm = "HmacSHA256";
+    final String algorithm = "HmacSHA1";
     final int offset = 0;
     Key key = new SecretKeySpec(privateKey, offset, privateKey.length, algorithm);
     Mac mac = Mac.getInstance(algorithm);

--- a/cdn/signed-urls/src/main/java/com/google/cdn/SignedUrls.java
+++ b/cdn/signed-urls/src/main/java/com/google/cdn/SignedUrls.java
@@ -44,7 +44,7 @@ public class SignedUrls {
    * @param expirationTime the date that the signed URL expires
    * @return a properly formatted signed URL
    * @throws InvalidKeyException when there is an error generating the signature for the input key
-   * @throws NoSuchAlgorithmException when HmacSHA256 algorithm is not available in the environment
+   * @throws NoSuchAlgorithmException when HmacSHA1 algorithm is not available in the environment
    */
   public static String signUrl(String url,
                                byte[] key,
@@ -66,7 +66,7 @@ public class SignedUrls {
   public static String getSignature(byte[] privateKey, String input)
       throws InvalidKeyException, NoSuchAlgorithmException {
 
-    final String algorithm = "HmacSHA256";
+    final String algorithm = "HmacSHA1";
     final int offset = 0;
     Key key = new SecretKeySpec(privateKey, offset, privateKey.length, algorithm);
     Mac mac = Mac.getInstance(algorithm);

--- a/cdn/signed-urls/src/test/java/com/google/cdn/SignedCookiesTest.java
+++ b/cdn/signed-urls/src/test/java/com/google/cdn/SignedCookiesTest.java
@@ -42,7 +42,7 @@ public class SignedCookiesTest {
     final String expected = "Cloud-CDN-Cookie="
         + "URLPrefix=aHR0cHM6Ly9tZWRpYS5leGFtcGxlLmNvbS92aWRlb3Mv"
         + ":Expires=1518135754:KeyName=my-key"
-        + ":Signature=sj6vcaTzRh0UWbbfjEKyKUKRyFOhdrWriGsOLy6aW2M=";
+        + ":Signature=c2oZduDcTH36_bCbO-hEoaLc_5o=";
     assertEquals(expected, result);
   }
 

--- a/cdn/signed-urls/src/test/java/com/google/cdn/SignedUrlWithPrefixTest.java
+++ b/cdn/signed-urls/src/test/java/com/google/cdn/SignedUrlWithPrefixTest.java
@@ -40,7 +40,7 @@ public class SignedUrlWithPrefixTest {
   @Test
   public void testUrlPathSignedWithPrefix() throws Exception {
     String result = signUrlWithPrefix(REQUEST_URL, URL_PREFIX, KEY_BYTES, KEY_NAME, EXPIRATION);
-    final String expected = "https://media.example.com/videos/id/main.m3u8?userID=abc123&starting_profile=1&URLPrefix=aHR0cHM6Ly9tZWRpYS5leGFtcGxlLmNvbS92aWRlb3Mv&Expires=1518135754&KeyName=my-key&Signature=FHY8GYuIs-7-ZUnmBFjGryFTxBHmnl90dIgC1jq_MSE=";
+    final String expected = "https://media.example.com/videos/id/main.m3u8?userID=abc123&starting_profile=1&URLPrefix=aHR0cHM6Ly9tZWRpYS5leGFtcGxlLmNvbS92aWRlb3Mv&Expires=1518135754&KeyName=my-key&Signature=SPov5sp5XKefUpuJaqUckinUO_4=";
     assertEquals(expected, result);
   }
 

--- a/cdn/signed-urls/src/test/java/com/google/cdn/SignedUrlsTest.java
+++ b/cdn/signed-urls/src/test/java/com/google/cdn/SignedUrlsTest.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package com.google.cdn;
 
 import static com.google.cdn.SignedUrls.signUrl;
@@ -41,22 +40,21 @@ public class SignedUrlsTest {
   @Test
   public void testUrlPath() throws Exception {
     String result = signUrl(BASE_URL + "foo", KEY_BYTES, KEY_NAME, EXPIRATION);
-    final String expected = "https://www.example.com/foo?Expires=1518135754&KeyName=my-key&Signature=lwLX4Vs5nAyKSc-AdJ7KzwCo3jBOmxV0Wxao8TRZsjE=";
+    final String expected = "https://www.example.com/foo?Expires=1518135754&KeyName=my-key&Signature=vUfG4yv47dyns1j9e_OI6_5meuA=";
     assertEquals(expected, result);
   }
 
   @Test
   public void testUrlParams() throws Exception {
     String result = signUrl(BASE_URL + "?param=true", KEY_BYTES, KEY_NAME, EXPIRATION);
-    final String expected = "https://www.example.com/?param=true&Expires=1518135754&KeyName=my-key&Signature=01iXNEFfnf4gIoQSerxC7gjTlGv24NV7_Ungxr_MNFI=";
+    final String expected = "https://www.example.com/?param=true&Expires=1518135754&KeyName=my-key&Signature=6TijW8OMX3gcMI5Kqs8ESiPY97c=";
     assertEquals(expected, result);
   }
-
 
   @Test
   public void testStandard() throws Exception {
     String result = signUrl(BASE_URL, KEY_BYTES, KEY_NAME, EXPIRATION);
-    final String expected = "https://www.example.com/?Expires=1518135754&KeyName=my-key&Signature=wTub7cBBwT_6tYugpzp8A5xW6flFn0l9YrUioxadDN0=";
+    final String expected = "https://www.example.com/?Expires=1518135754&KeyName=my-key&Signature=4D0AbT4y0O7ZCzCUcAtPOJDkl2g=";
     assertEquals(expected, result);
   }
 }


### PR DESCRIPTION
The Cloud CDN Signed URLs and Signed Cookies features expect signatures to be created with the HMAC-SHA1 algorithm; Google's servers validate signatures using this algorithm. PRs #8103, #8136, and #8183 updated the Java code samples to use HMAC-SHA256 instead, based on the argument that according to GCP's KMS docs on choosing a good algorithm, HMAC-SHA256 is recommended.

While it may be a better algorithm to use when designing a new system, it is not the algorithm used by the Signed URLs and Signed Cookies feature, so these code samples are currently 100% wrong and do not actually work to implement URL/cookie signing! (Fortunately the non-Java code samples are still correct.)

This PR reverts changes made in the above PRs to use the correct HMAC-SHA1 algorithm.

## Description

Fixes #8418

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [x] Appropriate changes to README are included in PR
- [x] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [x] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
