### PR TITLE
fix: remove deprecated method from bigtable change-streams sample

### DIFF
--- a/bigtable/beam/change-streams/pom.xml
+++ b/bigtable/beam/change-streams/pom.xml
@@ -45,7 +45,7 @@
       <dependency>
         <groupId>org.apache.beam</groupId>
         <artifactId>beam-sdks-java-bom</artifactId>
-        <version>2.48.0</version>
+        <version>2.49.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bigtable/beam/change-streams/src/main/java/SongRank.java
+++ b/bigtable/beam/change-streams/src/main/java/SongRank.java
@@ -64,7 +64,6 @@ public class SongRank {
                 .withInstanceId(options.getBigtableInstanceId())
                 .withTableId(options.getBigtableTableId())
                 .withAppProfileId(options.getBigtableAppProfile())
-                .withHeartbeatDuration(Duration.standardSeconds(1))
 
         )
         // [END bigtable_cdc_tut_readchangestream]


### PR DESCRIPTION
The `withHeartbeatDuration()` method was [removed](https://github.com/apache/beam/pull/27249) in the 2.49.0 Beam release, causing this sample to no longer compile with 2.49.0. The sample will now use the default value of 5 seconds.