### PR TITLE
chore: update workflow badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,17 +80,9 @@ Apache header:
 
 [ADC]: https://developers.google.com/identity/protocols/application-default-credentials
 [auth_command]: https://cloud.google.com/sdk/gcloud/reference/beta/auth/application-default/login
-[java-8-badge]:
-https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-8.svg
-[java-8-link]:
-https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-8.html
-[java-11-badge]:
-https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-11.svg
-[java-11-link]:
-https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-11.html
-[java-17-badge]:
-https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-17.svg
-[java-17-link]:
-https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-17.html
+[java-21-badge]:
+https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-21.svg
+[java-21-link]:
+https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-21.html
 
 Java is a registered trademark of Oracle and/or its affiliates.

--- a/README.md
+++ b/README.md
@@ -80,9 +80,17 @@ Apache header:
 
 [ADC]: https://developers.google.com/identity/protocols/application-default-credentials
 [auth_command]: https://cloud.google.com/sdk/gcloud/reference/beta/auth/application-default/login
+[java-11-badge]:
+https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-11.svg
+[java-11-link]:
+https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-11.html
+[java-17-badge]:
+https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-17.svg
+[java-17-link]:
+https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-17.html
 [java-21-badge]:
 https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-21.svg
 [java-21-link]:
-https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/java-docs-samples-21.html
+https://storage.googleapis.com/cloud-devrel-kokoro-resources/java/badges/
 
 Java is a registered trademark of Oracle and/or its affiliates.


### PR DESCRIPTION
Versions:

Java 8 : badge removed as this version is in maintenance mode for existing samples.
 
Java 11 and 17: badge supported as periodic builds reflect health of the samples against these versions

Java 21: badge added to reflect nightly build results