### PR TITLE
fix: update sql initialisation properties

### DIFF
--- a/run/idp-sql/pom.xml
+++ b/run/idp-sql/pom.xml
@@ -30,8 +30,8 @@ limitations under the License.
   </parent>
 
   <properties>
-    <maven.compiler.target>17</maven.compiler.target>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
 
   <dependencyManagement>

--- a/run/idp-sql/pom.xml
+++ b/run/idp-sql/pom.xml
@@ -40,7 +40,7 @@ limitations under the License.
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.7.16</version>
+        <version>2.7.17</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/run/idp-sql/pom.xml
+++ b/run/idp-sql/pom.xml
@@ -30,8 +30,8 @@ limitations under the License.
   </parent>
 
   <properties>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
   </properties>
 
   <dependencyManagement>

--- a/run/idp-sql/pom.xml
+++ b/run/idp-sql/pom.xml
@@ -47,7 +47,7 @@ limitations under the License.
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>spring-cloud-gcp-dependencies</artifactId>
-        <version>4.7.1</version>
+        <version>3.7.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/run/idp-sql/pom.xml
+++ b/run/idp-sql/pom.xml
@@ -30,8 +30,8 @@ limitations under the License.
   </parent>
 
   <properties>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
 
   <dependencyManagement>

--- a/run/idp-sql/pom.xml
+++ b/run/idp-sql/pom.xml
@@ -30,8 +30,8 @@ limitations under the License.
   </parent>
 
   <properties>
-    <maven.compiler.target>17</maven.compiler.target>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
   </properties>
 
   <dependencyManagement>
@@ -40,7 +40,7 @@ limitations under the License.
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>3.1.4</version>
+        <version>2.7.16</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/run/idp-sql/src/main/resources/application.properties
+++ b/run/idp-sql/src/main/resources/application.properties
@@ -24,7 +24,7 @@ server.port=${PORT:8080}
 # [END cloudrun_user_auth_sql_connect]
 
 # Create PostgreSQL table on startup
-spring.datasource.initialization-mode=always
+spring.sql.init.mode=always
 # Override "table already exists" error
-spring.datasource.continue-on-error=true
+spring.sql.init.continue-on-error=true
 

--- a/run/idp-sql/src/test/resources/application.properties
+++ b/run/idp-sql/src/test/resources/application.properties
@@ -18,7 +18,7 @@ spring.cloud.gcp.sql.database-name=${PG_DB}
 spring.cloud.gcp.sql.instance-connection-name=${PG_CONNECTION_NAME}
 
 # Create PostgreSQL table on startup
-spring.datasource.initialization-mode=always
+spring.sql.init.mode=always
 # Override "table already exists" error
-spring.datasource.continue-on-error=true
+spring.sql.init.continue-on-error=true
 


### PR DESCRIPTION
## Description

Fixes b/302827133

The `spring.datasource.*` properties were deprecated in a previous version of Spring Boot, meaning this sample didn't initialise the database, and the sample wouldn't operate correctly when deployed. 

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.5-Release-Notes#SQL-Script-DataSource-Initialization

Fix: update the settings to the new configurations. Manual debug and testing results in bug above. 

https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto.data-initialization.using-basic-sql-scripts

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [x] Please **merge** this PR for me once it is approved
