### PR TITLE
bug 347826138 clean up the deprecated region attribute custom_attribte_filter_multi_attributes

### DIFF
--- a/jobs/v3/src/main/java/com/google/samples/CustomAttributeSample.java
+++ b/jobs/v3/src/main/java/com/google/samples/CustomAttributeSample.java
@@ -148,7 +148,6 @@ public final class CustomAttributeSample {
   // [END custom_attribute_filter_long_value]
 
   // [START job_custom_attribute_filter_multi_attributes]
-  // [START custom_attribute_filter_multi_attributes]
 
   /** CustomAttributeFilter on multiple CustomAttributes */
   public static void filtersOnMultiCustomAttributes() throws IOException, InterruptedException {
@@ -181,7 +180,6 @@ public final class CustomAttributeSample {
     Thread.sleep(1000);
     System.out.printf("Custom search job results (multiple value): %s\n", response);
   }
-  // [END custom_attribute_filter_multi_attributes]
   // [END job_custom_attribute_filter_multi_attributes]
 
   public static void main(String... args) throws Exception {


### PR DESCRIPTION
## Description
The new region tag has been previously added and updated in the documentation. 
The old region tag can be now removed.

bug 347826138

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [x] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
