### PR TITLE
feat: samples for partitioned queries on Spanner with PostgreSQL

### DIFF
--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgAutoPartitionModeExample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgAutoPartitionModeExample.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class PgAutoPartitionModeExample {
+
+  public static void main(String[] args) throws SQLException {
+    autoPartitionMode();
+  }
+
+  static void autoPartitionMode() throws SQLException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project";
+    String instanceId = "my-instance";
+    String databaseId = "my-database";
+    autoPartitionMode(projectId, instanceId, databaseId);
+  }
+
+  // This example shows how to use 'spanner.auto_partition_mode=true' to execute partitioned queries
+  // with the JDBC driver for a PostgreSQL-dialect database.
+  static void autoPartitionMode(String projectId, String instanceId, String databaseId)
+      throws SQLException {
+    String connectionUrl = String.format("jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s",
+        projectId, instanceId, databaseId);
+    try (Connection connection = DriverManager.getConnection(
+        connectionUrl); Statement statement = connection.createStatement()) {
+      // A connection can also be set to 'spanner.auto_partition_mode', which will instruct it to
+      // execute all queries as a partitioned query. This is essentially the same as automatically
+      // prefixing all queries with 'RUN PARTITIONED QUERY ...'.
+      statement.execute("set spanner.auto_partition_mode=true");
+      // This will execute at most max_partitioned_parallelism partitions in parallel.
+      statement.execute("set spanner.max_partitioned_parallelism=8");
+      try (ResultSet resultSet = statement.executeQuery(
+          "SELECT SingerId, FirstName, LastName FROM singers")) {
+        while (resultSet.next()) {
+          System.out.printf("%s %s %s%n", resultSet.getString(1), resultSet.getString(2),
+              resultSet.getString(3));
+        }
+      }
+    }
+  }
+}

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgDataBoostExample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgDataBoostExample.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class PgDataBoostExample {
+
+  public static void main(String[] args) throws SQLException {
+    dataBoost();
+  }
+
+  static void dataBoost() throws SQLException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project";
+    String instanceId = "my-instance";
+    String databaseId = "my-database";
+    dataBoost(projectId, instanceId, databaseId);
+  }
+
+  // This example shows how to execute queries with data boost on PostgreSQL-dialect databases using
+  // the Google Cloud Spanner JDBC driver.
+  static void dataBoost(String projectId, String instanceId, String databaseId)
+      throws SQLException {
+    String connectionUrl = String.format("jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s",
+        projectId, instanceId, databaseId);
+    try (Connection connection = DriverManager.getConnection(
+        connectionUrl); Statement statement = connection.createStatement()) {
+
+      // A connection can also be set to 'spanner.auto_partition_mode', which will instruct it to
+      // execute all queries as a partitioned query. This is essentially the same as automatically
+      // prefixing all queries with 'RUN PARTITIONED QUERY ...'.
+      statement.execute("set spanner.auto_partition_mode=true");
+
+      // This will execute at most max_partitioned_parallelism partitions in parallel.
+      statement.execute("set spanner.max_partitioned_parallelism=8");
+
+      // Setting 'spanner.data_boost_enabled' to true will instruct the JDBC connection to execute
+      // all partitioned queries using Data Boost. This setting applies to all the above methods
+      // that can be used to run a partitioned query:
+      // 1. RUN PARTITION '...'
+      // 2. RUN PARTITIONED QUERY ...
+      // 3. SET AUTO_PARTITION_MODE=TRUE; SELECT ...
+      statement.execute("set spanner.data_boost_enabled=true");
+
+      // This query will be executed as a partitioned query using data boost.
+      try (ResultSet resultSet = statement.executeQuery(
+          "SELECT SingerId, FirstName, LastName FROM singers")) {
+        while (resultSet.next()) {
+          System.out.printf("%s %s %s%n", resultSet.getString(1), resultSet.getString(2),
+              resultSet.getString(3));
+        }
+      }
+    }
+  }
+}

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgPartitionQueryExample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgPartitionQueryExample.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PgPartitionQueryExample {
+
+  public static void main(String[] args) throws SQLException {
+    partitionQuery();
+  }
+
+  static void partitionQuery() throws SQLException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project";
+    String instanceId = "my-instance";
+    String databaseId = "my-database";
+    partitionQuery(projectId, instanceId, databaseId);
+  }
+
+  // This example shows how to partition a query and execute each returned partition on a
+  // PostgreSQL-dialect database with the JDBC driver.
+  static void partitionQuery(String projectId, String instanceId, String databaseId)
+      throws SQLException {
+    String connectionUrl = String.format("jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s",
+        projectId, instanceId, databaseId);
+    try (Connection connection = DriverManager.getConnection(
+        connectionUrl); Statement statement = connection.createStatement()) {
+
+      // Partition a query and then execute each partition sequentially.
+      List<String> partitions = new ArrayList<>();
+      // This will partition the query and return a result set with the partition IDs encoded as a
+      // string. Each of these partition IDs can be executed with "RUN PARTITION '<partition-id>'".
+      System.out.println("Partitioning query 'SELECT SingerId, FirstName, LastName from singers'");
+      try (ResultSet partitionsResultSet = statement.executeQuery(
+          "PARTITION SELECT SingerId, FirstName, LastName from Singers")) {
+        while (partitionsResultSet.next()) {
+          partitions.add(partitionsResultSet.getString(1));
+        }
+      }
+      System.out.printf("Partition command returned %d partitions\n", partitions.size());
+
+      // This executes the partitions serially on the same connection, but each partition can also
+      // be executed on a different JDBC connection (even on a different host).
+      for (String partitionId : partitions) {
+        try (ResultSet resultSet = statement.executeQuery(
+            String.format("RUN PARTITION '%s'", partitionId))) {
+          while (resultSet.next()) {
+            System.out.printf("%s %s %s%n", resultSet.getString(1), resultSet.getString(2),
+                resultSet.getString(3));
+          }
+        }
+      }
+      System.out.println("Finished executing all partitions");
+    }
+  }
+}

