### PR TITLE
feat: Add Makefile for constistent sample interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+# Makefile for running typical developer workflow actions.
+# To run actions in a subdirectory of the repo:
+#   make lint build dir=translate/snippets
+
+INTERFACE_ACTIONS="build test lint"
+
+.ONESHELL: #ease subdirectory work by using the same subshell for all commands
+.-PHONY: *
+
+# Default to current dir if not specified.
+dir ?= $(shell pwd)
+
+GOOGLE_CLOUD_PROJECT="${GOOGLE_SAMPLE_PROJECT}"
+
+build:
+	cd ${dir}
+	mvn compile
+
+test: check-env build
+	cd ${dir}
+	mvn verify
+
+lint:
+	cd ${dir}
+	mvn -P lint checkstyle:check
+
+check-env:
+ifndef GOOGLE_SAMPLE_PROJECT
+	$(error GOOGLE_SAMPLE_PROJECT environment variable is required to perform this action)
+endif
+
+list-actions:
+	@ echo ${INTERFACE_ACTIONS}
+

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 # Makefile for running typical developer workflow actions.
 # To run actions in a subdirectory of the repo:
 #   make lint build dir=translate/snippets
+# Note: testing requires Application Default Credentials.
+# For details about ADC, see https://cloud.google.com/docs/authentication/application-default-credentials
 
 INTERFACE_ACTIONS="build test lint"
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ INTERFACE_ACTIONS="build test lint"
 # Default to current dir if not specified.
 dir ?= $(shell pwd)
 
-GOOGLE_CLOUD_PROJECT="${GOOGLE_SAMPLE_PROJECT}"
+export GOOGLE_CLOUD_PROJECT = ${GOOGLE_SAMPLES_PROJECT}
 
 build:
 	cd ${dir}
@@ -18,15 +18,20 @@ build:
 
 test: check-env build
 	cd ${dir}
-	mvn verify
+	mvn --quiet --batch-mode --fail-at-end clean verify \
+    -Dfile.encoding="UTF-8" \
+    -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+    -Dmaven.test.redirectTestOutputToFile=true \
+    -Dbigtable.projectID="${GOOGLE_CLOUD_PROJECT}" \
+    -Dbigtable.instanceID=instance
 
 lint:
 	cd ${dir}
 	mvn -P lint checkstyle:check
 
 check-env:
-ifndef GOOGLE_SAMPLE_PROJECT
-	$(error GOOGLE_SAMPLE_PROJECT environment variable is required to perform this action)
+ifndef GOOGLE_SAMPLES_PROJECT
+	$(error GOOGLE_SAMPLES_PROJECT environment variable is required to perform this action)
 endif
 
 list-actions:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,13 @@ INTERFACE_ACTIONS="build test lint"
 # Default to current dir if not specified.
 dir ?= $(shell pwd)
 
-export GOOGLE_CLOUD_PROJECT = ${GOOGLE_SAMPLES_PROJECT}
+
+# GOOGLE_SAMPLES_PROJECT takes precedence over GOOGLE_CLOUD_PROJECT
+PROJECT_ID = ${GOOGLE_SAMPLES_PROJECT}
+PROJECT_ID ?= ${GOOGLE_CLOUD_PROJECT}
+# export our project ID as GOOGLE_CLOUD_PROJECT in the action environment
+override GOOGLE_CLOUD_PROJECT := ${PROJECT_ID}
+export GOOGLE_CLOUD_PROJECT
 
 build:
 	cd ${dir}
@@ -30,8 +36,8 @@ lint:
 	mvn -P lint checkstyle:check
 
 check-env:
-ifndef GOOGLE_SAMPLES_PROJECT
-	$(error GOOGLE_SAMPLES_PROJECT environment variable is required to perform this action)
+ifndef PROJECT_ID
+	$(error At least one of the following env vars must be set: GOOGLE_SAMPLES_PROJECT, GOOGLE_CLOUD_PROJECT.)
 endif
 
 list-actions:


### PR DESCRIPTION

This is a work in progress.

The goal is to provide a consistent way for contributors to built, test, and
lint their samples, regardless of the language repo they are working in.
(Similar PRs are open in other language repos)
