### PR TITLE
docs(samples): Update Dataflow Iceberg samples for Beam 2.58.0

### DIFF
--- a/dataflow/snippets/pom.xml
+++ b/dataflow/snippets/pom.xml
@@ -37,7 +37,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <apache_beam.version>2.57.0</apache_beam.version>
+    <apache_beam.version>2.58.0</apache_beam.version>
     <slf4j.version>2.0.12</slf4j.version>
     <parquet.version>1.14.0</parquet.version>
     <iceberg.version>1.4.2</iceberg.version>

--- a/dataflow/snippets/src/main/java/com/example/dataflow/ApacheIcebergRead.java
+++ b/dataflow/snippets/src/main/java/com/example/dataflow/ApacheIcebergRead.java
@@ -66,14 +66,14 @@ public class ApacheIcebergRead {
 
     // Configure the Iceberg source I/O
     Map catalogConfig = ImmutableMap.<String, Object>builder()
-        .put("catalog_name", options.getCatalogName())
-        .put("warehouse_location", options.getWarehouseLocation())
-        .put("catalog_type", CATALOG_TYPE)
+        .put("warehouse", options.getWarehouseLocation())
+        .put("type", CATALOG_TYPE)
         .build();
 
     ImmutableMap<String, Object> config = ImmutableMap.<String, Object>builder()
         .put("table", options.getTableName())
-        .put("catalog_config", catalogConfig)
+        .put("catalog_name", options.getCatalogName())
+        .put("catalog_properties", catalogConfig)
         .build();
 
     // Build the pipeline.

--- a/dataflow/snippets/src/main/java/com/example/dataflow/ApacheIcebergWrite.java
+++ b/dataflow/snippets/src/main/java/com/example/dataflow/ApacheIcebergWrite.java
@@ -74,14 +74,14 @@ public class ApacheIcebergWrite {
 
     // Configure the Iceberg source I/O
     Map catalogConfig = ImmutableMap.<String, Object>builder()
-        .put("catalog_name", options.getCatalogName())
-        .put("warehouse_location", options.getWarehouseLocation())
-        .put("catalog_type", CATALOG_TYPE)
+        .put("warehouse", options.getWarehouseLocation())
+        .put("type", CATALOG_TYPE)
         .build();
 
     ImmutableMap<String, Object> config = ImmutableMap.<String, Object>builder()
         .put("table", options.getTableName())
-        .put("catalog_config", catalogConfig)
+        .put("catalog_name", options.getCatalogName())
+        .put("catalog_properties", catalogConfig)
         .build();
 
     // Build the pipeline.


### PR DESCRIPTION
## Description

Beam 2.58.0 introduced breaking changes in the configuration parameters for the Apache Iceberg I/O connector. This PR updates the corresponding Dataflow snippets.

Doc bug: b/353519510

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
