### PR TITLE
fix(aiplatform): Update NVIDIA_TESLA_K80 to NVIDIA_TESLA_T4

### DIFF
--- a/aiplatform/src/main/java/aiplatform/CreateBatchPredictionJobSample.java
+++ b/aiplatform/src/main/java/aiplatform/CreateBatchPredictionJobSample.java
@@ -91,7 +91,7 @@ public class CreateBatchPredictionJobSample {
       MachineSpec machineSpec =
           MachineSpec.newBuilder()
               .setMachineType("n1-standard-2")
-              .setAcceleratorType(AcceleratorType.NVIDIA_TESLA_K80)
+              .setAcceleratorType(AcceleratorType.NVIDIA_TESLA_T4)
               .setAcceleratorCount(1)
               .build();
       BatchDedicatedResources dedicatedResources =

--- a/aiplatform/src/main/java/aiplatform/CreateCustomJobSample.java
+++ b/aiplatform/src/main/java/aiplatform/CreateCustomJobSample.java
@@ -59,7 +59,7 @@ public class CreateCustomJobSample {
       MachineSpec machineSpec =
           MachineSpec.newBuilder()
               .setMachineType("n1-standard-4")
-              .setAcceleratorType(AcceleratorType.NVIDIA_TESLA_K80)
+              .setAcceleratorType(AcceleratorType.NVIDIA_TESLA_T4)
               .setAcceleratorCount(1)
               .build();
 

--- a/aiplatform/src/main/java/aiplatform/CreateHyperparameterTuningJobPythonPackageSample.java
+++ b/aiplatform/src/main/java/aiplatform/CreateHyperparameterTuningJobPythonPackageSample.java
@@ -127,7 +127,7 @@ public class CreateHyperparameterTuningJobPythonPackageSample {
       MachineSpec machineSpec =
           MachineSpec.newBuilder()
               .setMachineType("n1-standard-4")
-              .setAcceleratorType(AcceleratorType.NVIDIA_TESLA_K80)
+              .setAcceleratorType(AcceleratorType.NVIDIA_TESLA_T4)
               .setAcceleratorCount(1)
               .build();
 

--- a/aiplatform/src/main/java/aiplatform/CreateHyperparameterTuningJobSample.java
+++ b/aiplatform/src/main/java/aiplatform/CreateHyperparameterTuningJobSample.java
@@ -72,7 +72,7 @@ public class CreateHyperparameterTuningJobSample {
       MachineSpec machineSpec =
           MachineSpec.newBuilder()
               .setMachineType("n1-standard-4")
-              .setAcceleratorType(AcceleratorType.NVIDIA_TESLA_K80)
+              .setAcceleratorType(AcceleratorType.NVIDIA_TESLA_T4)
               .setAcceleratorCount(1)
               .build();
       ContainerSpec containerSpec =


### PR DESCRIPTION
Updating NVIDIA_TESLA_K80 to NVIDIA_TESLA_T4, as the former has reached End of Life support (https://cloud.google.com/compute/docs/eol/k80-eol)