### PR TITLE
chore(proc): disabling tests for Java8 samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Google Cloud Platform Java Samples
 
-[![Build Status][java-8-badge]][java-8-link] [![Build 
-Status][java-11-badge]][java-11-link] [![Build 
+[![Build Status][java-11-badge]][java-11-link] [![Build 
 Status][java-17-badge]][java-17-link]
 
 <a href="https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=README.md">
@@ -47,6 +46,11 @@ To browse ready to use code samples check [Google Cloud Samples](https://cloud.g
 
 * See [LICENSE](LICENSE)
 
+## Supported Java runtimes
+
+The minimal supported Java runtime is Java 11.
+Code samples that are build with older Java runtimes (e.g. Java 8) are requested to pass tests with Java 11.
+
 ## Source Code Headers
 
 Every file containing source code must include copyright and license
@@ -74,10 +78,6 @@ Apache header:
 [cred]: http://google.github.io/google-auth-library-java/releases/0.6.0/apidocs/com/google/auth/Credentials.html?is-external=true
 [options]: http://googlecloudplatform.github.io/google-cloud-java/0.12.0/apidocs/com/google/cloud/ServiceOptions.Builder.html#setCredentials-com.google.auth.Credentials-
 [auth_command]: https://cloud.google.com/sdk/gcloud/reference/beta/auth/application-default/login
-[java-8-badge]: 
-https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-8.svg
-[java-8-link]: 
-https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-8.html
 [java-11-badge]: 
 https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-11.svg
 [java-11-link]: 

--- a/appengine-java8/appidentity/pom.xml
+++ b/appengine-java8/appidentity/pom.xml
@@ -134,6 +134,15 @@
           <deploy.stopPreviousVersion>true</deploy.stopPreviousVersion>
         </configuration>
       </plugin>
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/appengine-java8/bigquery/pom.xml
+++ b/appengine-java8/bigquery/pom.xml
@@ -126,13 +126,20 @@
           <deploy.stopPreviousVersion>true</deploy.stopPreviousVersion>
         </configuration>
       </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
         <version>3.4.0</version>
       </plugin>
-
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/appengine-java8/bigtable/pom.xml
+++ b/appengine-java8/bigtable/pom.xml
@@ -169,6 +169,15 @@ limitations under the License.
           </rules>
         </configuration>
       </plugin>
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/appengine-java8/datastore-indexes-exploding/pom.xml
+++ b/appengine-java8/datastore-indexes-exploding/pom.xml
@@ -109,6 +109,15 @@
           <deploy.stopPreviousVersion>true</deploy.stopPreviousVersion>
         </configuration>
       </plugin>
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/appengine-java8/datastore-indexes-perfect/pom.xml
+++ b/appengine-java8/datastore-indexes-perfect/pom.xml
@@ -109,6 +109,15 @@
           <deploy.stopPreviousVersion>true</deploy.stopPreviousVersion>
         </configuration>
       </plugin>
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/appengine-java8/datastore-indexes/pom.xml
+++ b/appengine-java8/datastore-indexes/pom.xml
@@ -110,6 +110,15 @@
           <deploy.stopPreviousVersion>true</deploy.stopPreviousVersion>
         </configuration>
       </plugin>
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/appengine-java8/datastore-schedule-export/pom.xml
+++ b/appengine-java8/datastore-schedule-export/pom.xml
@@ -108,6 +108,15 @@
           <version>GCLOUD_CONFIG</version>
         </configuration>
       </plugin>
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/appengine-java8/datastore/pom.xml
+++ b/appengine-java8/datastore/pom.xml
@@ -160,6 +160,15 @@
           </annotationProcessorPaths>
         </configuration>
       </plugin>
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/appengine-java8/firebase-tictactoe/pom.xml
+++ b/appengine-java8/firebase-tictactoe/pom.xml
@@ -153,6 +153,15 @@
           <version>GCLOUD_CONFIG</version>
         </configuration>
       </plugin>
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/appengine-java8/guestbook-cloud-datastore/pom.xml
+++ b/appengine-java8/guestbook-cloud-datastore/pom.xml
@@ -133,6 +133,15 @@
           <version>GCLOUD_CONFIG</version>
         </configuration>
       </plugin>
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/appengine-java8/helloworld/pom.xml
+++ b/appengine-java8/helloworld/pom.xml
@@ -112,6 +112,15 @@ limitations under the License.
           <version>GCLOUD_CONFIG</version>
         </configuration>
       </plugin>
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/appengine-java8/multitenancy/pom.xml
+++ b/appengine-java8/multitenancy/pom.xml
@@ -140,6 +140,15 @@
           <deploy.stopPreviousVersion>true</deploy.stopPreviousVersion>
         </configuration>
       </plugin>
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/appengine-java8/requests/pom.xml
+++ b/appengine-java8/requests/pom.xml
@@ -114,13 +114,20 @@ limitations under the License.
           <deploy.stopPreviousVersion>true</deploy.stopPreviousVersion>
         </configuration>
       </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
         <version>3.4.0</version>
       </plugin>
-
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/appengine-java8/search/pom.xml
+++ b/appengine-java8/search/pom.xml
@@ -102,11 +102,19 @@ Copyright 2015 Google Inc.
           <deploy.stopPreviousVersion>true</deploy.stopPreviousVersion>
         </configuration>
       </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
         <version>3.4.0</version>
+      </plugin>
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/appengine-java8/springboot-helloworld/pom.xml
+++ b/appengine-java8/springboot-helloworld/pom.xml
@@ -103,7 +103,6 @@
           <version>GCLOUD_CONFIG</version>
         </configuration>
       </plugin>
-
       <plugin>
         <artifactId>maven-war-plugin</artifactId>
         <version>3.4.0</version>
@@ -111,7 +110,15 @@
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>
       </plugin>
-
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/appengine-java8/taskqueues-push/pom.xml
+++ b/appengine-java8/taskqueues-push/pom.xml
@@ -105,13 +105,20 @@ Copyright 2016 Google Inc.
           <deploy.stopPreviousVersion>true</deploy.stopPreviousVersion>
         </configuration>
       </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
         <version>3.4.0</version>
       </plugin>
-
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/appengine-java8/tasks/app/pom.xml
+++ b/appengine-java8/tasks/app/pom.xml
@@ -99,13 +99,20 @@ Copyright 2019 Google LLC
           <deploy.stopPreviousVersion>true</deploy.stopPreviousVersion>
         </configuration>
       </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
         <version>3.4.0</version>
       </plugin>
-
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/appengine-java8/tasks/quickstart/pom.xml
+++ b/appengine-java8/tasks/quickstart/pom.xml
@@ -107,13 +107,6 @@ Copyright 2018 Google LLC
           <deploy.stopPreviousVersion>true</deploy.stopPreviousVersion>
         </configuration>
       </plugin>
-
-      <!-- <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-war-plugin</artifactId>
-        <version>3.3.0</version>
-      </plugin> -->
-
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
@@ -121,6 +114,15 @@ Copyright 2018 Google LLC
         <configuration>
           <mainClass>com.example.task.CreateTask</mainClass>
           <cleanupDaemonThreads>false</cleanupDaemonThreads>
+        </configuration>
+      </plugin>
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
         </configuration>
       </plugin>
     </plugins>

--- a/appengine-java8/tasks/snippets/pom.xml
+++ b/appengine-java8/tasks/snippets/pom.xml
@@ -95,6 +95,15 @@ Copyright 2019 Google LLC
           </execution>
         </executions>
       </plugin>
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/appengine-java8/users/pom.xml
+++ b/appengine-java8/users/pom.xml
@@ -123,6 +123,15 @@ Copyright 2015 Google Inc.
           <deploy.stopPreviousVersion>true</deploy.stopPreviousVersion>
         </configuration>
       </plugin>
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/flexible/java-8/helloworld-springboot/pom.xml
+++ b/flexible/java-8/helloworld-springboot/pom.xml
@@ -95,6 +95,15 @@
           <version>GCLOUD_CONFIG</version>
         </configuration>
       </plugin>
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/flexible/java-8/pubsub/pom.xml
+++ b/flexible/java-8/pubsub/pom.xml
@@ -122,6 +122,15 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>${jetty}</version>
       </plugin>
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/flexible/java-8/sparkjava/pom.xml
+++ b/flexible/java-8/sparkjava/pom.xml
@@ -122,6 +122,15 @@ limitations under the License.
           <version>GCLOUD_CONFIG</version>
         </configuration>
       </plugin>
+      <!-- disable tests due to discontinued support for Java 8 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
### Description

Add skipTest flags to POM files for code samples that are designated for Java 8. See #8935 for more info.
Remove Java8 badge from the root README.
Add section "Supported Java runtimes" to the root README
