### PR TITLE
chore(fix): refactor image create/delete test

### DIFF
--- a/compute/cloud-client/src/test/java/compute/windows/osimage/WindowsOsImageIT.java
+++ b/compute/cloud-client/src/test/java/compute/windows/osimage/WindowsOsImageIT.java
@@ -84,7 +84,8 @@ public class WindowsOsImageIT {
     requireEnvVar("GOOGLE_CLOUD_PROJECT");
 
     // Cleanup existing test instances.
-    Util.cleanUpExistingInstances("windowsimage-test-instance-", PROJECT_ID, ZONE);
+    // commenting out the line because it is a source of flaky testing (b/304088503)
+    // Util.cleanUpExistingInstances("windowsimage-test-instance-", PROJECT_ID, ZONE);
 
     String randomUUID = UUID.randomUUID().toString().split("-")[0];
     INSTANCE_NAME = "windowsimage-test-instance-" + randomUUID;


### PR DESCRIPTION
combine image creation and deletion into the one test. assert that image is created before deleting it.

### Description
Combines tests for create and delete image code samples in the single test.
Assert that the image is eventually created (READY) before deleting it.

Fixes #8730
