### PR TITLE
chore(aiplatform): clarify argument model_dir

### DIFF
--- a/aiplatform/src/main/java/aiplatform/CreateTrainingPipelineCustomJobSample.java
+++ b/aiplatform/src/main/java/aiplatform/CreateTrainingPipelineCustomJobSample.java
@@ -62,13 +62,13 @@ public class CreateTrainingPipelineCustomJobSample {
       JsonObject jsonMachineSpec = new JsonObject();
       jsonMachineSpec.addProperty("machineType", "n1-standard-4");
 
-      JsonArray jsonArgs = new JsonArray();
-      jsonArgs.add("--model_dir=$(AIP_MODEL_DIR)");
-
       // A working docker image can be found at
       // gs://cloud-samples-data/ai-platform/mnist_tfrecord/custom_job
+      // This sample image accepts a set of arguments including model_dir.
       JsonObject jsonContainerSpec = new JsonObject();
       jsonContainerSpec.addProperty("imageUri", containerImageUri);
+      JsonArray jsonArgs = new JsonArray();
+      jsonArgs.add("--model_dir=$(AIP_MODEL_DIR)");
       jsonContainerSpec.add("args", jsonArgs);
 
       JsonObject jsonJsonWorkerPoolSpec0 = new JsonObject();


### PR DESCRIPTION
## Description

Fixes b/305782039

Clarify that argument model_dir is specific to the custom job referred in this sample but not a general argument for all of the container images. This is because we don't use model_dir or model-dir consistently. 
