### PR TITLE
chore(proc): prevent dependency upgrades for java8 code samples

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,6 +14,8 @@
     "dependencyDashboardLabels": [
         "type: process",
     ],
+    // discontinue upgrades for java8 code samples
+    "ignorePaths": ["**/*java8*/**", "**/*java-8*/**"],
     "packageRules": [
         {
             "matchCategories": [

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Google Cloud Platform Java Samples
 
-[![Build Status][java-8-badge]][java-8-link] [![Build 
-Status][java-11-badge]][java-11-link] [![Build 
+[![Build Status][java-11-badge]][java-11-link] [![Build
 Status][java-17-badge]][java-17-link]
 
 <a href="https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=README.md">
@@ -47,6 +46,13 @@ To browse ready to use code samples check [Google Cloud Samples](https://cloud.g
 
 * See [LICENSE](LICENSE)
 
+## Supported Java runtimes
+
+The minimal supported Java runtime is Java 11.
+Testing of the code samples in Java 8 runtime is discontinued.
+Code samples that are build with older Java runtimes (e.g. Java 8) are requested to pass tests with Java 11.
+Code samples designated to build and run with Java 8 will be removed at end of support for Java 8 in GCP.
+
 ## Source Code Headers
 
 Every file containing source code must include copyright and license
@@ -71,20 +77,18 @@ Apache header:
     limitations under the License.
 
 [ADC]: https://developers.google.com/identity/protocols/application-default-credentials
-[cred]: http://google.github.io/google-auth-library-java/releases/0.6.0/apidocs/com/google/auth/Credentials.html?is-external=true
-[options]: http://googlecloudplatform.github.io/google-cloud-java/0.12.0/apidocs/com/google/cloud/ServiceOptions.Builder.html#setCredentials-com.google.auth.Credentials-
 [auth_command]: https://cloud.google.com/sdk/gcloud/reference/beta/auth/application-default/login
-[java-8-badge]: 
+[java-8-badge]:
 https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-8.svg
-[java-8-link]: 
+[java-8-link]:
 https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-8.html
-[java-11-badge]: 
+[java-11-badge]:
 https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-11.svg
-[java-11-link]: 
+[java-11-link]:
 https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-11.html
-[java-17-badge]: 
+[java-17-badge]:
 https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-17.svg
-[java-17-link]: 
+[java-17-link]:
 https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-17.html
 
 Java is a registered trademark of Oracle and/or its affiliates.


### PR DESCRIPTION
### Description

Remove Java8 badge and add section "Supported Java runtimes" to the root README.
Exclude code samples designated to run under Java 8 runtime from the renovate analysis.
This change is a part of the process described in #8935.
Excluding dependency updates for Java 8 code samples will allow to reduce a number of flaky tests in each renovate PR.
