### PR TITLE
Update comments for IAM samples

### DIFF
--- a/iam/snippets/src/main/java/DeleteServiceAccountKey.java
+++ b/iam/snippets/src/main/java/DeleteServiceAccountKey.java
@@ -41,7 +41,7 @@ public class DeleteServiceAccountKey {
       //Construct the service account email.
       //You can modify the ".iam.gserviceaccount.com" to match the service account name in which
       //you want to delete the key.
-      //See, https://cloud.google.com/iam/docs/creating-managing-service-account-keys?hl=en#deleting
+      //See, https://cloud.google.com/iam/docs/creating-managing-service-account-keys#deleting
 
       String accountEmail = String.format("%s@%s.iam.gserviceaccount.com", accountName, projectId);
 

--- a/iam/snippets/src/main/java/DisableServiceAccountKey.java
+++ b/iam/snippets/src/main/java/DisableServiceAccountKey.java
@@ -37,7 +37,7 @@ public class DisableServiceAccountKey {
     // Construct the service account email.
     // You can modify the ".iam.gserviceaccount.com" to match the service account name in which
     // you want to disable the key.
-    // See, https://cloud.google.com/iam/docs/creating-managing-service-account-keys?hl=en#disabling
+    // See, https://cloud.google.com/iam/docs/creating-managing-service-account-keys#disabling
     String email = String.format("%s@%s.iam.gserviceaccount.com", accountName, projectId);
     String name = String.format("projects/%s/serviceAccounts/%s/keys/%s", projectId, email, key);
 

--- a/iam/snippets/src/main/java/EnableServiceAccountKey.java
+++ b/iam/snippets/src/main/java/EnableServiceAccountKey.java
@@ -37,7 +37,7 @@ public class EnableServiceAccountKey {
     // Construct the service account email.
     // You can modify the ".iam.gserviceaccount.com" to match the service account name in which
     // you want to enable the key.
-    // See, https://cloud.google.com/iam/docs/creating-managing-service-account-keys?hl=en#enabling
+    // See, https://cloud.google.com/iam/docs/creating-managing-service-account-keys#enabling
     String email = String.format("%s@%s.iam.gserviceaccount.com", accountName, projectId);
     String name = String.format("projects/%s/serviceAccounts/%s/keys/%s", projectId, email, key);
 

--- a/iam/snippets/src/main/java/GetServiceAccountPolicy.java
+++ b/iam/snippets/src/main/java/GetServiceAccountPolicy.java
@@ -35,10 +35,8 @@ public class GetServiceAccountPolicy {
   public static Policy getPolicy(String projectId, String serviceAccount) throws IOException {
 
     // Construct the service account email.
-    // You can modify the ".iam.gserviceaccount.com" to match the service account name in which
-    // you want to delete the key.
-    // See, https://cloud.google.com/iam/docs/creating-managing-service-account-keys?hl=en#deleting
-
+    // You can modify the ".iam.gserviceaccount.com" to match the name of the service account
+    // whose allow policy you want to get.
     String serviceAccountEmail = serviceAccount + "@" + projectId + ".iam.gserviceaccount.com";
 
     // Initialize client that will be used to send requests.

--- a/iam/snippets/src/main/java/Quickstart.java
+++ b/iam/snippets/src/main/java/Quickstart.java
@@ -48,10 +48,8 @@ public class Quickstart {
                                 String member, String role) throws IOException {
 
     // Construct the service account email.
-    // You can modify the ".iam.gserviceaccount.com" to match the service account name in which
-    // you want to delete the key.
-    // See, https://cloud.google.com/iam/docs/creating-managing-service-account-keys?hl=en#deleting
-
+    // You can modify the ".iam.gserviceaccount.com" to match the name of the service account
+    // to use for authentication.
     serviceAccount = serviceAccount + "@" + projectId + ".iam.gserviceaccount.com";
 
     // Initialize client that will be used to send requests.

--- a/iam/snippets/src/main/java/SetServiceAccountPolicy.java
+++ b/iam/snippets/src/main/java/SetServiceAccountPolicy.java
@@ -43,7 +43,6 @@ public class SetServiceAccountPolicy {
     // Construct the service account email.
     // You can modify the ".iam.gserviceaccount.com" to match the name of the service account
     // whose allow policy you want to set.
-
     String accountEmail = String.format("%s@%s.iam.gserviceaccount.com", serviceAccount, projectId);
 
     // Initialize client that will be used to send requests.

--- a/iam/snippets/src/main/java/SetServiceAccountPolicy.java
+++ b/iam/snippets/src/main/java/SetServiceAccountPolicy.java
@@ -41,9 +41,8 @@ public class SetServiceAccountPolicy {
                                                String serviceAccount) throws IOException {
 
     // Construct the service account email.
-    // You can modify the ".iam.gserviceaccount.com" to match the service account name in which
-    // you want to delete the key.
-    // See, https://cloud.google.com/iam/docs/creating-managing-service-account-keys?hl=en#deleting
+    // You can modify the ".iam.gserviceaccount.com" to match the name of the service account
+    // whose allow policy you want to set.
 
     String accountEmail = String.format("%s@%s.iam.gserviceaccount.com", serviceAccount, projectId);
 


### PR DESCRIPTION
## Description

Fixes the following issues with the code comments:

- Removes query string that forces documentation links to go to the English version of the page (?hl=en)
- Updates text to correctly indicate what each service account is for (several pages incorrectly said that the service accounts were to specify which key should be deleted)