--- a/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgRunPartitionedQueryExample.java
+++ b/spanner/jdbc/src/main/java/com/example/spanner/jdbc/PgRunPartitionedQueryExample.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class PgRunPartitionedQueryExample {
+
+  public static void main(String[] args) throws SQLException {
+    runPartitionedQuery();
+  }
+
+  static void runPartitionedQuery() throws SQLException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project";
+    String instanceId = "my-instance";
+    String databaseId = "my-database";
+    runPartitionedQuery(projectId, instanceId, databaseId);
+  }
+
+  // This example shows how to run a query directly as a partitioned query on a JDBC connection.
+  // The query will be partitioned and each partition will be executed using the same JDBC
+  // connection. You can set the maximum parallelism that should be used to execute the query with
+  // the SQL statement 'SET spanner.max_partitioned_parallelism=<parallelism>'.
+  static void runPartitionedQuery(String projectId, String instanceId, String databaseId)
+      throws SQLException {
+    String connectionUrl = String.format("jdbc:cloudspanner:/projects/%s/instances/%s/databases/%s",
+        projectId, instanceId, databaseId);
+    try (Connection connection = DriverManager.getConnection(
+        connectionUrl); Statement statement = connection.createStatement()) {
+      // Run a query directly as a partitioned query.
+      // This will execute at most max_partitioned_parallelism partitions in parallel.
+      statement.execute("set spanner.max_partitioned_parallelism=8");
+      try (ResultSet resultSet = statement.executeQuery(
+          "RUN PARTITIONED QUERY SELECT SingerId, FirstName, LastName FROM singers")) {
+        while (resultSet.next()) {
+          System.out.printf("%s %s %s%n", resultSet.getString(1), resultSet.getString(2),
+              resultSet.getString(3));
+        }
+      }
+    }
+  }
+}

--- a/spanner/jdbc/src/test/java/com/example/spanner/jdbc/BaseJdbcPgExamplesIT.java
+++ b/spanner/jdbc/src/test/java/com/example/spanner/jdbc/BaseJdbcPgExamplesIT.java
@@ -112,6 +112,11 @@ public abstract class BaseJdbcPgExamplesIT {
       this.lastName = lastName;
       this.revenues = revenues;
     }
+
+    @Override
+    public String toString() {
+      return String.format("%d %s %s", singerId, firstName, lastName);
+    }
   }
 
   static final List<Singer> TEST_SINGERS =
@@ -140,7 +145,7 @@ public abstract class BaseJdbcPgExamplesIT {
           connection
               .createStatement()
               .execute(
-                  "CREATE TABLE Singers (\n"
+                  "CREATE TABLE IF NOT EXISTS Singers (\n"
                       + "  SingerId   BIGINT NOT NULL PRIMARY KEY,\n"
                       + "  FirstName  VARCHAR(1024),\n"
                       + "  LastName   VARCHAR(1024),\n"

--- a/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgPartitionedQueryIT.java
+++ b/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgPartitionedQueryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google Inc.
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgPartitionedQueryIT.java
+++ b/spanner/jdbc/src/test/java/com/example/spanner/jdbc/PgPartitionedQueryIT.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.spanner.jdbc;
+
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.ServiceOptions;
+import org.junit.Test;
+
+public class PgPartitionedQueryIT extends BaseJdbcPgExamplesIT {
+
+  @Override
+  protected boolean createTestTable() {
+    return true;
+  }
+
+  @Test
+  public void testPartitionQuery() {
+    String out = runExample(() -> PgPartitionQueryExample.partitionQuery(
+        ServiceOptions.getDefaultProjectId(), instanceId, databaseId));
+    assertOutputContainsAllSingers(out);
+  }
+
+  @Test
+  public void testAutoPartitionMode() {
+    String out = runExample(() -> PgAutoPartitionModeExample.autoPartitionMode(
+        ServiceOptions.getDefaultProjectId(), instanceId, databaseId));
+    assertOutputContainsAllSingers(out);
+  }
+
+  @Test
+  public void testDataBoost() {
+    String out = runExample(() -> PgDataBoostExample.dataBoost(
+        ServiceOptions.getDefaultProjectId(), instanceId, databaseId));
+    assertOutputContainsAllSingers(out);
+  }
+
+  @Test
+  public void testRunPartitionedQuery() {
+    String out = runExample(() -> PgRunPartitionedQueryExample.runPartitionedQuery(
+        ServiceOptions.getDefaultProjectId(), instanceId, databaseId));
+    assertOutputContainsAllSingers(out);
+  }
+
+  void assertOutputContainsAllSingers(String out) {
+    for (Singer singer : TEST_SINGERS) {
+      assertTrue(out + " should contain " + singer.toString(),
+          out.contains(singer.toString()));
+    }
+  }
+
+}


### PR DESCRIPTION
Adds samples for running partitioned queries with the Spanner JDBC driver on PostgreSQL-dialect databases.
