### PR TITLE
fix(aiplatform): correct the timeout setting for the endpoint service

### DIFF
--- a/aiplatform/src/main/java/aiplatform/DeployModelSample.java
+++ b/aiplatform/src/main/java/aiplatform/DeployModelSample.java
@@ -77,7 +77,7 @@ public class DeployModelSample {
     EndpointServiceStubSettings.Builder endpointServiceStubSettingsBuilder =
         EndpointServiceStubSettings.newBuilder();
     endpointServiceStubSettingsBuilder
-        .createEndpointOperationSettings()
+        .deployModelOperationSettings()
         .setPollingAlgorithm(operationTimedPollAlgorithm);
     EndpointServiceStubSettings endpointStubSettings = endpointServiceStubSettingsBuilder.build();
     EndpointServiceSettings endpointServiceSettings =


### PR DESCRIPTION
## Description

Fixes b/281672516

Correct the timeout setting for the endpoint service. It should use the deployModelOperationSettings instead of the createEndpointOperationSettings.