### PR TITLE
bigtable (docs): add multiple attempts for change stream test

### DIFF
--- a/bigtable/beam/change-streams/src/test/java/ChangeStreamsHelloWorldTest.java
+++ b/bigtable/beam/change-streams/src/test/java/ChangeStreamsHelloWorldTest.java
@@ -87,7 +87,7 @@ public class ChangeStreamsHelloWorldTest {
 
     dataClient.mutateRow(RowMutation.create(TABLE_ID, rowKey).deleteRow());
 
-    // Wait for change to be captured.
+    // Wait for written data to propagate into the Bigtable change stream.
     Thread.sleep(15 * 1000);
 
     String output = bout.toString();

--- a/bigtable/beam/change-streams/src/test/java/ChangeStreamsHelloWorldTest.java
+++ b/bigtable/beam/change-streams/src/test/java/ChangeStreamsHelloWorldTest.java
@@ -84,10 +84,19 @@ public class ChangeStreamsHelloWorldTest {
 
     dataClient.mutateRow(RowMutation.create(TABLE_ID, rowKey).deleteRow());
 
-    // Wait for change to be captured.
-    Thread.sleep(15 * 1000);
-
     String output = bout.toString();
+    int attempt = 0;
+
+    while (attempt < 5) {
+      if (output.contains("USER,SetCell,cf1,col a,a")) {
+        break;
+      }
+
+      // Wait for change to be captured.
+      Thread.sleep(15 * 1000);
+      attempt++;
+    }
+
     assertThat(output).contains("USER,SetCell,cf1,col a,a");
     assertThat(output).contains("USER,DeleteCells,cf1,col a,0-0");
     assertThat(output).contains("USER,DeleteFamily,cf1");


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
