### PR TITLE
fixit: remove redundant region tags

### DIFF
--- a/run/hello-broken/pom.xml
+++ b/run/hello-broken/pom.xml
@@ -25,7 +25,7 @@ limitations under the License.
     <artifactId>shared-configuration</artifactId>
     <version>1.2.0</version>
   </parent>
-  
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>
@@ -33,7 +33,6 @@ limitations under the License.
   </properties>
   <dependencies>
     <!-- [START cloudrun_broken_service_dep] -->
-    <!-- [START run_broken_service_dep] -->
     <dependency>
       <groupId>com.sparkjava</groupId>
       <artifactId>spark-core</artifactId>
@@ -49,7 +48,6 @@ limitations under the License.
       <artifactId>slf4j-simple</artifactId>
       <version>2.0.12</version>
     </dependency>
-    <!-- [END run_broken_service_dep] -->
     <!-- [END cloudrun_broken_service_dep] -->
     <dependency>
       <groupId>junit</groupId>
@@ -65,11 +63,9 @@ limitations under the License.
     </dependency>
   </dependencies>
   <!-- [START cloudrun_broken_service_build] -->
-  <!-- [START run_broken_service_build] -->
   <build>
     <plugins>
       <!-- [START cloudrun_broken_service_jib] -->
-      <!-- [START run_broken_service_jib] -->
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
@@ -80,10 +76,8 @@ limitations under the License.
           </to>
         </configuration>
       </plugin>
-      <!-- [END run_broken_service_jib] -->
       <!-- [END cloudrun_broken_service_jib] -->
     </plugins>
   </build>
-  <!-- [END run_broken_service_build] -->
   <!-- [END cloudrun_broken_service_build] -->
 </project>

--- a/run/helloworld/Dockerfile
+++ b/run/helloworld/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 # [START cloudrun_helloworld_dockerfile]
-# [START run_helloworld_dockerfile]
 # Use the official maven image to create a build artifact.
 # https://hub.docker.com/_/maven
 FROM maven:3-eclipse-temurin-17-alpine as builder
@@ -36,5 +35,4 @@ COPY --from=builder /app/target/helloworld-*.jar /helloworld.jar
 # Run the web service on container startup.
 CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/helloworld.jar"]
 
-# [END run_helloworld_dockerfile]
 # [END cloudrun_helloworld_dockerfile]

--- a/run/helloworld/pom.xml
+++ b/run/helloworld/pom.xml
@@ -81,7 +81,6 @@ limitations under the License.
         </executions>
       </plugin>
       <!-- [START cloudrun_helloworld_jib] -->
-      <!-- [START run_helloworld_jib] -->
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
@@ -92,7 +91,6 @@ limitations under the License.
           </to>
         </configuration>
       </plugin>
-      <!-- [END run_helloworld_jib] -->
       <!-- [END cloudrun_helloworld_jib] -->
     </plugins>
   </build>

--- a/run/helloworld/src/main/resources/application.properties
+++ b/run/helloworld/src/main/resources/application.properties
@@ -12,7 +12,5 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 # [START cloudrun_helloworld_properties]
-# [START run_helloworld_properties]
 server.port=${PORT:8080}
-# [END run_helloworld_properties]
 # [END cloudrun_helloworld_properties]

--- a/run/image-processing/Dockerfile
+++ b/run/image-processing/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 # [START cloudrun_imageproc_dockerfile]
-# [START run_imageproc_dockerfile]
 # Use eclipse-temurin for base image.
 # It's important to use JDK 8u191 or above that has container support enabled.
 # https://hub.docker.com/_/eclipse-temurin/
