### PR TITLE
feat: add new optional accelerator_type parameter

### DIFF
--- a/aiplatform/src/main/java/aiplatform/CreatePipelineJobModelTuningSample.java
+++ b/aiplatform/src/main/java/aiplatform/CreatePipelineJobModelTuningSample.java
@@ -77,6 +77,7 @@ public class CreatePipelineJobModelTuningSample {
               "us-central1")); // Deployment is only supported in us-central1 for Public Preview
       parameterValues.put("large_model_reference", stringToValue("text-bison@001"));
       parameterValues.put("train_steps", numberToValue(trainingSteps));
+      parameterValues.put("accelerator_type", stringToValue("GPU")); // Optional: GPU or TPU
 
       RuntimeConfig runtimeConfig =
           RuntimeConfig.newBuilder()


### PR DESCRIPTION
## Description

Fixes b/306723063

New optional accelerator_type = "GPU/TPU" parameter for tuning pipeline.
Public docs: https://cloud.devsite.corp.google.com/vertex-ai/docs/generative-ai/models/tune-text-models-supervised#generative-ai-tune-model-nodejs