### PR TITLE
chore(fixit): remove redundant region tags

### DIFF
--- a/run/hello-broken/src/main/java/com/example/cloudrun/App.java
+++ b/run/hello-broken/src/main/java/com/example/cloudrun/App.java
@@ -17,7 +17,6 @@
 package com.example.cloudrun;
 
 // [START cloudrun_broken_service]
-// [START run_broken_service]
 import static spark.Spark.get;
 import static spark.Spark.port;
 
@@ -37,7 +36,6 @@ public class App {
         (req, res) -> {
           logger.info("Hello: received request.");
           // [START cloudrun_broken_service_problem]
-          // [START run_broken_service_problem]
           String name = System.getenv("NAME");
           if (name == null) {
             // Standard error logs do not appear in Stackdriver Error Reporting.
@@ -47,31 +45,25 @@ public class App {
             res.status(500);
             return "Internal Server Error";
           }
-          // [END run_broken_service_problem]
           // [END cloudrun_broken_service_problem]
           res.status(200);
           return String.format("Hello %s!", name);
         });
-    // [END run_broken_service]
     // [END cloudrun_broken_service]
     get(
         "/improved",
         (req, res) -> {
           logger.info("Hello: received request.");
           // [START cloudrun_broken_service_upgrade]
-          // [START run_broken_service_upgrade]
           String name = System.getenv().getOrDefault("NAME", "World");
           if (System.getenv("NAME") == null) {
             logger.warn(String.format("NAME not set, default to %s", name));
           }
-          // [END run_broken_service_upgrade]
           // [END cloudrun_broken_service_upgrade]
           res.status(200);
           return String.format("Hello %s!", name);
         });
     // [START cloudrun_broken_service]
-    // [START run_broken_service]
   }
 }
-// [END run_broken_service]
 // [END cloudrun_broken_service]

--- a/run/image-processing/src/main/java/com/example/cloudrun/ImageMagick.java
+++ b/run/image-processing/src/main/java/com/example/cloudrun/ImageMagick.java
@@ -17,7 +17,6 @@
 package com.example.cloudrun;
 
 // [START cloudrun_imageproc_handler_setup]
-// [START run_imageproc_handler_setup]
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
@@ -44,11 +43,9 @@ public class ImageMagick {
 
   private static final String BLURRED_BUCKET_NAME = System.getenv("BLURRED_BUCKET_NAME");
   private static Storage storage = StorageOptions.getDefaultInstance().getService();
-  // [END run_imageproc_handler_setup]
   // [END cloudrun_imageproc_handler_setup]
 
   // [START cloudrun_imageproc_handler_analyze]
-  // [START run_imageproc_handler_analyze]
   // Blurs uploaded images that are flagged as Adult or Violence.
   public static void blurOffensiveImages(JsonObject data) {
     String fileName = data.get("name").getAsString();
@@ -89,11 +86,9 @@ public class ImageMagick {
       System.out.println(String.format("Error with Vision API: %s", e.getMessage()));
     }
   }
-  // [END run_imageproc_handler_analyze]
   // [END cloudrun_imageproc_handler_analyze]
 
   // [START cloudrun_imageproc_handler_blur]
-  // [START run_imageproc_handler_blur]
   // Blurs the file described by blobInfo using ImageMagick,
   // and uploads it to the blurred bucket.
   public static void blur(BlobInfo blobInfo) throws IOException {
@@ -138,5 +133,4 @@ public class ImageMagick {
     Files.delete(upload);
   }
 }
-// [END run_imageproc_handler_blur]
 // [END cloudrun_imageproc_handler_blur]

--- a/run/image-processing/src/main/java/com/example/cloudrun/PubSubController.java
+++ b/run/image-processing/src/main/java/com/example/cloudrun/PubSubController.java
@@ -17,7 +17,6 @@
 package com.example.cloudrun;
 
 // [START cloudrun_imageproc_controller]
-// [START run_imageproc_controller]
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import java.util.Base64;
@@ -70,5 +69,4 @@ public class PubSubController {
     return new ResponseEntity<>(HttpStatus.OK);
   }
 }
