### PR TITLE
fixit: remove redundant region tags

### DIFF
--- a/functions/concepts/lazy-fields/src/main/java/functions/LazyFields.java
+++ b/functions/concepts/lazy-fields/src/main/java/functions/LazyFields.java
@@ -18,7 +18,6 @@ package functions;
 
 // [START functions_tips_lazy_globals]
 // [START cloudrun_tips_global_lazy]
-// [START run_tips_global_lazy]
 
 import com.google.cloud.functions.HttpFunction;
 import com.google.cloud.functions.HttpRequest;
@@ -67,6 +66,5 @@ public class LazyFields implements HttpFunction {
     return Arrays.stream(numbers).reduce((t, x) -> t * x).getAsInt();
   }
 }
-// [END run_tips_global_lazy]
 // [END cloudrun_tips_global_lazy]
 // [END functions_tips_lazy_globals]

--- a/functions/concepts/scopes/src/main/java/functions/Scopes.java
+++ b/functions/concepts/scopes/src/main/java/functions/Scopes.java
@@ -18,7 +18,6 @@ package functions;
 
 // [START functions_tips_scopes]
 // [START cloudrun_tips_global_scope]
-// [START run_tips_global_scope]
 
 import com.google.cloud.functions.HttpFunction;
 import com.google.cloud.functions.HttpRequest;
@@ -54,6 +53,5 @@ public class Scopes implements HttpFunction {
     return Arrays.stream(numbers).reduce((t, x) -> t * x).getAsInt();
   }
 }
-// [END run_tips_global_scope]
 // [END cloudrun_tips_global_scope]
 // [END functions_tips_scopes]

--- a/run/helloworld/src/main/java/com/example/helloworld/HelloworldApplication.java
+++ b/run/helloworld/src/main/java/com/example/helloworld/HelloworldApplication.java
@@ -15,7 +15,6 @@
  */
 
 // [START cloudrun_helloworld_service]
-// [START run_helloworld_service]
 
 package com.example.helloworld;
 
@@ -43,5 +42,4 @@ public class HelloworldApplication {
     SpringApplication.run(HelloworldApplication.class, args);
   }
 }
-// [END run_helloworld_service]
 // [END cloudrun_helloworld_service]

--- a/run/markdown-preview/editor/src/main/java/com/example/cloudrun/RenderController.java
+++ b/run/markdown-preview/editor/src/main/java/com/example/cloudrun/RenderController.java
@@ -37,7 +37,6 @@ public class RenderController {
   private static final Logger logger = LoggerFactory.getLogger(RenderController.class);
 
   // [START cloudrun_secure_request_do]
-  // [START run_secure_request_do]
   // '/render' expects a JSON body payload with a 'data' property holding plain text
   // for rendering.
   @PostMapping(value = "/render", consumes = "application/json")
@@ -56,7 +55,6 @@ public class RenderController {
     String html = makeAuthenticatedRequest(url, markdown);
     return html;
   }
-  // [END run_secure_request_do]
   // [END cloudrun_secure_request_do]
 
   // Instantiate OkHttpClient
@@ -67,7 +65,6 @@ public class RenderController {
           .build();
 
   // [START cloudrun_secure_request]
-  // [START run_secure_request]
   // makeAuthenticatedRequest creates a new HTTP request authenticated by a JSON Web Tokens (JWT)
   // retrievd from Application Default Credentials.
   public String makeAuthenticatedRequest(String url, String markdown) {
@@ -100,6 +97,5 @@ public class RenderController {
     }
     return html;
   }
-  // [END run_secure_request]
   // [END cloudrun_secure_request]
 }

--- a/run/system-package/src/main/java/com/example/cloudrun/App.java
+++ b/run/system-package/src/main/java/com/example/cloudrun/App.java
@@ -31,7 +31,6 @@ public class App {
     int port = Integer.parseInt(System.getenv().getOrDefault("PORT", "8080"));
     port(port);
     // [START cloudrun_system_package_handler]
-    // [START run_system_package_handler]
     get(
         "/diagram.png",
         (req, res) -> {
@@ -53,12 +52,10 @@ public class App {
           }
           return image;
         });
-    // [END run_system_package_handler]
     // [END cloudrun_system_package_handler]
   }
 
   // [START cloudrun_system_package_exec]
-  // [START run_system_package_exec]
   // Generate a diagram based on a graphviz DOT diagram description.
   public static InputStream createDiagram(String dot) {
     if (dot == null || dot.isEmpty()) {
@@ -91,6 +88,5 @@ public class App {
     }
     return stdout;
   }
-  // [END run_system_package_exec]
   // [END cloudrun_system_package_exec]
 }


### PR DESCRIPTION
## Description

Remove redundant region tags: 

run_helloworld_service
run_secure_request
run_secure_request_do
run_system_package_exec
run_system_package_handler
run_tips_global_lazy
run_tips_global_scope

(Some tags remain in XML files (and also in java files if also in those XML files)

- [x] Please **merge** this PR for me once it is approved
