### PR TITLE
docs(generativeai): add region tags for code samples

### DIFF
--- a/aiplatform/src/main/java/aiplatform/CreatePipelineJobModelTuningSample.java
+++ b/aiplatform/src/main/java/aiplatform/CreatePipelineJobModelTuningSample.java
@@ -17,6 +17,7 @@
 package aiplatform;
 
 // [START aiplatform_sdk_tuning]
+// [START generativeaionvertexai_sdk_tuning]
 import com.google.cloud.aiplatform.v1.CreatePipelineJobRequest;
 import com.google.cloud.aiplatform.v1.LocationName;
 import com.google.cloud.aiplatform.v1.PipelineJob;
@@ -116,3 +117,4 @@ public class CreatePipelineJobModelTuningSample {
 }
 
 // [END aiplatform_sdk_tuning]
+// [END generativeaionvertexai_sdk_tuning]

--- a/aiplatform/src/main/java/aiplatform/EmbeddingModelTuningSample.java
+++ b/aiplatform/src/main/java/aiplatform/EmbeddingModelTuningSample.java
@@ -17,6 +17,7 @@
 package aiplatform;
 
 // [START aiplatform_sdk_embedding_model_tuning]
+// [START generativeaionvertexai_sdk_embedding_model_tuning]
 import com.google.cloud.aiplatform.v1.CreatePipelineJobRequest;
 import com.google.cloud.aiplatform.v1.LocationName;
 import com.google.cloud.aiplatform.v1.PipelineJob;
@@ -131,3 +132,4 @@ public class EmbeddingModelTuningSample {
   }
 }
 // [END aiplatform_sdk_embedding_model_tuning]
+// [END generativeaionvertexai_sdk_embedding_model_tuning]

--- a/aiplatform/src/main/java/aiplatform/PredictChatPromptSample.java
+++ b/aiplatform/src/main/java/aiplatform/PredictChatPromptSample.java
@@ -17,6 +17,7 @@
 package aiplatform;
 
 // [START aiplatform_sdk_chat]
+// [START generativeaionvertexai_sdk_chat]
 
 import com.google.cloud.aiplatform.v1beta1.EndpointName;
 import com.google.cloud.aiplatform.v1beta1.PredictResponse;
@@ -97,3 +98,4 @@ public class PredictChatPromptSample {
   }
 }
 // [END aiplatform_sdk_chat]
+// [END generativeaionvertexai_sdk_chat]

--- a/aiplatform/src/main/java/aiplatform/PredictCodeChatSample.java
+++ b/aiplatform/src/main/java/aiplatform/PredictCodeChatSample.java
@@ -17,6 +17,7 @@
 package aiplatform;
 
 // [START aiplatform_sdk_code_chat]
+// [START generativeaionvertexai_sdk_code_chat]
 
 import com.google.cloud.aiplatform.v1.EndpointName;
 import com.google.cloud.aiplatform.v1.PredictResponse;
@@ -102,3 +103,4 @@ public class PredictCodeChatSample {
   }
 }
 // [END aiplatform_sdk_code_chat]
+// [END generativeaionvertexai_sdk_code_chat]

--- a/aiplatform/src/main/java/aiplatform/PredictCodeCompletionCommentSample.java
+++ b/aiplatform/src/main/java/aiplatform/PredictCodeCompletionCommentSample.java
@@ -17,6 +17,7 @@
 package aiplatform;
 
 // [START aiplatform_sdk_code_completion_comment]
+// [START generativeaionvertexai_sdk_code_completion_comment]
 
 import com.google.cloud.aiplatform.v1.EndpointName;
 import com.google.cloud.aiplatform.v1.PredictResponse;
@@ -92,3 +93,4 @@ public class PredictCodeCompletionCommentSample {
   }
 }
 // [END aiplatform_sdk_code_completion_comment]
+// [END generativeaionvertexai_sdk_code_completion_comment]

--- a/aiplatform/src/main/java/aiplatform/PredictCodeGenerationFunctionSample.java
+++ b/aiplatform/src/main/java/aiplatform/PredictCodeGenerationFunctionSample.java
@@ -17,6 +17,7 @@
 package aiplatform;
 
 // [START aiplatform_sdk_code_generation_function]
+// [START generativeaionvertexai_sdk_code_generation_function]
 
 import com.google.cloud.aiplatform.v1.EndpointName;
 import com.google.cloud.aiplatform.v1.PredictResponse;
