### PR TITLE
fix(storageinsights): Replace sleep with retry rule

### DIFF
--- a/storageinsights/src/test/java/com/google/cloud/storage/storageinsights/samples/test/ITStorageinsightsSamplesTest.java
+++ b/storageinsights/src/test/java/com/google/cloud/storage/storageinsights/samples/test/ITStorageinsightsSamplesTest.java
@@ -36,6 +36,7 @@ import com.google.cloud.storage.testing.RemoteStorageHelper;
 import com.google.cloud.storageinsights.v1.LocationName;
 import com.google.cloud.storageinsights.v1.ReportConfig;
 import com.google.cloud.storageinsights.v1.StorageInsightsClient;
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import com.google.cloud.testing.junit4.StdOutCaptureRule;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
@@ -60,6 +61,10 @@ public class ITStorageinsightsSamplesTest {
   private static StorageInsightsClient insights;
 
   @Rule public final StdOutCaptureRule stdOutCaptureRule = new StdOutCaptureRule();
+
+  // This is in case the tests fail due to the permissions for the service account needing extra
+  // time to propagate.
+  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(5);
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -98,7 +103,6 @@ public class ITStorageinsightsSamplesTest {
 
     grantBucketsInsightsPermissions(insightsServiceAccount, SOURCE_BUCKET);
     grantBucketsInsightsPermissions(insightsServiceAccount, SINK_BUCKET);
-    Thread.sleep(10000); //gives time for service account permissions to propagate.
   }
 
   @AfterClass

--- a/storageinsights/src/test/java/com/google/cloud/storage/storageinsights/samples/test/ITStorageinsightsSamplesTest.java
+++ b/storageinsights/src/test/java/com/google/cloud/storage/storageinsights/samples/test/ITStorageinsightsSamplesTest.java
@@ -230,6 +230,7 @@ public class ITStorageinsightsSamplesTest {
     String reportConfigName = getReportConfigNameFromSampleOutput(sampleOutput);
     insights.deleteReportConfig(reportConfigName);
   }
+
   // Gets the last instance of a Report Config Name from an output string
   private static String getReportConfigNameFromSampleOutput(String sampleOutput)
       throws IOException {

--- a/storageinsights/src/test/java/com/google/cloud/storage/storageinsights/samples/test/ITStorageinsightsSamplesTest.java
+++ b/storageinsights/src/test/java/com/google/cloud/storage/storageinsights/samples/test/ITStorageinsightsSamplesTest.java
@@ -64,7 +64,7 @@ public class ITStorageinsightsSamplesTest {
 
   // This is in case the tests fail due to the permissions for the service account needing extra
   // time to propagate.
-  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(5);
+  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(10);
 
   @BeforeClass
   public static void beforeClass() throws Exception {


### PR DESCRIPTION
Replaces the sleep in the storageinsights tests with a retry rule, so that delays only happen as much as is needed

Fixes https://github.com/GoogleCloudPlatform/java-docs-samples/issues/8534