### PR TITLE
test(otel): re-enable integration tests

### DIFF
--- a/opentelemetry/spring-boot-instrumentation/pom.xml
+++ b/opentelemetry/spring-boot-instrumentation/pom.xml
@@ -82,7 +82,9 @@
         <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
-            <version>7.4</version>
+            <!-- Cannot be updated until logback is updated to 1.3+, probably in the next
+            Spring Boot major version -->
+            <version>7.3</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/opentelemetry/spring-boot-instrumentation/src/test/java/com/example/demo/DockerComposeTestsIT.java
+++ b/opentelemetry/spring-boot-instrumentation/src/test/java/com/example/demo/DockerComposeTestsIT.java
@@ -26,7 +26,6 @@ import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.regex.Pattern;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.testcontainers.containers.ComposeContainer;
@@ -47,7 +46,6 @@ public class DockerComposeTestsIT {
           .withBuild(true);
 
   @Test
-  @Ignore("TODO: Remove after fixing https://github.com/GoogleCloudPlatform/java-docs-samples/issues/8979")
   public void testApp() throws InterruptedException, IOException, URISyntaxException {
     // Let the docker compose app run until some spans/logs/metrics are sent to
     // GCP


### PR DESCRIPTION
## Description

Fixes https://github.com/GoogleCloudPlatform/java-docs-samples/issues/8979

The breakage was actually caused by upgrading logstash-encoder to 7.4 because [it does not support logback versions prior to 1.3.0](https://github.com/logfellow/logstash-logback-encoder#:~:text=Support%20for%20logback%20versions%20prior%20to%201.3.0%20was%20removed%20in%20logstash%2Dlogback%2Dencoder%207.4.). Spring Boot 2 uses an [older logback version](https://docs.spring.io/spring-boot/docs/2.7.18/reference/html/dependency-versions.html).

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [x] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved 