### PR TITLE
docs: fix Bigtable flakey filters test

### DIFF
--- a/bigtable/hbase/snippets/src/test/java/com/example/bigtable/FiltersTest.java
+++ b/bigtable/hbase/snippets/src/test/java/com/example/bigtable/FiltersTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertNotNull;
 
 import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
 import com.google.cloud.bigtable.hbase.BigtableConfiguration;
-import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -39,12 +38,9 @@ import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
 
 public class FiltersTest {
-
-  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(5);
 
   private static final String INSTANCE_ENV = "BIGTABLE_TESTING_INSTANCE";
   private static final String TABLE_ID =
@@ -77,8 +73,10 @@ public class FiltersTest {
       try (Admin admin = connection.getAdmin()) {
         admin.createTable(
             new HTableDescriptor(TableName.valueOf(TABLE_ID))
-                .addFamily(new HColumnDescriptor(COLUMN_FAMILY_NAME_STATS))
-                .addFamily(new HColumnDescriptor(COLUMN_FAMILY_NAME_DATA)));
+                .addFamily(new HColumnDescriptor(COLUMN_FAMILY_NAME_STATS).setMaxVersions(
+                    Integer.MAX_VALUE))
+                .addFamily(new HColumnDescriptor(COLUMN_FAMILY_NAME_DATA).setMaxVersions(
+                    Integer.MAX_VALUE)));
 
         try (BufferedMutator batcher = connection.getBufferedMutator(TableName.valueOf(TABLE_ID))) {
 

--- a/bigtable/hbase/snippets/src/test/java/com/example/bigtable/FiltersTest.java
+++ b/bigtable/hbase/snippets/src/test/java/com/example/bigtable/FiltersTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 
 import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
 import com.google.cloud.bigtable.hbase.BigtableConfiguration;
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -38,9 +39,13 @@ import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class FiltersTest {
+
+  @Rule
+  public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(5);
 
   private static final String INSTANCE_ENV = "BIGTABLE_TESTING_INSTANCE";
   private static final String TABLE_ID =


### PR DESCRIPTION
## Description

Updated the table creation to remove any garbage collection. Default for most Bigtable clients is none, but for HBase client it was 1 max version for consistency with HBase API.

Fixes https://github.com/GoogleCloudPlatform/java-docs-samples/issues/7963
Fixes https://github.com/GoogleCloudPlatform/java-docs-samples/issues/7964
Fixes https://github.com/GoogleCloudPlatform/java-docs-samples/issues/7965
Fixes https://github.com/GoogleCloudPlatform/java-docs-samples/issues/7966
Fixes https://github.com/GoogleCloudPlatform/java-docs-samples/issues/7967

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
