### PR TITLE
Use image first in prompts

### DIFF
--- a/vertexai/snippets/src/main/java/vertexai/gemini/SingleTurnMultimodal.java
+++ b/vertexai/snippets/src/main/java/vertexai/gemini/SingleTurnMultimodal.java
@@ -61,8 +61,8 @@ public class SingleTurnMultimodal {
       GenerativeModel model = new GenerativeModel(modelName, generationConfig, vertexAI);
       ResponseStream<GenerateContentResponse> responseStream = model.generateContentStream(
           ContentMaker.fromMultiModalData(
-              textPrompt,
-              PartMaker.fromMimeTypeAndData("image/jpg", decodedImage)
+              PartMaker.fromMimeTypeAndData("image/jpg", decodedImage),
+              textPrompt
           ));
       responseStream.stream().forEach(System.out::println);
     }

--- a/vertexai/snippets/src/main/java/vertexai/gemini/SingleTurnMultimodal.java
+++ b/vertexai/snippets/src/main/java/vertexai/gemini/SingleTurnMultimodal.java
@@ -61,8 +61,8 @@ public class SingleTurnMultimodal {
       GenerativeModel model = new GenerativeModel(modelName, generationConfig, vertexAI);
       ResponseStream<GenerateContentResponse> responseStream = model.generateContentStream(
           ContentMaker.fromMultiModalData(
-              PartMaker.fromMimeTypeAndData("image/jpg", decodedImage),
-              textPrompt
+              textPrompt,
+              PartMaker.fromMimeTypeAndData("image/jpg", decodedImage)
           ));
       responseStream.stream().forEach(System.out::println);
     }


### PR DESCRIPTION
## Description

Fixes internal bug tracked as b/316922981
Favor putting images first, prompt second, in multimodal queries.