### PR TITLE
Add snippet for using cloud functions gen 2 with Datastore

### DIFF
--- a/functions/v2/datastore/pom.xml
+++ b/functions/v2/datastore/pom.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright 2023 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example.functions</groupId>
+  <artifactId>functions-firebase-firestore</artifactId>
+
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.2.0</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <artifactId>libraries-bom</artifactId>
+        <groupId>com.google.cloud</groupId>
+        <scope>import</scope>
+        <type>pom</type>
+        <version>26.22.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloudevent-types</artifactId>
+      <version>0.14.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <!-- Required for Function primitives -->
+    <dependency>
+      <groupId>com.google.cloud.functions</groupId>
+      <artifactId>functions-framework-api</artifactId>
+      <version>1.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- The following dependencies are only required for testing -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.10.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.1.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava-testlib</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.cloudevents</groupId>
+      <artifactId>cloudevents-core</artifactId>
+      <version>2.5.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <!--
+          Google Cloud Functions Framework Maven plugin
+
+          This plugin allows you to run Cloud Functions Java code
+          locally. Use the following terminal command to run a
+          given function locally:
+
+          mvn function:run -Drun.functionTarget=your.package.yourFunction
+        -->
+        <groupId>com.google.cloud.functions</groupId>
+        <artifactId>function-maven-plugin</artifactId>
+        <version>0.11.0</version>
+        <configuration>
+          <functionTarget>functions.FirebaseFirestore</functionTarget>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <!-- version 3.0.0-M4 does not load JUnit5 correctly -->
+        <!-- see https://issues.apache.org/jira/browse/SUREFIRE-1750 -->
+        <version>3.1.2</version>
+        <configuration>
+          <includes>
+            <include>**/*Test.java</include>
+          </includes>
+          <skipTests>${skipTests}</skipTests>
+          <reportNameSuffix>sponge_log</reportNameSuffix>
+          <trimStackTrace>false</trimStackTrace>
+        </configuration>
+      </plugin>
+      <plugin> <!-- Required for Java 8 (Alpha) functions in the inline editor -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>testCompile</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <excludes>
+            <exclude>.google/</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/functions/v2/datastore/pom.xml
+++ b/functions/v2/datastore/pom.xml
@@ -22,7 +22,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.example.functions</groupId>
-  <artifactId>functions-firebase-firestore</artifactId>
+  <artifactId>functions-datastore</artifactId>
 
   <parent>
     <groupId>com.google.cloud.samples</groupId>
@@ -108,7 +108,7 @@
         <artifactId>function-maven-plugin</artifactId>
         <version>0.11.0</version>
         <configuration>
-          <functionTarget>functions.FirebaseFirestore</functionTarget>
+          <functionTarget>functions.Datastore</functionTarget>
         </configuration>
       </plugin>
       <plugin>

--- a/functions/v2/datastore/src/main/java/functions/Datastore.java
+++ b/functions/v2/datastore/src/main/java/functions/Datastore.java
@@ -23,8 +23,8 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import io.cloudevents.CloudEvent;
 import java.util.logging.Logger;
 
-public class DatastoreFunction implements CloudEventsFunction {
-  private static final Logger logger = Logger.getLogger(DatastoreFunction.class.getName());
+public class Datastore implements CloudEventsFunction {
+  private static final Logger logger = Logger.getLogger(Datastore.class.getName());
 
   @Override
   public void accept(CloudEvent event) throws InvalidProtocolBufferException {

--- a/functions/v2/datastore/src/main/java/functions/Datastore.java
+++ b/functions/v2/datastore/src/main/java/functions/Datastore.java
@@ -18,27 +18,27 @@ package functions;
 
 // [START functions_cloudevent_datastore]
 import com.google.cloud.functions.CloudEventsFunction;
-import com.google.events.cloud.firestore.v1.DocumentEventData;
+import com.google.events.cloud.datastore.v1.EntityEventData;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.cloudevents.CloudEvent;
 import java.util.logging.Logger;
 
-public class FirebaseFirestore implements CloudEventsFunction {
-  private static final Logger logger = Logger.getLogger(FirebaseFirestore.class.getName());
+public class DatastoreFunction implements CloudEventsFunction {
+  private static final Logger logger = Logger.getLogger(DatastoreFunction.class.getName());
 
   @Override
   public void accept(CloudEvent event) throws InvalidProtocolBufferException {
-    DocumentEventData firestorEventData = DocumentEventData.parseFrom(event.getData().toBytes());
+    EntityEventData datastoreEventData = EntityEventData.parseFrom(event.getData().toBytes());
 
     logger.info("Function triggered by event on: " + event.getSource());
     logger.info("Event type: " + event.getType());
 
     logger.info("Old value:");
-    logger.info(firestorEventData.getOldValue().toString());
+    logger.info(datastoreEventData.getOldValue().toString());
 
     logger.info("New value:");
-    logger.info(firestorEventData.getValue().toString());
+    logger.info(datastoreEventData.getValue().toString());
   }
 }
 
-// [END functions_cloudevent_firebase_firestore]
+// [END functions_cloudevent_datastore]

--- a/functions/v2/datastore/src/main/java/functions/Datastore.java
+++ b/functions/v2/datastore/src/main/java/functions/Datastore.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package functions;
+
+// [START functions_cloudevent_datastore]
+import com.google.cloud.functions.CloudEventsFunction;
+import com.google.events.cloud.firestore.v1.DocumentEventData;
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.cloudevents.CloudEvent;
+import java.util.logging.Logger;
+
+public class FirebaseFirestore implements CloudEventsFunction {
+  private static final Logger logger = Logger.getLogger(FirebaseFirestore.class.getName());
+
+  @Override
+  public void accept(CloudEvent event) throws InvalidProtocolBufferException {
+    DocumentEventData firestorEventData = DocumentEventData.parseFrom(event.getData().toBytes());
+
+    logger.info("Function triggered by event on: " + event.getSource());
+    logger.info("Event type: " + event.getType());
+
+    logger.info("Old value:");
+    logger.info(firestorEventData.getOldValue().toString());
+
+    logger.info("New value:");
+    logger.info(firestorEventData.getValue().toString());
+  }
+}
+
+// [END functions_cloudevent_firebase_firestore]

--- a/functions/v2/datastore/src/test/java/functions/DatastoreTest.java
+++ b/functions/v2/datastore/src/test/java/functions/DatastoreTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package functions;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.TestLogHandler;
+import com.google.events.cloud.firestore.v1.Document;
+import com.google.events.cloud.firestore.v1.DocumentEventData;
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import java.net.URI;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class FirebaseFirestoreTest {
+
+  // Loggers + handlers for various tested classes
+  // (Must be declared at class-level, or LoggingHandler won't detect log
+  // records!)
+  private static final Logger logger = Logger.getLogger(FirebaseFirestore.class.getName());
+
+  private static final TestLogHandler LOG_HANDLER = new TestLogHandler();
+
+  @BeforeClass
+  public static void beforeClass() {
+    logger.addHandler(LOG_HANDLER);
+  }
+
+  @After
+  public void afterTest() {
+    LOG_HANDLER.clear();
+  }
+
+  @Test
+  public void functionsFirebaseFirestore_shouldUnmarshalAndPrint()
+      throws InvalidProtocolBufferException {
+    Document oldValue = Document.newBuilder()
+        .setName("oldValue")
+        .build();
+    Document newValue = Document.newBuilder()
+        .setName("newValue")
+        .build();
+    DocumentEventData firestorePayload = DocumentEventData.newBuilder()
+        .setValue(newValue)
+        .setOldValue(oldValue)
+        .build();
+
+    CloudEvent event = CloudEventBuilder.v1()
+        .withId("0")
+        .withSubject("test subject")
+        .withSource(URI.create("https://example.com"))
+        .withType("google.cloud.firestore.document.v1.written")
+        .withData(firestorePayload.toByteArray())
+        .build();
+
+    new FirebaseFirestore().accept(event);
+
+    assertThat(LOG_HANDLER.getStoredLogRecords().get(0).getMessage()).isEqualTo(
+        "Function triggered by event on: " + event.getSource());
+    assertThat(LOG_HANDLER.getStoredLogRecords().get(1).getMessage()).isEqualTo(
+        "Event type: " + event.getType());
+    assertThat(LOG_HANDLER.getStoredLogRecords().get(2).getMessage()).isEqualTo(
+        "Old value:");
+    assertThat(LOG_HANDLER.getStoredLogRecords().get(3).getMessage()).isEqualTo(
+        oldValue.toString());
+    assertThat(LOG_HANDLER.getStoredLogRecords().get(4).getMessage()).isEqualTo(
+        "New value:");
+    assertThat(LOG_HANDLER.getStoredLogRecords().get(5).getMessage()).isEqualTo(
+        newValue.toString());
+  }
+}

--- a/functions/v2/datastore/src/test/java/functions/DatastoreTest.java
+++ b/functions/v2/datastore/src/test/java/functions/DatastoreTest.java
@@ -19,8 +19,10 @@ package functions;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.TestLogHandler;
-import com.google.events.cloud.firestore.v1.Document;
-import com.google.events.cloud.firestore.v1.DocumentEventData;
+import com.google.events.cloud.datastore.v1.Entity;
+import com.google.events.cloud.datastore.v1.EntityEventData;
+import com.google.events.cloud.datastore.v1.EntityResult;
+import com.google.events.cloud.datastore.v1.Value;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
@@ -33,12 +35,12 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class FirebaseFirestoreTest {
+public class DatastoreTest {
 
   // Loggers + handlers for various tested classes
   // (Must be declared at class-level, or LoggingHandler won't detect log
   // records!)
-  private static final Logger logger = Logger.getLogger(FirebaseFirestore.class.getName());
+  private static final Logger logger = Logger.getLogger(Datastore.class.getName());
 
   private static final TestLogHandler LOG_HANDLER = new TestLogHandler();
 
@@ -53,40 +55,40 @@ public class FirebaseFirestoreTest {
   }
 
   @Test
-  public void functionsFirebaseFirestore_shouldUnmarshalAndPrint()
-      throws InvalidProtocolBufferException {
-    Document oldValue = Document.newBuilder()
-        .setName("oldValue")
-        .build();
-    Document newValue = Document.newBuilder()
-        .setName("newValue")
-        .build();
-    DocumentEventData firestorePayload = DocumentEventData.newBuilder()
-        .setValue(newValue)
-        .setOldValue(oldValue)
-        .build();
+  public void functionsDatastore_shouldUnmarshalAndPrint() throws InvalidProtocolBufferException {
+    Entity oldEntity =
+        Entity.newBuilder()
+            .putProperties("Name", Value.newBuilder().setStringValue("oldValue").build())
+            .build();
+    EntityResult oldResult = EntityResult.newBuilder().setEntity(oldEntity).build();
+    Entity newEntity =
+        Entity.newBuilder()
+            .putProperties("Name", Value.newBuilder().setStringValue("newValue").build())
+            .build();
+    EntityResult newResult = EntityResult.newBuilder().setEntity(newEntity).build();
+    EntityEventData datastorePayload =
+        EntityEventData.newBuilder().setValue(newResult).setOldValue(oldResult).build();
 
-    CloudEvent event = CloudEventBuilder.v1()
-        .withId("0")
-        .withSubject("test subject")
-        .withSource(URI.create("https://example.com"))
-        .withType("google.cloud.firestore.document.v1.written")
-        .withData(firestorePayload.toByteArray())
-        .build();
+    CloudEvent event =
+        CloudEventBuilder.v1()
+            .withId("0")
+            .withSubject("test subject")
+            .withSource(URI.create("https://example.com"))
+            .withType("google.cloud.datastore.entity.v1.written")
+            .withData(datastorePayload.toByteArray())
+            .build();
 
-    new FirebaseFirestore().accept(event);
+    new Datastore().accept(event);
 
-    assertThat(LOG_HANDLER.getStoredLogRecords().get(0).getMessage()).isEqualTo(
-        "Function triggered by event on: " + event.getSource());
-    assertThat(LOG_HANDLER.getStoredLogRecords().get(1).getMessage()).isEqualTo(
-        "Event type: " + event.getType());
-    assertThat(LOG_HANDLER.getStoredLogRecords().get(2).getMessage()).isEqualTo(
-        "Old value:");
-    assertThat(LOG_HANDLER.getStoredLogRecords().get(3).getMessage()).isEqualTo(
-        oldValue.toString());
-    assertThat(LOG_HANDLER.getStoredLogRecords().get(4).getMessage()).isEqualTo(
-        "New value:");
-    assertThat(LOG_HANDLER.getStoredLogRecords().get(5).getMessage()).isEqualTo(
-        newValue.toString());
+    assertThat(LOG_HANDLER.getStoredLogRecords().get(0).getMessage())
+        .isEqualTo("Function triggered by event on: " + event.getSource());
+    assertThat(LOG_HANDLER.getStoredLogRecords().get(1).getMessage())
+        .isEqualTo("Event type: " + event.getType());
+    assertThat(LOG_HANDLER.getStoredLogRecords().get(2).getMessage()).isEqualTo("Old value:");
+    assertThat(LOG_HANDLER.getStoredLogRecords().get(3).getMessage())
+        .isEqualTo(oldResult.toString());
+    assertThat(LOG_HANDLER.getStoredLogRecords().get(4).getMessage()).isEqualTo("New value:");
+    assertThat(LOG_HANDLER.getStoredLogRecords().get(5).getMessage())
+        .isEqualTo(newResult.toString());
   }
 }


### PR DESCRIPTION
## Description

Fixes #296612970

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
