### PR TITLE
chore(proc): Update TPC test config

### DIFF
--- a/.kokoro/prptst/run_tests.sh
+++ b/.kokoro/prptst/run_tests.sh
@@ -45,8 +45,11 @@ gradle -v
 # Setup required env variables
 export GOOGLE_CLOUD_PROJECT="tpczero-system:java-docs-samples-testing"
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secrets/prptst-java-docs-samples-service-account.json
+export JAVA_DOCS_COMPUTE_TEST_ZONES="u-us-prp1-a,u-us-prp1-b,u-us-prp1-c"
+export JAVA_DOCS_COMPUTE_TEST_IMAGE_PROJECT="tpczero-system:java-docs-samples-testing" # test will fail anyway because images are not there
 
 mkdir -p "${KOKORO_GFILE_DIR}/secrets"
+# read secrets from GDU project 'java-docs-samples-testing'
 gcloud secrets versions access latest --project="java-docs-samples-testing" --secret="prptst-java-docs-samples-service-account" > "${KOKORO_GFILE_DIR}/secrets/prptst-java-docs-samples-service-account.json"
 
 # Add PRPTST configuration to gcloud CLI (becomes active)

--- a/.kokoro/prptst/run_tests.sh
+++ b/.kokoro/prptst/run_tests.sh
@@ -47,7 +47,7 @@ export GOOGLE_CLOUD_PROJECT="tpczero-system:java-docs-samples-testing"
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secrets/prptst-java-docs-samples-service-account.json
 
 mkdir -p "${KOKORO_GFILE_DIR}/secrets"
-gcloud secrets versions access latest --project="java-docs-samples-testing" --secret="prptst-java-docs-samples-service-account.json" > "${KOKORO_GFILE_DIR}/secrets/prptst-java-docs-samples-service-account.json"
+gcloud secrets versions access latest --project="java-docs-samples-testing" --secret="prptst-java-docs-samples-service-account" > "${KOKORO_GFILE_DIR}/secrets/prptst-java-docs-samples-service-account.json"
 
 # Add PRPTST configuration to gcloud CLI (becomes active)
 gcloud config configurations create prptst


### PR DESCRIPTION
## Description

Fix the name of the project sa key.
Set up the names of the compute zones to the list supported by PRPTST.
Set up the project ID that is used for compute images tests to be real project. Note that the test will still fail because expected images aren't there yet.