### PR TITLE
docs(samples): Add error handling for BigQueryIO streaming example

### DIFF
--- a/dataflow/snippets/src/test/java/com/example/dataflow/BigQueryWriteIT.java
+++ b/dataflow/snippets/src/test/java/com/example/dataflow/BigQueryWriteIT.java
@@ -17,6 +17,7 @@
 package com.example.dataflow;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQuery.DatasetDeleteOption;
@@ -136,5 +137,8 @@ public class BigQueryWriteIT {
         QueryJobConfiguration.newBuilder(query).setDefaultDataset(datasetName).build();
     TableResult result = bigquery.query(queryConfig);
     assertEquals(3, result.getTotalRows());
+    // Verify that the bad data was written to the error collection.
+    String got = bout.toString();
+    assertTrue(got.contains("Failed insert: "));
   }
 }


### PR DESCRIPTION
Adds error handling to show the [dead-letter pattern](https://beam.apache.org/documentation/patterns/bigqueryio/#bigqueryio-deadletter-pattern).

Also removes the call to withNumStorageWriteApiStreams, because this setting now [defaults to autosharding](https://beam.apache.org/documentation/io/built-in/google-bigquery/#exactly-once-semantics), so there is no need to explicitly set a value.