### PR TITLE
chore(appengine-java8): Remove region tag gae_java8_app_identity_versioned_hostnames

### DIFF
--- a/appengine-java8/appidentity/src/main/java/com/example/appengine/appidentity/IdentityServlet.java
+++ b/appengine-java8/appidentity/src/main/java/com/example/appengine/appidentity/IdentityServlet.java
@@ -32,7 +32,6 @@ import javax.servlet.http.HttpServletResponse;
 )
 public class IdentityServlet extends HttpServlet {
 
-  // [START gae_java8_app_identity_versioned_hostnames]
   @Override
   public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
     resp.setContentType("text/plain");
@@ -41,5 +40,4 @@ public class IdentityServlet extends HttpServlet {
     resp.getWriter()
         .println(env.getAttributes().get("com.google.appengine.runtime.default_version_hostname"));
   }
-  // [END gae_java8_app_identity_versioned_hostnames]
 }


### PR DESCRIPTION
## Description

This sample is no longer deployable, removing region tag. Once the last region tag is ready to be removed from this sample app the whole directory can be deleted.

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
