### PR TITLE
feat: update samples with LROs to not use a try block

### DIFF
--- a/media/stitcher/src/main/java/com/example/stitcher/CreateCdnKey.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/CreateCdnKey.java
@@ -63,42 +63,43 @@ public class CreateCdnKey {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
-    try (VideoStitcherServiceClient videoStitcherServiceClient =
-        VideoStitcherServiceClient.create()) {
-      CdnKey cdnKey;
-      if (isMediaCdn) {
-        cdnKey =
-            CdnKey.newBuilder()
-                .setHostname(hostname)
-                .setMediaCdnKey(
-                    MediaCdnKey.newBuilder()
-                        .setKeyName(keyName)
-                        .setPrivateKey(ByteString.copyFromUtf8(privateKey))
-                        .build())
-                .build();
-      } else {
-        cdnKey =
-            CdnKey.newBuilder()
-                .setHostname(hostname)
-                .setGoogleCdnKey(
-                    GoogleCdnKey.newBuilder()
-                        .setKeyName(keyName)
-                        .setPrivateKey(ByteString.copyFromUtf8(privateKey))
-                        .build())
-                .build();
-      }
-
-      CreateCdnKeyRequest createCdnKeyRequest =
-          CreateCdnKeyRequest.newBuilder()
-              .setParent(LocationName.of(projectId, location).toString())
-              .setCdnKeyId(cdnKeyId)
-              .setCdnKey(cdnKey)
+    VideoStitcherServiceClient videoStitcherServiceClient = VideoStitcherServiceClient.create();
+    CdnKey cdnKey;
+    if (isMediaCdn) {
+      cdnKey =
+          CdnKey.newBuilder()
+              .setHostname(hostname)
+              .setMediaCdnKey(
+                  MediaCdnKey.newBuilder()
+                      .setKeyName(keyName)
+                      .setPrivateKey(ByteString.copyFromUtf8(privateKey))
+                      .build())
               .build();
-
-      CdnKey result = videoStitcherServiceClient.createCdnKeyAsync(createCdnKeyRequest)
-          .get(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
-      System.out.println("Created new CDN key: " + result.getName());
+    } else {
+      cdnKey =
+          CdnKey.newBuilder()
+              .setHostname(hostname)
+              .setGoogleCdnKey(
+                  GoogleCdnKey.newBuilder()
+                      .setKeyName(keyName)
+                      .setPrivateKey(ByteString.copyFromUtf8(privateKey))
+                      .build())
+              .build();
     }
+
+    CreateCdnKeyRequest createCdnKeyRequest =
+        CreateCdnKeyRequest.newBuilder()
+            .setParent(LocationName.of(projectId, location).toString())
+            .setCdnKeyId(cdnKeyId)
+            .setCdnKey(cdnKey)
+            .build();
+
+    CdnKey result =
+        videoStitcherServiceClient
+            .createCdnKeyAsync(createCdnKeyRequest)
+            .get(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
+    System.out.println("Created new CDN key: " + result.getName());
+    videoStitcherServiceClient.close();
   }
 }
 // [END videostitcher_create_cdn_key]

--- a/media/stitcher/src/main/java/com/example/stitcher/CreateCdnKeyAkamai.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/CreateCdnKeyAkamai.java
@@ -51,28 +51,29 @@ public class CreateCdnKeyAkamai {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
-    try (VideoStitcherServiceClient videoStitcherServiceClient =
-        VideoStitcherServiceClient.create()) {
-      CdnKey cdnKey =
-          CdnKey.newBuilder()
-              .setHostname(hostname)
-              .setAkamaiCdnKey(
-                  AkamaiCdnKey.newBuilder()
-                      .setTokenKey(ByteString.copyFromUtf8(akamaiTokenKey))
-                      .build())
-              .build();
+    VideoStitcherServiceClient videoStitcherServiceClient = VideoStitcherServiceClient.create();
+    CdnKey cdnKey =
+        CdnKey.newBuilder()
+            .setHostname(hostname)
+            .setAkamaiCdnKey(
+                AkamaiCdnKey.newBuilder()
+                    .setTokenKey(ByteString.copyFromUtf8(akamaiTokenKey))
+                    .build())
+            .build();
 
-      CreateCdnKeyRequest createCdnKeyRequest =
-          CreateCdnKeyRequest.newBuilder()
-              .setParent(LocationName.of(projectId, location).toString())
-              .setCdnKeyId(cdnKeyId)
-              .setCdnKey(cdnKey)
-              .build();
+    CreateCdnKeyRequest createCdnKeyRequest =
+        CreateCdnKeyRequest.newBuilder()
+            .setParent(LocationName.of(projectId, location).toString())
+            .setCdnKeyId(cdnKeyId)
+            .setCdnKey(cdnKey)
+            .build();
 
-      CdnKey result = videoStitcherServiceClient.createCdnKeyAsync(createCdnKeyRequest)
-          .get(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
-      System.out.println("Created new CDN key: " + result.getName());
-    }
+    CdnKey result =
+        videoStitcherServiceClient
+            .createCdnKeyAsync(createCdnKeyRequest)
+            .get(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
+    System.out.println("Created new CDN key: " + result.getName());
+    videoStitcherServiceClient.close();
   }
 }
 // [END videostitcher_create_cdn_key_akamai]

--- a/media/stitcher/src/main/java/com/example/stitcher/CreateLiveConfig.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/CreateLiveConfig.java
@@ -50,31 +50,38 @@ public class CreateLiveConfig {
     createLiveConfig(projectId, location, liveConfigId, sourceUri, adTagUri, slateId);
   }
 
-  public static void createLiveConfig(String projectId, String location, String liveConfigId,
-      String sourceUri, String adTagUri, String slateId)
+  public static void createLiveConfig(
+      String projectId,
+      String location,
+      String liveConfigId,
+      String sourceUri,
+      String adTagUri,
+      String slateId)
       throws IOException, ExecutionException, InterruptedException, TimeoutException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
-    try (VideoStitcherServiceClient videoStitcherServiceClient =
-        VideoStitcherServiceClient.create()) {
-      CreateLiveConfigRequest createLiveConfigRequest =
-          CreateLiveConfigRequest.newBuilder()
-              .setParent(LocationName.of(projectId, location).toString())
-              .setLiveConfigId(liveConfigId)
-              .setLiveConfig(LiveConfig.newBuilder()
-                  .setSourceUri(sourceUri)
-                  .setAdTagUri(adTagUri)
-                  .setDefaultSlate(SlateName.format(projectId, location, slateId))
-                  .setAdTracking(AdTracking.SERVER)
-                  .setStitchingPolicy(StitchingPolicy.CUT_CURRENT).build())
-              .build();
+    VideoStitcherServiceClient videoStitcherServiceClient = VideoStitcherServiceClient.create();
+    CreateLiveConfigRequest createLiveConfigRequest =
+        CreateLiveConfigRequest.newBuilder()
+            .setParent(LocationName.of(projectId, location).toString())
+            .setLiveConfigId(liveConfigId)
+            .setLiveConfig(
+                LiveConfig.newBuilder()
+                    .setSourceUri(sourceUri)
+                    .setAdTagUri(adTagUri)
+                    .setDefaultSlate(SlateName.format(projectId, location, slateId))
+                    .setAdTracking(AdTracking.SERVER)
+                    .setStitchingPolicy(StitchingPolicy.CUT_CURRENT)
+                    .build())
+            .build();
 
-      LiveConfig response = videoStitcherServiceClient.createLiveConfigAsync(
-              createLiveConfigRequest)
-          .get(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
-      System.out.println("Created new live config: " + response.getName());
-    }
+    LiveConfig response =
+        videoStitcherServiceClient
+            .createLiveConfigAsync(createLiveConfigRequest)
+            .get(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
+    System.out.println("Created new live config: " + response.getName());
+    videoStitcherServiceClient.close();
   }
 }
 // [END videostitcher_create_live_config]

--- a/media/stitcher/src/main/java/com/example/stitcher/CreateLiveSession.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/CreateLiveSession.java
@@ -36,12 +36,11 @@ public class CreateLiveSession {
     createLiveSession(projectId, location, liveConfigId);
   }
 
-  public static void createLiveSession(
-      String projectId, String location, String liveConfigId)
+  public static void createLiveSession(String projectId, String location, String liveConfigId)
       throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
-    // once, and can be reused for multiple requests. After completing all of your requests, call
-    // the "close" method on the client to safely clean up any remaining background resources.
+    // once, and can be reused for multiple requests. In this example, try-with-resources is used
+    // which automatically calls close() on the client to clean up resources.
     try (VideoStitcherServiceClient videoStitcherServiceClient =
         VideoStitcherServiceClient.create()) {
       CreateLiveSessionRequest createLiveSessionRequest =

--- a/media/stitcher/src/main/java/com/example/stitcher/CreateSlate.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/CreateSlate.java
@@ -47,19 +47,20 @@ public class CreateSlate {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
-    try (VideoStitcherServiceClient videoStitcherServiceClient =
-        VideoStitcherServiceClient.create()) {
-      CreateSlateRequest createSlateRequest =
-          CreateSlateRequest.newBuilder()
-              .setParent(LocationName.of(projectId, location).toString())
-              .setSlateId(slateId)
-              .setSlate(Slate.newBuilder().setUri(slateUri).build())
-              .build();
+    VideoStitcherServiceClient videoStitcherServiceClient = VideoStitcherServiceClient.create();
+    CreateSlateRequest createSlateRequest =
+        CreateSlateRequest.newBuilder()
+            .setParent(LocationName.of(projectId, location).toString())
+            .setSlateId(slateId)
+            .setSlate(Slate.newBuilder().setUri(slateUri).build())
+            .build();
 
-      Slate response = videoStitcherServiceClient.createSlateAsync(createSlateRequest)
-          .get(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
-      System.out.println("Created new slate: " + response.getName());
-    }
+    Slate response =
+        videoStitcherServiceClient
+            .createSlateAsync(createSlateRequest)
+            .get(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
+    System.out.println("Created new slate: " + response.getName());
+    videoStitcherServiceClient.close();
   }
 }
 // [END videostitcher_create_slate]

--- a/media/stitcher/src/main/java/com/example/stitcher/CreateVodSession.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/CreateVodSession.java
@@ -43,17 +43,19 @@ public class CreateVodSession {
   public static void createVodSession(
       String projectId, String location, String sourceUri, String adTagUri) throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
-    // once, and can be reused for multiple requests. After completing all of your requests, call
-    // the "close" method on the client to safely clean up any remaining background resources.
+    // once, and can be reused for multiple requests. In this example, try-with-resources is used
+    // which automatically calls close() on the client to clean up resources.
     try (VideoStitcherServiceClient videoStitcherServiceClient =
         VideoStitcherServiceClient.create()) {
       CreateVodSessionRequest createVodSessionRequest =
           CreateVodSessionRequest.newBuilder()
               .setParent(LocationName.of(projectId, location).toString())
               .setVodSession(
-                  VodSession.newBuilder().setSourceUri(sourceUri).setAdTagUri(adTagUri)
-                      .setAdTracking(
-                          AdTracking.SERVER).build())
+                  VodSession.newBuilder()
+                      .setSourceUri(sourceUri)
+                      .setAdTagUri(adTagUri)
+                      .setAdTracking(AdTracking.SERVER)
+                      .build())
               .build();
 
       VodSession response = videoStitcherServiceClient.createVodSession(createVodSessionRequest);

--- a/media/stitcher/src/main/java/com/example/stitcher/DeleteCdnKey.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/DeleteCdnKey.java
@@ -44,17 +44,17 @@ public class DeleteCdnKey {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
-    try (VideoStitcherServiceClient videoStitcherServiceClient =
-        VideoStitcherServiceClient.create()) {
-      DeleteCdnKeyRequest deleteCdnKeyRequest =
-          DeleteCdnKeyRequest.newBuilder()
-              .setName(CdnKeyName.of(projectId, location, cdnKeyId).toString())
-              .build();
+    VideoStitcherServiceClient videoStitcherServiceClient = VideoStitcherServiceClient.create();
+    DeleteCdnKeyRequest deleteCdnKeyRequest =
+        DeleteCdnKeyRequest.newBuilder()
+            .setName(CdnKeyName.of(projectId, location, cdnKeyId).toString())
+            .build();
 
-      videoStitcherServiceClient.deleteCdnKeyAsync(deleteCdnKeyRequest)
-          .get(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
-      System.out.println("Deleted CDN key");
-    }
+    videoStitcherServiceClient
+        .deleteCdnKeyAsync(deleteCdnKeyRequest)
+        .get(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
+    System.out.println("Deleted CDN key");
+    videoStitcherServiceClient.close();
   }
 }
 // [END videostitcher_delete_cdn_key]

--- a/media/stitcher/src/main/java/com/example/stitcher/DeleteLiveConfig.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/DeleteLiveConfig.java
@@ -44,17 +44,17 @@ public class DeleteLiveConfig {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
-    try (VideoStitcherServiceClient videoStitcherServiceClient =
-        VideoStitcherServiceClient.create()) {
-      DeleteLiveConfigRequest deleteLiveConfigRequest =
-          DeleteLiveConfigRequest.newBuilder()
-              .setName(LiveConfigName.of(projectId, location, liveConfigId).toString())
-              .build();
+    VideoStitcherServiceClient videoStitcherServiceClient = VideoStitcherServiceClient.create();
+    DeleteLiveConfigRequest deleteLiveConfigRequest =
+        DeleteLiveConfigRequest.newBuilder()
+            .setName(LiveConfigName.of(projectId, location, liveConfigId).toString())
+            .build();
 
-      videoStitcherServiceClient.deleteLiveConfigAsync(deleteLiveConfigRequest)
-          .get(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
-      System.out.println("Deleted live config");
-    }
+    videoStitcherServiceClient
+        .deleteLiveConfigAsync(deleteLiveConfigRequest)
+        .get(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
+    System.out.println("Deleted live config");
+    videoStitcherServiceClient.close();
   }
 }
 // [END videostitcher_delete_live_config]

--- a/media/stitcher/src/main/java/com/example/stitcher/DeleteSlate.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/DeleteSlate.java
@@ -44,17 +44,17 @@ public class DeleteSlate {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
-    try (VideoStitcherServiceClient videoStitcherServiceClient =
-        VideoStitcherServiceClient.create()) {
-      DeleteSlateRequest deleteSlateRequest =
-          DeleteSlateRequest.newBuilder()
-              .setName(SlateName.of(projectId, location, slateId).toString())
-              .build();
+    VideoStitcherServiceClient videoStitcherServiceClient = VideoStitcherServiceClient.create();
+    DeleteSlateRequest deleteSlateRequest =
+        DeleteSlateRequest.newBuilder()
+            .setName(SlateName.of(projectId, location, slateId).toString())
+            .build();
 
-      videoStitcherServiceClient.deleteSlateAsync(deleteSlateRequest)
-          .get(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
-      System.out.println("Deleted slate");
-    }
+    videoStitcherServiceClient
+        .deleteSlateAsync(deleteSlateRequest)
+        .get(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
+    System.out.println("Deleted slate");
+    videoStitcherServiceClient.close();
   }
 }
 // [END videostitcher_delete_slate]

--- a/media/stitcher/src/main/java/com/example/stitcher/GetCdnKey.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/GetCdnKey.java
@@ -38,8 +38,8 @@ public class GetCdnKey {
   public static void getCdnKey(String projectId, String location, String cdnKeyId)
       throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
-    // once, and can be reused for multiple requests. After completing all of your requests, call
-    // the "close" method on the client to safely clean up any remaining background resources.
+    // once, and can be reused for multiple requests. In this example, try-with-resources is used
+    // which automatically calls close() on the client to clean up resources.
     try (VideoStitcherServiceClient videoStitcherServiceClient =
         VideoStitcherServiceClient.create()) {
       GetCdnKeyRequest getCdnKeyRequest =

--- a/media/stitcher/src/main/java/com/example/stitcher/GetLiveAdTagDetail.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/GetLiveAdTagDetail.java
@@ -40,8 +40,8 @@ public class GetLiveAdTagDetail {
       String projectId, String location, String sessionId, String adTagDetailId)
       throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
-    // once, and can be reused for multiple requests. After completing all of your requests, call
-    // the "close" method on the client to safely clean up any remaining background resources.
+    // once, and can be reused for multiple requests. In this example, try-with-resources is used
+    // which automatically calls close() on the client to clean up resources.
     try (VideoStitcherServiceClient videoStitcherServiceClient =
         VideoStitcherServiceClient.create()) {
       GetLiveAdTagDetailRequest getLiveAdTagDetailRequest =

--- a/media/stitcher/src/main/java/com/example/stitcher/GetLiveConfig.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/GetLiveConfig.java
@@ -38,8 +38,8 @@ public class GetLiveConfig {
   public static void getLiveConfig(String projectId, String location, String liveConfigId)
       throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
-    // once, and can be reused for multiple requests. After completing all of your requests, call
-    // the "close" method on the client to safely clean up any remaining background resources.
+    // once, and can be reused for multiple requests. In this example, try-with-resources is used
+    // which automatically calls close() on the client to clean up resources.
     try (VideoStitcherServiceClient videoStitcherServiceClient =
         VideoStitcherServiceClient.create()) {
       GetLiveConfigRequest getLiveConfigRequest =

--- a/media/stitcher/src/main/java/com/example/stitcher/GetLiveSession.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/GetLiveSession.java
@@ -38,8 +38,8 @@ public class GetLiveSession {
   public static void getLiveSession(String projectId, String location, String sessionId)
       throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
-    // once, and can be reused for multiple requests. After completing all of your requests, call
-    // the "close" method on the client to safely clean up any remaining background resources.
+    // once, and can be reused for multiple requests. In this example, try-with-resources is used
+    // which automatically calls close() on the client to clean up resources.
     try (VideoStitcherServiceClient videoStitcherServiceClient =
         VideoStitcherServiceClient.create()) {
       GetLiveSessionRequest getLiveSessionRequest =

--- a/media/stitcher/src/main/java/com/example/stitcher/GetSlate.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/GetSlate.java
@@ -38,8 +38,8 @@ public class GetSlate {
   public static void getSlate(String projectId, String location, String slateId)
       throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
-    // once, and can be reused for multiple requests. After completing all of your requests, call
-    // the "close" method on the client to safely clean up any remaining background resources.
+    // once, and can be reused for multiple requests. In this example, try-with-resources is used
+    // which automatically calls close() on the client to clean up resources.
     try (VideoStitcherServiceClient videoStitcherServiceClient =
         VideoStitcherServiceClient.create()) {
       GetSlateRequest getSlateRequest =

--- a/media/stitcher/src/main/java/com/example/stitcher/GetVodAdTagDetail.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/GetVodAdTagDetail.java
@@ -40,8 +40,8 @@ public class GetVodAdTagDetail {
       String projectId, String location, String sessionId, String adTagDetailId)
       throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
-    // once, and can be reused for multiple requests. After completing all of your requests, call
-    // the "close" method on the client to safely clean up any remaining background resources.
+    // once, and can be reused for multiple requests. In this example, try-with-resources is used
+    // which automatically calls close() on the client to clean up resources.
     try (VideoStitcherServiceClient videoStitcherServiceClient =
         VideoStitcherServiceClient.create()) {
       GetVodAdTagDetailRequest getVodAdTagDetailRequest =

--- a/media/stitcher/src/main/java/com/example/stitcher/GetVodSession.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/GetVodSession.java
@@ -38,8 +38,8 @@ public class GetVodSession {
   public static void getVodSession(String projectId, String location, String sessionId)
       throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
-    // once, and can be reused for multiple requests. After completing all of your requests, call
-    // the "close" method on the client to safely clean up any remaining background resources.
+    // once, and can be reused for multiple requests. In this example, try-with-resources is used
+    // which automatically calls close() on the client to clean up resources.
     try (VideoStitcherServiceClient videoStitcherServiceClient =
         VideoStitcherServiceClient.create()) {
       GetVodSessionRequest getVodSessionRequest =

--- a/media/stitcher/src/main/java/com/example/stitcher/GetVodStitchDetail.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/GetVodStitchDetail.java
@@ -40,8 +40,8 @@ public class GetVodStitchDetail {
       String projectId, String location, String sessionId, String stitchDetailId)
       throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
-    // once, and can be reused for multiple requests. After completing all of your requests, call
-    // the "close" method on the client to safely clean up any remaining background resources.
+    // once, and can be reused for multiple requests. In this example, try-with-resources is used
+    // which automatically calls close() on the client to clean up resources.
     try (VideoStitcherServiceClient videoStitcherServiceClient =
         VideoStitcherServiceClient.create()) {
       GetVodStitchDetailRequest getVodStitchDetailRequest =

--- a/media/stitcher/src/main/java/com/example/stitcher/ListCdnKeys.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/ListCdnKeys.java
@@ -36,8 +36,8 @@ public class ListCdnKeys {
 
   public static void listCdnKeys(String projectId, String location) throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
-    // once, and can be reused for multiple requests. After completing all of your requests, call
-    // the "close" method on the client to safely clean up any remaining background resources.
+    // once, and can be reused for multiple requests. In this example, try-with-resources is used
+    // which automatically calls close() on the client to clean up resources.
     try (VideoStitcherServiceClient videoStitcherServiceClient =
         VideoStitcherServiceClient.create()) {
       ListCdnKeysRequest listCdnKeysRequest =

--- a/media/stitcher/src/main/java/com/example/stitcher/ListLiveAdTagDetails.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/ListLiveAdTagDetails.java
@@ -38,8 +38,8 @@ public class ListLiveAdTagDetails {
   public static void listLiveAdTagDetails(String projectId, String location, String sessionId)
       throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
-    // once, and can be reused for multiple requests. After completing all of your requests, call
-    // the "close" method on the client to safely clean up any remaining background resources.
+    // once, and can be reused for multiple requests. In this example, try-with-resources is used
+    // which automatically calls close() on the client to clean up resources.
     try (VideoStitcherServiceClient videoStitcherServiceClient =
         VideoStitcherServiceClient.create()) {
       ListLiveAdTagDetailsRequest listLiveAdTagDetailsRequest =

--- a/media/stitcher/src/main/java/com/example/stitcher/ListLiveConfigs.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/ListLiveConfigs.java
@@ -36,8 +36,8 @@ public class ListLiveConfigs {
 
   public static void listLiveConfigs(String projectId, String location) throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
-    // once, and can be reused for multiple requests. After completing all of your requests, call
-    // the "close" method on the client to safely clean up any remaining background resources.
+    // once, and can be reused for multiple requests. In this example, try-with-resources is used
+    // which automatically calls close() on the client to clean up resources.
     try (VideoStitcherServiceClient videoStitcherServiceClient =
         VideoStitcherServiceClient.create()) {
       ListLiveConfigsRequest listLiveConfigsRequest =

--- a/media/stitcher/src/main/java/com/example/stitcher/ListSlates.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/ListSlates.java
@@ -36,8 +36,8 @@ public class ListSlates {
 
   public static void listSlates(String projectId, String location) throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
-    // once, and can be reused for multiple requests. After completing all of your requests, call
-    // the "close" method on the client to safely clean up any remaining background resources.
+    // once, and can be reused for multiple requests. In this example, try-with-resources is used
+    // which automatically calls close() on the client to clean up resources.
     try (VideoStitcherServiceClient videoStitcherServiceClient =
         VideoStitcherServiceClient.create()) {
       ListSlatesRequest listSlatesRequest =

--- a/media/stitcher/src/main/java/com/example/stitcher/ListVodAdTagDetails.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/ListVodAdTagDetails.java
@@ -38,8 +38,8 @@ public class ListVodAdTagDetails {
   public static void listVodAdTagDetails(String projectId, String location, String sessionId)
       throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
-    // once, and can be reused for multiple requests. After completing all of your requests, call
-    // the "close" method on the client to safely clean up any remaining background resources.
+    // once, and can be reused for multiple requests. In this example, try-with-resources is used
+    // which automatically calls close() on the client to clean up resources.
     try (VideoStitcherServiceClient videoStitcherServiceClient =
         VideoStitcherServiceClient.create()) {
       ListVodAdTagDetailsRequest listVodAdTagDetailsRequest =

--- a/media/stitcher/src/main/java/com/example/stitcher/ListVodStitchDetails.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/ListVodStitchDetails.java
@@ -38,8 +38,8 @@ public class ListVodStitchDetails {
   public static void listVodStitchDetails(String projectId, String location, String sessionId)
       throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
-    // once, and can be reused for multiple requests. After completing all of your requests, call
-    // the "close" method on the client to safely clean up any remaining background resources.
+    // once, and can be reused for multiple requests. In this example, try-with-resources is used
+    // which automatically calls close() on the client to clean up resources.
     try (VideoStitcherServiceClient videoStitcherServiceClient =
         VideoStitcherServiceClient.create()) {
       ListVodStitchDetailsRequest listVodStitchDetailsRequest =

--- a/media/stitcher/src/main/java/com/example/stitcher/UpdateCdnKey.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/UpdateCdnKey.java
@@ -64,48 +64,49 @@ public class UpdateCdnKey {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
-    try (VideoStitcherServiceClient videoStitcherServiceClient =
-        VideoStitcherServiceClient.create()) {
-      CdnKey cdnKey;
-      String path;
-      if (isMediaCdn) {
-        path = "media_cdn_key";
-        cdnKey =
-            CdnKey.newBuilder()
-                .setName(CdnKeyName.of(projectId, location, cdnKeyId).toString())
-                .setHostname(hostname)
-                .setMediaCdnKey(
-                    MediaCdnKey.newBuilder()
-                        .setKeyName(keyName)
-                        .setPrivateKey(ByteString.copyFromUtf8(privateKey))
-                        .build())
-                .build();
-      } else {
-        path = "google_cdn_key";
-        cdnKey =
-            CdnKey.newBuilder()
-                .setName(CdnKeyName.of(projectId, location, cdnKeyId).toString())
-                .setHostname(hostname)
-                .setGoogleCdnKey(
-                    GoogleCdnKey.newBuilder()
-                        .setKeyName(keyName)
-                        .setPrivateKey(ByteString.copyFromUtf8(privateKey))
-                        .build())
-                .build();
-      }
-
-      UpdateCdnKeyRequest updateCdnKeyRequest =
-          UpdateCdnKeyRequest.newBuilder()
-              .setCdnKey(cdnKey)
-              // Update the hostname field and the fields for the specific key type (Media CDN
-              // or Cloud CDN). You must set the mask to the fields you want to update.
-              .setUpdateMask(FieldMask.newBuilder().addPaths("hostname").addPaths(path).build())
+    VideoStitcherServiceClient videoStitcherServiceClient = VideoStitcherServiceClient.create();
+    CdnKey cdnKey;
+    String path;
+    if (isMediaCdn) {
+      path = "media_cdn_key";
+      cdnKey =
+          CdnKey.newBuilder()
+              .setName(CdnKeyName.of(projectId, location, cdnKeyId).toString())
+              .setHostname(hostname)
+              .setMediaCdnKey(
+                  MediaCdnKey.newBuilder()
+                      .setKeyName(keyName)
+                      .setPrivateKey(ByteString.copyFromUtf8(privateKey))
+                      .build())
               .build();
-
-      CdnKey response = videoStitcherServiceClient.updateCdnKeyAsync(updateCdnKeyRequest)
-          .get(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
-      System.out.println("Updated CDN key: " + response.getName());
+    } else {
+      path = "google_cdn_key";
+      cdnKey =
+          CdnKey.newBuilder()
+              .setName(CdnKeyName.of(projectId, location, cdnKeyId).toString())
+              .setHostname(hostname)
+              .setGoogleCdnKey(
+                  GoogleCdnKey.newBuilder()
+                      .setKeyName(keyName)
+                      .setPrivateKey(ByteString.copyFromUtf8(privateKey))
+                      .build())
+              .build();
     }
+
+    UpdateCdnKeyRequest updateCdnKeyRequest =
+        UpdateCdnKeyRequest.newBuilder()
+            .setCdnKey(cdnKey)
+            // Update the hostname field and the fields for the specific key type (Media CDN
+            // or Cloud CDN). You must set the mask to the fields you want to update.
+            .setUpdateMask(FieldMask.newBuilder().addPaths("hostname").addPaths(path).build())
+            .build();
+
+    CdnKey response =
+        videoStitcherServiceClient
+            .updateCdnKeyAsync(updateCdnKeyRequest)
+            .get(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
+    System.out.println("Updated CDN key: " + response.getName());
+    videoStitcherServiceClient.close();
   }
 }
 // [END videostitcher_update_cdn_key]

--- a/media/stitcher/src/main/java/com/example/stitcher/UpdateCdnKeyAkamai.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/UpdateCdnKeyAkamai.java
@@ -52,31 +52,32 @@ public class UpdateCdnKeyAkamai {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
-    try (VideoStitcherServiceClient videoStitcherServiceClient =
-        VideoStitcherServiceClient.create()) {
-      CdnKey cdnKey =
-          CdnKey.newBuilder()
-              .setName(CdnKeyName.of(projectId, location, cdnKeyId).toString())
-              .setHostname(hostname)
-              .setAkamaiCdnKey(
-                  AkamaiCdnKey.newBuilder()
-                      .setTokenKey(ByteString.copyFromUtf8(akamaiTokenKey))
-                      .build())
-              .build();
+    VideoStitcherServiceClient videoStitcherServiceClient = VideoStitcherServiceClient.create();
+    CdnKey cdnKey =
+        CdnKey.newBuilder()
+            .setName(CdnKeyName.of(projectId, location, cdnKeyId).toString())
+            .setHostname(hostname)
+            .setAkamaiCdnKey(
+                AkamaiCdnKey.newBuilder()
+                    .setTokenKey(ByteString.copyFromUtf8(akamaiTokenKey))
+                    .build())
+            .build();
 
-      UpdateCdnKeyRequest updateCdnKeyRequest =
-          UpdateCdnKeyRequest.newBuilder()
-              .setCdnKey(cdnKey)
-              // Update the hostname field and token key field. You must set the mask to the fields
-              // you want to update.
-              .setUpdateMask(
-                  FieldMask.newBuilder().addPaths("hostname").addPaths("akamai_cdn_key").build())
-              .build();
+    UpdateCdnKeyRequest updateCdnKeyRequest =
+        UpdateCdnKeyRequest.newBuilder()
+            .setCdnKey(cdnKey)
+            // Update the hostname field and token key field. You must set the mask to the fields
+            // you want to update.
+            .setUpdateMask(
+                FieldMask.newBuilder().addPaths("hostname").addPaths("akamai_cdn_key").build())
+            .build();
 
-      CdnKey response = videoStitcherServiceClient.updateCdnKeyAsync(updateCdnKeyRequest)
-          .get(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
-      System.out.println("Updated CDN key: " + response.getName());
-    }
+    CdnKey response =
+        videoStitcherServiceClient
+            .updateCdnKeyAsync(updateCdnKeyRequest)
+            .get(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
+    System.out.println("Updated CDN key: " + response.getName());
+    videoStitcherServiceClient.close();
   }
 }
 // [END videostitcher_update_cdn_key_akamai]

--- a/media/stitcher/src/main/java/com/example/stitcher/UpdateSlate.java
+++ b/media/stitcher/src/main/java/com/example/stitcher/UpdateSlate.java
@@ -49,24 +49,25 @@ public class UpdateSlate {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
-    try (VideoStitcherServiceClient videoStitcherServiceClient =
-        VideoStitcherServiceClient.create()) {
-      UpdateSlateRequest updateSlateRequest =
-          UpdateSlateRequest.newBuilder()
-              .setSlate(
-                  Slate.newBuilder()
-                      .setName(SlateName.of(projectId, location, slateId).toString())
-                      .setUri(slateUri)
-                      .build())
-              // Set the update mask to the uri field in the existing slate. You must set the mask
-              // to the field you want to update.
-              .setUpdateMask(FieldMask.newBuilder().addPaths("uri").build())
-              .build();
+    VideoStitcherServiceClient videoStitcherServiceClient = VideoStitcherServiceClient.create();
+    UpdateSlateRequest updateSlateRequest =
+        UpdateSlateRequest.newBuilder()
+            .setSlate(
+                Slate.newBuilder()
+                    .setName(SlateName.of(projectId, location, slateId).toString())
+                    .setUri(slateUri)
+                    .build())
+            // Set the update mask to the uri field in the existing slate. You must set the mask
+            // to the field you want to update.
+            .setUpdateMask(FieldMask.newBuilder().addPaths("uri").build())
+            .build();
 
-      Slate response = videoStitcherServiceClient.updateSlateAsync(updateSlateRequest)
-          .get(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
-      System.out.println("Updated slate: " + response.getName());
-    }
+    Slate response =
+        videoStitcherServiceClient
+            .updateSlateAsync(updateSlateRequest)
+            .get(TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
+    System.out.println("Updated slate: " + response.getName());
+    videoStitcherServiceClient.close();
   }
 }
 // [END videostitcher_update_slate]


### PR DESCRIPTION
## Description

Remove try block for LROs and call close on the client per https://github.com/GoogleCloudPlatform/java-docs-samples/pull/8494#pullrequestreview-1561456858. Also, update comments on non-LROs that you don't need to call close when using try-with-resources.

- [X] Please **merge** this PR for me once it is approved
