### PR TITLE
docs: migrating Bigtable workload generator example to not use Hbase

### DIFF
--- a/bigtable/beam/workload-generator/README.md
+++ b/bigtable/beam/workload-generator/README.md
@@ -27,9 +27,9 @@ be run as a Dataflow job.
     --template-file-gcs-location "$TEMPLATE_PATH" \
     --parameters bigtableInstanceId="$INSTANCE_ID" \
     --parameters bigtableTableId="$TABLE_ID" \
-    --region "$REGION" \
-    --parameters workloadRate=$WORKLOAD_RATE
-    --parameters workloadDurationMinutes=$WORKLOAD_DURATION
+    --region "$REGION \
+    --parameters workloadRate=$WORKLOAD_RATE \
+    --parameters workloadDurationMinutes=$WORKLOAD_DURATION"
     ```
 
 ### Deploying a template instructions
@@ -89,10 +89,10 @@ If you would like to modify this and run it yourself you can use these commands:
 1. Run the command
 
    ```
-   mvn compile exec:java -Dexec.mainClass=WorkloadGenerator \
+   mvn compile exec:java -Dexec.mainClass=bigtable.WorkloadGenerator \
    "-Dexec.args=--bigtableInstanceId=$INSTANCE_ID --bigtableTableId=$TABLE_ID \
    --runner=dataflow --project=$GOOGLE_CLOUD_PROJECT \
-   --region=$REGION" \
-   --workloadRate=$WORKLOAD_RATE 
-   --workloadDurationMinutes=$WORKLOAD_DURATION 
+   --region=$REGION \
+   --workloadRate=$WORKLOAD_RATE \
+   --workloadDurationMinutes=$WORKLOAD_DURATION" 
    ```

--- a/bigtable/beam/workload-generator/README.md
+++ b/bigtable/beam/workload-generator/README.md
@@ -27,9 +27,9 @@ be run as a Dataflow job.
     --template-file-gcs-location "$TEMPLATE_PATH" \
     --parameters bigtableInstanceId="$INSTANCE_ID" \
     --parameters bigtableTableId="$TABLE_ID" \
-    --region "$REGION \
-    --parameters workloadRate=$WORKLOAD_RATE \
-    --parameters workloadDurationMinutes=$WORKLOAD_DURATION"
+    --region="$REGION" \
+    --parameters workloadRate="$WORKLOAD_RATE" \
+    --parameters workloadDurationMinutes="$WORKLOAD_DURATION"
     ```
 
 ### Deploying a template instructions

--- a/bigtable/beam/workload-generator/pom.xml
+++ b/bigtable/beam/workload-generator/pom.xml
@@ -119,12 +119,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.cloud.bigtable</groupId>
-      <artifactId>bigtable-hbase-beam</artifactId>
-      <version>2.12.0</version>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-dataflow</artifactId>
       <scope>test</scope>

--- a/bigtable/beam/workload-generator/src/test/java/bigtable/WorkloadGeneratorTest.java
+++ b/bigtable/beam/workload-generator/src/test/java/bigtable/WorkloadGeneratorTest.java
@@ -26,7 +26,6 @@ import com.google.api.services.dataflow.model.Job;
 import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
 import com.google.cloud.bigtable.admin.v2.BigtableTableAdminSettings;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
-import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import com.google.cloud.monitoring.v3.MetricServiceClient;
 import com.google.cloud.monitoring.v3.MetricServiceClient.ListTimeSeriesPagedResponse;
 import com.google.dataflow.v1beta3.FlexTemplatesServiceClient;
@@ -79,24 +78,20 @@ public class WorkloadGeneratorTest {
   }
 
   @BeforeClass
-  public static void beforeClass() {
+  public static void beforeClass() throws IOException {
     projectId = requireEnv("GOOGLE_CLOUD_PROJECT");
     instanceId = requireEnv("BIGTABLE_TESTING_INSTANCE");
 
-    try {
-      BigtableTableAdminSettings adminSettings =
-          BigtableTableAdminSettings.newBuilder()
-              .setProjectId(projectId)
-              .setInstanceId(instanceId)
-              .build();
+    BigtableTableAdminSettings adminSettings =
+        BigtableTableAdminSettings.newBuilder()
+            .setProjectId(projectId)
+            .setInstanceId(instanceId)
+            .build();
 
-      adminClient = BigtableTableAdminClient.create(adminSettings);
-      CreateTableRequest createTableRequest =
-          CreateTableRequest.of(TABLE_ID).addFamily(COLUMN_FAMILY_NAME);
-      adminClient.createTable(createTableRequest);
-    } catch (Exception e) {
-      System.out.println("Error during beforeClass: \n" + e.toString());
-    }
+    adminClient = BigtableTableAdminClient.create(adminSettings);
+    CreateTableRequest createTableRequest =
+        CreateTableRequest.of(TABLE_ID).addFamily(COLUMN_FAMILY_NAME);
+    adminClient.createTable(createTableRequest);
   }
 
   @Before
@@ -107,11 +102,7 @@ public class WorkloadGeneratorTest {
 
   @AfterClass
   public static void afterClass() {
-    try {
-      adminClient.deleteTable(TABLE_ID);
-    } catch (Exception e) {
-      System.out.println("Error during afterClass: \n" + e.toString());
-    }
+    adminClient.deleteTable(TABLE_ID);
   }
 
   @Test
@@ -123,9 +114,6 @@ public class WorkloadGeneratorTest {
     options.setRegion(REGION_ID);
 
     Pipeline p = Pipeline.create(options);
-
-    BigtableDataClient bigtableDataClient = BigtableDataClient.create(options.getProject(),
-        options.getBigtableInstanceId());
 
     // Initiates a new pipeline every second
     p.apply(Create.of(1L))

--- a/bigtable/beam/workload-generator/src/test/java/bigtable/WorkloadGeneratorTest.java
+++ b/bigtable/beam/workload-generator/src/test/java/bigtable/WorkloadGeneratorTest.java
@@ -129,7 +129,7 @@ public class WorkloadGeneratorTest {
 
     // Initiates a new pipeline every second
     p.apply(Create.of(1L))
-        .apply(ParDo.of(new ReadFromTableFn(bigtableDataClient)));
+        .apply(ParDo.of(new ReadFromTableFn(projectId, instanceId)));
     p.run().waitUntilFinish();
 
     String output = bout.toString();

--- a/bigtable/beam/workload-generator/src/test/java/bigtable/WorkloadGeneratorTest.java
+++ b/bigtable/beam/workload-generator/src/test/java/bigtable/WorkloadGeneratorTest.java
@@ -133,7 +133,7 @@ public class WorkloadGeneratorTest {
     p.run().waitUntilFinish();
 
     String output = bout.toString();
-    assertThat(output).contains("Connected to table");
+    assertThat(output).contains("Connected to client");
   }
 
   // todo: Fix test flakiness


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
