### PR TITLE
docs(samples): Set the assessment.event.expected_action when sending …

### DIFF
--- a/recaptcha_enterprise/demosite/src/main/java/app/MainController.java
+++ b/recaptcha_enterprise/demosite/src/main/java/app/MainController.java
@@ -119,9 +119,8 @@ public class MainController {
     try {
       // <!-- ATTENTION: reCAPTCHA Example (Server Part 1/2) Starts -->
       assessmentResponse = CreateAssessment.createAssessment(
-          CONTEXT.get("project_id"),
-          CONTEXT.get("site_key"),
-          jsonData.get("token"));
+          CONTEXT.get("project_id"), CONTEXT.get("site_key"),
+          jsonData.get("token"), recaptchaAction);
 
       // Check if the token is valid, score is above threshold score and the action equals expected.
       // Take action based on the result (BAD / NOT_BAD).
@@ -172,9 +171,8 @@ public class MainController {
     try {
       // <!-- ATTENTION: reCAPTCHA Example (Server Part 1/2) Starts -->
       assessmentResponse = CreateAssessment.createAssessment(
-          CONTEXT.get("project_id"),
-          CONTEXT.get("site_key"),
-          jsonData.get("token").toString());
+          CONTEXT.get("project_id"), CONTEXT.get("site_key"),
+          jsonData.get("token").toString(), recaptchaAction);
 
       // Check if the token is valid, score is above threshold score and the action equals expected.
       // Take action based on the result (BAD / NOT_BAD).
@@ -227,9 +225,8 @@ public class MainController {
     try {
       // <!-- ATTENTION: reCAPTCHA Example (Server Part 1/2) Starts -->
       assessmentResponse = CreateAssessment.createAssessment(
-          CONTEXT.get("project_id"),
-          CONTEXT.get("site_key"),
-          jsonData.get("token"));
+          CONTEXT.get("project_id"), CONTEXT.get("site_key"),
+          jsonData.get("token"), recaptchaAction);
 
       // Check if the token is valid, score is above threshold score and the action equals expected.
       // Take action based on the result (BAD / NOT_BAD).
@@ -282,9 +279,8 @@ public class MainController {
     try {
       // <!-- ATTENTION: reCAPTCHA Example (Server Part 1/2) Starts -->
       assessmentResponse = CreateAssessment.createAssessment(
-          CONTEXT.get("project_id"),
-          CONTEXT.get("site_key"),
-          jsonData.get("token").toString());
+          CONTEXT.get("project_id"), CONTEXT.get("site_key"),
+          jsonData.get("token").toString(), recaptchaAction);
 
       // Check if the token is valid, score is above threshold score and the action equals expected.
       // Take action based on the result (BAD / NOT_BAD).
@@ -336,9 +332,8 @@ public class MainController {
     try {
       // <!-- ATTENTION: reCAPTCHA Example (Server Part 1/2) Starts -->
       assessmentResponse = CreateAssessment.createAssessment(
-          CONTEXT.get("project_id"),
-          CONTEXT.get("site_key"),
-          jsonData.get("token"));
+          CONTEXT.get("project_id"), CONTEXT.get("site_key"),
+          jsonData.get("token"), recaptchaAction);
 
       // Check if the token is valid, score is above threshold score and the action equals expected.
       // Take action based on the result (BAD / NOT_BAD).

--- a/recaptcha_enterprise/demosite/src/main/java/recaptcha/CreateAssessment.java
+++ b/recaptcha_enterprise/demosite/src/main/java/recaptcha/CreateAssessment.java
@@ -28,22 +28,26 @@ public class CreateAssessment {
    * Create an assessment to analyze the risk of a UI action.
    *
    * @param projectID : Google Cloud Project ID
-   * @param recaptchaSiteKey : Site key obtained by registering a domain/app to use recaptcha
-   *     services. (score/ checkbox type)
-   * @param token : The token obtained from the client on passing the recaptchaSiteKey.
+   * @param recaptchaSiteKey : Site key obtained by registering a domain/app to
+   *     use recaptcha services. (score/ checkbox type)
+   * @param token : The token obtained from the client on passing the
+   *     recaptchaSiteKey.
+   * @param expectedAction : The expected action for this type of event.
    * @return Assessment response.
    */
-  public static Assessment createAssessment(
-      String projectID, String recaptchaSiteKey, String token)
+  public static Assessment createAssessment(String projectID,
+                                            String recaptchaSiteKey,
+                                            String token, String expectedAction)
       throws Exception {
 
     // <!-- ATTENTION: reCAPTCHA Example (Server Part 2/2) Starts -->
     try (RecaptchaEnterpriseServiceClient client = RecaptchaEnterpriseServiceClient.create()) {
       // Set the properties of the event to be tracked.
       Event event = Event.newBuilder()
-          .setSiteKey(recaptchaSiteKey)
-          .setToken(token)
-          .build();
+                        .setSiteKey(recaptchaSiteKey)
+                        .setToken(token)
+                        .setExpectedAction(expectedAction)
+                        .build();
 
       // Build the assessment request.
       CreateAssessmentRequest createAssessmentRequest =


### PR DESCRIPTION
## Description

Demonstrate setting the [`assessment.event.expected_action`](https://cloud.google.com/recaptcha-enterprise/docs/reference/rpc/google.cloud.recaptchaenterprise.v1#event) during the `CreateAssessment` request, so the `action` from the generated `execute` token can be compared on the backend.

## Checklist

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [X] **Tests** pass:   `mvn clean verify` **required**
- [X] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [X] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [X] Please **merge** this PR for me once it is approved
