### PR TITLE
chore(aiplatform): re-add skipped tests back to the integration

### DIFF
--- a/aiplatform/src/test/java/aiplatform/FeaturestoreSamplesTest.java
+++ b/aiplatform/src/test/java/aiplatform/FeaturestoreSamplesTest.java
@@ -29,7 +29,6 @@ import java.util.concurrent.TimeoutException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -76,12 +75,12 @@ public class FeaturestoreSamplesTest {
 
   @After
   public void tearDown()
-          throws InterruptedException, ExecutionException, IOException, TimeoutException {
+      throws InterruptedException, ExecutionException, IOException, TimeoutException {
 
     if (featurestoreId != null) {
       // Delete the featurestore
-      DeleteFeaturestoreSample.deleteFeaturestoreSample(PROJECT_ID, featurestoreId, USE_FORCE,
-          LOCATION, ENDPOINT, TIMEOUT);
+      DeleteFeaturestoreSample.deleteFeaturestoreSample(
+          PROJECT_ID, featurestoreId, USE_FORCE, LOCATION, ENDPOINT, TIMEOUT);
 
       // Assert
       String deleteFeaturestoreResponse = bout.toString();
@@ -92,7 +91,6 @@ public class FeaturestoreSamplesTest {
   }
 
   @Test
-  @Ignore("Temporarily skipping due to b/288815617")
   public void testCreateFeaturestoreSample()
       throws IOException, InterruptedException, ExecutionException, TimeoutException {
     // Create the featurestore


### PR DESCRIPTION
## Description

Fixes #8620

Re-add featurestore tests back to the integration tests as the stability issue has been resolved b/290339336.