### PR TITLE
chore: exclude flakybot to run on Java8 tests

### DIFF
--- a/.kokoro/tests/run_test_java.sh
+++ b/.kokoro/tests/run_test_java.sh
@@ -101,9 +101,9 @@ if [[ "$file" == *"run/"* && ("$file" != *"run/filesystem"* && "$file" != *"run/
     fi
 fi
 
-# If this is a periodic build, send the test log to the FlakyBot.
+# If this is a periodic build, send the test log to the FlakyBot except for Java 8
 # See https://github.com/googleapis/repo-automation-bots/tree/main/packages/flakybot.
-if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"periodic"* ]]; then
+if [[ $JAVA_VERSION != "1.8" && $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"periodic"* ]]; then
     chmod +x $KOKORO_GFILE_DIR/linux_amd64/flakybot
     $KOKORO_GFILE_DIR/linux_amd64/flakybot
 fi


### PR DESCRIPTION
### Description

Change Kokoro test script execution to exclude running [flakybot] on the test results of Java8 tests.
We run tests on Java 8 runtime for the reference only since Java 8 runtime support is deprecated.
 