### PR TITLE
fix: catch timing issue on pubsublitetogcs test

### DIFF
--- a/pubsublite/streaming-analytics/src/test/java/examples/PubsubliteToGcsIT.java
+++ b/pubsublite/streaming-analytics/src/test/java/examples/PubsubliteToGcsIT.java
@@ -142,8 +142,7 @@ public class PubsubliteToGcsIT {
       System.out.println(responseTopic.getAllFields() + " created successfully.");
       Subscription response = adminClient.createSubscription(subscription).get();
       System.out.println(response.getAllFields() + " created successfully.");
-    }
-    catch (ExecutionException e) {
+    } catch (ExecutionException e) {
       e.printStackTrace();
     }
   }
@@ -156,8 +155,7 @@ public class PubsubliteToGcsIT {
       System.out.println("Deleted topic: " + topicPath);
       adminClient.deleteSubscription(subscriptionPath).get();
       System.out.println("Deleted subscription: " + subscriptionPath);
-    }
-    catch (ExecutionException e) {
+    } catch (ExecutionException e) {
       e.printStackTrace();
     }
 

--- a/pubsublite/streaming-analytics/src/test/java/examples/PubsubliteToGcsIT.java
+++ b/pubsublite/streaming-analytics/src/test/java/examples/PubsubliteToGcsIT.java
@@ -143,6 +143,9 @@ public class PubsubliteToGcsIT {
       Subscription response = adminClient.createSubscription(subscription).get();
       System.out.println(response.getAllFields() + " created successfully.");
     }
+    catch (ExecutionException e) {
+      e.printStackTrace();
+    }
   }
 
   @After
@@ -154,6 +157,10 @@ public class PubsubliteToGcsIT {
       adminClient.deleteSubscription(subscriptionPath).get();
       System.out.println("Deleted subscription: " + subscriptionPath);
     }
+    catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+
 
     // Delete the output files.
     Page<Blob> blobs = storage.list(bucketName, Storage.BlobListOption.prefix(directoryPrefix));


### PR DESCRIPTION
Fixes #8772

This flaky issue has existed for some time, and retries have not helped.

This change catches an exception when creating the topic and it already exists. That should allow the test to continue. Also, a catch statement has been added to the teardown method when the topic has already been deleted.