### PR TITLE
fix: add skip to test blocked on #8798

### DIFF
--- a/asset/src/test/java/com/example/asset/QuickStartIT.java
+++ b/asset/src/test/java/com/example/asset/QuickStartIT.java
@@ -51,14 +51,14 @@ public class QuickStartIT {
   @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
   
   private static final String bucketName = "java-docs-samples-testing";
-  private static final String[] assetTypes = { "compute.googleapis.com/Disk" };
+  private static final String[] assetTypes = { "compute.googleapis.com/Network" };
 
   private ByteArrayOutputStream bout;
   private PrintStream out;
   private PrintStream originalPrintStream;
   private BigQuery bigquery;
 
-  private static final void deleteObjects(String path) {
+  private static void deleteObjects(String path) {
     Storage storage = StorageOptions.getDefaultInstance().getService();
     for (BlobInfo info :
         storage

--- a/asset/src/test/java/com/example/asset/SearchIT.java
+++ b/asset/src/test/java/com/example/asset/SearchIT.java
@@ -29,6 +29,7 @@ import java.io.PrintStream;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -66,6 +67,7 @@ public class SearchIT {
     bigquery.delete(datasetId, DatasetDeleteOption.deleteContents());
   }
 
+  @Ignore("Blocked on https://github.com/GoogleCloudPlatform/java-docs-samples/issues/8798")
   @Test
   public void testSearchAllResourcesExample() throws Exception {
     // Wait 120 seconds to let dataset creation event go to CAI


### PR DESCRIPTION
Adding an `@Ignore` annotation to a test that consistently fails, blocking other PRs. Will add a comment to the existing issue #8798  to remove this when the issue is resolved.

Also:
* Addressed style warning (`final` unnecessary if `private`)
* Selected a different resource type with fewer instances (to address a timeout in another test)