### PR TITLE
chore(aiplatform): Revert "chore(aiplatform): temporarily remove unready samples"

### DIFF
--- a/aiplatform/src/main/java/aiplatform/PredictImageFromImageAndTextSample.java
+++ b/aiplatform/src/main/java/aiplatform/PredictImageFromImageAndTextSample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/aiplatform/src/main/java/aiplatform/PredictImageFromImageAndTextSample.java
+++ b/aiplatform/src/main/java/aiplatform/PredictImageFromImageAndTextSample.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package aiplatform;
+
+// [START aiplatform_sdk_text_image_embedding]
+
+import com.google.cloud.aiplatform.v1beta1.EndpointName;
+import com.google.cloud.aiplatform.v1beta1.PredictResponse;
+import com.google.cloud.aiplatform.v1beta1.PredictionServiceClient;
+import com.google.cloud.aiplatform.v1beta1.PredictionServiceSettings;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Value;
+import com.google.protobuf.util.JsonFormat;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PredictImageFromImageAndTextSample {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace this variable before running the sample.
+    String project = "YOUR_PROJECT_ID";
+    String textPrompt = "YOUR_TEXT_PROMPT";
+    String baseImagePath = "YOUR_BASE_IMAGE_PATH";
+
+    // Learn how to use text prompts to update an image:
+    // https://cloud.google.com/vertex-ai/docs/generative-ai/image/edit-images
+    Map<String, Object> parameters = new HashMap<String, Object>();
+    parameters.put("sampleCount", 1);
+
+    String location = "us-central1";
+    String publisher = "google";
+    String model = "multimodalembedding@001";
+
+    predictImageFromImageAndText(
+        project, location, publisher, model, textPrompt, baseImagePath, parameters);
+  }
+
+  // Update images using text prompts
+  public static void predictImageFromImageAndText(
+      String project,
+      String location,
+      String publisher,
+      String model,
+      String textPrompt,
+      String baseImagePath,
+      Map<String, Object> parameters)
+      throws IOException {
+    final String endpoint = String.format("%s-aiplatform.googleapis.com:443", location);
+    final PredictionServiceSettings predictionServiceSettings =
+        PredictionServiceSettings.newBuilder().setEndpoint(endpoint).build();
+
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    try (PredictionServiceClient predictionServiceClient =
+        PredictionServiceClient.create(predictionServiceSettings)) {
+      final EndpointName endpointName =
+          EndpointName.ofProjectLocationPublisherModelName(project, location, publisher, model);
+
+      // Convert the image to Base64
+      byte[] imageData = Base64.getEncoder().encode(Files.readAllBytes(Paths.get(baseImagePath)));
+      String encodedImage = new String(imageData, StandardCharsets.UTF_8);
+
+      JsonObject jsonInstance = new JsonObject();
+      jsonInstance.addProperty("text", textPrompt);
+      JsonObject jsonImage = new JsonObject();
+      jsonImage.addProperty("bytesBase64Encoded", encodedImage);
+      jsonInstance.add("image", jsonImage);
+
+      Value instanceValue = stringToValue(jsonInstance.toString());
+      List<Value> instances = new ArrayList<>();
+      instances.add(instanceValue);
+
+      Gson gson = new Gson();
+      String gsonString = gson.toJson(parameters);
+      Value parameterValue = stringToValue(gsonString);
+
+      PredictResponse predictResponse =
+          predictionServiceClient.predict(endpointName, instances, parameterValue);
+      System.out.println("Predict Response");
+      System.out.println(predictResponse);
+      for (Value prediction : predictResponse.getPredictionsList()) {
+        System.out.format("\tPrediction: %s\n", prediction);
+      }
+    }
+  }
+
+  // Convert a Json string to a protobuf.Value
+  static Value stringToValue(String value) throws InvalidProtocolBufferException {
+    Value.Builder builder = Value.newBuilder();
+    JsonFormat.parser().merge(value, builder);
+    return builder.build();
+  }
+}
+// [END aiplatform_sdk_text_image_embedding]

