### PR TITLE
fix(healthcare): don't store DICOM instance before each DICOMweb test

### DIFF
--- a/healthcare/v1/src/test/java/snippets/healthcare/DicomWebTests.java
+++ b/healthcare/v1/src/test/java/snippets/healthcare/DicomWebTests.java
@@ -36,9 +36,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.junit.runners.MethodSorters;
-
-import com.google.api.client.googleapis.json.GoogleJsonResponseException;
-
 import snippets.healthcare.datasets.DatasetCreate;
 import snippets.healthcare.datasets.DatasetDelete;
 import snippets.healthcare.dicom.DicomStoreCreate;
@@ -64,8 +61,8 @@ public class DicomWebTests {
   private static String studyId = "2.25.330012077234033941963257891139480825153";
   private static String seriesId = "2.25.143186483950719304925806365081717734297";
   private static String instanceId = "2.25.195151962645072062560826889007364152748";
-  private static String dicomWebInstancePath = String.format("studies/%s/series/%s/instances/%s", studyId, seriesId,
-      instanceId);
+  private static String dicomWebInstancePath = String.format("studies/%s/series/%s/instances/%s",
+      studyId, seriesId, instanceId);
   private static String dicomWebRenderedPath = dicomWebInstancePath + "/rendered";
 
   private static String instanceOutput = "instance.dcm";
@@ -92,7 +89,8 @@ public class DicomWebTests {
   @BeforeClass
   public static void setUp() throws IOException {
     String datasetId = "dataset-" + UUID.randomUUID().toString().replaceAll("-", "_");
-    datasetName = String.format("projects/%s/locations/%s/datasets/%s", PROJECT_ID, REGION_ID, datasetId);
+    datasetName = String.format("projects/%s/locations/%s/datasets/%s",
+        PROJECT_ID, REGION_ID, datasetId);
     DatasetCreate.datasetCreate(PROJECT_ID, REGION_ID, datasetId);
 
     String dicomStoreId = "dicom-" + UUID.randomUUID().toString().replaceAll("-", "_");
@@ -180,7 +178,6 @@ public class DicomWebTests {
   // Test order is NAME_ASCENDING, so ensure that we delete the DICOM study
   // last, otherwise it might run before DicomWebRetrieve methods
   // (see https://github.com/GoogleCloudPlatform/java-docs-samples/issues/3845).
-  @SuppressWarnings("checkstyle:MethodName")
   public void testZ_DicomWebDeleteStudy() throws IOException {
     DicomWebDeleteStudy.dicomWebDeleteStudy(dicomStoreName, studyId);
 

--- a/healthcare/v1/src/test/java/snippets/healthcare/DicomWebTests.java
+++ b/healthcare/v1/src/test/java/snippets/healthcare/DicomWebTests.java
@@ -36,6 +36,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.junit.runners.MethodSorters;
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+
 import snippets.healthcare.datasets.DatasetCreate;
 import snippets.healthcare.datasets.DatasetDelete;
 import snippets.healthcare.dicom.DicomStoreCreate;
@@ -56,12 +59,13 @@ public class DicomWebTests {
   private static String dicomStoreName;
   private static String datasetName;
 
-  // The studyUid is not assigned by the server and is part of the metadata of dcmFile.
+  // The studyUid is not assigned by the server and is part of the metadata of
+  // dcmFile.
   private static String studyId = "2.25.330012077234033941963257891139480825153";
   private static String seriesId = "2.25.143186483950719304925806365081717734297";
   private static String instanceId = "2.25.195151962645072062560826889007364152748";
-  private static String dicomWebInstancePath =
-      String.format("studies/%s/series/%s/instances/%s", studyId, seriesId, instanceId);
+  private static String dicomWebInstancePath = String.format("studies/%s/series/%s/instances/%s", studyId, seriesId,
+      instanceId);
   private static String dicomWebRenderedPath = dicomWebInstancePath + "/rendered";
 
   private static String instanceOutput = "instance.dcm";
@@ -88,8 +92,7 @@ public class DicomWebTests {
   @BeforeClass
   public static void setUp() throws IOException {
     String datasetId = "dataset-" + UUID.randomUUID().toString().replaceAll("-", "_");
-    datasetName =
-        String.format("projects/%s/locations/%s/datasets/%s", PROJECT_ID, REGION_ID, datasetId);
+    datasetName = String.format("projects/%s/locations/%s/datasets/%s", PROJECT_ID, REGION_ID, datasetId);
     DatasetCreate.datasetCreate(PROJECT_ID, REGION_ID, datasetId);
 
     String dicomStoreId = "dicom-" + UUID.randomUUID().toString().replaceAll("-", "_");
@@ -108,9 +111,6 @@ public class DicomWebTests {
     bout = new ByteArrayOutputStream();
     System.setOut(new PrintStream(bout));
 
-    // Store DICOM instance before each test so it is always available.
-    DicomWebStoreInstance.dicomWebStoreInstance(dicomStoreName, "src/test/resources/jpeg_text.dcm");
-
     bout = new ByteArrayOutputStream();
     System.setOut(new PrintStream(bout));
   }
@@ -122,7 +122,7 @@ public class DicomWebTests {
   }
 
   @Test
-  public void test_DicomWebStoreInstance() throws Exception {
+  public void testA_DicomWebStoreInstance() throws Exception {
     DicomWebStoreInstance.dicomWebStoreInstance(dicomStoreName, "src/test/resources/jpeg_text.dcm");
 
     String output = bout.toString();
@@ -130,21 +130,21 @@ public class DicomWebTests {
   }
 
   @Test
-  public void test_DicomWebSearchInstances() throws Exception {
+  public void testB_DicomWebSearchInstances() throws Exception {
     DicomWebSearchForInstances.dicomWebSearchForInstances(dicomStoreName);
     String output = bout.toString();
     assertThat(output, containsString("Dicom store instances found:"));
   }
 
   @Test
-  public void test_DicomWebSearchStudies() throws Exception {
+  public void testC_DicomWebSearchStudies() throws Exception {
     DicomWebSearchStudies.dicomWebSearchStudies(dicomStoreName);
     String output = bout.toString();
     assertThat(output, containsString("Studies found:"));
   }
 
   @Test
-  public void test_DicomWebRetrieveStudy() throws Exception {
+  public void testD_DicomWebRetrieveStudy() throws Exception {
     DicomWebRetrieveStudy.dicomWebRetrieveStudy(dicomStoreName, studyId);
 
     outputFile = new File(studyOutput);
@@ -155,7 +155,7 @@ public class DicomWebTests {
   }
 
   @Test
-  public void test_DicomWebRetrieveInstance() throws Exception {
+  public void testE_DicomWebRetrieveInstance() throws Exception {
     DicomWebRetrieveInstance.dicomWebRetrieveInstance(dicomStoreName, dicomWebInstancePath);
 
     outputFile = new File(instanceOutput);
@@ -166,7 +166,7 @@ public class DicomWebTests {
   }
 
   @Test
-  public void test_DicomWebRetrieveRendered() throws Exception {
+  public void testF_DicomWebRetrieveRendered() throws Exception {
     DicomWebRetrieveRendered.dicomWebRetrieveRendered(dicomStoreName, dicomWebRenderedPath);
 
     outputFile = new File(renderedOutput);
@@ -181,7 +181,7 @@ public class DicomWebTests {
   // last, otherwise it might run before DicomWebRetrieve methods
   // (see https://github.com/GoogleCloudPlatform/java-docs-samples/issues/3845).
   @SuppressWarnings("checkstyle:MethodName")
-  public void z_test_DicomWebDeleteStudy() throws IOException {
+  public void testZ_DicomWebDeleteStudy() throws IOException {
     DicomWebDeleteStudy.dicomWebDeleteStudy(dicomStoreName, studyId);
 
     String output = bout.toString();


### PR DESCRIPTION
## Description

Only store DICOM instance once for all DICOMweb tests. Previously, storing a duplicate instance returned a 200, but it now returns a 409, causing tests to fail.

The JUnit4 MethodSorters (https://junit.org/junit4/javadoc/4.12/org/junit/runners/MethodSorters.html) functionality is also incorrectly running the DicomWebDeleteStudy test too early, even though its name was modified so that it ran last in the NAME_ASCENDING order, so update each test's name to ensure that they run in order.

Fixes
* #9266
* #9265 
* #9264 
* #9263 
* #9262 
* #9261 

## Checklist

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [X] `pom.xml` parent set to latest `shared-configuration`
- [] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [X] **Tests** pass:   `mvn clean verify` **required**
- [X] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [X] Please **merge** this PR for me once it is approved
