### PR TITLE
chore: add customization to fixed names

### DIFF
--- a/compute/cloud-client/src/test/java/compute/SnippetsIT.java
+++ b/compute/cloud-client/src/test/java/compute/SnippetsIT.java
@@ -19,6 +19,7 @@ package compute;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static compute.Util.getZone;
+import static compute.Util.getEnvVar;
 
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.cloud.compute.v1.AttachedDisk;
@@ -53,9 +54,11 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 @Timeout(value = 10, unit = TimeUnit.MINUTES)
 public class SnippetsIT {
-  @Rule public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
+  @Rule
+  public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3);
 
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static final String TEST_IMAGE_PROJECT_NAME = "JAVA_DOCS_COMPUTE_TEST_IMAGE_PROJECT";
   private static String ZONE;
   private static String MACHINE_NAME;
   private static String MACHINE_NAME_LIST_INSTANCE;
@@ -90,7 +93,7 @@ public class SnippetsIT {
     MACHINE_NAME_ENCRYPTED = "encrypted-test-instance" + UUID.randomUUID();
     MACHINE_NAME_WITH_SSD = "test-instance-with-ssd" + UUID.randomUUID();
     BUCKET_NAME = "my-new-test-bucket" + UUID.randomUUID();
-    IMAGE_PROJECT_NAME = "windows-sql-cloud";
+    IMAGE_PROJECT_NAME = getEnvVar(TEST_IMAGE_PROJECT_NAME, "windows-sql-cloud");
     RAW_KEY = Util.getBase64EncodedKey();
 
     // Cleanup existing stale resources.
@@ -113,7 +116,6 @@ public class SnippetsIT {
     stdOut.close();
     System.setOut(out);
   }
-
 
   @AfterAll
   public static void cleanup()
@@ -138,7 +140,6 @@ public class SnippetsIT {
     stdOut.close();
     System.setOut(out);
   }
-
 
   @BeforeEach
   public void beforeEach() {

--- a/compute/cloud-client/src/test/java/compute/Util.java
+++ b/compute/cloud-client/src/test/java/compute/Util.java
@@ -44,19 +44,14 @@ import java.util.stream.IntStream;
 
 public abstract class Util {
   // Cleans existing test resources if any.
-  // If the project contains too many instances, use "filter" when listing resources
+  // If the project contains too many instances, use "filter" when listing
+  // resources
   // and delete the listed resources based on the timestamp.
 
   private static final int DELETION_THRESHOLD_TIME_HOURS = 24;
-  private static final String[] ZONES;
-
-  static {
-    ZONES = new String[]{
-        "us-central1-a",
-        "us-west1-a",
-        "asia-south1-a",
-    };
-  }
+  // comma separate list of zone names
+  private static final String TEST_ZONES_NAME = "JAVA_DOCS_COMPUTE_TEST_ZONES";
+  private static final String DEFAULT_ZONES = "us-central1-a,us-west1-a,asia-south1-a";
 
   // Delete templates which starts with the given prefixToDelete and
   // has creation timestamp >24 hours.
@@ -119,11 +114,10 @@ public abstract class Util {
   public static ListPagedResponse listFilteredInstanceTemplates(String projectId,
       String instanceTemplatePrefix) throws IOException {
     try (InstanceTemplatesClient instanceTemplatesClient = InstanceTemplatesClient.create()) {
-      ListInstanceTemplatesRequest listInstanceTemplatesRequest =
-          ListInstanceTemplatesRequest.newBuilder()
-              .setProject(projectId)
-              .setFilter(String.format("name:%s", instanceTemplatePrefix))
-              .build();
+      ListInstanceTemplatesRequest listInstanceTemplatesRequest = ListInstanceTemplatesRequest.newBuilder()
+          .setProject(projectId)
+          .setFilter(String.format("name:%s", instanceTemplatePrefix))
+          .build();
 
       return instanceTemplatesClient.list(listInstanceTemplatesRequest);
     }
@@ -171,7 +165,19 @@ public abstract class Util {
 
   // Returns a random zone.
   public static String getZone() {
-    return ZONES[new Random().nextInt(ZONES.length)];
+    String zones = getEnvVar(TEST_ZONES_NAME, DEFAULT_ZONES);
+    String[] parsedZones = zones.split(",");
+    if (parsedZones.length == 0) {
+      return "unknown";
+    }
+    return parsedZones[new Random().nextInt(parsedZones.length)];
   }
 
+  public static String getEnvVar(String envVarName, String defaultValue) {
+    String val = System.getenv(envVarName);
+    if (val == "") {
+      return defaultValue;
+    }
+    return val;
+  }
 }


### PR DESCRIPTION
## Description

Modifies existing tests in `compute/cloud-client` to enable running testing on other Google Cloud universes.

Adds support for the `JAVA_DOCS_COMPUTE_TEST_ZONES` environment variable to provide a custom list of compute zones that are used for testing compute instances and compute storage.
Adds support for the `JAVA_DOCS_COMPUTE_TEST_IMAGE_PROJECT` environment variable to provide a custom project ID for the project that is used to test samples of compute images.
