### PR TITLE
fix: generativeaionvertexai_gemini_get_started

### DIFF
--- a/vertexai/snippets/src/main/java/vertexai/gemini/Quickstart.java
+++ b/vertexai/snippets/src/main/java/vertexai/gemini/Quickstart.java
@@ -43,7 +43,7 @@ public class Quickstart {
     // Initialize client that will be used to send requests. This client only needs
     // to be created once, and can be reused for multiple requests.
     try (VertexAI vertexAI = new VertexAI(projectId, location)) {
-      String imageUri = "gs://cloud-samples-data/vertex-ai/llm/prompts/landmark1.png";
+      String imageUri = "gs://generativeai-downloads/images/scones.jpg";
 
       GenerativeModel model = new GenerativeModel(modelName, vertexAI);
       GenerateContentResponse response = model.generateContent(ContentMaker.fromMultiModalData(

--- a/vertexai/snippets/src/test/java/vertexai/gemini/SnippetsIT.java
+++ b/vertexai/snippets/src/test/java/vertexai/gemini/SnippetsIT.java
@@ -172,8 +172,8 @@ public class SnippetsIT {
 
   @Test
   public void testQuickstart() throws IOException {
-    Quickstart.quickstart(PROJECT_ID, LOCATION, GEMINI_FLASH);
-    assertThat(bout.toString()).contains("scones");
+    String output = Quickstart.quickstart(PROJECT_ID, LOCATION, GEMINI_FLASH);
+    assertThat(output).contains("scones");
   }
 
   @Test

--- a/vertexai/snippets/src/test/java/vertexai/gemini/SnippetsIT.java
+++ b/vertexai/snippets/src/test/java/vertexai/gemini/SnippetsIT.java
@@ -172,9 +172,8 @@ public class SnippetsIT {
 
   @Test
   public void testQuickstart() throws IOException {
-    String output = Quickstart.quickstart(PROJECT_ID, LOCATION, GEMINI_FLASH);
-    // Disabled assertion, pending resolution of b/342637034
-    // assertThat(output).contains("Colosseum");
+    Quickstart.quickstart(PROJECT_ID, LOCATION, GEMINI_FLASH);
+    assertThat(bout.toString()).contains("scones");
   }
 
   @Test


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