@@ -87,3 +88,4 @@ public class PredictCodeGenerationFunctionSample {
   }
 }
 // [END aiplatform_sdk_code_generation_function]
+// [END generativeaionvertexai_sdk_code_generation_function]

--- a/aiplatform/src/main/java/aiplatform/PredictImageFromImageAndTextSample.java
+++ b/aiplatform/src/main/java/aiplatform/PredictImageFromImageAndTextSample.java
@@ -17,6 +17,7 @@
 package aiplatform;
 
 // [START aiplatform_sdk_text_image_embedding]
+// [START generativeaionvertexai_sdk_text_image_embedding]
 
 import com.google.cloud.aiplatform.v1beta1.EndpointName;
 import com.google.cloud.aiplatform.v1beta1.PredictResponse;
@@ -115,3 +116,4 @@ public class PredictImageFromImageAndTextSample {
   }
 }
 // [END aiplatform_sdk_text_image_embedding]
+// [END generativeaionvertexai_sdk_text_image_embedding]

--- a/aiplatform/src/main/java/aiplatform/PredictTextEmbeddingsSample.java
+++ b/aiplatform/src/main/java/aiplatform/PredictTextEmbeddingsSample.java
@@ -17,6 +17,7 @@
 package aiplatform;
 
 // [START aiplatform_sdk_embedding]
+// [START generativeaionvertexai_sdk_embedding]
 import static java.util.stream.Collectors.toList;
 
 import com.google.cloud.aiplatform.v1.EndpointName;
@@ -111,3 +112,4 @@ public class PredictTextEmbeddingsSample {
   }
 }
 // [END aiplatform_sdk_embedding]
+// [END generativeaionvertexai_sdk_embedding]

--- a/aiplatform/src/main/java/aiplatform/PredictTextPromptSample.java
+++ b/aiplatform/src/main/java/aiplatform/PredictTextPromptSample.java
@@ -17,6 +17,7 @@
 package aiplatform;
 
 // [START aiplatform_sdk_ideation]
+// [START generativeaionvertexai_sdk_ideation]
 
 import com.google.cloud.aiplatform.v1.EndpointName;
 import com.google.cloud.aiplatform.v1.PredictResponse;
@@ -92,3 +93,4 @@ public class PredictTextPromptSample {
   }
 }
 // [END aiplatform_sdk_ideation]
+// [END generativeaionvertexai_sdk_ideation]

--- a/vertexai/snippets/src/main/java/vertexai/gemini/GetTokenCount.java
+++ b/vertexai/snippets/src/main/java/vertexai/gemini/GetTokenCount.java
@@ -16,7 +16,6 @@
 
 package vertexai.gemini;
 
-// [START generativeaionvertexai_gemini_token_count]
 // [START aiplatform_gemini_token_count]
 // [START generativeaionvertexai_gemini_token_count]
 import com.google.cloud.vertexai.VertexAI;
@@ -67,5 +66,4 @@ public class GetTokenCount {
   }
 }
 // [END aiplatform_gemini_token_count]
-// [END generativeaionvertexai_gemini_token_count]
 // [END generativeaionvertexai_gemini_token_count]

--- a/vertexai/snippets/src/main/java/vertexai/gemini/GetTokenCount.java
+++ b/vertexai/snippets/src/main/java/vertexai/gemini/GetTokenCount.java
@@ -18,6 +18,7 @@ package vertexai.gemini;
 
 // [START generativeaionvertexai_gemini_token_count]
 // [START aiplatform_gemini_token_count]
+// [START generativeaionvertexai_gemini_token_count]
 import com.google.cloud.vertexai.VertexAI;
 import com.google.cloud.vertexai.api.CountTokensResponse;
 import com.google.cloud.vertexai.api.GenerateContentResponse;
@@ -66,4 +67,5 @@ public class GetTokenCount {
   }
 }
 // [END aiplatform_gemini_token_count]
+// [END generativeaionvertexai_gemini_token_count]
 // [END generativeaionvertexai_gemini_token_count]


### PR DESCRIPTION
## Description

Adding `generativeaionvertexai_` region tags to replace old `aiplatform_`

In near future GenAI code samples, will only use `generativeaionvertexai_` region tag prefix.

Fixes: [b/350918509](b/350918509)

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
