### PR TITLE
spanner/r2dbc test(s) are failing #8978

### DIFF
--- a/spanner/r2dbc/src/test/java/com/example/spanner/r2dbc/R2dbcSampleApplicationIT.java
+++ b/spanner/r2dbc/src/test/java/com/example/spanner/r2dbc/R2dbcSampleApplicationIT.java
@@ -19,13 +19,17 @@ package com.example.spanner.r2dbc;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import com.google.cloud.ServiceOptions;
-import com.google.cloud.spanner.DatabaseAdminClient;
+import com.google.cloud.spanner.InstanceConfigId;
+import com.google.cloud.spanner.InstanceId;
+import com.google.cloud.spanner.InstanceInfo;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerOptions;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
 import org.junit.Before;
@@ -48,9 +52,11 @@ import reactor.core.publisher.Mono;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class R2dbcSampleApplicationIT {
 
+  private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+
   @DynamicPropertySource
   static void registerProperties(DynamicPropertyRegistry registry) {
-    registry.add("project", () -> ServiceOptions.getDefaultProjectId());
+    registry.add("project", () -> PROJECT_ID);
     // Spanner DB name limit is 30 characters; cannot end with "-".
     String suffix = UUID.randomUUID().toString().substring(0, 23);
     registry.add("database", () -> "r2dbc-" + suffix);
@@ -71,20 +77,36 @@ public class R2dbcSampleApplicationIT {
 
   @Autowired DatabaseClient databaseClient;
 
-  DatabaseAdminClient dbAdminClient;
+  Spanner spanner;
 
   // setup/teardown cannot be static because then properties will not be injected yet
   @Before
-  public void createDatabase() {
+  public void setUp() {
     SpannerOptions options = SpannerOptions.newBuilder().build();
     Spanner spanner = options.getService();
-    dbAdminClient = spanner.getDatabaseAdminClient();
-    dbAdminClient.createDatabase(instance, this.databaseName, Collections.emptyList());
+    try {
+      InstanceInfo instanceInfo = InstanceInfo.newBuilder(InstanceId.of(PROJECT_ID, instance))
+              .setInstanceConfigId(InstanceConfigId.of(PROJECT_ID, "regional-us-central1"))
+              .setDisplayName(instance)
+              .setNodeCount(0)
+              .setProcessingUnits(100)
+              .build();
+      spanner.getInstanceAdminClient().createInstance(instanceInfo).get(60, TimeUnit.SECONDS);
+
+      spanner.getDatabaseAdminClient().createDatabase(instance, this.databaseName, Collections.emptyList()).get(60, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @After
-  public void dropDatabase() {
-    dbAdminClient.dropDatabase(instance, this.databaseName);
+  public void tearDown() {
+    try {
+      spanner.getDatabaseAdminClient().dropDatabase(instance, this.databaseName);
+      spanner.getInstanceAdminClient().deleteInstance(instance);
+    } finally {
+      spanner.close();
+    }
   }
 
   @Test

--- a/spanner/r2dbc/src/test/java/com/example/spanner/r2dbc/R2dbcSampleApplicationIT.java
+++ b/spanner/r2dbc/src/test/java/com/example/spanner/r2dbc/R2dbcSampleApplicationIT.java
@@ -93,7 +93,9 @@ public class R2dbcSampleApplicationIT {
               .build();
       spanner.getInstanceAdminClient().createInstance(instanceInfo).get(60, TimeUnit.SECONDS);
 
-      spanner.getDatabaseAdminClient().createDatabase(instance, this.databaseName, Collections.emptyList()).get(60, TimeUnit.SECONDS);
+      spanner.getDatabaseAdminClient()
+              .createDatabase(instance, this.databaseName, Collections.emptyList())
+              .get(60, TimeUnit.SECONDS);
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION

## Description
added creation of the instance and only then the creation of database, added after block to close delete an instance, db and close all connections
Fixes #8978

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
