### PR TITLE
storageinsights: update edit inventory report config sample

### DIFF
--- a/storageinsights/src/main/java/com/google/cloud/storage/storageinsights/samples/EditInventoryReportConfig.java
+++ b/storageinsights/src/main/java/com/google/cloud/storage/storageinsights/samples/EditInventoryReportConfig.java
@@ -23,7 +23,6 @@ import com.google.cloud.storageinsights.v1.ReportConfigName;
 import com.google.cloud.storageinsights.v1.StorageInsightsClient;
 import com.google.cloud.storageinsights.v1.UpdateReportConfigRequest;
 import com.google.protobuf.FieldMask;
-
 import java.io.IOException;
 
 public class EditInventoryReportConfig {
@@ -56,7 +55,8 @@ public class EditInventoryReportConfig {
       storageInsightsClient.updateReportConfig(
               UpdateReportConfigRequest.newBuilder()
                       // Make sure to add any fields that you want to update into the update mask, in snake case
-                      .setUpdateMask(FieldMask.newBuilder().addPaths("display_name").build())
+                      .setUpdateMask(FieldMask.newBuilder().addPaths("display_name")
+                              .build())
                       .setReportConfig(updatedReportConfig).build());
 
       System.out.println("Edited inventory report config with name " + name);

--- a/storageinsights/src/main/java/com/google/cloud/storage/storageinsights/samples/EditInventoryReportConfig.java
+++ b/storageinsights/src/main/java/com/google/cloud/storage/storageinsights/samples/EditInventoryReportConfig.java
@@ -54,7 +54,7 @@ public class EditInventoryReportConfig {
 
       storageInsightsClient.updateReportConfig(
               UpdateReportConfigRequest.newBuilder()
-                      // Make sure to add any fields that you want to update into the update mask, in snake case
+                      // Add any fields that you want to update to the update mask, in snake case
                       .setUpdateMask(FieldMask.newBuilder().addPaths("display_name")
                               .build())
                       .setReportConfig(updatedReportConfig).build());

--- a/storageinsights/src/main/java/com/google/cloud/storage/storageinsights/samples/EditInventoryReportConfig.java
+++ b/storageinsights/src/main/java/com/google/cloud/storage/storageinsights/samples/EditInventoryReportConfig.java
@@ -22,6 +22,8 @@ import com.google.cloud.storageinsights.v1.ReportConfig;
 import com.google.cloud.storageinsights.v1.ReportConfigName;
 import com.google.cloud.storageinsights.v1.StorageInsightsClient;
 import com.google.cloud.storageinsights.v1.UpdateReportConfigRequest;
+import com.google.protobuf.FieldMask;
+
 import java.io.IOException;
 
 public class EditInventoryReportConfig {
@@ -42,17 +44,20 @@ public class EditInventoryReportConfig {
   // [START storageinsights_edit_inventory_report_config]
 
   public static void editInventoryReportConfig(
-      String projectId, String location, String inventoryReportConfigUuid) throws IOException {
+          String projectId, String location, String inventoryReportConfigUuid) throws IOException {
     try (StorageInsightsClient storageInsightsClient = StorageInsightsClient.create()) {
       ReportConfigName name = ReportConfigName.of(projectId, location, inventoryReportConfigUuid);
       ReportConfig reportConfig = storageInsightsClient.getReportConfig(name);
 
       // Set any other fields you want to update here
       ReportConfig updatedReportConfig =
-          reportConfig.toBuilder().setDisplayName("Updated Display Name").build();
+              reportConfig.toBuilder().setDisplayName("Updated Display Name").build();
 
       storageInsightsClient.updateReportConfig(
-          UpdateReportConfigRequest.newBuilder().setReportConfig(updatedReportConfig).build());
+              UpdateReportConfigRequest.newBuilder()
+                      // Make sure to add any fields that you want to update into the update mask, in snake case
+                      .setUpdateMask(FieldMask.newBuilder().addPaths("display_name").build())
+                      .setReportConfig(updatedReportConfig).build());
 
       System.out.println("Edited inventory report config with name " + name);
     }

--- a/storageinsights/src/test/java/com/google/cloud/storage/storageinsights/samples/test/ITStorageinsightsSamplesTest.java
+++ b/storageinsights/src/test/java/com/google/cloud/storage/storageinsights/samples/test/ITStorageinsightsSamplesTest.java
@@ -182,7 +182,7 @@ public class ITStorageinsightsSamplesTest {
       EditInventoryReportConfig.editInventoryReportConfig(
           PROJECT_ID, BUCKET_LOCATION, reportConfigName.split("/")[5]);
       ReportConfig reportConfig = insights.getReportConfig(reportConfigName);
-      assertThat(reportConfig.getDisplayName().contains("Updated"));
+      assertThat(reportConfig.getDisplayName()).contains("Updated");
     } finally {
       insights.deleteReportConfig(reportConfigName);
     }


### PR DESCRIPTION
In storageinsights, you need to set the field mask in order to update an inventory report config. This fixes the sample so that it takes this into account, and fixes the test to catch it. 