### PR TITLE
fix: use model id instead of model name in undeployModelAsync

### DIFF
--- a/aiplatform/src/main/java/aiplatform/UndeployModelSample.java
+++ b/aiplatform/src/main/java/aiplatform/UndeployModelSample.java
@@ -22,7 +22,6 @@ import com.google.api.gax.longrunning.OperationFuture;
 import com.google.cloud.aiplatform.v1.EndpointName;
 import com.google.cloud.aiplatform.v1.EndpointServiceClient;
 import com.google.cloud.aiplatform.v1.EndpointServiceSettings;
-import com.google.cloud.aiplatform.v1.ModelName;
 import com.google.cloud.aiplatform.v1.UndeployModelOperationMetadata;
 import com.google.cloud.aiplatform.v1.UndeployModelResponse;
 import java.io.IOException;
@@ -57,7 +56,6 @@ public class UndeployModelSample {
         EndpointServiceClient.create(endpointServiceSettings)) {
       String location = "us-central1";
       EndpointName endpointName = EndpointName.of(project, location, endpointId);
-      ModelName modelName = ModelName.of(project, location, modelId);
 
       // key '0' assigns traffic for the newly deployed model
       // Traffic percentage values must add up to 100
@@ -66,7 +64,7 @@ public class UndeployModelSample {
 
       OperationFuture<UndeployModelResponse, UndeployModelOperationMetadata> operation =
           endpointServiceClient.undeployModelAsync(
-              endpointName.toString(), modelName.toString(), trafficSplit);
+              endpointName.toString(), modelId, trafficSplit);
       System.out.format("Operation name: %s\n", operation.getInitialFuture().get().getName());
       System.out.println("Waiting for operation to finish...");
       UndeployModelResponse undeployModelResponse = operation.get(180, TimeUnit.SECONDS);


### PR DESCRIPTION
## Description

Fixes #8985


## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
