### PR TITLE
fix(aiplatform): not to set trafficSplit when undeploying model

### DIFF
--- a/aiplatform/src/main/java/aiplatform/UndeployModelSample.java
+++ b/aiplatform/src/main/java/aiplatform/UndeployModelSample.java
@@ -63,7 +63,6 @@ public class UndeployModelSample {
       // Traffic percentage values must add up to 100
       // Leave dictionary empty if endpoint should not accept any traffic
       Map<String, Integer> trafficSplit = new HashMap<>();
-      trafficSplit.put("0", 100);
 
       OperationFuture<UndeployModelResponse, UndeployModelOperationMetadata> operation =
           endpointServiceClient.undeployModelAsync(


### PR DESCRIPTION
## Description

Fixes b/293345808

We should not to specify trafficSplit when un-deploying a model,  otherwise error ""The following DeployedModel ID(s) [0] do not exist." occurs.
