### PR TITLE
feat: adding bigqueryreservation snippets

### DIFF
--- a/bigquery/bigqueryreservation/snippets/pom.xml
+++ b/bigquery/bigqueryreservation/snippets/pom.xml
@@ -22,8 +22,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-
-  <!-- [START bigqueryreservations_install_with_bom] -->
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -41,7 +39,6 @@
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigqueryreservation</artifactId>
     </dependency>
-    <!-- [END bigqueryreservations_install_with_bom] -->
 
     <dependency>
       <groupId>junit</groupId>

--- a/bigquery/bigqueryreservation/snippets/pom.xml
+++ b/bigquery/bigqueryreservation/snippets/pom.xml
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.bigquery</groupId>
+  <artifactId>bigqueryreservations-snippets</artifactId>
+  <packaging>jar</packaging>
+  <name>Google Cloud BigQuery Reservations Snippets</name>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.2.0</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+
+  <!-- [START bigqueryreservations_install_with_bom] -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.18.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigqueryreservation</artifactId>
+    </dependency>
+    <!-- [END bigqueryreservations_install_with_bom] -->
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.1.3</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/bigquery/bigqueryreservation/snippets/src/main/java/com/example/bigqueryreservation/QuickstartSample.java
+++ b/bigquery/bigqueryreservation/snippets/src/main/java/com/example/bigqueryreservation/QuickstartSample.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigqueryreservation;
+
+// [START bigqueryreservation_quickstart]
+import com.google.cloud.bigquery.reservation.v1.ReservationServiceClient;
+import java.io.IOException;
+
+public class QuickstartSample {
+
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "YOUR_PROJECT_ID";
+    String location = "LOCATION";
+    quickStartSample(projectId, location);
+  }
+
+  public static void quickStartSample(String projectId, String location) throws IOException {
+    try (ReservationServiceClient client = ReservationServiceClient.create()) {
+      // list reservations in the project
+      String parent = String.format("projects/%s/locations/%s", projectId, location);
+      client
+          .listReservations(parent)
+          .iterateAll()
+          .forEach(res -> System.out.println("Reservation resource name: " + res.getName()));
+
+      // list capacity commitments in the project
+      client
+          .listCapacityCommitments(parent)
+          .iterateAll()
+          .forEach(
+              commitment ->
+                  System.out.println("Capacity commitment resource name: " + commitment.getName()));
+    }
+  }
+}
+// [END bigqueryreservation_quickstart]

--- a/bigquery/bigqueryreservation/snippets/src/test/java/com/example/bigqueryreservation/QuickstartSampleIT.java
+++ b/bigquery/bigqueryreservation/snippets/src/test/java/com/example/bigqueryreservation/QuickstartSampleIT.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigqueryreservation;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for quickstart sample. */
+@RunWith(JUnit4.class)
+@SuppressWarnings("checkstyle:abbreviationaswordinname")
+public class QuickstartSampleIT {
+
+  private static final Logger LOG = Logger.getLogger(QuickstartSampleIT.class.getName());
+  private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    LOG.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testQuickstart() throws Exception {
+    QuickstartSample.quickStartSample(PROJECT_ID, "US");
+    String got = bout.toString();
+    assertThat(got).contains("resource name:");
+  }
+}


### PR DESCRIPTION
Moving the snippet from https://github.com/googleapis/java-bigqueryreservation/tree/68cf1f5/samples/snippets

The test was succeeding in the old repository https://source.cloud.google.com/results/invocations/31176557-31be-4e48-9539-228a2ea65948.

## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [x] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
