### PR TITLE
docs(samples): Add Kafka to Dataflow snippet

### DIFF
--- a/dataflow/snippets/pom.xml
+++ b/dataflow/snippets/pom.xml
@@ -156,6 +156,24 @@
       <version>${iceberg.version}</version>
     </dependency>
 
+    <!-- Kafka -->
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-io-kafka</artifactId>
+      <version>${apache_beam.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>3.8.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>kafka</artifactId>
+      <version>1.20.0</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Google Cloud -->
     <dependency>
       <groupId>com.google.cloud</groupId>

--- a/dataflow/snippets/pom.xml
+++ b/dataflow/snippets/pom.xml
@@ -163,11 +163,14 @@
       <version>${apache_beam.version}</version>
     </dependency>
     <dependency>
+      <!-- For sending Kafka messages in the integration test -->
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
       <version>3.8.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
+      <!-- For running containerized Kafka instance in the integration test -->
       <groupId>org.testcontainers</groupId>
       <artifactId>kafka</artifactId>
       <version>1.20.0</version>

--- a/dataflow/snippets/src/main/java/com/example/dataflow/KafkaRead.java
+++ b/dataflow/snippets/src/main/java/com/example/dataflow/KafkaRead.java
@@ -31,7 +31,7 @@ import org.apache.beam.sdk.values.TypeDescriptors;
 
 public class KafkaRead {
 
-// [END dataflow_kafka_read]
+  // [END dataflow_kafka_read]
   public interface Options extends StreamingOptions {
     @Description("The Kafka bootstrap server. Example: localhost:9092")
     String getBootstrapServer();
@@ -93,8 +93,7 @@ public class KafkaRead {
             .write()
             .to(options.getOutputPath())
             .withSuffix(".txt")
-            .withNumShards(1)
-        );
+            .withNumShards(1));
     return pipeline;
   }
 }

--- a/dataflow/snippets/src/main/java/com/example/dataflow/KafkaRead.java
+++ b/dataflow/snippets/src/main/java/com/example/dataflow/KafkaRead.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.dataflow;
+
+// [START dataflow_kafka_read]
+import com.google.common.collect.ImmutableMap;
+import java.io.UnsupportedEncodingException;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.managed.Managed;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.StreamingOptions;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.values.TypeDescriptors;
+
+public class KafkaRead {
+
+  public interface Options extends StreamingOptions {
+    @Description("The Kafka bootstrap server. Example: localhost:9092")
+    String getBootstrapServer();
+
+    void setBootstrapServer(String value);
+
+    @Description("The Kafka topic to read from.")
+    String getTopic();
+
+    void setTopic(String value);
+
+    @Description("Path to write the output file")
+    String getOutputPath();
+
+    void setOutputPath(String value);
+  }
+
+  public static void main(String[] args) {
+    // Parse the pipeline options passed into the application. Example:
+    //   --bootstrap_servers=$BOOTSTRAP_SERVERS --topic=$KAFKA_TOPIC --outputPath=$OUTPUT_FILE
+    // For more information, see https://beam.apache.org/documentation/programming-guide/#configuring-pipeline-options
+    var options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+    options.setStreaming(true);
+
+    var pipeline = Pipeline.create(options);
+    ImmutableMap<String, Object> config = ImmutableMap.<String, Object>builder()
+        .put("bootstrap_servers", options.getBootstrapServer())
+        .put("topic", options.getTopic())
+        .put("data_format", "RAW")
+        .put("max_read_time_seconds", 15)
+        .put("auto_offset_reset_config", "earliest")
+        .build();
+
+    // Build the pipeline.
+    pipeline
+        // Read messages from Kafka.
+        .apply(Managed.read(Managed.KAFKA).withConfig(config)).getSinglePCollection()
+        // Get the payload of each message and convert to a string.
+        .apply(MapElements
+            .into(TypeDescriptors.strings())
+            .via((row -> {
+              var bytes = row.getBytes("payload");
+              try {
+                return new String(bytes, "UTF-8");
+              } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+              }
+            })))
+        // Write the payload to a text file.
+        .apply(TextIO
+            .write()
+            .to(options.getOutputPath())
+            .withSuffix(".txt")
+            .withNumShards(1)
+    );
+    pipeline.run().waitUntilFinish();
+  }
+}
+// [END dataflow_kafka_read]

--- a/dataflow/snippets/src/main/java/com/example/dataflow/KafkaRead.java
+++ b/dataflow/snippets/src/main/java/com/example/dataflow/KafkaRead.java
@@ -20,6 +20,7 @@ package com.example.dataflow;
 import com.google.common.collect.ImmutableMap;
 import java.io.UnsupportedEncodingException;
 import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.managed.Managed;
 import org.apache.beam.sdk.options.Description;
@@ -47,7 +48,7 @@ public class KafkaRead {
     void setOutputPath(String value);
   }
 
-  public static void main(String[] args) {
+  public static PipelineResult.State main(String[] args) {
     // Parse the pipeline options passed into the application. Example:
     //   --bootstrap_servers=$BOOTSTRAP_SERVERS --topic=$KAFKA_TOPIC --outputPath=$OUTPUT_FILE
     // For more information, see https://beam.apache.org/documentation/programming-guide/#configuring-pipeline-options
@@ -85,7 +86,7 @@ public class KafkaRead {
             .withSuffix(".txt")
             .withNumShards(1)
     );
-    pipeline.run().waitUntilFinish();
+    return pipeline.run().waitUntilFinish();
   }
 }
 // [END dataflow_kafka_read]

