### PR TITLE
feat(testing): convert CI to use Makefile for testing

### DIFF
--- a/.kokoro/tests/run_test_java.sh
+++ b/.kokoro/tests/run_test_java.sh
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 file="$(pwd)"
+project_root="$(git rev-parse --show-toplevel)"
+rel_dir=$(realpath --relative-to=${project_root} $file)
 SCRIPT_DIR="$(dirname $0)/"
 
 # Fail the tests if no Java version was found.
@@ -67,13 +69,10 @@ if [[ "$file" == *"functions/helloworld/"* ]]; then
 fi
 
 # Use maven to execute the tests for the project.
-mvn --quiet --batch-mode --fail-at-end clean verify \
-    -Dfile.encoding="UTF-8" \
-    -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
-    -Dmaven.test.redirectTestOutputToFile=true \
-    -Dbigtable.projectID="${GOOGLE_CLOUD_PROJECT}" \
-    -Dbigtable.instanceID=instance
+pushd ${project_root}
+make test dir=${rel_dir}
 EXIT=$?
+popd
 
 # Tear down (deployed) Cloud Functions after deployment tests are run
 if [[ "$file" == *"functions/helloworld/"* ]]; then


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
