### PR TITLE
fix: update references to deprecated hashed_account_id

### DIFF
--- a/recaptcha_enterprise/snippets/src/main/java/recaptcha/account_defender/SearchRelatedAccountGroupMemberships.java
+++ b/recaptcha_enterprise/snippets/src/main/java/recaptcha/account_defender/SearchRelatedAccountGroupMemberships.java
@@ -19,7 +19,6 @@ package account_defender;
 // [START recaptcha_enterprise_search_related_account_group_membership]
 
 import com.google.cloud.recaptchaenterprise.v1.RecaptchaEnterpriseServiceClient;
-import com.google.protobuf.ByteString;
 import com.google.recaptchaenterprise.v1.RelatedAccountGroupMembership;
 import com.google.recaptchaenterprise.v1.SearchRelatedAccountGroupMembershipsRequest;
 import java.io.IOException;
@@ -32,21 +31,21 @@ public class SearchRelatedAccountGroupMemberships {
     // projectId: Google Cloud Project Id.
     String projectId = "project-id";
 
-    // HMAC SHA-256 hashed unique id of the customer.
-    ByteString hashedAccountId = ByteString.copyFrom(new byte[] {});
+    // Unique id of the customer.
+    String accountId = "default" + UUID.randomUUID().toString().split("-")[0];
 
-    searchRelatedAccountGroupMemberships(projectId, hashedAccountId);
+    searchRelatedAccountGroupMemberships(projectId, accountId);
   }
 
-  // List group memberships for the hashed account id.
+  // List group memberships for the account id.
   public static void searchRelatedAccountGroupMemberships(
-      String projectId, ByteString hashedAccountId) throws IOException {
+      String projectId, String accountId) throws IOException {
     try (RecaptchaEnterpriseServiceClient client = RecaptchaEnterpriseServiceClient.create()) {
 
       SearchRelatedAccountGroupMembershipsRequest request =
           SearchRelatedAccountGroupMembershipsRequest.newBuilder()
               .setProject(projectId)
-              .setHashedAccountId(hashedAccountId)
+              .setAccountId(accountId)
               .build();
 
       for (RelatedAccountGroupMembership groupMembership :
@@ -54,7 +53,7 @@ public class SearchRelatedAccountGroupMemberships {
         System.out.println(groupMembership.getName());
       }
       System.out.printf(
-          "Finished searching related account group memberships for %s!", hashedAccountId);
+          "Finished searching related account group memberships for %s!", accountId);
     }
   }
 }

--- a/recaptcha_enterprise/snippets/src/test/java/app/SnippetsIT.java
+++ b/recaptcha_enterprise/snippets/src/test/java/app/SnippetsIT.java
@@ -221,7 +221,7 @@ public class SnippetsIT {
     ListRelatedAccountGroupMemberships.listRelatedAccountGroupMemberships(PROJECT_ID, "legitimate");
     assertThat(stdOut.toString()).contains("Finished listing related account group memberships.");
 
-    // Search related group memberships for a hashed account id.
+    // Search related group memberships for a account id.
     SearchRelatedAccountGroupMemberships.searchRelatedAccountGroupMemberships(
         PROJECT_ID, hashedAccountId);
     assertThat(stdOut.toString())

--- a/recaptcha_enterprise/snippets/src/test/java/app/SnippetsIT.java
+++ b/recaptcha_enterprise/snippets/src/test/java/app/SnippetsIT.java
@@ -38,7 +38,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -183,16 +182,6 @@ public class SnippetsIT {
 
     String testURL = "http://localhost:" + randomServerPort + "/";
     String accountId = "default-" + UUID.randomUUID().toString().split("-")[0];
-
-    // Secret not shared with Google.
-    String HMAC_KEY = "123456789";
-    // Get instance of Mac object implementing HmacSHA256, and initialize it with the above
-    // secret key.
-    Mac mac = Mac.getInstance("HmacSHA256");
-    SecretKeySpec secretKeySpec = new SecretKeySpec(HMAC_KEY.getBytes(StandardCharsets.UTF_8),
-        "HmacSHA256");
-    mac.init(secretKeySpec);
-    byte[] hashBytes = mac.doFinal(accountId.getBytes(StandardCharsets.UTF_8));
 
     // Create the assessment.
     JSONObject createAssessmentResult =

--- a/recaptcha_enterprise/snippets/src/test/java/app/SnippetsIT.java
+++ b/recaptcha_enterprise/snippets/src/test/java/app/SnippetsIT.java
@@ -193,7 +193,6 @@ public class SnippetsIT {
         "HmacSHA256");
     mac.init(secretKeySpec);
     byte[] hashBytes = mac.doFinal(accountId.getBytes(StandardCharsets.UTF_8));
-    asdfByteString hashedAccountId = ByteString.copyFrom(hashBytes);
 
     // Create the assessment.
     JSONObject createAssessmentResult =
@@ -223,11 +222,11 @@ public class SnippetsIT {
 
     // Search related group memberships for a account id.
     SearchRelatedAccountGroupMemberships.searchRelatedAccountGroupMemberships(
-        PROJECT_ID, hashedAccountId);
+        PROJECT_ID, accountId);
     assertThat(stdOut.toString())
         .contains(
             String.format(
-                "Finished searching related account group memberships for %s", hashedAccountId));
+                "Finished searching related account group memberships for %s", accountId));
   }
 
   @Test


### PR DESCRIPTION
This is the leftover from https://github.com/GoogleCloudPlatform/java-docs-samples/pull/8844.

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [x] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