--- a/dataflow/snippets/src/main/java/com/example/dataflow/KafkaRead.java
+++ b/dataflow/snippets/src/main/java/com/example/dataflow/KafkaRead.java
@@ -31,6 +31,7 @@ import org.apache.beam.sdk.values.TypeDescriptors;
 
 public class KafkaRead {
 
+// [END dataflow_kafka_read]
   public interface Options extends StreamingOptions {
     @Description("The Kafka bootstrap server. Example: localhost:9092")
     String getBootstrapServer();
@@ -55,7 +56,14 @@ public class KafkaRead {
     var options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
     options.setStreaming(true);
 
-    var pipeline = Pipeline.create(options);
+    Pipeline pipeline = createPipeline(options);
+    return pipeline.run().waitUntilFinish();
+  }
+
+  // [START dataflow_kafka_read]
+  public static Pipeline createPipeline(Options options) {
+
+    // Create configuration parameters for the Managed I/O transform.
     ImmutableMap<String, Object> config = ImmutableMap.<String, Object>builder()
         .put("bootstrap_servers", options.getBootstrapServer())
         .put("topic", options.getTopic())
@@ -65,6 +73,7 @@ public class KafkaRead {
         .build();
 
     // Build the pipeline.
+    var pipeline = Pipeline.create(options);
     pipeline
         // Read messages from Kafka.
         .apply(Managed.read(Managed.KAFKA).withConfig(config)).getSinglePCollection()
@@ -85,8 +94,8 @@ public class KafkaRead {
             .to(options.getOutputPath())
             .withSuffix(".txt")
             .withNumShards(1)
-    );
-    return pipeline.run().waitUntilFinish();
+        );
+    return pipeline;
   }
 }
 // [END dataflow_kafka_read]

--- a/dataflow/snippets/src/test/java/com/example/dataflow/KafkaReadIT.java
+++ b/dataflow/snippets/src/test/java/com/example/dataflow/KafkaReadIT.java
@@ -16,6 +16,7 @@
 
 package com.example.dataflow;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -26,6 +27,8 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.PipelineResult.State;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -76,12 +79,14 @@ public class KafkaReadIT {
 
   @Test
   public void testApacheKafkaRead() throws IOException {
-    KafkaRead.main(new String[] {
+    PipelineResult.State state = KafkaRead.main(new String[] {
         "--runner=DirectRunner",
         "--bootstrapServer=" + bootstrapServer,
         "--topic=" + TOPIC_NAME,
         "--outputPath=" + OUTPUT_FILE_NAME_PREFIX
     });
+    assertEquals(PipelineResult.State.DONE, state);
+
     // Verify the pipeline wrote the output.
     String output = Files.readString(Paths.get(OUTPUT_FILE_NAME));
     assertTrue(output.contains("event-0"));

--- a/dataflow/snippets/src/test/java/com/example/dataflow/KafkaReadIT.java
+++ b/dataflow/snippets/src/test/java/com/example/dataflow/KafkaReadIT.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.dataflow;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class KafkaReadIT {
+  private static final String TOPIC_NAME = "topic-" + UUID.randomUUID();
+
+  private static final String OUTPUT_FILE_NAME_PREFIX = UUID.randomUUID().toString();
+  private static final String OUTPUT_FILE_NAME = OUTPUT_FILE_NAME_PREFIX + "-00000-of-00001.txt";
+
+  private static KafkaContainer kafka;
+  private static String bootstrapServer;
+
+  @Before
+  public void setUp() throws ExecutionException, InterruptedException {
+    // Start a containerized Kafka instance.
+    kafka = new KafkaContainer(DockerImageName.parse("apache/kafka:3.7.0"));
+    kafka.start();
+    bootstrapServer = kafka.getBootstrapServers();
+
+    // Create a topic.
+    Properties properties = new Properties();
+    properties.put("bootstrap.servers", bootstrapServer);
+    AdminClient adminClient = AdminClient.create(properties);
+    var topic = new NewTopic(TOPIC_NAME, 1, (short) 1);
+    adminClient.createTopics(Arrays.asList(topic));
+
+    // Send a message to the topic.
+    properties.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+    properties.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+    KafkaProducer<String, String> producer = new KafkaProducer<>(properties);
+    ProducerRecord<String, String> record = new ProducerRecord<>(TOPIC_NAME, "key-0", "event-0");
+    Future future = producer.send(record);
+    future.get();
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    kafka.stop();
+    Files.deleteIfExists(Paths.get(OUTPUT_FILE_NAME));
+  }
+
+  @Test
+  public void testApacheKafkaRead() throws IOException {
+    KafkaRead.main(new String[] {
+        "--runner=DirectRunner",
+        "--bootstrapServer=" + bootstrapServer,
+        "--topic=" + TOPIC_NAME,
+        "--outputPath=" + OUTPUT_FILE_NAME_PREFIX
+    });
+    // Verify the pipeline wrote the output.
+    String output = Files.readString(Paths.get(OUTPUT_FILE_NAME));
+    assertTrue(output.contains("event-0"));
+  }
+}

--- a/dataflow/snippets/src/test/java/com/example/dataflow/KafkaReadIT.java
+++ b/dataflow/snippets/src/test/java/com/example/dataflow/KafkaReadIT.java
@@ -28,7 +28,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import org.apache.beam.sdk.PipelineResult;
-import org.apache.beam.sdk.PipelineResult.State;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.KafkaProducer;


### PR DESCRIPTION
## Description

Add code snippets for reading from Kafka using the Dataflow managed I/O transform.

Doc bugs:

- b/338063763: Managed I/O documentation [includes Kafka support]
- b/342015050: Document best practices for using Kafka with Dataflow
- 
## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
