### PR TITLE
docs(samples): Update Dataflow snippets to Beam 2.57

### DIFF
--- a/dataflow/snippets/pom.xml
+++ b/dataflow/snippets/pom.xml
@@ -37,7 +37,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <apache_beam.version>2.56.0</apache_beam.version>
+    <apache_beam.version>2.57.0</apache_beam.version>
     <slf4j.version>2.0.12</slf4j.version>
     <parquet.version>1.14.0</parquet.version>
     <iceberg.version>1.4.2</iceberg.version>

--- a/dataflow/snippets/src/main/java/com/example/dataflow/ApacheIcebergRead.java
+++ b/dataflow/snippets/src/main/java/com/example/dataflow/ApacheIcebergRead.java
@@ -59,7 +59,7 @@ public class ApacheIcebergRead {
 
     // Parse the pipeline options passed into the application. Example:
     //   --runner=DirectRunner --warehouseLocation=$LOCATION --catalogName=$CATALOG \
-    //   -tableName= $TABLE_NAME --outputPath=$OUTPUT_FILE
+    //   --tableName= $TABLE_NAME --outputPath=$OUTPUT_FILE
     // For more information, see https://beam.apache.org/documentation/programming-guide/#configuring-pipeline-options
     Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
     Pipeline pipeline = Pipeline.create(options);
@@ -77,11 +77,8 @@ public class ApacheIcebergRead {
         .build();
 
     // Build the pipeline.
-    PCollectionRowTuple.empty(pipeline).apply(
-            Managed.read(Managed.ICEBERG)
-                .withConfig(config)
-        )
-        .get("output")
+    pipeline.apply(Managed.read(Managed.ICEBERG).withConfig(config))
+        .getSinglePCollection()
         // Format each record as a string with the format 'id:name'.
         .apply(MapElements
             .into(TypeDescriptors.strings())

--- a/dataflow/snippets/src/main/java/com/example/dataflow/ApacheIcebergWrite.java
+++ b/dataflow/snippets/src/main/java/com/example/dataflow/ApacheIcebergWrite.java
@@ -87,12 +87,8 @@ public class ApacheIcebergWrite {
     // Build the pipeline.
     var input = pipeline
         .apply(Create.of(TABLE_ROWS))
-        .apply(JsonToRow.withSchema(SCHEMA));
-
-    PCollectionRowTuple.of("input", input).apply(
-        Managed.write(Managed.ICEBERG)
-            .withConfig(config)
-    );
+        .apply(JsonToRow.withSchema(SCHEMA))
+        .apply(Managed.write(Managed.ICEBERG).withConfig(config));
 
     pipeline.run().waitUntilFinish();
   }

--- a/dataflow/snippets/src/main/java/com/example/dataflow/ApacheIcebergWrite.java
+++ b/dataflow/snippets/src/main/java/com/example/dataflow/ApacheIcebergWrite.java
@@ -85,8 +85,7 @@ public class ApacheIcebergWrite {
         .build();
 
     // Build the pipeline.
-    var input = pipeline
-        .apply(Create.of(TABLE_ROWS))
+    pipeline.apply(Create.of(TABLE_ROWS))
         .apply(JsonToRow.withSchema(SCHEMA))
         .apply(Managed.write(Managed.ICEBERG).withConfig(config));
 

--- a/dataflow/snippets/src/main/java/com/example/dataflow/PubSubWriteWithAttributes.java
+++ b/dataflow/snippets/src/main/java/com/example/dataflow/PubSubWriteWithAttributes.java
@@ -70,7 +70,7 @@ public class PubSubWriteWithAttributes {
     );
 
     // Parse the pipeline options passed into the application. Example:
-    //   ----runner=DirectRunner --topic=projects/MY_PROJECT/topics/MY_TOPIC"
+    //   --runner=DirectRunner --topic=projects/MY_PROJECT/topics/MY_TOPIC"
     // For more information, see https://beam.apache.org/documentation/programming-guide/#configuring-pipeline-options
     var options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
     var pipeline = Pipeline.create(options);


### PR DESCRIPTION
## Description

- Bump Apache Beam version
- Update Iceberg snippets to latest API
- Minor fixes to comments

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
