### PR TITLE
chore: use managed dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,8 +41,9 @@ secrets.env
 *.iml
 
 # Eclipse files
-.project
 .classpath
+.metadata
+.project
 .settings
 
 # vim
@@ -67,3 +68,6 @@ out/
 terraform.tfstate*
 .terraform*
 *.output
+
+# PMD
+.pmdCache

--- a/accessapproval/snippets/pom.xml
+++ b/accessapproval/snippets/pom.xml
@@ -55,7 +55,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-core</artifactId>
-      <version>2.22.0</version>
       <classifier>tests</classifier>
     </dependency>
   </dependencies>

--- a/aiplatform/pom.xml
+++ b/aiplatform/pom.xml
@@ -55,7 +55,6 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.10.1</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -72,7 +71,6 @@
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-aiplatform-v1beta1</artifactId>
-      <version>0.39.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>

--- a/flexible/java-11/analytics/pom.xml
+++ b/flexible/java-11/analytics/pom.xml
@@ -60,31 +60,26 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>${spring.boot.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.4.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
-      <version>${spring.boot.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/flexible/java-11/cloudstorage/pom.xml
+++ b/flexible/java-11/cloudstorage/pom.xml
@@ -75,7 +75,6 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>
@@ -93,13 +92,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
-      <version>5.2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>5.4.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/flexible/java-11/datastore/pom.xml
+++ b/flexible/java-11/datastore/pom.xml
@@ -72,7 +72,6 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>
@@ -84,7 +83,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
-      <version>5.2.0</version>
       <scope>test</scope>
     </dependency>
     <!-- [START gae_flex_datastore_config] -->

--- a/flexible/java-11/pubsub/pom.xml
+++ b/flexible/java-11/pubsub/pom.xml
@@ -65,7 +65,6 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>
@@ -114,7 +113,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.4.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/flexible/java-11/static-files/pom.xml
+++ b/flexible/java-11/static-files/pom.xml
@@ -57,7 +57,6 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>

--- a/flexible/java-8/pubsub/pom.xml
+++ b/flexible/java-8/pubsub/pom.xml
@@ -54,18 +54,6 @@
     </dependencies>
   </dependencyManagement>
 
-  <!-- FIXME(lesv) Temporary fix due to Datastore having the wrong version -->
-  <!--<dependencyManagement>
-    <dependencies>
-      <dependency>
-          <groupId>io.grpc</groupId>
-          <artifactId>grpc-core</artifactId>
-          <version>1.2.0</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>-->
-  <!-- end of FIXME -->
-
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -107,6 +95,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <version>5.4.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/flexible/java-8/pubsub/pom.xml
+++ b/flexible/java-8/pubsub/pom.xml
@@ -107,7 +107,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.4.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Updated `pom.xml` where we are overriding/duplicating the managed versions. This keeps our dependencies in sync within a sample, and also reduces dependency PRs.

Also, added a couple `.gitignore` entries with this PR.