--- a/aiplatform/src/main/java/aiplatform/PredictImageFromTextSample.java
+++ b/aiplatform/src/main/java/aiplatform/PredictImageFromTextSample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/aiplatform/src/main/java/aiplatform/PredictImageFromTextSample.java
+++ b/aiplatform/src/main/java/aiplatform/PredictImageFromTextSample.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package aiplatform;
+
+// [START aiplatform_sdk_text_image_embedding]
+
+import com.google.cloud.aiplatform.v1beta1.EndpointName;
+import com.google.cloud.aiplatform.v1beta1.PredictResponse;
+import com.google.cloud.aiplatform.v1beta1.PredictionServiceClient;
+import com.google.cloud.aiplatform.v1beta1.PredictionServiceSettings;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Value;
+import com.google.protobuf.util.JsonFormat;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PredictImageFromTextSample {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace this variable before running the sample.
+    String project = "YOUR_PROJECT_ID";
+    String textPrompt = "YOUR_TEXT_PROMPT";
+
+    // Learn how to generate images from text prompts:
+    // https://cloud.google.com/vertex-ai/docs/generative-ai/image/generate-images
+    Map<String, Object> parameters = new HashMap<String, Object>();
+    parameters.put("sampleCount", 1);
+
+    String location = "us-central1";
+    String publisher = "google";
+    String model = "multimodalembedding@001";
+
+    predictImageFromText(project, location, publisher, model, textPrompt, parameters);
+  }
+
+  // Generate images using text prompts
+  public static void predictImageFromText(
+      String project,
+      String location,
+      String publisher,
+      String model,
+      String textPrompt,
+      Map<String, Object> parameters)
+      throws IOException {
+    final String endpoint = String.format("%s-aiplatform.googleapis.com:443", location);
+    final PredictionServiceSettings predictionServiceSettings =
+        PredictionServiceSettings.newBuilder().setEndpoint(endpoint).build();
+
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    try (PredictionServiceClient predictionServiceClient =
+        PredictionServiceClient.create(predictionServiceSettings)) {
+      final EndpointName endpointName =
+          EndpointName.ofProjectLocationPublisherModelName(project, location, publisher, model);
+
+      JsonObject jsonInstance = new JsonObject();
+      jsonInstance.addProperty("text", textPrompt);
+      Value instanceValue = stringToValue(jsonInstance.toString());
+      List<Value> instances = new ArrayList<>();
+      instances.add(instanceValue);
+
+      Gson gson = new Gson();
+      String gsonString = gson.toJson(parameters);
+      Value parameterValue = stringToValue(gsonString);
+
+      PredictResponse predictResponse =
+          predictionServiceClient.predict(endpointName, instances, parameterValue);
+      System.out.println("Predict Response");
+      System.out.println(predictResponse);
+      for (Value prediction : predictResponse.getPredictionsList()) {
+        System.out.format("\tPrediction: %s\n", prediction);
+      }
+    }
+  }
+
+  // Convert a Json string to a protobuf.Value
+  static Value stringToValue(String value) throws InvalidProtocolBufferException {
+    Value.Builder builder = Value.newBuilder();
+    JsonFormat.parser().merge(value, builder);
+    return builder.build();
+  }
+}
+// [END aiplatform_sdk_text_image_embedding]

--- a/aiplatform/src/test/java/aiplatform/PredictImageFromImageAndTextSampleTest.java
+++ b/aiplatform/src/test/java/aiplatform/PredictImageFromImageAndTextSampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/aiplatform/src/test/java/aiplatform/PredictImageFromImageAndTextSampleTest.java
+++ b/aiplatform/src/test/java/aiplatform/PredictImageFromImageAndTextSampleTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package aiplatform;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class PredictImageFromImageAndTextSampleTest {
+
+  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
+
+  private static final String PROJECT = System.getenv("UCAIP_PROJECT_ID");
+  private static final String PUBLISHER = "google";
+  private static final String LOCATION = "us-central1";
+  private static final String MODEL = "multimodalembedding@001";
+  private static final String BASE_IMAGE_PATH = "resources/image_flower_daisy.jpg";
+  private static final String TEXT_PROMPT = "an impressionist painting";
+  private static final Map<String, Object> PARAMETERS = new HashMap<String, Object>();
+
+  static {
+    PARAMETERS.put("sampleCount", 1);
+  }
+
+  private ByteArrayOutputStream bout;
+  private PrintStream originalPrintStream;
+
+  private static void requireEnvVar(String varName) {
+    String errorMessage =
+        String.format("Environment variable '%s' is required to perform these tests.", varName);
+    assertNotNull(errorMessage, System.getenv(varName));
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+    requireEnvVar("UCAIP_PROJECT_ID");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    PrintStream out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    System.out.flush();
+    System.setOut(originalPrintStream);
+  }
+
+  @Test
+  public void testPredictImageFromImageAndText() throws IOException {
+    // Act
+    PredictImageFromImageAndTextSample.predictImageFromImageAndText(
+        PROJECT, LOCATION, PUBLISHER, MODEL, TEXT_PROMPT, BASE_IMAGE_PATH, PARAMETERS);
+
+    // Assert
+    String got = bout.toString();
+    assertThat(got).contains("Predict Response");
+  }
+}

--- a/aiplatform/src/test/java/aiplatform/PredictImageFromTextSampleTest.java
+++ b/aiplatform/src/test/java/aiplatform/PredictImageFromTextSampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/aiplatform/src/test/java/aiplatform/PredictImageFromTextSampleTest.java
+++ b/aiplatform/src/test/java/aiplatform/PredictImageFromTextSampleTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package aiplatform;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class PredictImageFromTextSampleTest {
+
+  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
+
+  private static final String PROJECT = System.getenv("UCAIP_PROJECT_ID");
+  private static final String TEXT_PROMPT =
+      "small red boat on water in the morning watercolor illustration muted colors";
+  private static final Map<String, Object> PARAMETERS = new HashMap<String, Object>();
+
+  static {
+    PARAMETERS.put("sampleCount", 1);
+  }
+
+  private static final String PUBLISHER = "google";
+  private static final String LOCATION = "us-central1";
+  private static final String MODEL = "multimodalembedding@001";
+
+  private ByteArrayOutputStream bout;
+  private PrintStream originalPrintStream;
+
+  private static void requireEnvVar(String varName) {
+    String errorMessage =
+        String.format("Environment variable '%s' is required to perform these tests.", varName);
+    assertNotNull(errorMessage, System.getenv(varName));
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+    requireEnvVar("UCAIP_PROJECT_ID");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    PrintStream out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    System.out.flush();
+    System.setOut(originalPrintStream);
+  }
+
+  @Test
+  public void testPredictImageFromText() throws IOException {
+    // Act
+    PredictImageFromTextSample.predictImageFromText(
+        PROJECT, LOCATION, PUBLISHER, MODEL, TEXT_PROMPT, PARAMETERS);
+
+    // Assert
+    String got = bout.toString();
+    assertThat(got).contains("Predict Response");
+  }
+}


### PR DESCRIPTION
Reverts GoogleCloudPlatform/java-docs-samples#8391

The samples can be republished as the underlying features become publicly available.