### PR TITLE
docs(samples): Add snippets for Apache Iceberg using Managed I/O

### DIFF
--- a/dataflow/snippets/pom.xml
+++ b/dataflow/snippets/pom.xml
@@ -37,8 +37,10 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <apache_beam.version>2.54.0</apache_beam.version>
+    <apache_beam.version>2.56.0</apache_beam.version>
     <slf4j.version>2.0.12</slf4j.version>
+    <parquet.version>1.14.0</parquet.version>
+    <iceberg.version>1.4.2</iceberg.version>
   </properties>
 
   <build>
@@ -117,6 +119,41 @@
           <artifactId>google-api-services-storage</artifactId>
         </exclusion>
       </exclusions>     
+    </dependency>
+
+
+    <!-- Managed I/O -->
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-managed</artifactId>
+      <version>${apache_beam.version}</version>
+    </dependency>
+
+    <!-- Apache Iceberg I/O -->
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-io-iceberg</artifactId>
+      <version>${apache_beam.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-column</artifactId>
+      <version>${parquet.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-hadoop</artifactId>
+      <version>${parquet.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-core</artifactId>
+      <version>1.2.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-data</artifactId>
+      <version>${iceberg.version}</version>
     </dependency>
 
     <!-- Google Cloud -->

--- a/dataflow/snippets/pom.xml
+++ b/dataflow/snippets/pom.xml
@@ -147,8 +147,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-core</artifactId>
-      <version>1.2.1</version>
+      <artifactId>hadoop-client-runtime</artifactId>
+      <version>3.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.iceberg</groupId>

--- a/dataflow/snippets/src/main/java/com/example/dataflow/ApacheIcebergRead.java
+++ b/dataflow/snippets/src/main/java/com/example/dataflow/ApacheIcebergRead.java
@@ -83,4 +83,4 @@ public class ApacheIcebergRead {
     pipeline.run().waitUntilFinish();
   }
 }
-// [START dataflow_apache_iceberg_read]
+// [END dataflow_apache_iceberg_read]

--- a/dataflow/snippets/src/main/java/com/example/dataflow/ApacheIcebergRead.java
+++ b/dataflow/snippets/src/main/java/com/example/dataflow/ApacheIcebergRead.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.dataflow;
+
+// [START dataflow_apache_iceberg_read]
+import java.util.Map;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.managed.Managed;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.values.PCollectionRowTuple;
+import org.apache.beam.sdk.values.TypeDescriptors;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
+
+public class ApacheIcebergRead {
+
+  public interface Options extends PipelineOptions {
+    @Description("The URI of the Apache Iceberg warehouse location")
+    String getWarehouseLocation();
+
+    void setWarehouseLocation(String value);
+
+    @Description("Path to write the output file")
+    String getOutputPath();
+
+    void setOutputPath(String value);
+  }
+
+  public static void main(String[] args) {
+    Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+    Pipeline pipeline = Pipeline.create(options);
+
+    // Configure the Iceberg source I/O
+    Map catalogConfig = ImmutableMap.<String, Object>builder()
+        .put("catalog_name", "local")
+        .put("warehouse_location", options.getWarehouseLocation())
+        .put("catalog_type", "hadoop")
+        .build();
+
+    ImmutableMap<String, Object> config = ImmutableMap.<String, Object>builder()
+        .put("table", "db.table1")
+        .put("catalog_config", catalogConfig)
+        .build();
+
+    // Build the pipeline
+    PCollectionRowTuple.empty(pipeline).apply(
+            Managed.read(Managed.ICEBERG)
+                .withConfig(config)
+        )
+        .get("output")
+        // Format each record as a string with the format 'id:name'.
+        .apply(MapElements
+            .into(TypeDescriptors.strings())
+            .via((row -> {
+              return String.format("%d:%s",
+                  row.getInt64("id"),
+                  row.getString("name"));
+            })))
+        // Write to a text file.
+        .apply(
+            TextIO.write()
+                .to(options.getOutputPath())
+                .withNumShards(1)
+                .withSuffix(".txt"));
+
+    pipeline.run().waitUntilFinish();
+  }
+}
+// [START dataflow_apache_iceberg_read]

--- a/dataflow/snippets/src/main/java/com/example/dataflow/ApacheIcebergWrite.java
+++ b/dataflow/snippets/src/main/java/com/example/dataflow/ApacheIcebergWrite.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.dataflow;
+
+// [START dataflow_apache_iceberg_write]
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.managed.Managed;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.JsonToRow;
+import org.apache.beam.sdk.values.PCollectionRowTuple;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
+
+public class ApacheIcebergWrite {
+  static final List<String> TABLE_ROWS = Arrays.asList(
+      "{\"id\":0, \"name\":\"Alice\"}",
+      "{\"id\":1, \"name\":\"Bob\"}",
+      "{\"id\":2, \"name\":\"Charles\"}"
+  );
+
+  public interface Options extends PipelineOptions {
+    @Description("The URI of the Apache Iceberg warehouse location")
+    String getWarehouseLocation();
+
+    void setWarehouseLocation(String value);
+  }
+
+  public static void main(String[] args) {
+    // Create a pipeline
+    Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+    Pipeline pipeline = Pipeline.create(options);
+
+    // Configure the Iceberg source I/O
+    Map catalogConfig = ImmutableMap.<String, Object>builder()
+        .put("catalog_name", "local")
+        .put("warehouse_location", options.getWarehouseLocation())
+        .put("catalog_type", "hadoop")
+        .build();
+
+    ImmutableMap<String, Object> config = ImmutableMap.<String, Object>builder()
+        .put("table", "db.table1")
+        .put("catalog_config", catalogConfig)
+        .build();
+
+    Schema schema = new Schema.Builder()
+        .addStringField("name")
+        .addInt64Field("id")
+        .build();
+
+    var input = pipeline
+        .apply(Create.of(TABLE_ROWS))
+        .apply(JsonToRow.withSchema(schema));
+
+    PCollectionRowTuple.of("input", input).apply(
+        Managed.write(Managed.ICEBERG)
+            .withConfig(config)
+    );
+
+    pipeline.run().waitUntilFinish();
+  }
+}
+// [END dataflow_apache_iceberg_write]

--- a/dataflow/snippets/src/test/java/com/example/dataflow/ApacheIcebergIT.java
+++ b/dataflow/snippets/src/test/java/com/example/dataflow/ApacheIcebergIT.java
@@ -71,6 +71,10 @@ public class ApacheIcebergIT {
 
 
   private void createIcebergTable(Catalog catalog, TableIdentifier tableId) {
+
+    // This schema represents an Iceberg table schema. It needs to match the
+    // org.apache.beam.sdk.schemas.Schema that is defined in ApacheIcebergWrite. However, these
+    // are unrelated types so there isn't a straightforward conversion from one to the other.
     var schema = new Schema(
         NestedField.required(1, "id", Types.LongType.get()),
         NestedField.optional(2, "name", Types.StringType.get()));

--- a/dataflow/snippets/src/test/java/com/example/dataflow/ApacheIcebergIT.java
+++ b/dataflow/snippets/src/test/java/com/example/dataflow/ApacheIcebergIT.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.dataflow;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.IcebergGenerics;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.hadoop.HadoopInputFile;
+import org.apache.iceberg.hadoop.HadoopOutputFile;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.NestedField;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class ApacheIcebergIT {
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private String location;
+
+  private Configuration hadoopConf = new Configuration();
+  private Catalog catalog;
+  private static final TableIdentifier tableId = TableIdentifier.of("db", "table1");
+  private Table table;
+
+  private static final String ouputFileName = "output-00000-of-00001.txt";
+
+  private void createIcebergTable(Catalog catalog, TableIdentifier tableId) throws IOException {
+    var schema = new Schema(
+        NestedField.required(1, "id", Types.LongType.get()),
+        NestedField.optional(2, "name", Types.StringType.get()));
+
+    table = catalog.createTable(tableId, schema);
+  }
+
+  private void writeRecords()
+      throws IOException {
+    GenericRecord record = GenericRecord.create(table.schema());
+    ImmutableList<Record> records =
+        ImmutableList.of(
+            record.copy(ImmutableMap.of("id", 0L, "name", "Person-0")),
+            record.copy(ImmutableMap.of("id", 1L, "name", "Person-1")),
+            record.copy(ImmutableMap.of("id", 2L, "name", "Person-2")));
+
+    Path path = new Path(location, "file1.parquet");
+
+    FileAppender<Record> appender =
+        Parquet.write(HadoopOutputFile.fromPath(path, hadoopConf))
+            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .schema(table.schema())
+            .overwrite()
+            .build();
+    appender.addAll(records);
+    appender.close();
+
+    DataFile dataFile = DataFiles.builder(PartitionSpec.unpartitioned())
+        .withInputFile(HadoopInputFile.fromPath(path, hadoopConf))
+        .withMetrics(appender.metrics())
+        .build();
+
+    table.newFastAppend()
+        .appendFile(dataFile)
+        .commit();
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    System.setOut(out);
+
+    // Create an Apache Iceberg catalog with a table and write some test data.
+    File warehouseFolder = temporaryFolder.newFolder();
+    location = "file:" + warehouseFolder.toString();
+    catalog =
+        CatalogUtil.loadCatalog(
+            CatalogUtil.ICEBERG_CATALOG_HADOOP,
+            "local",
+            ImmutableMap.of(CatalogProperties.WAREHOUSE_LOCATION, location),
+            hadoopConf);
+
+    createIcebergTable(catalog, tableId);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    Files.deleteIfExists(Paths.get(ouputFileName));
+    System.setOut(null);
+  }
+
+  @Test
+  public void testApacheIcebergWrite() {
+    // Run the Dataflow pipeline.
+    ApacheIcebergWrite.main(
+        new String[] {
+            "--runner=DirectRunner",
+            "--warehouseLocation=" + location
+        });
+
+    // Verify that the pipeline wrote records to the table.
+    Table table = catalog.loadTable(tableId);
+    CloseableIterable<Record> records = IcebergGenerics.read(table)
+        .build();
+    for (Record r : records) {
+      System.out.println(r);
+    }
+
+    String got = bout.toString();
+    assertTrue(got.contains("0, Alice"));
+    assertTrue(got.contains("1, Bob"));
+    assertTrue(got.contains("2, Charles"));
+  }
+
+  @Test
+  public void testApacheIcebergRead() throws IOException {
+    // Seed the Apache Iceberg table with data.
+    writeRecords();
+
+    // Run the Dataflow pipeline.
+    ApacheIcebergRead.main(
+        new String[] {
+            "--runner=DirectRunner",
+            "--warehouseLocation=" + location,
+            "--outputPath=output"
+        });
+
+    // Verify the pipeline wrote the table data to a local file.
+    String output = Files.readString(Paths.get(ouputFileName));
+    assertTrue(output.contains("0:Person-0"));
+    assertTrue(output.contains("1:Person-1"));
+    assertTrue(output.contains("2:Person-2"));
+  }
+}


### PR DESCRIPTION
## Description

Add code snippets for reading and writing to Apache Iceberg using the Dataflow managed I/O transform.

Fixes doc bug: b/341806230 (part of the work for b/338063763)

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
