### PR TITLE
chore(appengine-java8): remove unused gae_java8_datastore_inequality_filters_sort_orders_valid

### DIFF
--- a/appengine-java8/datastore/src/test/java/com/example/appengine/QueriesTest.java
+++ b/appengine-java8/datastore/src/test/java/com/example/appengine/QueriesTest.java
@@ -615,7 +615,6 @@ public class QueriesTest {
     datastore.put(ImmutableList.<Entity>of(a, b, c, d));
     long minBirthYear = 1940;
 
-    // [START gae_java8_datastore_inequality_filters_sort_orders_valid]
     Filter birthYearMinFilter =
         new FilterPredicate("birthYear", FilterOperator.GREATER_THAN_OR_EQUAL, minBirthYear);
 
@@ -624,7 +623,6 @@ public class QueriesTest {
             .setFilter(birthYearMinFilter)
             .addSort("birthYear", SortDirection.ASCENDING)
             .addSort("lastName", SortDirection.ASCENDING);
-    // [END gae_java8_datastore_inequality_filters_sort_orders_valid]
 
     // Assert
     List<Entity> results =


### PR DESCRIPTION
The sample with region tag `gae_java8_datastore_inequality_filters_sort_orders_valid` is no longer used.

Removing the region tag. Since there are other region tags in the file that could be disrupted, I am not deleting the code now. Code cleanup will be handled with last dependents on the code are removed.

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
