### PR TITLE
chore(automl): ignore AutoML tests because the API is deprecated

### DIFF
--- a/automl/src/test/java/beta/automl/BatchPredictTest.java
+++ b/automl/src/test/java/beta/automl/BatchPredictTest.java
@@ -27,11 +27,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class BatchPredictTest {

--- a/automl/src/test/java/beta/automl/CancelOperationTest.java
+++ b/automl/src/test/java/beta/automl/CancelOperationTest.java
@@ -28,11 +28,13 @@ import java.io.PrintStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class CancelOperationTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/beta/automl/DeleteDatasetTest.java
+++ b/automl/src/test/java/beta/automl/DeleteDatasetTest.java
@@ -32,11 +32,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class DeleteDatasetTest {

--- a/automl/src/test/java/beta/automl/DeleteModelTest.java
+++ b/automl/src/test/java/beta/automl/DeleteModelTest.java
@@ -27,11 +27,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class DeleteModelTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/beta/automl/DeployModelTest.java
+++ b/automl/src/test/java/beta/automl/DeployModelTest.java
@@ -27,11 +27,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class DeployModelTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/beta/automl/GetModelEvaluationTest.java
+++ b/automl/src/test/java/beta/automl/GetModelEvaluationTest.java
@@ -30,11 +30,13 @@ import java.io.PrintStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class GetModelEvaluationTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/beta/automl/GetModelTest.java
+++ b/automl/src/test/java/beta/automl/GetModelTest.java
@@ -26,11 +26,13 @@ import java.io.PrintStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class GetModelTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/beta/automl/GetOperationStatusTest.java
+++ b/automl/src/test/java/beta/automl/GetOperationStatusTest.java
@@ -30,11 +30,13 @@ import java.io.PrintStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class GetOperationStatusTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/beta/automl/ImportDatasetTest.java
+++ b/automl/src/test/java/beta/automl/ImportDatasetTest.java
@@ -29,11 +29,13 @@ import java.util.concurrent.TimeoutException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class ImportDatasetTest {

--- a/automl/src/test/java/beta/automl/ListDatasetsTest.java
+++ b/automl/src/test/java/beta/automl/ListDatasetsTest.java
@@ -26,11 +26,13 @@ import java.io.PrintStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class ListDatasetsTest {

--- a/automl/src/test/java/beta/automl/ListModelEvaluationsTest.java
+++ b/automl/src/test/java/beta/automl/ListModelEvaluationsTest.java
@@ -26,11 +26,13 @@ import java.io.PrintStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class ListModelEvaluationsTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/beta/automl/ListModelsTest.java
+++ b/automl/src/test/java/beta/automl/ListModelsTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class ListModelsTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/beta/automl/SetEndpointIT.java
+++ b/automl/src/test/java/beta/automl/SetEndpointIT.java
@@ -26,12 +26,14 @@ import java.io.PrintStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Tests for Automl Set Endpoint */
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class SetEndpointIT {

--- a/automl/src/test/java/beta/automl/TablesBatchPredictBigQueryTest.java
+++ b/automl/src/test/java/beta/automl/TablesBatchPredictBigQueryTest.java
@@ -27,11 +27,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class TablesBatchPredictBigQueryTest {

--- a/automl/src/test/java/beta/automl/TablesCreateDatasetTest.java
+++ b/automl/src/test/java/beta/automl/TablesCreateDatasetTest.java
@@ -28,11 +28,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class TablesCreateDatasetTest {

--- a/automl/src/test/java/beta/automl/TablesCreateModelTest.java
+++ b/automl/src/test/java/beta/automl/TablesCreateModelTest.java
@@ -28,11 +28,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class TablesCreateModelTest {

--- a/automl/src/test/java/beta/automl/TablesGetModelTest.java
+++ b/automl/src/test/java/beta/automl/TablesGetModelTest.java
@@ -26,11 +26,13 @@ import java.io.PrintStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class TablesGetModelTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/beta/automl/TablesImportDatasetTest.java
+++ b/automl/src/test/java/beta/automl/TablesImportDatasetTest.java
@@ -27,11 +27,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class TablesImportDatasetTest {

--- a/automl/src/test/java/beta/automl/TablesPredictTest.java
+++ b/automl/src/test/java/beta/automl/TablesPredictTest.java
@@ -34,11 +34,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class TablesPredictTest {

--- a/automl/src/test/java/beta/automl/UndeployModelTest.java
+++ b/automl/src/test/java/beta/automl/UndeployModelTest.java
@@ -27,11 +27,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class UndeployModelTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/beta/automl/VideoClassificationCreateDatasetTest.java
+++ b/automl/src/test/java/beta/automl/VideoClassificationCreateDatasetTest.java
@@ -30,11 +30,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class VideoClassificationCreateDatasetTest {

--- a/automl/src/test/java/beta/automl/VideoClassificationCreateModelTest.java
+++ b/automl/src/test/java/beta/automl/VideoClassificationCreateModelTest.java
@@ -28,11 +28,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class VideoClassificationCreateModelTest {

--- a/automl/src/test/java/beta/automl/VideoObjectTrackingCreateDatasetTest.java
+++ b/automl/src/test/java/beta/automl/VideoObjectTrackingCreateDatasetTest.java
@@ -30,11 +30,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class VideoObjectTrackingCreateDatasetTest {

--- a/automl/src/test/java/beta/automl/VideoObjectTrackingCreateModelTest.java
+++ b/automl/src/test/java/beta/automl/VideoObjectTrackingCreateModelTest.java
@@ -28,11 +28,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class VideoObjectTrackingCreateModelTest {

--- a/automl/src/test/java/com/example/automl/BatchPredictTest.java
+++ b/automl/src/test/java/com/example/automl/BatchPredictTest.java
@@ -27,11 +27,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class BatchPredictTest {

--- a/automl/src/test/java/com/example/automl/DeleteDatasetTest.java
+++ b/automl/src/test/java/com/example/automl/DeleteDatasetTest.java
@@ -28,11 +28,14 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class DeleteDatasetTest {

--- a/automl/src/test/java/com/example/automl/DeleteModelTest.java
+++ b/automl/src/test/java/com/example/automl/DeleteModelTest.java
@@ -27,11 +27,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class DeleteModelTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/com/example/automl/DeployModelTest.java
+++ b/automl/src/test/java/com/example/automl/DeployModelTest.java
@@ -27,11 +27,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class DeployModelTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/com/example/automl/ExportDatasetTest.java
+++ b/automl/src/test/java/com/example/automl/ExportDatasetTest.java
@@ -27,11 +27,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class ExportDatasetTest {

--- a/automl/src/test/java/com/example/automl/GetDatasetTest.java
+++ b/automl/src/test/java/com/example/automl/GetDatasetTest.java
@@ -26,11 +26,13 @@ import java.io.PrintStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class GetDatasetTest {

--- a/automl/src/test/java/com/example/automl/GetModelEvaluationTest.java
+++ b/automl/src/test/java/com/example/automl/GetModelEvaluationTest.java
@@ -26,11 +26,13 @@ import java.io.PrintStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class GetModelEvaluationTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/com/example/automl/GetModelTest.java
+++ b/automl/src/test/java/com/example/automl/GetModelTest.java
@@ -26,11 +26,13 @@ import java.io.PrintStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class GetModelTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/com/example/automl/GetOperationStatusTest.java
+++ b/automl/src/test/java/com/example/automl/GetOperationStatusTest.java
@@ -26,11 +26,13 @@ import java.io.PrintStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class GetOperationStatusTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/com/example/automl/ImportDatasetTest.java
+++ b/automl/src/test/java/com/example/automl/ImportDatasetTest.java
@@ -30,11 +30,13 @@ import java.util.concurrent.TimeoutException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class ImportDatasetTest {

--- a/automl/src/test/java/com/example/automl/LanguageEntityExtractionCreateDatasetTest.java
+++ b/automl/src/test/java/com/example/automl/LanguageEntityExtractionCreateDatasetTest.java
@@ -28,11 +28,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class LanguageEntityExtractionCreateDatasetTest {

--- a/automl/src/test/java/com/example/automl/LanguageEntityExtractionCreateModelTest.java
+++ b/automl/src/test/java/com/example/automl/LanguageEntityExtractionCreateModelTest.java
@@ -28,11 +28,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class LanguageEntityExtractionCreateModelTest {

--- a/automl/src/test/java/com/example/automl/LanguageEntityExtractionPredictTest.java
+++ b/automl/src/test/java/com/example/automl/LanguageEntityExtractionPredictTest.java
@@ -31,11 +31,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class LanguageEntityExtractionPredictTest {

--- a/automl/src/test/java/com/example/automl/LanguageSentimentAnalysisCreateDatasetTest.java
+++ b/automl/src/test/java/com/example/automl/LanguageSentimentAnalysisCreateDatasetTest.java
@@ -28,11 +28,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class LanguageSentimentAnalysisCreateDatasetTest {

--- a/automl/src/test/java/com/example/automl/LanguageSentimentAnalysisCreateModelTest.java
+++ b/automl/src/test/java/com/example/automl/LanguageSentimentAnalysisCreateModelTest.java
@@ -28,11 +28,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class LanguageSentimentAnalysisCreateModelTest {

--- a/automl/src/test/java/com/example/automl/LanguageSentimentAnalysisPredictTest.java
+++ b/automl/src/test/java/com/example/automl/LanguageSentimentAnalysisPredictTest.java
@@ -31,11 +31,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class LanguageSentimentAnalysisPredictTest {

--- a/automl/src/test/java/com/example/automl/LanguageTextClassificationCreateDatasetTest.java
+++ b/automl/src/test/java/com/example/automl/LanguageTextClassificationCreateDatasetTest.java
@@ -28,11 +28,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class LanguageTextClassificationCreateDatasetTest {

--- a/automl/src/test/java/com/example/automl/LanguageTextClassificationCreateModelTest.java
+++ b/automl/src/test/java/com/example/automl/LanguageTextClassificationCreateModelTest.java
@@ -28,11 +28,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class LanguageTextClassificationCreateModelTest {

--- a/automl/src/test/java/com/example/automl/LanguageTextClassificationPredictTest.java
+++ b/automl/src/test/java/com/example/automl/LanguageTextClassificationPredictTest.java
@@ -31,11 +31,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class LanguageTextClassificationPredictTest {

--- a/automl/src/test/java/com/example/automl/ListDatasetsTest.java
+++ b/automl/src/test/java/com/example/automl/ListDatasetsTest.java
@@ -26,11 +26,13 @@ import java.io.PrintStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class ListDatasetsTest {

--- a/automl/src/test/java/com/example/automl/ListModelEvaluationsTest.java
+++ b/automl/src/test/java/com/example/automl/ListModelEvaluationsTest.java
@@ -26,11 +26,13 @@ import java.io.PrintStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class ListModelEvaluationsTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/com/example/automl/ListModelsTest.java
+++ b/automl/src/test/java/com/example/automl/ListModelsTest.java
@@ -26,11 +26,13 @@ import java.io.PrintStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class ListModelsTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/com/example/automl/ListOperationStatusTest.java
+++ b/automl/src/test/java/com/example/automl/ListOperationStatusTest.java
@@ -36,11 +36,13 @@ import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class ListOperationStatusTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/com/example/automl/TranslateCreateDatasetTest.java
+++ b/automl/src/test/java/com/example/automl/TranslateCreateDatasetTest.java
@@ -28,11 +28,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class TranslateCreateDatasetTest {

--- a/automl/src/test/java/com/example/automl/TranslateCreateModelTest.java
+++ b/automl/src/test/java/com/example/automl/TranslateCreateModelTest.java
@@ -28,12 +28,14 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 // Tests for Automl translation models.
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class TranslateCreateModelTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/com/example/automl/TranslatePredictTest.java
+++ b/automl/src/test/java/com/example/automl/TranslatePredictTest.java
@@ -26,12 +26,14 @@ import java.io.PrintStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 // Tests for translation "Predict" sample.
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class TranslatePredictTest {

--- a/automl/src/test/java/com/example/automl/UndeployModelTest.java
+++ b/automl/src/test/java/com/example/automl/UndeployModelTest.java
@@ -27,11 +27,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class UndeployModelTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/com/example/automl/VisionClassificationCreateDatasetTest.java
+++ b/automl/src/test/java/com/example/automl/VisionClassificationCreateDatasetTest.java
@@ -28,11 +28,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class VisionClassificationCreateDatasetTest {

--- a/automl/src/test/java/com/example/automl/VisionClassificationCreateModelTest.java
+++ b/automl/src/test/java/com/example/automl/VisionClassificationCreateModelTest.java
@@ -28,11 +28,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class VisionClassificationCreateModelTest {

--- a/automl/src/test/java/com/example/automl/VisionClassificationDeployModelNodeCountTest.java
+++ b/automl/src/test/java/com/example/automl/VisionClassificationDeployModelNodeCountTest.java
@@ -27,11 +27,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class VisionClassificationDeployModelNodeCountTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/com/example/automl/VisionClassificationPredictTest.java
+++ b/automl/src/test/java/com/example/automl/VisionClassificationPredictTest.java
@@ -31,11 +31,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class VisionClassificationPredictTest {

--- a/automl/src/test/java/com/example/automl/VisionObjectDetectionCreateDatasetTest.java
+++ b/automl/src/test/java/com/example/automl/VisionObjectDetectionCreateDatasetTest.java
@@ -28,11 +28,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class VisionObjectDetectionCreateDatasetTest {

--- a/automl/src/test/java/com/example/automl/VisionObjectDetectionCreateModelTest.java
+++ b/automl/src/test/java/com/example/automl/VisionObjectDetectionCreateModelTest.java
@@ -28,11 +28,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class VisionObjectDetectionCreateModelTest {

--- a/automl/src/test/java/com/example/automl/VisionObjectDetectionDeployModelNodeCountTest.java
+++ b/automl/src/test/java/com/example/automl/VisionObjectDetectionDeployModelNodeCountTest.java
@@ -27,11 +27,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 public class VisionObjectDetectionDeployModelNodeCountTest {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);

--- a/automl/src/test/java/com/example/automl/VisionObjectDetectionPredictTest.java
+++ b/automl/src/test/java/com/example/automl/VisionObjectDetectionPredictTest.java
@@ -31,11 +31,13 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class VisionObjectDetectionPredictTest {

--- a/automl/src/test/java/com/google/cloud/translate/automl/DatasetApiIT.java
+++ b/automl/src/test/java/com/google/cloud/translate/automl/DatasetApiIT.java
@@ -26,11 +26,13 @@ import java.io.PrintStream;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Tests for Automl translation "Dataset API" sample. */
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class DatasetApiIT {

--- a/automl/src/test/java/com/google/cloud/vision/samples/automl/ClassificationDeployModelIT.java
+++ b/automl/src/test/java/com/google/cloud/vision/samples/automl/ClassificationDeployModelIT.java
@@ -24,8 +24,10 @@ import java.io.PrintStream;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 public class ClassificationDeployModelIT {
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
   private static final String MODEL_ID = "ICN0000000000000000000";

--- a/automl/src/test/java/com/google/cloud/vision/samples/automl/ObjectDetectionDeployModelNodeCountIT.java
+++ b/automl/src/test/java/com/google/cloud/vision/samples/automl/ObjectDetectionDeployModelNodeCountIT.java
@@ -24,11 +24,13 @@ import java.io.PrintStream;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Tests for vision "Deploy Model Node Count" sample. */
+@Ignore("This test is ignored because the legacy version of AutoML API is deprecated")
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class ObjectDetectionDeployModelNodeCountIT {


### PR DESCRIPTION
## Description

Fixes b/299926147

Ignore 62 AutoML tests because the legacy version of the AutoML API is deprecated.

https://cloud.google.com/vision/automl/docs/deprecations
https://cloud.google.com/natural-language/automl/docs/deprecations