@@ -27,5 +26,4 @@ RUN set -ex; \
   apt-get -y update; \
   apt-get -y install imagemagick; \
   rm -rf /var/lib/apt/lists/*
-# [END run_imageproc_dockerfile]
 # [END cloudrun_imageproc_dockerfile]

--- a/run/image-processing/pom.xml
+++ b/run/image-processing/pom.xml
@@ -41,7 +41,6 @@ limitations under the License.
         <scope>import</scope>
       </dependency>
       <!-- [START cloudrun_imageproc_dep_management] -->
-      <!-- [START run_imageproc_dep_management] -->
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>spring-cloud-gcp-dependencies</artifactId>
@@ -49,7 +48,6 @@ limitations under the License.
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!-- [END run_imageproc_dep_management] -->
       <!-- [END cloudrun_imageproc_dep_management] -->
     </dependencies>
   </dependencyManagement>
@@ -69,7 +67,6 @@ limitations under the License.
       <scope>test</scope>
     </dependency>
     <!-- [START cloudrun_imageproc_dep] -->
-    <!-- [START run_imageproc_dep] -->
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
@@ -83,7 +80,6 @@ limitations under the License.
       <groupId>com.google.cloud</groupId>
       <artifactId>spring-cloud-gcp-starter-storage</artifactId>
     </dependency>
-    <!-- [END run_imageproc_dep] -->
     <!-- [END cloudrun_imageproc_dep] -->
     <dependency>
       <groupId>junit</groupId>
@@ -99,7 +95,6 @@ limitations under the License.
         <version>${spring-boot.version}</version>
       </plugin>
       <!-- [START cloudrun_imageproc_jib] -->
-      <!-- [START run_imageproc_jib] -->
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
@@ -113,7 +108,6 @@ limitations under the License.
           </to>
         </configuration>
       </plugin>
-      <!-- [END run_imageproc_jib] -->
       <!-- [END cloudrun_imageproc_jib] -->
     </plugins>
   </build>

--- a/run/logging-manual/src/main/resources/logback.xml
+++ b/run/logging-manual/src/main/resources/logback.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- [START cloudrun_manual_logging_logback] -->
-<!-- [START run_manual_logging_logback] -->
 <configuration>
   <appender name="jsonConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
     <encoder class="net.logstash.logback.encoder.LogstashEncoder">
@@ -19,5 +18,4 @@
     <appender-ref ref="jsonConsoleAppender"/>
   </root>
 </configuration>
-<!-- [END run_manual_logging_logback] -->
 <!-- [END cloudrun_manual_logging_logback] -->

--- a/run/pubsub/pom.xml
+++ b/run/pubsub/pom.xml
@@ -86,7 +86,6 @@ limitations under the License.
         <version>${spring-boot.version}</version>
       </plugin>
       <!-- [START cloudrun_pubsub_jib] -->
-      <!-- [START run_pubsub_jib] -->
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
@@ -97,7 +96,6 @@ limitations under the License.
           </to>
         </configuration>
       </plugin>
-      <!-- [END run_pubsub_jib] -->
       <!-- [END cloudrun_pubsub_jib] -->
     </plugins>
   </build>

--- a/run/system-package/Dockerfile
+++ b/run/system-package/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 # [START cloudrun_system_package_dockerfile]
-# [START run_system_package_dockerfile]
 # Use the Official eclipse-temurin image for a lean production stage of our multi-stage build.
 # https://hub.docker.com/_/eclipse-temurin/
 FROM eclipse-temurin:17.0.10_7-jre
@@ -21,5 +20,4 @@ FROM eclipse-temurin:17.0.10_7-jre
 RUN apt-get update -y && apt-get install -y \
   graphviz \
   && apt-get clean
-# [END run_system_package_dockerfile]
 # [END cloudrun_system_package_dockerfile]

--- a/run/system-package/pom.xml
+++ b/run/system-package/pom.xml
@@ -67,7 +67,6 @@ limitations under the License.
         </configuration>
       </plugin>
       <!-- [START cloudrun_system_package_jib] -->
-      <!-- [START run_system_package_jib] -->
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
@@ -81,7 +80,6 @@ limitations under the License.
           </to>
         </configuration>
       </plugin>
-      <!-- [END run_system_package_jib] -->
       <!-- [END cloudrun_system_package_jib] -->
     </plugins>
   </build>


### PR DESCRIPTION
Remove redundant run_ tags from xml and Dockerfiles:

run_broken_service_build
run_broken_service_dep
run_broken_service_jib
run_helloworld_dockerfile
run_helloworld_jib
run_helloworld_properties
run_imageproc_dep
run_imageproc_dep_management
run_imageproc_dockerfile
run_imageproc_jib
run_manual_logging_logback
run_pubsub_jib
run_system_package_dockerfile
run_system_package_jib

Follow up from #9312

- [x] Please **merge** this PR for me once it is approved