-// [END run_imageproc_controller]
 // [END cloudrun_imageproc_controller]

--- a/run/logging-manual/pom.xml
+++ b/run/logging-manual/pom.xml
@@ -34,8 +34,6 @@ limitations under the License.
       <artifactId>spark-core</artifactId>
       <version>2.9.4</version>
     </dependency>
-    <!-- [START cloudrun_manual_logging_dep] -->
-    <!-- [START run_manual_logging_dep] -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
@@ -51,8 +49,6 @@ limitations under the License.
       <artifactId>logback-classic</artifactId>
       <version>1.4.14</version>
     </dependency>
-    <!-- [END run_manual_logging_dep] -->
-    <!-- [END cloudrun_manual_logging_dep] -->
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
@@ -68,8 +64,6 @@ limitations under the License.
 
   <build>
     <plugins>
-      <!-- [START cloudrun_manual_logging_jib] -->
-      <!-- [START run_manual_logging_jib] -->
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
@@ -80,8 +74,6 @@ limitations under the License.
           </to>
         </configuration>
       </plugin>
-      <!-- [END run_manual_logging_jib] -->
-      <!-- [END cloudrun_manual_logging_jib] -->
     </plugins>
   </build>
 </project>

--- a/run/logging-manual/src/main/java/com/example/cloudrun/App.java
+++ b/run/logging-manual/src/main/java/com/example/cloudrun/App.java
@@ -41,7 +41,6 @@ public class App {
         "/",
         (req, res) -> {
           // [START cloudrun_manual_logging]
-          // [START run_manual_logging]
           // Build structured log messages as an object.
           Object globalLogFields = null;
 
@@ -64,7 +63,6 @@ public class App {
               kv("component", "arbitrary-property"),
               kv("severity", "NOTICE"),
               globalLogFields);
-          // [END run_manual_logging]
           // [END cloudrun_manual_logging]
           res.status(200);
           return "Hello Logger!";

--- a/run/pubsub/src/main/java/com/example/cloudrun/PubSubApplication.java
+++ b/run/pubsub/src/main/java/com/example/cloudrun/PubSubApplication.java
@@ -17,7 +17,6 @@
 package com.example.cloudrun;
 
 // [START cloudrun_pubsub_server]
-// [START run_pubsub_server]
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -27,5 +26,4 @@ public class PubSubApplication {
     SpringApplication.run(PubSubApplication.class, args);
   }
 }
-// [END run_pubsub_server]
 // [END cloudrun_pubsub_server]

--- a/run/pubsub/src/main/java/com/example/cloudrun/PubSubController.java
+++ b/run/pubsub/src/main/java/com/example/cloudrun/PubSubController.java
@@ -17,7 +17,6 @@
 package com.example.cloudrun;
 
 // [START cloudrun_pubsub_handler]
-// [START run_pubsub_handler]
 import com.example.cloudrun.Body;
 import java.util.Base64;
 import org.apache.commons.lang3.StringUtils;
@@ -50,5 +49,4 @@ public class PubSubController {
     return new ResponseEntity<>(msg, HttpStatus.OK);
   }
 }
-// [END run_pubsub_handler]
 // [END cloudrun_pubsub_handler]


### PR DESCRIPTION
## Description

Manually searched docs and confirmed no references remain. Only removed comments, no code changes.

Removed these tags:
run_broken_service_upgrade
run_broken_service_problem
run_broken_service
run_pubsub_server
run_pubsub_handler
run_manual_logging
run_imageproc_controller
run_imageproc_handler_setup
run_imageproc_handler_blur
run_imageproc_handler_analyze

These tags are referenced in docs at all, so removed both variations: run_manual_logging_dep
cloudrun_manual_logging_dep
run_manual_logging_jib
cloudrun_manual_logging_jib


## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
