### PR TITLE
fix(video): increase timeout to avoid flaky test

### DIFF
--- a/video/src/main/java/video/LogoDetectionGcs.java
+++ b/video/src/main/java/video/LogoDetectionGcs.java
@@ -65,7 +65,7 @@ public class LogoDetectionGcs {
 
       System.out.println("Waiting for operation to complete...");
       // The first result is retrieved because a single video was processed.
-      AnnotateVideoResponse response = future.get(300, TimeUnit.SECONDS);
+      AnnotateVideoResponse response = future.get(600, TimeUnit.SECONDS);
       VideoAnnotationResults annotationResult = response.getAnnotationResults(0);
 
       // Annotations for list of logos detected, tracked and recognized in video.


### PR DESCRIPTION
## Description

Fixes #8611
Increase the timeout from 300s to 600s to avoid flaky test. 
The operation can take from 40s to 400s to complete.
