### PR TITLE
feat: migrating bigquerydatatransfer snippet

### DIFF
--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -81,7 +81,8 @@ if [[ "$SCRIPT_DEBUG" != "true" ]]; then
     "java-cloud-sql-samples-secrets.txt" \
     "java-iam-samples-secrets.txt" \
     "java-scc-samples-secrets.txt" \
-    "java-bigqueryconnection-samples-secrets.txt")
+    "java-bigqueryconnection-samples-secrets.txt" \
+    "java-bigquerydatatransfer-samples-secrets.txt")
 
     # create secret dir
     mkdir -p "${KOKORO_GFILE_DIR}/secrets"

--- a/bigquery/bigquerydatatransfer/snippets/pom.xml
+++ b/bigquery/bigquerydatatransfer/snippets/pom.xml
@@ -1,0 +1,75 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.bigquery</groupId>
+  <artifactId>bigquerydatatransfer-snippets</artifactId>
+  <packaging>jar</packaging>
+  <name>Google Cloud BigQuery Data Transfer Service Snippets</name>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.2.0</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+
+  <!-- [START bigquerydatatransfer_install_with_bom] -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.18.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigquerydatatransfer</artifactId>
+    </dependency>
+    <!-- [END bigquerydatatransfer_install_with_bom] -->
+
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigquery</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-pubsub</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CopyDataset.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CopyDataset.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_copy_dataset]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.CreateTransferConfigRequest;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.ProjectName;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+// Sample to copy dataset from another gcp project
+public class CopyDataset {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    final String destinationProjectId = "MY_DESTINATION_PROJECT_ID";
+    final String destinationDatasetId = "MY_DESTINATION_DATASET_ID";
+    final String sourceProjectId = "MY_SOURCE_PROJECT_ID";
+    final String sourceDatasetId = "MY_SOURCE_DATASET_ID";
+    Map<String, Value> params = new HashMap<>();
+    params.put("source_project_id", Value.newBuilder().setStringValue(sourceProjectId).build());
+    params.put("source_dataset_id", Value.newBuilder().setStringValue(sourceDatasetId).build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(destinationDatasetId)
+            .setDisplayName("Your Dataset Copy Name")
+            .setDataSourceId("cross_region_copy")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .setSchedule("every 24 hours")
+            .build();
+    copyDataset(destinationProjectId, transferConfig);
+  }
+
+  public static void copyDataset(String projectId, TransferConfig transferConfig)
+      throws IOException {
+    try (DataTransferServiceClient dataTransferServiceClient = DataTransferServiceClient.create()) {
+      ProjectName parent = ProjectName.of(projectId);
+      CreateTransferConfigRequest request =
+          CreateTransferConfigRequest.newBuilder()
+              .setParent(parent.toString())
+              .setTransferConfig(transferConfig)
+              .build();
+      TransferConfig config = dataTransferServiceClient.createTransferConfig(request);
+      System.out.println("Copy dataset created successfully :" + config.getName());
+    } catch (ApiException ex) {
+      System.out.print("Copy dataset was not created." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_copy_dataset]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateAdManagerTransfer.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateAdManagerTransfer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_create_admanager_transfer]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.CreateTransferConfigRequest;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.ProjectName;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+// Sample to create a ad manager(formerly DFP) transfer config
+public class CreateAdManagerTransfer {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    final String projectId = "MY_PROJECT_ID";
+    String datasetId = "MY_DATASET_ID";
+    String bucket = "gs://cloud-sample-data";
+    // the network_code can only be digits with length 1 to 15
+    String networkCode = "12345678";
+    Map<String, Value> params = new HashMap<>();
+    params.put("bucket", Value.newBuilder().setStringValue(bucket).build());
+    params.put("network_code", Value.newBuilder().setStringValue(networkCode).build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(datasetId)
+            .setDisplayName("Your Ad Manager Config Name")
+            .setDataSourceId("dfp_dt")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .build();
+    createAdManagerTransfer(projectId, transferConfig);
+  }
+
+  public static void createAdManagerTransfer(String projectId, TransferConfig transferConfig)
+      throws IOException {
+    try (DataTransferServiceClient client = DataTransferServiceClient.create()) {
+      ProjectName parent = ProjectName.of(projectId);
+      CreateTransferConfigRequest request =
+          CreateTransferConfigRequest.newBuilder()
+              .setParent(parent.toString())
+              .setTransferConfig(transferConfig)
+              .build();
+      TransferConfig config = client.createTransferConfig(request);
+      System.out.println("Ad manager transfer created successfully :" + config.getName());
+    } catch (ApiException ex) {
+      System.out.print("Ad manager transfer was not created." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_create_admanager_transfer]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateAdsTransfer.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateAdsTransfer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_create_ads_transfer]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.CreateTransferConfigRequest;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.ProjectName;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+// Sample to create ads(formerly AdWords) transfer config
+public class CreateAdsTransfer {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    final String projectId = "MY_PROJECT_ID";
+    String datasetId = "MY_DATASET_ID";
+    // the customer_id only allows digits and hyphen ('-').
+    String customerId = "012-345-6789";
+    String refreshWindow = "100";
+    Map<String, Value> params = new HashMap<>();
+    params.put("customer_id", Value.newBuilder().setStringValue(customerId).build());
+    params.put("refreshWindow", Value.newBuilder().setStringValue(refreshWindow).build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(datasetId)
+            .setDisplayName("Your Ads Transfer Config Name")
+            .setDataSourceId("adwords")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .build();
+    createAdsTransfer(projectId, transferConfig);
+  }
+
+  public static void createAdsTransfer(String projectId, TransferConfig transferConfig)
+      throws IOException {
+    try (DataTransferServiceClient client = DataTransferServiceClient.create()) {
+      ProjectName parent = ProjectName.of(projectId);
+      CreateTransferConfigRequest request =
+          CreateTransferConfigRequest.newBuilder()
+              .setParent(parent.toString())
+              .setTransferConfig(transferConfig)
+              .build();
+      TransferConfig config = client.createTransferConfig(request);
+      System.out.println("Ads transfer created successfully :" + config.getName());
+    } catch (ApiException ex) {
+      System.out.print("Ads transfer was not created." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_create_ads_transfer]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateAmazonS3Transfer.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateAmazonS3Transfer.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_create_amazons3_transfer]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.CreateTransferConfigRequest;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.ProjectName;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+// Sample to create amazon s3 transfer config.
+public class CreateAmazonS3Transfer {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    final String projectId = "MY_PROJECT_ID";
+    String datasetId = "MY_DATASET_ID";
+    String tableId = "MY_TABLE_ID";
+    // Amazon S3 Bucket Uri with read role permission
+    String sourceUri = "s3://your-bucket-name/*";
+    String awsAccessKeyId = "MY_AWS_ACCESS_KEY_ID";
+    String awsSecretAccessId = "AWS_SECRET_ACCESS_ID";
+    String sourceFormat = "CSV";
+    String fieldDelimiter = ",";
+    String skipLeadingRows = "1";
+    Map<String, Value> params = new HashMap<>();
+    params.put(
+        "destination_table_name_template", Value.newBuilder().setStringValue(tableId).build());
+    params.put("data_path", Value.newBuilder().setStringValue(sourceUri).build());
+    params.put("access_key_id", Value.newBuilder().setStringValue(awsAccessKeyId).build());
+    params.put("secret_access_key", Value.newBuilder().setStringValue(awsSecretAccessId).build());
+    params.put("source_format", Value.newBuilder().setStringValue(sourceFormat).build());
+    params.put("field_delimiter", Value.newBuilder().setStringValue(fieldDelimiter).build());
+    params.put("skip_leading_rows", Value.newBuilder().setStringValue(skipLeadingRows).build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(datasetId)
+            .setDisplayName("Your Aws S3 Config Name")
+            .setDataSourceId("amazon_s3")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .setSchedule("every 24 hours")
+            .build();
+    createAmazonS3Transfer(projectId, transferConfig);
+  }
+
+  public static void createAmazonS3Transfer(String projectId, TransferConfig transferConfig)
+      throws IOException {
+    try (DataTransferServiceClient client = DataTransferServiceClient.create()) {
+      ProjectName parent = ProjectName.of(projectId);
+      CreateTransferConfigRequest request =
+          CreateTransferConfigRequest.newBuilder()
+              .setParent(parent.toString())
+              .setTransferConfig(transferConfig)
+              .build();
+      TransferConfig config = client.createTransferConfig(request);
+      System.out.println("Amazon s3 transfer created successfully :" + config.getName());
+    } catch (ApiException ex) {
+      System.out.print("Amazon s3 transfer was not created." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_create_amazons3_transfer]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateCampaignmanagerTransfer.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateCampaignmanagerTransfer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_create_campaignmanager_transfer]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.CreateTransferConfigRequest;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.ProjectName;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+// Sample to create campaign manager transfer config
+public class CreateCampaignmanagerTransfer {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    final String projectId = "MY_PROJECT_ID";
+    String datasetId = "MY_DATASET_ID";
+    String bucket = "gs://cloud-sample-data";
+    // the network_id only allows digits
+    String networkId = "7878";
+    String fileNamePrefix = "test_";
+    Map<String, Value> params = new HashMap<>();
+    params.put("bucket", Value.newBuilder().setStringValue(bucket).build());
+    params.put("network_id", Value.newBuilder().setStringValue(networkId).build());
+    params.put("file_name_prefix", Value.newBuilder().setStringValue(fileNamePrefix).build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(datasetId)
+            .setDisplayName("Your Campaignmanager Config Name")
+            .setDataSourceId("dcm_dt")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .build();
+    createCampaignmanagerTransfer(projectId, transferConfig);
+  }
+
+  public static void createCampaignmanagerTransfer(String projectId, TransferConfig transferConfig)
+      throws IOException {
+    try (DataTransferServiceClient client = DataTransferServiceClient.create()) {
+      ProjectName parent = ProjectName.of(projectId);
+      CreateTransferConfigRequest request =
+          CreateTransferConfigRequest.newBuilder()
+              .setParent(parent.toString())
+              .setTransferConfig(transferConfig)
+              .build();
+      TransferConfig config = client.createTransferConfig(request);
+      System.out.println("Campaignmanager transfer created successfully :" + config.getName());
+    } catch (ApiException ex) {
+      System.out.print("Campaignmanager transfer was not created." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_create_campaignmanager_transfer]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateCloudStorageTransfer.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateCloudStorageTransfer.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_create_cloudstorage_transfer]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.CreateTransferConfigRequest;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.ProjectName;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+// Sample to create google cloud storage transfer config
+public class CreateCloudStorageTransfer {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    final String projectId = "MY_PROJECT_ID";
+    String datasetId = "MY_DATASET_ID";
+    String tableId = "MY_TABLE_ID";
+    // GCS Uri
+    String sourceUri = "gs://cloud-samples-data/bigquery/us-states/us-states.csv";
+    String fileFormat = "CSV";
+    String fieldDelimiter = ",";
+    String skipLeadingRows = "1";
+    Map<String, Value> params = new HashMap<>();
+    params.put(
+        "destination_table_name_template", Value.newBuilder().setStringValue(tableId).build());
+    params.put("data_path_template", Value.newBuilder().setStringValue(sourceUri).build());
+    params.put("write_disposition", Value.newBuilder().setStringValue("APPEND").build());
+    params.put("file_format", Value.newBuilder().setStringValue(fileFormat).build());
+    params.put("field_delimiter", Value.newBuilder().setStringValue(fieldDelimiter).build());
+    params.put("skip_leading_rows", Value.newBuilder().setStringValue(skipLeadingRows).build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(datasetId)
+            .setDisplayName("Your Google Cloud Storage Config Name")
+            .setDataSourceId("google_cloud_storage")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .setSchedule("every 24 hours")
+            .build();
+    createCloudStorageTransfer(projectId, transferConfig);
+  }
+
+  public static void createCloudStorageTransfer(String projectId, TransferConfig transferConfig)
+      throws IOException {
+    try (DataTransferServiceClient client = DataTransferServiceClient.create()) {
+      ProjectName parent = ProjectName.of(projectId);
+      CreateTransferConfigRequest request =
+          CreateTransferConfigRequest.newBuilder()
+              .setParent(parent.toString())
+              .setTransferConfig(transferConfig)
+              .build();
+      TransferConfig config = client.createTransferConfig(request);
+      System.out.println("Cloud storage transfer created successfully :" + config.getName());
+    } catch (ApiException ex) {
+      System.out.print("Cloud storage transfer was not created." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_create_cloudstorage_transfer]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreatePlayTransfer.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreatePlayTransfer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_create_play_transfer]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.CreateTransferConfigRequest;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.ProjectName;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+// Sample to create a play transfer config.
+public class CreatePlayTransfer {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    final String projectId = "MY_PROJECT_ID";
+    String datasetId = "MY_DATASET_ID";
+    String bucket = "gs://cloud-sample-data";
+    String tableSuffix = "_test";
+    Map<String, Value> params = new HashMap<>();
+    params.put("bucket", Value.newBuilder().setStringValue(bucket).build());
+    params.put("table_suffix", Value.newBuilder().setStringValue(tableSuffix).build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(datasetId)
+            .setDisplayName("Your Play Config Name")
+            .setDataSourceId("play")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .build();
+    createPlayTransfer(projectId, transferConfig);
+  }
+
+  public static void createPlayTransfer(String projectId, TransferConfig transferConfig)
+      throws IOException {
+    try (DataTransferServiceClient client = DataTransferServiceClient.create()) {
+      ProjectName parent = ProjectName.of(projectId);
+      CreateTransferConfigRequest request =
+          CreateTransferConfigRequest.newBuilder()
+              .setParent(parent.toString())
+              .setTransferConfig(transferConfig)
+              .build();
+      TransferConfig config = client.createTransferConfig(request);
+      System.out.println("play transfer created successfully :" + config.getName());
+    } catch (ApiException ex) {
+      System.out.print("play transfer was not created." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_create_play_transfer]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateRedshiftTransfer.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateRedshiftTransfer.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_create_redshift_transfer]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.CreateTransferConfigRequest;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.ProjectName;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+// Sample to create redshift transfer config
+public class CreateRedshiftTransfer {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    final String projectId = "MY_PROJECT_ID";
+    String datasetId = "MY_DATASET_ID";
+    String datasetRegion = "US";
+    String jdbcUrl = "MY_JDBC_URL_CONNECTION_REDSHIFT";
+    String dbUserName = "MY_USERNAME";
+    String dbPassword = "MY_PASSWORD";
+    String accessKeyId = "MY_AWS_ACCESS_KEY_ID";
+    String secretAccessId = "MY_AWS_SECRET_ACCESS_ID";
+    String s3Bucket = "MY_S3_BUCKET_URI";
+    String redShiftSchema = "MY_REDSHIFT_SCHEMA";
+    String tableNamePatterns = "*";
+    String vpcAndReserveIpRange = "MY_VPC_AND_IP_RANGE";
+    Map<String, Value> params = new HashMap<>();
+    params.put("jdbc_url", Value.newBuilder().setStringValue(jdbcUrl).build());
+    params.put("database_username", Value.newBuilder().setStringValue(dbUserName).build());
+    params.put("database_password", Value.newBuilder().setStringValue(dbPassword).build());
+    params.put("access_key_id", Value.newBuilder().setStringValue(accessKeyId).build());
+    params.put("secret_access_key", Value.newBuilder().setStringValue(secretAccessId).build());
+    params.put("s3_bucket", Value.newBuilder().setStringValue(s3Bucket).build());
+    params.put("redshift_schema", Value.newBuilder().setStringValue(redShiftSchema).build());
+    params.put("table_name_patterns", Value.newBuilder().setStringValue(tableNamePatterns).build());
+    params.put(
+        "migration_infra_cidr", Value.newBuilder().setStringValue(vpcAndReserveIpRange).build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(datasetId)
+            .setDatasetRegion(datasetRegion)
+            .setDisplayName("Your Redshift Config Name")
+            .setDataSourceId("redshift")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .setSchedule("every 24 hours")
+            .build();
+    createRedshiftTransfer(projectId, transferConfig);
+  }
+
+  public static void createRedshiftTransfer(String projectId, TransferConfig transferConfig)
+      throws IOException {
+    try (DataTransferServiceClient client = DataTransferServiceClient.create()) {
+      ProjectName parent = ProjectName.of(projectId);
+      CreateTransferConfigRequest request =
+          CreateTransferConfigRequest.newBuilder()
+              .setParent(parent.toString())
+              .setTransferConfig(transferConfig)
+              .build();
+      TransferConfig config = client.createTransferConfig(request);
+      System.out.println("Cloud redshift transfer created successfully :" + config.getName());
+    } catch (ApiException ex) {
+      System.out.print("Cloud redshift transfer was not created." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_create_redshift_transfer]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateScheduledQuery.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateScheduledQuery.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_create_scheduled_query]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.CreateTransferConfigRequest;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.ProjectName;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+// Sample to create a scheduled query
+public class CreateScheduledQuery {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    final String projectId = "MY_PROJECT_ID";
+    final String datasetId = "MY_DATASET_ID";
+    final String query =
+        "SELECT CURRENT_TIMESTAMP() as current_time, @run_time as intended_run_time, "
+            + "@run_date as intended_run_date, 17 as some_integer";
+    Map<String, Value> params = new HashMap<>();
+    params.put("query", Value.newBuilder().setStringValue(query).build());
+    params.put(
+        "destination_table_name_template",
+        Value.newBuilder().setStringValue("my_destination_table_{run_date}").build());
+    params.put("write_disposition", Value.newBuilder().setStringValue("WRITE_TRUNCATE").build());
+    params.put("partitioning_field", Value.newBuilder().build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(datasetId)
+            .setDisplayName("Your Scheduled Query Name")
+            .setDataSourceId("scheduled_query")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .setSchedule("every 24 hours")
+            .build();
+    createScheduledQuery(projectId, transferConfig);
+  }
+
+  public static void createScheduledQuery(String projectId, TransferConfig transferConfig)
+      throws IOException {
+    try (DataTransferServiceClient dataTransferServiceClient = DataTransferServiceClient.create()) {
+      ProjectName parent = ProjectName.of(projectId);
+      CreateTransferConfigRequest request =
+          CreateTransferConfigRequest.newBuilder()
+              .setParent(parent.toString())
+              .setTransferConfig(transferConfig)
+              .build();
+      TransferConfig config = dataTransferServiceClient.createTransferConfig(request);
+      System.out.println("\nScheduled query created successfully :" + config.getName());
+    } catch (ApiException ex) {
+      System.out.print("\nScheduled query was not created." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_create_scheduled_query]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateScheduledQueryWithServiceAccount.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateScheduledQueryWithServiceAccount.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_create_scheduled_query_with_service_account]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.CreateTransferConfigRequest;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.ProjectName;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+// Sample to create a scheduled query with service account
+public class CreateScheduledQueryWithServiceAccount {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    final String projectId = "MY_PROJECT_ID";
+    final String datasetId = "MY_DATASET_ID";
+    final String serviceAccount = "MY_SERVICE_ACCOUNT";
+    final String query =
+        "SELECT CURRENT_TIMESTAMP() as current_time, @run_time as intended_run_time, "
+            + "@run_date as intended_run_date, 17 as some_integer";
+    Map<String, Value> params = new HashMap<>();
+    params.put("query", Value.newBuilder().setStringValue(query).build());
+    params.put(
+        "destination_table_name_template",
+        Value.newBuilder().setStringValue("my_destination_table_{run_date}").build());
+    params.put("write_disposition", Value.newBuilder().setStringValue("WRITE_TRUNCATE").build());
+    params.put("partitioning_field", Value.newBuilder().build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(datasetId)
+            .setDisplayName("Your Scheduled Query Name")
+            .setDataSourceId("scheduled_query")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .setSchedule("every 24 hours")
+            .build();
+    createScheduledQueryWithServiceAccount(projectId, transferConfig, serviceAccount);
+  }
+
+  public static void createScheduledQueryWithServiceAccount(
+      String projectId, TransferConfig transferConfig, String serviceAccount) throws IOException {
+    try (DataTransferServiceClient dataTransferServiceClient = DataTransferServiceClient.create()) {
+      ProjectName parent = ProjectName.of(projectId);
+      CreateTransferConfigRequest request =
+          CreateTransferConfigRequest.newBuilder()
+              .setParent(parent.toString())
+              .setTransferConfig(transferConfig)
+              .setServiceAccountName(serviceAccount)
+              .build();
+      TransferConfig config = dataTransferServiceClient.createTransferConfig(request);
+      System.out.println(
+          "\nScheduled query with service account created successfully :" + config.getName());
+    } catch (ApiException ex) {
+      System.out.print("\nScheduled query with service account was not created." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_create_scheduled_query_with_service_account]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateTeradataTransfer.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateTeradataTransfer.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_create_teradata_transfer]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.CreateTransferConfigRequest;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.ProjectName;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+// Sample to create a teradata transfer config.
+public class CreateTeradataTransfer {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    final String projectId = "MY_PROJECT_ID";
+    String datasetId = "MY_DATASET_ID";
+    String databaseType = "Teradata";
+    String bucket = "cloud-sample-data";
+    String databaseName = "MY_DATABASE_NAME";
+    String tableNamePatterns = "*";
+    String serviceAccount = "MY_SERVICE_ACCOUNT";
+    String schemaFilePath = "/your-schema-path";
+    Map<String, Value> params = new HashMap<>();
+    params.put("database_type", Value.newBuilder().setStringValue(databaseType).build());
+    params.put("bucket", Value.newBuilder().setStringValue(bucket).build());
+    params.put("database_name", Value.newBuilder().setStringValue(databaseName).build());
+    params.put("table_name_patterns", Value.newBuilder().setStringValue(tableNamePatterns).build());
+    params.put("agent_service_account", Value.newBuilder().setStringValue(serviceAccount).build());
+    params.put("schema_file_path", Value.newBuilder().setStringValue(schemaFilePath).build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(datasetId)
+            .setDisplayName("Your Teradata Config Name")
+            .setDataSourceId("on_premises")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .setSchedule("every 24 hours")
+            .build();
+    createTeradataTransfer(projectId, transferConfig);
+  }
+
+  public static void createTeradataTransfer(String projectId, TransferConfig transferConfig)
+      throws IOException {
+    try (DataTransferServiceClient client = DataTransferServiceClient.create()) {
+      ProjectName parent = ProjectName.of(projectId);
+      CreateTransferConfigRequest request =
+          CreateTransferConfigRequest.newBuilder()
+              .setParent(parent.toString())
+              .setTransferConfig(transferConfig)
+              .build();
+      TransferConfig config = client.createTransferConfig(request);
+      System.out.println("Cloud teradata transfer created successfully :" + config.getName());
+    } catch (ApiException ex) {
+      System.out.print("Cloud teradata transfer was not created." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_create_teradata_transfer]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateYoutubeChannelTransfer.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateYoutubeChannelTransfer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_create_youtubechannel_transfer]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.CreateTransferConfigRequest;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.ProjectName;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+// Sample to create youtube channel transfer config.
+public class CreateYoutubeChannelTransfer {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    final String projectId = "MY_PROJECT_ID";
+    String datasetId = "MY_DATASET_ID";
+    String tableSuffix = "_test";
+    Map<String, Value> params = new HashMap<>();
+    params.put("table_suffix", Value.newBuilder().setStringValue(tableSuffix).build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(datasetId)
+            .setDisplayName("Your Youtube Channel Config Name")
+            .setDataSourceId("youtube_channel")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .build();
+    createYoutubeChannelTransfer(projectId, transferConfig);
+  }
+
+  public static void createYoutubeChannelTransfer(String projectId, TransferConfig transferConfig)
+      throws IOException {
+    try (DataTransferServiceClient client = DataTransferServiceClient.create()) {
+      ProjectName parent = ProjectName.of(projectId);
+      CreateTransferConfigRequest request =
+          CreateTransferConfigRequest.newBuilder()
+              .setParent(parent.toString())
+              .setTransferConfig(transferConfig)
+              .build();
+      TransferConfig config = client.createTransferConfig(request);
+      System.out.println("Youtube channel transfer created successfully :" + config.getName());
+    } catch (ApiException ex) {
+      System.out.print("Youtube channel transfer was not created." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_create_youtubechannel_transfer]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateYoutubeContentOwnerTransfer.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/CreateYoutubeContentOwnerTransfer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_create_youtubecontentowner_transfer]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.CreateTransferConfigRequest;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.ProjectName;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+// Sample to create youtube content owner channel transfer config
+public class CreateYoutubeContentOwnerTransfer {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    final String projectId = "MY_PROJECT_ID";
+    String datasetId = "MY_DATASET_ID";
+    String contentOwnerId = "MY_CONTENT_OWNER_ID";
+    String tableSuffix = "_test";
+    Map<String, Value> params = new HashMap<>();
+    params.put("content_owner_id", Value.newBuilder().setStringValue(contentOwnerId).build());
+    params.put("table_suffix", Value.newBuilder().setStringValue(tableSuffix).build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(datasetId)
+            .setDisplayName("Your Youtube Owner Channel Config Name")
+            .setDataSourceId("youtube_content_owner")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .build();
+    createYoutubeContentOwnerTransfer(projectId, transferConfig);
+  }
+
+  public static void createYoutubeContentOwnerTransfer(
+      String projectId, TransferConfig transferConfig) throws IOException {
+    try (DataTransferServiceClient client = DataTransferServiceClient.create()) {
+      ProjectName parent = ProjectName.of(projectId);
+      CreateTransferConfigRequest request =
+          CreateTransferConfigRequest.newBuilder()
+              .setParent(parent.toString())
+              .setTransferConfig(transferConfig)
+              .build();
+      TransferConfig config = client.createTransferConfig(request);
+      System.out.println(
+          "Youtube content owner channel transfer created successfully :" + config.getName());
+    } catch (ApiException ex) {
+      System.out.print("Youtube content owner channel transfer was not created." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_create_youtubecontentowner_transfer]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/DeleteScheduledQuery.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/DeleteScheduledQuery.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_delete_scheduled_query]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.DeleteTransferConfigRequest;
+import java.io.IOException;
+
+// Sample to delete a scheduled query
+public class DeleteScheduledQuery {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    // i.e projects/{project_id}/transferConfigs/{config_id}` or
+    // `projects/{project_id}/locations/{location_id}/transferConfigs/{config_id}`
+    String name = "MY_CONFIG_ID";
+    deleteScheduledQuery(name);
+  }
+
+  public static void deleteScheduledQuery(String name) throws IOException {
+    try (DataTransferServiceClient dataTransferServiceClient = DataTransferServiceClient.create()) {
+      DeleteTransferConfigRequest request =
+          DeleteTransferConfigRequest.newBuilder().setName(name).build();
+      dataTransferServiceClient.deleteTransferConfig(request);
+      System.out.print("Scheduled query deleted successfully.\n");
+    } catch (ApiException ex) {
+      System.out.print("Scheduled query was not deleted." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_delete_scheduled_query]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/DeleteTransferConfig.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/DeleteTransferConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_delete_transfer]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.DeleteTransferConfigRequest;
+import java.io.IOException;
+
+// Sample to delete a transfer config
+public class DeleteTransferConfig {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    // i.e projects/{project_id}/transferConfigs/{config_id}` or
+    // `projects/{project_id}/locations/{location_id}/transferConfigs/{config_id}`
+    String configId = "MY_CONFIG_ID";
+    deleteTransferConfig(configId);
+  }
+
+  public static void deleteTransferConfig(String configId) throws IOException {
+    try (DataTransferServiceClient dataTransferServiceClient = DataTransferServiceClient.create()) {
+      DeleteTransferConfigRequest request =
+          DeleteTransferConfigRequest.newBuilder().setName(configId).build();
+      dataTransferServiceClient.deleteTransferConfig(request);
+      System.out.println("Transfer config deleted successfully");
+    } catch (ApiException ex) {
+      System.out.println("Transfer config was not deleted." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_delete_transfer]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/DisableTransferConfig.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/DisableTransferConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_disable_transfer]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.cloud.bigquery.datatransfer.v1.UpdateTransferConfigRequest;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.util.FieldMaskUtil;
+import java.io.IOException;
+
+// Sample to disable transfer config.
+public class DisableTransferConfig {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String configId = "MY_CONFIG_ID";
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder().setName(configId).setDisabled(true).build();
+    FieldMask updateMask = FieldMaskUtil.fromString("disabled");
+    disableTransferConfig(transferConfig, updateMask);
+  }
+
+  public static void disableTransferConfig(TransferConfig transferConfig, FieldMask updateMask)
+      throws IOException {
+    try (DataTransferServiceClient dataTransferServiceClient = DataTransferServiceClient.create()) {
+      UpdateTransferConfigRequest request =
+          UpdateTransferConfigRequest.newBuilder()
+              .setTransferConfig(transferConfig)
+              .setUpdateMask(updateMask)
+              .build();
+      TransferConfig updateConfig = dataTransferServiceClient.updateTransferConfig(request);
+      System.out.println("Transfer config disabled successfully :" + updateConfig.getDisplayName());
+    } catch (ApiException ex) {
+      System.out.print("Transfer config was not disabled." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_disable_transfer]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/GetTransferConfigInfo.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/GetTransferConfigInfo.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_get_config_info]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.GetTransferConfigRequest;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import java.io.IOException;
+
+// Sample to get config info.
+public class GetTransferConfigInfo {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String configId = "MY_CONFIG_ID";
+    // i.e projects/{project_id}/transferConfigs/{config_id}` or
+    // `projects/{project_id}/locations/{location_id}/transferConfigs/{config_id}`
+    getTransferConfigInfo(configId);
+  }
+
+  public static void getTransferConfigInfo(String configId) throws IOException {
+    try (DataTransferServiceClient dataTransferServiceClient = DataTransferServiceClient.create()) {
+      GetTransferConfigRequest request =
+          GetTransferConfigRequest.newBuilder().setName(configId).build();
+      TransferConfig info = dataTransferServiceClient.getTransferConfig(request);
+      System.out.print("Config info retrieved successfully." + info.getName() + "\n");
+    } catch (ApiException ex) {
+      System.out.print("config not found." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_get_config_info]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/ListTransferConfigs.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/ListTransferConfigs.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_list_configs]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.ListTransferConfigsRequest;
+import com.google.cloud.bigquery.datatransfer.v1.ProjectName;
+import java.io.IOException;
+
+// Sample to get list of transfer config
+public class ListTransferConfigs {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    final String projectId = "MY_PROJECT_ID";
+    listTransferConfigs(projectId);
+  }
+
+  public static void listTransferConfigs(String projectId) throws IOException {
+    try (DataTransferServiceClient dataTransferServiceClient = DataTransferServiceClient.create()) {
+      ProjectName parent = ProjectName.of(projectId);
+      ListTransferConfigsRequest request =
+          ListTransferConfigsRequest.newBuilder().setParent(parent.toString()).build();
+      dataTransferServiceClient
+          .listTransferConfigs(request)
+          .iterateAll()
+          .forEach(config -> System.out.print("Success! Config ID :" + config.getName() + "\n"));
+    } catch (ApiException ex) {
+      System.out.println("Config list not found due to error." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_list_configs]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/QuickstartSample.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/QuickstartSample.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_quickstart]
+// Imports the Google Cloud client library
+
+import com.google.cloud.bigquery.datatransfer.v1.DataSource;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient.ListDataSourcesPagedResponse;
+import com.google.cloud.bigquery.datatransfer.v1.ListDataSourcesRequest;
+
+public class QuickstartSample {
+  /** List available data sources for the BigQuery Data Transfer service. */
+  public static void main(String... args) throws Exception {
+    // Sets your Google Cloud Platform project ID.
+    // String projectId = "YOUR_PROJECT_ID";
+    String projectId = args[0];
+
+    // Instantiate a client. If you don't specify credentials when constructing a client, the
+    // client library will look for credentials in the environment, such as the
+    // GOOGLE_APPLICATION_CREDENTIALS environment variable.
+    try (DataTransferServiceClient client = DataTransferServiceClient.create()) {
+      // Request the list of available data sources.
+      String parent = String.format("projects/%s", projectId);
+      ListDataSourcesRequest request =
+          ListDataSourcesRequest.newBuilder().setParent(parent).build();
+      ListDataSourcesPagedResponse response = client.listDataSources(request);
+
+      // Print the results.
+      System.out.println("Supported Data Sources:");
+      for (DataSource dataSource : response.iterateAll()) {
+        System.out.println(dataSource.getDisplayName());
+        System.out.printf("\tID: %s%n", dataSource.getDataSourceId());
+        System.out.printf("\tFull path: %s%n", dataSource.getName());
+        System.out.printf("\tDescription: %s%n", dataSource.getDescription());
+      }
+    }
+  }
+}
+// [END bigquerydatatransfer_quickstart]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/ReEnableTransferConfig.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/ReEnableTransferConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_reenable_transfer]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.cloud.bigquery.datatransfer.v1.UpdateTransferConfigRequest;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.util.FieldMaskUtil;
+import java.io.IOException;
+
+// Sample to re-enable transfer config.
+public class ReEnableTransferConfig {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String configId = "MY_CONFIG_ID";
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder().setName(configId).setDisabled(false).build();
+    FieldMask updateMask = FieldMaskUtil.fromString("disabled");
+    reEnableTransferConfig(transferConfig, updateMask);
+  }
+
+  public static void reEnableTransferConfig(TransferConfig transferConfig, FieldMask updateMask)
+      throws IOException {
+    try (DataTransferServiceClient dataTransferServiceClient = DataTransferServiceClient.create()) {
+      UpdateTransferConfigRequest request =
+          UpdateTransferConfigRequest.newBuilder()
+              .setTransferConfig(transferConfig)
+              .setUpdateMask(updateMask)
+              .build();
+      TransferConfig updateConfig = dataTransferServiceClient.updateTransferConfig(request);
+      System.out.println("Transfer config reenable successfully :" + updateConfig.getDisplayName());
+    } catch (ApiException ex) {
+      System.out.print("Transfer config was not reenable." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_reenable_transfer]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/RunDetails.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/RunDetails.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_get_run_details]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.GetTransferRunRequest;
+import com.google.cloud.bigquery.datatransfer.v1.TransferRun;
+import java.io.IOException;
+
+// Sample to get run details from transfer config.
+public class RunDetails {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    // runId examples:
+    // `projects/{project_id}/transferConfigs/{config_id}/runs/{run_id}` or
+    // `projects/{project_id}/locations/{location_id}/transferConfigs/{config_id}/runs/{run_id}`
+    String runId = "MY_RUN_ID";
+    runDetails(runId);
+  }
+
+  public static void runDetails(String runId) throws IOException {
+    try (DataTransferServiceClient dataTransferServiceClient = DataTransferServiceClient.create()) {
+      GetTransferRunRequest request = GetTransferRunRequest.newBuilder().setName(runId).build();
+      TransferRun run = dataTransferServiceClient.getTransferRun(request);
+      System.out.print("Run details retrieved successfully :" + run.getName() + "\n");
+    } catch (ApiException ex) {
+      System.out.print("Run details not found." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_get_run_details]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/RunHistory.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/RunHistory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_get_run_history]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.ListTransferRunsRequest;
+import java.io.IOException;
+
+// Sample to get run history from transfer config.
+public class RunHistory {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String configId = "MY_CONFIG_ID";
+    // i.e projects/{project_id}/transferConfigs/{config_id}` or
+    // `projects/{project_id}/locations/{location_id}/transferConfigs/{config_id}`
+    runHistory(configId);
+  }
+
+  public static void runHistory(String configId) throws IOException {
+    try (DataTransferServiceClient dataTransferServiceClient = DataTransferServiceClient.create()) {
+      ListTransferRunsRequest request =
+          ListTransferRunsRequest.newBuilder().setParent(configId).build();
+      dataTransferServiceClient
+          .listTransferRuns(request)
+          .iterateAll()
+          .forEach(run -> System.out.print("Success! Run ID :" + run.getName() + "\n"));
+    } catch (ApiException ex) {
+      System.out.println("Run history not found due to error." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_get_run_history]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/RunNotification.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/RunNotification.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_run_notification]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.CreateTransferConfigRequest;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.ProjectName;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+// Sample to get run notification
+public class RunNotification {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    final String projectId = "MY_PROJECT_ID";
+    final String datasetId = "MY_DATASET_ID";
+    final String pubsubTopicName = "MY_TOPIC_NAME";
+    final String query =
+        "SELECT CURRENT_TIMESTAMP() as current_time, @run_time as intended_run_time, "
+            + "@run_date as intended_run_date, 17 as some_integer";
+    Map<String, Value> params = new HashMap<>();
+    params.put("query", Value.newBuilder().setStringValue(query).build());
+    params.put(
+        "destination_table_name_template",
+        Value.newBuilder().setStringValue("my_destination_table_{run_date}").build());
+    params.put("write_disposition", Value.newBuilder().setStringValue("WRITE_TRUNCATE").build());
+    params.put("partitioning_field", Value.newBuilder().build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(datasetId)
+            .setDisplayName("Your Scheduled Query Name")
+            .setDataSourceId("scheduled_query")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .setSchedule("every 24 hours")
+            .setNotificationPubsubTopic(pubsubTopicName)
+            .build();
+    runNotification(projectId, transferConfig);
+  }
+
+  public static void runNotification(String projectId, TransferConfig transferConfig)
+      throws IOException {
+    try (DataTransferServiceClient dataTransferServiceClient = DataTransferServiceClient.create()) {
+      ProjectName parent = ProjectName.of(projectId);
+      CreateTransferConfigRequest request =
+          CreateTransferConfigRequest.newBuilder()
+              .setParent(parent.toString())
+              .setTransferConfig(transferConfig)
+              .build();
+      TransferConfig config = dataTransferServiceClient.createTransferConfig(request);
+      System.out.println(
+          "\nScheduled query with run notification created successfully :" + config.getName());
+    } catch (ApiException ex) {
+      System.out.print("\nScheduled query with run notification was not created." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_run_notification]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/ScheduleBackFill.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/ScheduleBackFill.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_schedule_backfill]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.ScheduleTransferRunsRequest;
+import com.google.cloud.bigquery.datatransfer.v1.ScheduleTransferRunsResponse;
+import com.google.protobuf.Timestamp;
+import java.io.IOException;
+import org.threeten.bp.Clock;
+import org.threeten.bp.Instant;
+import org.threeten.bp.temporal.ChronoUnit;
+
+// Sample to run schedule back fill for transfer config
+public class ScheduleBackFill {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String configId = "MY_CONFIG_ID";
+    Clock clock = Clock.systemDefaultZone();
+    Instant instant = clock.instant();
+    Timestamp startTime =
+        Timestamp.newBuilder()
+            .setSeconds(instant.minus(5, ChronoUnit.DAYS).getEpochSecond())
+            .setNanos(instant.minus(5, ChronoUnit.DAYS).getNano())
+            .build();
+    Timestamp endTime =
+        Timestamp.newBuilder()
+            .setSeconds(instant.minus(2, ChronoUnit.DAYS).getEpochSecond())
+            .setNanos(instant.minus(2, ChronoUnit.DAYS).getNano())
+            .build();
+    scheduleBackFill(configId, startTime, endTime);
+  }
+
+  public static void scheduleBackFill(String configId, Timestamp startTime, Timestamp endTime)
+      throws IOException {
+    try (DataTransferServiceClient client = DataTransferServiceClient.create()) {
+      ScheduleTransferRunsRequest request =
+          ScheduleTransferRunsRequest.newBuilder()
+              .setParent(configId)
+              .setStartTime(startTime)
+              .setEndTime(endTime)
+              .build();
+      ScheduleTransferRunsResponse response = client.scheduleTransferRuns(request);
+      System.out.println("Schedule backfill run successfully :" + response.getRunsCount());
+    } catch (ApiException ex) {
+      System.out.print("Schedule backfill was not run." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_schedule_backfill]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/UpdateCredentials.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/UpdateCredentials.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_update_credentials]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.cloud.bigquery.datatransfer.v1.UpdateTransferConfigRequest;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.util.FieldMaskUtil;
+import java.io.IOException;
+
+// Sample to update credentials in transfer config.
+public class UpdateCredentials {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String configId = "MY_CONFIG_ID";
+    String serviceAccount = "MY_SERVICE_ACCOUNT";
+    TransferConfig transferConfig = TransferConfig.newBuilder().setName(configId).build();
+    FieldMask updateMask = FieldMaskUtil.fromString("service_account_name");
+    updateCredentials(transferConfig, serviceAccount, updateMask);
+  }
+
+  public static void updateCredentials(
+      TransferConfig transferConfig, String serviceAccount, FieldMask updateMask)
+      throws IOException {
+    try (DataTransferServiceClient dataTransferServiceClient = DataTransferServiceClient.create()) {
+      UpdateTransferConfigRequest request =
+          UpdateTransferConfigRequest.newBuilder()
+              .setTransferConfig(transferConfig)
+              .setUpdateMask(updateMask)
+              .setServiceAccountName(serviceAccount)
+              .build();
+      dataTransferServiceClient.updateTransferConfig(request);
+      System.out.println("Credentials updated successfully");
+    } catch (ApiException ex) {
+      System.out.print("Credentials was not updated." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_update_credentials]

--- a/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/UpdateTransferConfig.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/main/java/com/example/bigquerydatatransfer/UpdateTransferConfig.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+// [START bigquerydatatransfer_update_config]
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.cloud.bigquery.datatransfer.v1.UpdateTransferConfigRequest;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.util.FieldMaskUtil;
+import java.io.IOException;
+
+// Sample to update transfer config.
+public class UpdateTransferConfig {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String configId = "MY_CONFIG_ID";
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setName(configId)
+            .setDisplayName("UPDATED_DISPLAY_NAME")
+            .build();
+    FieldMask updateMask = FieldMaskUtil.fromString("display_name");
+    updateTransferConfig(transferConfig, updateMask);
+  }
+
+  public static void updateTransferConfig(TransferConfig transferConfig, FieldMask updateMask)
+      throws IOException {
+    try (DataTransferServiceClient dataTransferServiceClient = DataTransferServiceClient.create()) {
+      UpdateTransferConfigRequest request =
+          UpdateTransferConfigRequest.newBuilder()
+              .setTransferConfig(transferConfig)
+              .setUpdateMask(updateMask)
+              .build();
+      TransferConfig updateConfig = dataTransferServiceClient.updateTransferConfig(request);
+      System.out.println("Transfer config updated successfully :" + updateConfig.getDisplayName());
+    } catch (ApiException ex) {
+      System.out.print("Transfer config was not updated." + ex.toString());
+    }
+  }
+}
+// [END bigquerydatatransfer_update_config]

--- a/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/CopyDatasetIT.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/CopyDatasetIT.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.DatasetInfo;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CopyDatasetIT {
+
+  private static final Logger LOG = Logger.getLogger(CopyDatasetIT.class.getName());
+  private BigQuery bigquery;
+  private ByteArrayOutputStream bout;
+  private String name;
+  private String displayName;
+  private String datasetName;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() {
+    displayName = "MY_COPY_DATASET_NAME_TEST_" + UUID.randomUUID().toString().substring(0, 8);
+    datasetName = "MY_DATASET_NAME_TEST_" + UUID.randomUUID().toString().substring(0, 8);
+    // create a temporary dataset
+    bigquery = BigQueryOptions.getDefaultInstance().getService();
+    bigquery.create(DatasetInfo.of(datasetName));
+
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    // TODO(pmakani) replace DeleteTransferConfig once PR merged.
+    // Clean up
+    DeleteScheduledQuery.deleteScheduledQuery(name);
+    // delete a temporary dataset
+    bigquery.delete(datasetName, BigQuery.DatasetDeleteOption.deleteContents());
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testCopyDataset() throws IOException {
+    Map<String, Value> params = new HashMap<>();
+    params.put(
+        "source_project_id", Value.newBuilder().setStringValue("bigquery-public-data").build());
+    params.put("source_dataset_id", Value.newBuilder().setStringValue("usa_names").build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(datasetName)
+            .setDisplayName(displayName)
+            .setDataSourceId("cross_region_copy")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .setSchedule("every 24 hours")
+            .build();
+    CopyDataset.copyDataset(PROJECT_ID, transferConfig);
+    String result = bout.toString();
+    name = result.substring(result.indexOf(":") + 1, result.length() - 1);
+    assertThat(result).contains("Copy dataset created successfully :");
+  }
+}

--- a/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/CreateAmazonS3TransferIT.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/CreateAmazonS3TransferIT.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.DatasetInfo;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.TableDefinition;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CreateAmazonS3TransferIT {
+
+  private static final Logger LOG = Logger.getLogger(CreateAmazonS3TransferIT.class.getName());
+  private static final String ID = UUID.randomUUID().toString().substring(0, 8);
+  private BigQuery bigquery;
+  private ByteArrayOutputStream bout;
+  private String name;
+  private String displayName;
+  private String datasetName;
+  private String tableName;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  private static final String AWS_ACCESS_KEY_ID = requireEnvVar("AWS_ACCESS_KEY_ID");
+  private static final String AWS_SECRET_ACCESS_KEY = requireEnvVar("AWS_SECRET_ACCESS_KEY");
+  private static final String AWS_BUCKET = requireEnvVar("AWS_BUCKET");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+    requireEnvVar("AWS_ACCESS_KEY_ID");
+    requireEnvVar("AWS_SECRET_ACCESS_KEY");
+    requireEnvVar("AWS_BUCKET");
+  }
+
+  @Before
+  public void setUp() {
+    displayName = "MY_SCHEDULE_NAME_TEST_" + ID;
+    datasetName = "MY_DATASET_NAME_TEST_" + ID;
+    tableName = "MY_TABLE_NAME_TEST_" + ID;
+    // create a temporary dataset
+    bigquery = BigQueryOptions.getDefaultInstance().getService();
+    bigquery.create(DatasetInfo.of(datasetName));
+    // create a temporary table
+    Schema schema =
+        Schema.of(
+            Field.of("name", StandardSQLTypeName.STRING),
+            Field.of("post_abbr", StandardSQLTypeName.STRING));
+    TableDefinition tableDefinition = StandardTableDefinition.of(schema);
+    TableInfo tableInfo = TableInfo.of(TableId.of(datasetName, tableName), tableDefinition);
+    bigquery.create(tableInfo);
+
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    // Clean up
+    DeleteScheduledQuery.deleteScheduledQuery(name);
+    // delete a temporary table
+    bigquery.delete(TableId.of(datasetName, tableName));
+    // delete a temporary dataset
+    bigquery.delete(datasetName, BigQuery.DatasetDeleteOption.deleteContents());
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testCreateAmazonS3Transfer() throws IOException {
+    String sourceUri = String.format("s3://%s/*", AWS_BUCKET);
+    String fileFormat = "CSV";
+    String fieldDelimiter = ",";
+    String skipLeadingRows = "1";
+    Map<String, Value> params = new HashMap<>();
+    params.put(
+        "destination_table_name_template", Value.newBuilder().setStringValue(tableName).build());
+    params.put("data_path", Value.newBuilder().setStringValue(sourceUri).build());
+    params.put("access_key_id", Value.newBuilder().setStringValue(AWS_ACCESS_KEY_ID).build());
+    params.put(
+        "secret_access_key", Value.newBuilder().setStringValue(AWS_SECRET_ACCESS_KEY).build());
+    params.put("file_format", Value.newBuilder().setStringValue(fileFormat).build());
+    params.put("field_delimiter", Value.newBuilder().setStringValue(fieldDelimiter).build());
+    params.put("skip_leading_rows", Value.newBuilder().setStringValue(skipLeadingRows).build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(datasetName)
+            .setDisplayName(displayName)
+            .setDataSourceId("amazon_s3")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .setSchedule("every 24 hours")
+            .build();
+    CreateAmazonS3Transfer.createAmazonS3Transfer(PROJECT_ID, transferConfig);
+    String result = bout.toString();
+    name = result.substring(result.indexOf(":") + 1, result.length() - 1);
+    assertThat(result).contains("Amazon s3 transfer created successfully :");
+  }
+}

--- a/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/CreateCloudStorageTransferIT.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/CreateCloudStorageTransferIT.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.DatasetInfo;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.TableDefinition;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CreateCloudStorageTransferIT {
+
+  private static final Logger LOG = Logger.getLogger(CreateCloudStorageTransferIT.class.getName());
+  private static final String ID = UUID.randomUUID().toString().substring(0, 8);
+  private BigQuery bigquery;
+  private ByteArrayOutputStream bout;
+  private String name;
+  private String displayName;
+  private String datasetName;
+  private String tableName;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() {
+    displayName = "CLOUD_STORAGE_CONFIG_TEST_" + ID;
+    datasetName = "CLOUD_STORAGE_DATASET_NAME_TEST_" + ID;
+    tableName = "CLOUD_STORAGE_TABLE_NAME_TEST_" + ID;
+    // create a temporary dataset
+    bigquery = BigQueryOptions.getDefaultInstance().getService();
+    bigquery.create(DatasetInfo.of(datasetName));
+    // create a temporary table
+    Schema schema =
+        Schema.of(
+            Field.of("name", StandardSQLTypeName.STRING),
+            Field.of("post_abbr", StandardSQLTypeName.STRING));
+    TableDefinition tableDefinition = StandardTableDefinition.of(schema);
+    TableInfo tableInfo = TableInfo.of(TableId.of(datasetName, tableName), tableDefinition);
+    bigquery.create(tableInfo);
+
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    // Clean up
+    DeleteTransferConfig.deleteTransferConfig(name);
+    // delete a temporary table
+    bigquery.delete(TableId.of(datasetName, tableName));
+    // delete a temporary dataset
+    bigquery.delete(datasetName, BigQuery.DatasetDeleteOption.deleteContents());
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testCreateCloudStorageTransfer() throws IOException {
+    String sourceUri = "gs://cloud-samples-data/bigquery/us-states/us-states.csv";
+    String fileFormat = "CSV";
+    String fieldDelimiter = ",";
+    String skipLeadingRows = "1";
+    Map<String, Value> params = new HashMap<>();
+    params.put(
+        "destination_table_name_template", Value.newBuilder().setStringValue(tableName).build());
+    params.put("data_path_template", Value.newBuilder().setStringValue(sourceUri).build());
+    params.put("write_disposition", Value.newBuilder().setStringValue("APPEND").build());
+    params.put("file_format", Value.newBuilder().setStringValue(fileFormat).build());
+    params.put("field_delimiter", Value.newBuilder().setStringValue(fieldDelimiter).build());
+    params.put("skip_leading_rows", Value.newBuilder().setStringValue(skipLeadingRows).build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(datasetName)
+            .setDisplayName(displayName)
+            .setDataSourceId("google_cloud_storage")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .setSchedule("every 24 hours")
+            .build();
+    CreateCloudStorageTransfer.createCloudStorageTransfer(PROJECT_ID, transferConfig);
+    String result = bout.toString();
+    name = result.substring(result.indexOf(":") + 1, result.length() - 1);
+    assertThat(result).contains("Cloud storage transfer created successfully :");
+  }
+}

--- a/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/CreateScheduledQueryIT.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/CreateScheduledQueryIT.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.DatasetInfo;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.cloud.bigquery.datatransfer.v1.TransferState;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CreateScheduledQueryIT {
+
+  private static final Logger LOG = Logger.getLogger(CreateScheduledQueryIT.class.getName());
+  private BigQuery bigquery;
+  private ByteArrayOutputStream bout;
+  private String name;
+  private String displayName;
+  private String datasetName;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() {
+    displayName = "MY_SCHEDULE_NAME_TEST_" + UUID.randomUUID().toString().substring(0, 8);
+    datasetName = "MY_DATASET_NAME_TEST_" + UUID.randomUUID().toString().substring(0, 8);
+    // create a temporary dataset
+    bigquery = BigQueryOptions.getDefaultInstance().getService();
+    bigquery.create(DatasetInfo.of(datasetName));
+
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    // Clean up
+    DeleteScheduledQuery.deleteScheduledQuery(name);
+    // delete a temporary dataset
+    bigquery.delete(datasetName, BigQuery.DatasetDeleteOption.deleteContents());
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testCreateScheduledQuery() throws IOException {
+    String query =
+        "SELECT CURRENT_TIMESTAMP() as current_time, @run_time as intended_run_time, "
+            + "@run_date as intended_run_date, 17 as some_integer";
+    String destinationTableName =
+        "MY_DESTINATION_TABLE_" + UUID.randomUUID().toString().substring(0, 8) + "_{run_date}";
+    Map<String, Value> params = new HashMap<>();
+    params.put("query", Value.newBuilder().setStringValue(query).build());
+    params.put(
+        "destination_table_name_template",
+        Value.newBuilder().setStringValue(destinationTableName).build());
+    params.put("write_disposition", Value.newBuilder().setStringValue("WRITE_TRUNCATE").build());
+    params.put("partitioning_field", Value.newBuilder().setStringValue("").build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(datasetName)
+            .setDisplayName(displayName)
+            .setDataSourceId("scheduled_query")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .setSchedule("every 24 hours")
+            .setState(TransferState.CANCELLED)
+            .build();
+    CreateScheduledQuery.createScheduledQuery(PROJECT_ID, transferConfig);
+    String result = bout.toString();
+    name = result.substring(result.indexOf(":") + 1, result.length() - 1);
+    assertThat(result).contains("Scheduled query created successfully");
+  }
+}

--- a/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/CreateScheduledQueryWithServiceAccountIT.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/CreateScheduledQueryWithServiceAccountIT.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.DatasetInfo;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.cloud.bigquery.datatransfer.v1.TransferState;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CreateScheduledQueryWithServiceAccountIT {
+
+  private final Logger log = Logger.getLogger(this.getClass().getName());
+  private BigQuery bigquery;
+  private ByteArrayOutputStream bout;
+  private String name;
+  private String displayName;
+  private String datasetName;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() {
+    displayName = "MY_SCHEDULE_NAME_TEST_" + UUID.randomUUID().toString().substring(0, 8);
+    datasetName = "MY_DATASET_NAME_TEST_" + UUID.randomUUID().toString().substring(0, 8);
+    // create a temporary dataset
+    bigquery = BigQueryOptions.getDefaultInstance().getService();
+    bigquery.create(DatasetInfo.of(datasetName));
+
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    // Clean up
+    DeleteScheduledQuery.deleteScheduledQuery(name);
+    // delete a temporary dataset
+    bigquery.delete(datasetName, BigQuery.DatasetDeleteOption.deleteContents());
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    log.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testCreateScheduledQueryWithServiceAccount() throws IOException {
+    String query =
+        "SELECT CURRENT_TIMESTAMP() as current_time, @run_time as intended_run_time, "
+            + "@run_date as intended_run_date, 17 as some_integer";
+    String destinationTableName =
+        "MY_DESTINATION_TABLE_" + UUID.randomUUID().toString().substring(0, 8) + "_{run_date}";
+    Map<String, Value> params = new HashMap<>();
+    params.put("query", Value.newBuilder().setStringValue(query).build());
+    params.put(
+        "destination_table_name_template",
+        Value.newBuilder().setStringValue(destinationTableName).build());
+    params.put("write_disposition", Value.newBuilder().setStringValue("WRITE_TRUNCATE").build());
+    params.put("partitioning_field", Value.newBuilder().setStringValue("").build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(datasetName)
+            .setDisplayName(displayName)
+            .setDataSourceId("scheduled_query")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .setSchedule("every 24 hours")
+            .setState(TransferState.CANCELLED)
+            .build();
+    ServiceAccountCredentials credentials =
+        (ServiceAccountCredentials) ServiceAccountCredentials.getApplicationDefault();
+    CreateScheduledQueryWithServiceAccount.createScheduledQueryWithServiceAccount(
+        PROJECT_ID, transferConfig, credentials.getClientEmail());
+    String result = bout.toString();
+    name = result.substring(result.indexOf(":") + 1, result.length() - 1);
+    assertThat(result).contains("Scheduled query with service account created successfully");
+  }
+}

--- a/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/DeleteScheduledQueryIT.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/DeleteScheduledQueryIT.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.DatasetInfo;
+import com.google.cloud.bigquery.datatransfer.v1.CreateTransferConfigRequest;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.ProjectName;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DeleteScheduledQueryIT {
+
+  private static final Logger LOG = Logger.getLogger(DeleteScheduledQueryIT.class.getName());
+  private BigQuery bigquery;
+  private ByteArrayOutputStream bout;
+  private String name;
+  private String displayName;
+  private String datasetName;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+
+    displayName = "MY_SCHEDULE_NAME_TEST_" + UUID.randomUUID().toString().substring(0, 8);
+    datasetName = "MY_DATASET_NAME_TEST_" + UUID.randomUUID().toString().substring(0, 8);
+    // create a temporary dataset
+    bigquery = BigQueryOptions.getDefaultInstance().getService();
+    bigquery.create(DatasetInfo.of(datasetName));
+
+    // create a scheduled query
+    String query =
+        "SELECT CURRENT_TIMESTAMP() as current_time, @run_time as intended_run_time, "
+            + "@run_date as intended_run_date, 17 as some_integer";
+    String destinationTableName =
+        "MY_DESTINATION_TABLE_" + UUID.randomUUID().toString().substring(0, 8) + "_{run_date}";
+    Map<String, Value> params = new HashMap<>();
+    params.put("query", Value.newBuilder().setStringValue(query).build());
+    params.put(
+        "destination_table_name_template",
+        Value.newBuilder().setStringValue(destinationTableName).build());
+    params.put("write_disposition", Value.newBuilder().setStringValue("WRITE_TRUNCATE").build());
+    params.put("partitioning_field", Value.newBuilder().setStringValue("").build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(datasetName)
+            .setDisplayName(displayName)
+            .setDataSourceId("scheduled_query")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .setSchedule("every 24 hours")
+            .build();
+    try (DataTransferServiceClient dataTransferServiceClient = DataTransferServiceClient.create()) {
+      ProjectName parent = ProjectName.of(PROJECT_ID);
+      CreateTransferConfigRequest request =
+          CreateTransferConfigRequest.newBuilder()
+              .setParent(parent.toString())
+              .setTransferConfig(transferConfig)
+              .build();
+      name = dataTransferServiceClient.createTransferConfig(request).getName();
+      System.out.println("\nScheduled query created successfully :" + name);
+    }
+  }
+
+  @After
+  public void tearDown() {
+    // delete a temporary dataset
+    bigquery.delete(datasetName, BigQuery.DatasetDeleteOption.deleteContents());
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testDeleteScheduledQuery() throws IOException {
+    // delete scheduled query that was just created
+    DeleteScheduledQuery.deleteScheduledQuery(name);
+    assertThat(bout.toString()).contains("Scheduled query deleted successfully.");
+  }
+}

--- a/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/DeleteTransferConfigIT.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/DeleteTransferConfigIT.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.DatasetInfo;
+import com.google.cloud.bigquery.datatransfer.v1.CreateTransferConfigRequest;
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import com.google.cloud.bigquery.datatransfer.v1.ProjectName;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DeleteTransferConfigIT {
+
+  private static final Logger LOG = Logger.getLogger(DeleteTransferConfigIT.class.getName());
+  private BigQuery bigquery;
+  private ByteArrayOutputStream bout;
+  private String name;
+  private String displayName;
+  private String datasetName;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+
+    displayName = "MY_SCHEDULE_NAME_TEST_" + UUID.randomUUID().toString().substring(0, 8);
+    datasetName = "MY_DATASET_NAME_TEST_" + UUID.randomUUID().toString().substring(0, 8);
+    // create a temporary dataset
+    bigquery = BigQueryOptions.getDefaultInstance().getService();
+    bigquery.create(DatasetInfo.of(datasetName));
+
+    // create a scheduled query
+    String query =
+        "SELECT CURRENT_TIMESTAMP() as current_time, @run_time as intended_run_time, "
+            + "@run_date as intended_run_date, 17 as some_integer";
+    String destinationTableName =
+        "MY_DESTINATION_TABLE_" + UUID.randomUUID().toString().substring(0, 8) + "_{run_date}";
+    Map<String, Value> params = new HashMap<>();
+    params.put("query", Value.newBuilder().setStringValue(query).build());
+    params.put(
+        "destination_table_name_template",
+        Value.newBuilder().setStringValue(destinationTableName).build());
+    params.put("write_disposition", Value.newBuilder().setStringValue("WRITE_TRUNCATE").build());
+    params.put("partitioning_field", Value.newBuilder().setStringValue("").build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(datasetName)
+            .setDisplayName(displayName)
+            .setDataSourceId("scheduled_query")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .setSchedule("every 24 hours")
+            .build();
+    try (DataTransferServiceClient dataTransferServiceClient = DataTransferServiceClient.create()) {
+      ProjectName parent = ProjectName.of(PROJECT_ID);
+      CreateTransferConfigRequest request =
+          CreateTransferConfigRequest.newBuilder()
+              .setParent(parent.toString())
+              .setTransferConfig(transferConfig)
+              .build();
+      name = dataTransferServiceClient.createTransferConfig(request).getName();
+      System.out.println("Transfer config created successfully :" + name);
+    }
+  }
+
+  @After
+  public void tearDown() {
+    // delete a temporary dataset
+    bigquery.delete(datasetName, BigQuery.DatasetDeleteOption.deleteContents());
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testDeleteTransferConfig() throws IOException {
+    // delete scheduled query that was just created
+    DeleteTransferConfig.deleteTransferConfig(name);
+    assertThat(bout.toString()).contains("Transfer config deleted successfully");
+  }
+}

--- a/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/DisableTransferConfigIT.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/DisableTransferConfigIT.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.util.FieldMaskUtil;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DisableTransferConfigIT {
+
+  private static final Logger LOG = Logger.getLogger(DisableTransferConfigIT.class.getName());
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String CONFIG_NAME = requireEnvVar("DTS_TRANSFER_CONFIG_NAME");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("DTS_TRANSFER_CONFIG_NAME");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testDisableTransferConfig() throws IOException {
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder().setName(CONFIG_NAME).setDisabled(true).build();
+    FieldMask updateMask = FieldMaskUtil.fromString("disabled");
+    DisableTransferConfig.disableTransferConfig(transferConfig, updateMask);
+    assertThat(bout.toString()).contains("Transfer config disabled successfully");
+  }
+}

--- a/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/GetTransferConfigInfoIT.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/GetTransferConfigInfoIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class GetTransferConfigInfoIT {
+
+  private static final Logger LOG = Logger.getLogger(GetTransferConfigInfoIT.class.getName());
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String CONFIG_NAME = requireEnvVar("DTS_TRANSFER_CONFIG_NAME");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("DTS_TRANSFER_CONFIG_NAME");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testGetTransferConfigInfo() throws IOException {
+    GetTransferConfigInfo.getTransferConfigInfo(CONFIG_NAME);
+    assertThat(bout.toString()).contains("Config info retrieved successfully.");
+  }
+}

--- a/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/ListTransferConfigsIT.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/ListTransferConfigsIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ListTransferConfigsIT {
+
+  private static final Logger LOG = Logger.getLogger(ListTransferConfigsIT.class.getName());
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("DTS_TRANSFER_CONFIG_NAME");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testListTransferConfigs() throws IOException {
+    ListTransferConfigs.listTransferConfigs(PROJECT_ID);
+    assertThat(bout.toString()).contains("Success! Config ID ");
+  }
+}

--- a/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/QuickstartSampleIT.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/QuickstartSampleIT.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for quickstart sample. */
+@RunWith(JUnit4.class)
+@SuppressWarnings("checkstyle:abbreviationaswordinname")
+public class QuickstartSampleIT {
+
+  private static final Logger LOG = Logger.getLogger(QuickstartSampleIT.class.getName());
+  private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testQuickstart() throws Exception {
+    QuickstartSample.main(PROJECT_ID);
+    String got = bout.toString();
+    assertThat(got).contains("Supported Data Sources:");
+  }
+}

--- a/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/ReEnableTransferConfigIT.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/ReEnableTransferConfigIT.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.util.FieldMaskUtil;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ReEnableTransferConfigIT {
+
+  private static final Logger LOG = Logger.getLogger(ReEnableTransferConfigIT.class.getName());
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String CONFIG_NAME = requireEnvVar("DTS_TRANSFER_CONFIG_NAME");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("DTS_TRANSFER_CONFIG_NAME");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testReEnableTransferConfig() throws IOException {
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder().setName(CONFIG_NAME).setDisabled(false).build();
+    FieldMask updateMask = FieldMaskUtil.fromString("disabled");
+    ReEnableTransferConfig.reEnableTransferConfig(transferConfig, updateMask);
+    assertThat(bout.toString()).contains("Transfer config reenable successfully");
+  }
+}

--- a/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/RunDetailsIT.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/RunDetailsIT.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class RunDetailsIT {
+
+  private static final Logger LOG = Logger.getLogger(GetTransferConfigInfoIT.class.getName());
+  private ByteArrayOutputStream bout;
+  private String runName;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String CONFIG_NAME = requireEnvVar("DTS_TRANSFER_CONFIG_NAME");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("DTS_TRANSFER_CONFIG_NAME");
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+    try (DataTransferServiceClient client = DataTransferServiceClient.create()) {
+      client.listTransferRuns(CONFIG_NAME).iterateAll().forEach(run -> runName = run.getName());
+    }
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testRunDetails() throws IOException {
+    RunDetails.runDetails(runName);
+    assertThat(bout.toString()).contains("Run details retrieved successfully :");
+  }
+}

--- a/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/RunHistoryIT.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/RunHistoryIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class RunHistoryIT {
+
+  private static final Logger LOG = Logger.getLogger(GetTransferConfigInfoIT.class.getName());
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String CONFIG_NAME = requireEnvVar("DTS_TRANSFER_CONFIG_NAME");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("DTS_TRANSFER_CONFIG_NAME");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testRunHistory() throws IOException {
+    RunHistory.runHistory(CONFIG_NAME);
+    assertThat(bout.toString()).contains("Success! Run ID :");
+  }
+}

--- a/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/RunNotificationIT.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/RunNotificationIT.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.DatasetInfo;
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.ProjectTopicName;
+import com.google.pubsub.v1.Subscription;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class RunNotificationIT {
+
+  private static final Logger LOG = Logger.getLogger(RunNotificationIT.class.getName());
+  private BigQuery bigquery;
+  private ByteArrayOutputStream bout;
+  private String name;
+  private String displayName;
+  private String datasetName;
+  private String topicName;
+  private String formattedTopicName;
+  private String subscriberName;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String PROJECT_ID = requireEnvVar("GOOGLE_CLOUD_PROJECT");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    String id = UUID.randomUUID().toString().substring(0, 8);
+    displayName = "MY_SCHEDULE_NAME_TEST_" + id;
+    datasetName = "MY_DATASET_NAME_TEST_" + id;
+    topicName = "MY_TOPIC_TEST_" + id;
+    formattedTopicName = String.format("projects/%s/topics/%s", PROJECT_ID, topicName);
+    subscriberName = "MY_SUBSCRIBER_TEST_" + id;
+    // create a temporary dataset
+    bigquery = BigQueryOptions.getDefaultInstance().getService();
+    bigquery.create(DatasetInfo.of(datasetName));
+    // create a temporary pubsub topic
+    try (TopicAdminClient client = TopicAdminClient.create()) {
+      client.createTopic(formattedTopicName);
+    }
+    // create a temporary subscriber
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      ProjectTopicName projectTopicName = ProjectTopicName.of(PROJECT_ID, topicName);
+      ProjectSubscriptionName subscriptionName =
+          ProjectSubscriptionName.of(PROJECT_ID, subscriberName);
+      subscriptionAdminClient.createSubscription(
+          Subscription.newBuilder()
+              .setName(subscriptionName.toString())
+              .setTopic(projectTopicName.toString())
+              .setEnableMessageOrdering(true)
+              .build());
+    }
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    // Clean up
+    // delete a temporary subscriber
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      String formatSubscriberName =
+          String.format("projects/%s/subscriptions/%s", PROJECT_ID, subscriberName);
+      subscriptionAdminClient.deleteSubscription(formatSubscriberName);
+    }
+    // delete a temporary pubsub topic
+    try (TopicAdminClient client = TopicAdminClient.create()) {
+      client.deleteTopic(formattedTopicName);
+    }
+    DeleteScheduledQuery.deleteScheduledQuery(name);
+    // delete a temporary dataset
+    bigquery.delete(datasetName, BigQuery.DatasetDeleteOption.deleteContents());
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testRunNotification() throws IOException {
+    String query =
+        "SELECT CURRENT_TIMESTAMP() as current_time, @run_time as intended_run_time, "
+            + "@run_date as intended_run_date, 17 as some_integer";
+    String destinationTableName =
+        "MY_DESTINATION_TABLE_" + UUID.randomUUID().toString().substring(0, 8) + "_{run_date}";
+    Map<String, Value> params = new HashMap<>();
+    params.put("query", Value.newBuilder().setStringValue(query).build());
+    params.put(
+        "destination_table_name_template",
+        Value.newBuilder().setStringValue(destinationTableName).build());
+    params.put("write_disposition", Value.newBuilder().setStringValue("WRITE_TRUNCATE").build());
+    params.put("partitioning_field", Value.newBuilder().setStringValue("").build());
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setDestinationDatasetId(datasetName)
+            .setDisplayName(displayName)
+            .setDataSourceId("scheduled_query")
+            .setParams(Struct.newBuilder().putAllFields(params).build())
+            .setSchedule("every 24 hours")
+            .setNotificationPubsubTopic(formattedTopicName)
+            .build();
+    RunNotification.runNotification(PROJECT_ID, transferConfig);
+    String result = bout.toString();
+    name = result.substring(result.indexOf(":") + 1, result.length() - 1);
+    assertThat(result).contains("Scheduled query with run notification created successfully");
+    assertThat(bout.toString()).contains(name);
+  }
+}

--- a/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/ScheduleBackFillIT.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/ScheduleBackFillIT.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.FieldMaskUtil;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.threeten.bp.Clock;
+import org.threeten.bp.Instant;
+import org.threeten.bp.temporal.ChronoUnit;
+
+public class ScheduleBackFillIT {
+
+  private static final Logger LOG = Logger.getLogger(ScheduleBackFillIT.class.getName());
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String CONFIG_NAME = requireEnvVar("DTS_TRANSFER_CONFIG_NAME");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("DTS_TRANSFER_CONFIG_NAME");
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+    // enable transfer config
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder().setName(CONFIG_NAME).setDisabled(false).build();
+    FieldMask updateMask = FieldMaskUtil.fromString("disabled");
+    ReEnableTransferConfig.reEnableTransferConfig(transferConfig, updateMask);
+  }
+
+  @After
+  public void tearDown() {
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testScheduleBackFill() throws IOException {
+    Clock clock = Clock.systemDefaultZone();
+    Instant instant = clock.instant().truncatedTo(ChronoUnit.DAYS);
+    Timestamp startTime =
+        Timestamp.newBuilder()
+            .setSeconds(instant.minus(5, ChronoUnit.DAYS).getEpochSecond())
+            .setNanos(instant.minus(5, ChronoUnit.DAYS).getNano())
+            .build();
+    Timestamp endTime =
+        Timestamp.newBuilder()
+            .setSeconds(instant.minus(2, ChronoUnit.DAYS).getEpochSecond())
+            .setNanos(instant.minus(2, ChronoUnit.DAYS).getNano())
+            .build();
+    ScheduleBackFill.scheduleBackFill(CONFIG_NAME, startTime, endTime);
+    assertThat(bout.toString()).contains("Schedule backfill run successfully :");
+  }
+}

--- a/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/UpdateCredentialsIT.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/UpdateCredentialsIT.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.util.FieldMaskUtil;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class UpdateCredentialsIT {
+
+  private static final Logger LOG = Logger.getLogger(UpdateCredentialsIT.class.getName());
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String CONFIG_NAME = requireEnvVar("DTS_TRANSFER_CONFIG_NAME");
+  private static final String SERVICE_ACCOUNT = requireEnvVar("DTS_UPDATED_SERVICE_ACCOUNT");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("DTS_TRANSFER_CONFIG_NAME");
+    requireEnvVar("DTS_UPDATED_SERVICE_ACCOUNT");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testUpdateCredentials() throws IOException {
+    TransferConfig transferConfig = TransferConfig.newBuilder().setName(CONFIG_NAME).build();
+    FieldMask updateMask = FieldMaskUtil.fromString("service_account_name");
+    UpdateCredentials.updateCredentials(transferConfig, SERVICE_ACCOUNT, updateMask);
+    assertThat(bout.toString()).contains("Credentials updated successfully");
+  }
+}

--- a/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/UpdateTransferConfigIT.java
+++ b/bigquery/bigquerydatatransfer/snippets/src/test/java/com/example/bigquerydatatransfer/UpdateTransferConfigIT.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquerydatatransfer;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.datatransfer.v1.TransferConfig;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.util.FieldMaskUtil;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class UpdateTransferConfigIT {
+
+  private static final Logger LOG = Logger.getLogger(UpdateTransferConfigIT.class.getName());
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String CONFIG_NAME = requireEnvVar("DTS_TRANSFER_CONFIG_NAME");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("DTS_TRANSFER_CONFIG_NAME");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testUpdateTransferConfig() throws IOException {
+    TransferConfig transferConfig =
+        TransferConfig.newBuilder()
+            .setName(CONFIG_NAME)
+            .setDisplayName("UPDATED_DISPLAY_NAME")
+            .build();
+    FieldMask updateMask = FieldMaskUtil.fromString("display_name");
+    UpdateTransferConfig.updateTransferConfig(transferConfig, updateMask);
+    assertThat(bout.toString()).contains("Transfer config updated successfully");
+  }
+}


### PR DESCRIPTION
Migrating the snippet files from
https://github.com/googleapis/java-bigquerydatatransfer/tree/f0f22ce/samples/snippets.

Memo: Before this migration, the test was succeeding in java-bigquerydatatransfer repository: https://source.cloud.google.com/results/invocations/5dca9d6a-cd83-4c3c-8bc5-3e73fb64526b


## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
