### PR TITLE
docs(generativeai): clear unused region tags for code samples

### DIFF
--- a/vertexai/snippets/src/main/java/vertexai/gemini/ChatDiscussion.java
+++ b/vertexai/snippets/src/main/java/vertexai/gemini/ChatDiscussion.java
@@ -17,7 +17,6 @@
 package vertexai.gemini;
 
 // [START generativeaionvertexai_gemini_multiturn_chat]
-// [START aiplatform_gemini_multiturn_chat]
 import com.google.cloud.vertexai.VertexAI;
 import com.google.cloud.vertexai.api.GenerateContentResponse;
 import com.google.cloud.vertexai.generativeai.ChatSession;
@@ -60,5 +59,4 @@ public class ChatDiscussion {
     }
   }
 }
-// [END aiplatform_gemini_multiturn_chat]
 // [END generativeaionvertexai_gemini_multiturn_chat]

--- a/vertexai/snippets/src/main/java/vertexai/gemini/FunctionCalling.java
+++ b/vertexai/snippets/src/main/java/vertexai/gemini/FunctionCalling.java
@@ -17,7 +17,6 @@
 package vertexai.gemini;
 
 // [START generativeaionvertexai_gemini_function_calling]
-// [START aiplatform_gemini_function_calling]
 import com.google.cloud.vertexai.VertexAI;
 import com.google.cloud.vertexai.api.Content;
 import com.google.cloud.vertexai.api.FunctionDeclaration;
@@ -112,5 +111,4 @@ public class FunctionCalling {
     }
   }
 }
-// [END aiplatform_gemini_function_calling]
 // [END generativeaionvertexai_gemini_function_calling]

--- a/vertexai/snippets/src/main/java/vertexai/gemini/GetTokenCount.java
+++ b/vertexai/snippets/src/main/java/vertexai/gemini/GetTokenCount.java
@@ -17,7 +17,6 @@
 package vertexai.gemini;
 
 // [START generativeaionvertexai_gemini_token_count]
-// [START aiplatform_gemini_token_count]
 import com.google.cloud.vertexai.VertexAI;
 import com.google.cloud.vertexai.api.CountTokensResponse;
 import com.google.cloud.vertexai.api.GenerateContentResponse;
@@ -65,5 +64,4 @@ public class GetTokenCount {
     }
   }
 }
-// [END aiplatform_gemini_token_count]
 // [END generativeaionvertexai_gemini_token_count]

--- a/vertexai/snippets/src/main/java/vertexai/gemini/MultimodalMultiImage.java
+++ b/vertexai/snippets/src/main/java/vertexai/gemini/MultimodalMultiImage.java
@@ -17,7 +17,6 @@
 package vertexai.gemini;
 
 // [START generativeaionvertexai_gemini_single_turn_multi_image]
-// [START aiplatform_gemini_single_turn_multi_image]
 import com.google.cloud.vertexai.VertexAI;
 import com.google.cloud.vertexai.api.Content;
 import com.google.cloud.vertexai.api.GenerateContentResponse;
@@ -92,5 +91,4 @@ public class MultimodalMultiImage {
     }
   }
 }
-// [END aiplatform_gemini_single_turn_multi_image]
 // [END generativeaionvertexai_gemini_single_turn_multi_image]

--- a/vertexai/snippets/src/main/java/vertexai/gemini/MultimodalQuery.java
+++ b/vertexai/snippets/src/main/java/vertexai/gemini/MultimodalQuery.java
@@ -17,7 +17,6 @@
 package vertexai.gemini;
 
 // [START generativeaionvertexai_gemini_pro_example]
-// [START aiplatform_gemini_pro_example]
 import com.google.cloud.vertexai.VertexAI;
 import com.google.cloud.vertexai.api.GenerateContentResponse;
 import com.google.cloud.vertexai.generativeai.ContentMaker;
@@ -61,5 +60,4 @@ public class MultimodalQuery {
     }
   }
 }
-// [END aiplatform_gemini_pro_example]
 // [END generativeaionvertexai_gemini_pro_example]

--- a/vertexai/snippets/src/main/java/vertexai/gemini/MultimodalVideoInput.java
+++ b/vertexai/snippets/src/main/java/vertexai/gemini/MultimodalVideoInput.java
@@ -17,7 +17,6 @@
 package vertexai.gemini;
 
 // [START generativeaionvertexai_gemini_single_turn_video]
-// [START aiplatform_gemini_single_turn_video]
 import com.google.cloud.vertexai.VertexAI;
 import com.google.cloud.vertexai.api.GenerateContentResponse;
 import com.google.cloud.vertexai.generativeai.ContentMaker;
@@ -57,5 +56,4 @@ public class MultimodalVideoInput {
     }
   }
 }
-// [END aiplatform_gemini_single_turn_video]
 // [END generativeaionvertexai_gemini_single_turn_video]

--- a/vertexai/snippets/src/main/java/vertexai/gemini/Quickstart.java
+++ b/vertexai/snippets/src/main/java/vertexai/gemini/Quickstart.java
@@ -17,7 +17,6 @@
 package vertexai.gemini;
 
 // [START generativeaionvertexai_gemini_get_started]
-// [START aiplatform_gemini_get_started]
 import com.google.cloud.vertexai.VertexAI;
 import com.google.cloud.vertexai.api.GenerateContentResponse;
 import com.google.cloud.vertexai.generativeai.ContentMaker;
@@ -55,5 +54,4 @@ public class Quickstart {
     }
   }
 }
-// [END aiplatform_gemini_get_started]
 // [END generativeaionvertexai_gemini_get_started]

--- a/vertexai/snippets/src/main/java/vertexai/gemini/SingleTurnMultimodal.java
+++ b/vertexai/snippets/src/main/java/vertexai/gemini/SingleTurnMultimodal.java
@@ -17,7 +17,6 @@
 package vertexai.gemini;
 
 // [START generativeaionvertexai_gemini_single_turn_image]
-// [START aiplatform_gemini_pro_config_example]
 import com.google.cloud.vertexai.VertexAI;
 import com.google.cloud.vertexai.api.GenerateContentResponse;
 import com.google.cloud.vertexai.api.GenerationConfig;
@@ -71,5 +70,4 @@ public class SingleTurnMultimodal {
     }
   }
 }
-// [END aiplatform_gemini_pro_config_example]
 // [END generativeaionvertexai_gemini_single_turn_image]

--- a/vertexai/snippets/src/main/java/vertexai/gemini/WithSafetySettings.java
+++ b/vertexai/snippets/src/main/java/vertexai/gemini/WithSafetySettings.java
@@ -17,7 +17,6 @@
 package vertexai.gemini;
 
 // [START generativeaionvertexai_gemini_safety_settings]
-// [START aiplatform_gemini_safety_settings]
 import com.google.cloud.vertexai.VertexAI;
 import com.google.cloud.vertexai.api.Candidate;
 import com.google.cloud.vertexai.api.GenerateContentResponse;
@@ -85,5 +84,4 @@ public class WithSafetySettings {
     }
   }
 }
-// [END aiplatform_gemini_safety_settings]
 // [END generativeaionvertexai_gemini_safety_settings]


### PR DESCRIPTION
No code change. Goal of this PR is to remove unsed `aiplatform_` region tags

I have added `generativeaionvertexai_` region tags to replace old `aiplatform_`; In near future GenAI code samples, will only use `generativeaionvertexai_` region tag prefix.

In Cloud documentation, all samples using `aiplatform_` are cleared. Any pending Samples browser page, will be update automatically after this PR.

## Description

Fixes b/355202776

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [x] Please **merge** this PR for me once it is approved
