### PR TITLE
fix: Updates to Vertex AI Search samples after GA

### DIFF
--- a/discoveryengine/src/main/java/discoveryengine/v1/Search.java
+++ b/discoveryengine/src/main/java/discoveryengine/v1/Search.java
@@ -31,20 +31,20 @@ public class Search {
     // TODO(developer): Replace these variables before running the sample.
     // Project ID or project number of the Cloud project you want to use.
     String projectId = "PROJECT_ID";
-    // Location of the search engine. Options: "global", "us", "eu"
+    // Location of the data store. Options: "global", "us", "eu"
     String location = "global";
-    // Collection containing the datastore.
+    // Collection containing the data store.
     String collectionId = "default_collection";
     // Data store ID.
     String dataStoreId = "DATA_STORE_ID";
     // Serving configuration. Options: "default_search"
     String servingConfigId = "default_search";
-    // Search Query for the search engine.
+    // Search Query for the data store.
     String searchQuery = "Google";
     search(projectId, location, collectionId, dataStoreId, servingConfigId, searchQuery);
   }
 
-  /** Performs a search on a given datastore/search engine. */
+  /** Performs a search on a given datastore. */
   public static void search(
       String projectId,
       String location,

--- a/discoveryengine/src/main/java/discoveryengine/v1/Search.java
+++ b/discoveryengine/src/main/java/discoveryengine/v1/Search.java
@@ -55,11 +55,9 @@ public class Search {
       throws IOException, ExecutionException {
     // For more information, refer to:
     // https://cloud.google.com/generative-ai-app-builder/docs/locations#specify_a_multi-region_for_your_data_store
-    if (location == "global") {
-      String endpoint = String.format("discoveryengine.googleapis.com:443", location);
-    } else {
-      String endpoint = String.format("%s-discoveryengine.googleapis.com:443", location);
-    }
+    String endpoint = (location.equals("global")) 
+        ? String.format("discoveryengine.googleapis.com:443", location) 
+        : String.format("%s-discoveryengine.googleapis.com:443", location);
     SearchServiceSettings settings =
         SearchServiceSettings.newBuilder().setEndpoint(endpoint).build();
     // Initialize client that will be used to send requests. This client only needs to be created

--- a/discoveryengine/src/main/java/discoveryengine/v1/Search.java
+++ b/discoveryengine/src/main/java/discoveryengine/v1/Search.java
@@ -60,7 +60,8 @@ public class Search {
     } else {
       String endpoint = String.format("%s-discoveryengine.googleapis.com:443", location);
     }
-    SearchServiceSettings settings = SearchServiceSettings.newBuilder().setEndpoint(endpoint).build();
+    SearchServiceSettings settings =
+        SearchServiceSettings.newBuilder().setEndpoint(endpoint).build();
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the `searchServiceClient.close()` method on the client to safely

--- a/discoveryengine/src/main/java/discoveryengine/v1/Search.java
+++ b/discoveryengine/src/main/java/discoveryengine/v1/Search.java
@@ -21,6 +21,7 @@ package discoveryengine.v1;
 import com.google.cloud.discoveryengine.v1.SearchRequest;
 import com.google.cloud.discoveryengine.v1.SearchResponse;
 import com.google.cloud.discoveryengine.v1.SearchServiceClient;
+import com.google.cloud.discoveryengine.v1.SearchServiceSettings;
 import com.google.cloud.discoveryengine.v1.ServingConfigName;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
@@ -30,17 +31,17 @@ public class Search {
     // TODO(developer): Replace these variables before running the sample.
     // Project ID or project number of the Cloud project you want to use.
     String projectId = "PROJECT_ID";
-    // Location of the search engine. Options: "global"
+    // Location of the search engine. Options: "global", "us", "eu"
     String location = "global";
     // Collection containing the datastore.
     String collectionId = "default_collection";
-    // Datastore/Search Engine ID.
-    String searchEngineId = "DATA_STORE_ID";
+    // Data store ID.
+    String dataStoreId = "DATA_STORE_ID";
     // Serving configuration. Options: "default_search"
     String servingConfigId = "default_search";
     // Search Query for the search engine.
     String searchQuery = "Google";
-    search(projectId, location, collectionId, searchEngineId, servingConfigId, searchQuery);
+    search(projectId, location, collectionId, dataStoreId, servingConfigId, searchQuery);
   }
 
   /** Performs a search on a given datastore/search engine. */
@@ -48,20 +49,28 @@ public class Search {
       String projectId,
       String location,
       String collectionId,
-      String searchEngineId,
+      String dataStoreId,
       String servingConfigId,
       String searchQuery)
       throws IOException, ExecutionException {
+    // For more information, refer to:
+    // https://cloud.google.com/generative-ai-app-builder/docs/locations#specify_a_multi-region_for_your_data_store
+    if (location == "global") {
+      String endpoint = String.format("discoveryengine.googleapis.com:443", location);
+    } else {
+      String endpoint = String.format("%s-discoveryengine.googleapis.com:443", location);
+    }
+    SearchServiceSettings settings = SearchServiceSettings.newBuilder().setEndpoint(endpoint).build();
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the `searchServiceClient.close()` method on the client to safely
     // clean up any remaining background resources.
-    try (SearchServiceClient searchServiceClient = SearchServiceClient.create()) {
+    try (SearchServiceClient searchServiceClient = SearchServiceClient.create(settings)) {
       SearchRequest request =
           SearchRequest.newBuilder()
               .setServingConfig(
                   ServingConfigName.formatProjectLocationCollectionDataStoreServingConfigName(
-                      projectId, location, collectionId, searchEngineId, servingConfigId))
+                      projectId, location, collectionId, dataStoreId, servingConfigId))
               .setQuery(searchQuery)
               .setPageSize(10)
               .build();

--- a/discoveryengine/src/test/java/discoveryengine/v1/SearchTest.java
+++ b/discoveryengine/src/test/java/discoveryengine/v1/SearchTest.java
@@ -33,7 +33,7 @@ public class SearchTest {
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
   private static final String LOCATION = "global";
   private static final String COLLECTION_ID = "default_collection";
-  private static final String SEARCH_ENGINE_ID = "test-search-engine";
+  private static final String DATA_STORE_ID = "test-search-engine";
   private static final String SERVING_CONFIG_ID = "default_search";
   private static final String SEARCH_QUERY = "Google";
 
@@ -64,7 +64,7 @@ public class SearchTest {
   @Test
   public void testSearch() throws Exception {
     Search.search(
-        PROJECT_ID, LOCATION, COLLECTION_ID, SEARCH_ENGINE_ID, SERVING_CONFIG_ID, SEARCH_QUERY);
+        PROJECT_ID, LOCATION, COLLECTION_ID, DATA_STORE_ID, SERVING_CONFIG_ID, SEARCH_QUERY);
     String got = bout.toString();
 
     assertThat(got).contains("Response content:");


### PR DESCRIPTION
- Change `searchEngineId` to `dataStoreId`
- Add Endpoint for non-global data stores.

## Description

Fixes Internal ticket 300400448