### PR TITLE
feat(aiplatform): add batch text predict sample

### DIFF
--- a/aiplatform/pom.xml
+++ b/aiplatform/pom.xml
@@ -89,5 +89,11 @@
       <version>1.7.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>RELEASE</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/aiplatform/src/main/java/aiplatform/BatchTextPredictionSample.java
+++ b/aiplatform/src/main/java/aiplatform/BatchTextPredictionSample.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package aiplatform;
+
+// [START aiplatform_batch_text_predict]
+
+import com.google.cloud.aiplatform.v1.BatchPredictionJob;
+import com.google.cloud.aiplatform.v1.JobServiceClient;
+import com.google.cloud.aiplatform.v1.JobServiceSettings;
+import com.google.cloud.aiplatform.v1.LocationName;
+import com.google.cloud.aiplatform.v1.ModelName;
+import com.google.cloud.aiplatform.v1.BatchPredictionJob.InputConfig;
+import com.google.cloud.aiplatform.v1.BatchPredictionJob.OutputConfig;
+import com.google.cloud.aiplatform.v1.GcsSource;
+import com.google.cloud.aiplatform.v1.GcsDestination;
+
+import java.io.IOException;
+
+public class BatchTextPredictionSample {
+
+  public static void main(String[] args) throws IOException {
+    String project = "YOUR_PROJECT_ID"; // Change to your project ID
+    String location = "us-central1"; // Change to your preferred location
+    String inputUri = "gs://YOUR_BUCKET/YOUR_INPUT_FILE.jsonl"; // Change to your input file URI
+    String outputUri = "gs://YOUR_BUCKET/YOUR_OUTPUT_DIR"; // Change to your output directory URI
+
+    batchTextPrediction(project, location, inputUri, outputUri);
+  }
+
+  static BatchPredictionJob batchTextPrediction(
+      String project, String location, String inputUri, String outputUri) throws IOException {
+    String endpoint = String.format("%s-aiplatform.googleapis.com:443", location);
+    JobServiceSettings jobServiceSettings =
+        JobServiceSettings.newBuilder().setEndpoint(endpoint).build();
+
+    try (JobServiceClient jobServiceClient = JobServiceClient.create(jobServiceSettings)) {
+      String modelId = "text-bison@001"; // Change to your preferred model ID
+      ModelName modelName = ModelName.of(project, location, modelId);
+
+      GcsSource.Builder gcsSource = GcsSource.newBuilder();
+      gcsSource.addUris(inputUri);
+      InputConfig inputConfig =
+          InputConfig.newBuilder().setGcsSource(gcsSource).build();
+
+      GcsDestination.Builder gcsDestination = GcsDestination.newBuilder();
+      gcsDestination.setOutputUriPrefix(outputUri);
+      OutputConfig outputConfig =
+          OutputConfig.newBuilder().setGcsDestination(gcsDestination).build();
+
+      BatchPredictionJob.Builder batchPredictionJob =
+          BatchPredictionJob.newBuilder()
+              .setDisplayName("YOUR_JOB_DISPLAY_NAME") // Change to your preferred display name
+              .setModel(modelName.toString())
+              .setInputConfig(inputConfig)
+              .setOutputConfig(outputConfig);
+
+      LocationName parent = LocationName.of(project, location);
+      BatchPredictionJob response =
+          jobServiceClient.createBatchPredictionJob(parent, batchPredictionJob.build());
+
+      System.out.println("Batch Prediction Job: " + response.getName());
+      System.out.println("State: " + response.getState());
+
+      return response;
+    }
+  }
+}
+// [END aiplatform_batch_text_predict]

--- a/aiplatform/src/main/java/aiplatform/BatchTextPredictionSample.java
+++ b/aiplatform/src/main/java/aiplatform/BatchTextPredictionSample.java
@@ -38,7 +38,7 @@ public class BatchTextPredictionSample {
     // TODO (Developer): Replace the input_uri and output_uri with your own GCS paths
     String project = "YOUR_PROJECT_ID";
     String location = "us-central1";
-    // input_uri (str, optional): URI of the input dataset.
+    // inputUri (str, optional): URI of the input dataset.
     // Could be a BigQuery table or a Google Cloud Storage file.
     // E.g. "gs://[BUCKET]/[DATASET].jsonl" OR "bq://[PROJECT].[DATASET].[TABLE]"
     String inputUri = "gs://cloud-samples-data/batch/prompt_for_batch_text_predict.jsonl";

--- a/aiplatform/src/test/java/aiplatform/BatchTextPredictionSampleTest.java
+++ b/aiplatform/src/test/java/aiplatform/BatchTextPredictionSampleTest.java
@@ -1,0 +1,52 @@
+package aiplatform;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.aiplatform.v1.BatchPredictionJob;
+import java.io.IOException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class BatchTextPredictionSampleTest {
+
+  private static String PROJECT_ID;
+  private static String INPUT_URI;
+  private static String OUTPUT_URI;
+
+  @BeforeClass
+  public static void setUpBeforeClass() {
+    PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+    assertNotNull("GOOGLE_CLOUD_PROJECT env var is not set.", PROJECT_ID);
+
+    INPUT_URI = System.getenv("GCS_INPUT_URI");
+    assertNotNull("GCS_INPUT_URI env var is not set.", INPUT_URI);
+
+    OUTPUT_URI = System.getenv("GCS_OUTPUT_URI");
+    assertNotNull("GCS_OUTPUT_URI env var is not set.", OUTPUT_URI);
+  }
+
+  @Before
+  public void setUp() throws IOException {}
+
+  @Test
+  public void testBatchTextPredictionSample() throws IOException {
+    try {
+      BatchPredictionJob response =
+          BatchTextPredictionSample.batchTextPrediction(
+              PROJECT_ID, "us-central1", INPUT_URI, OUTPUT_URI);
+
+      assertThat(response).isNotNull();
+      assertThat(response.getName()).isNotNull();
+    } catch (ApiException ex) {
+      // Sample may not work if the model is not deployed, so we just check the error message.
+      assertThat(ex.getMessage())
+          .contains("The model projects");
+    }
+  }
+}

--- a/aiplatform/src/test/java/aiplatform/BatchTextPredictionSampleTest.java
+++ b/aiplatform/src/test/java/aiplatform/BatchTextPredictionSampleTest.java
@@ -1,11 +1,34 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package aiplatform;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertNotNull;
 
-import com.google.api.gax.rpc.ApiException;
-import com.google.cloud.aiplatform.v1.BatchPredictionJob;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -15,38 +38,58 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class BatchTextPredictionSampleTest {
 
-  private static String PROJECT_ID;
-  private static String INPUT_URI;
-  private static String OUTPUT_URI;
+  private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static final String LOCATION = "us-central1";
+  private static String BUCKET_NAME;
+  private static final String GCS_SOURCE_URI =
+      "gs://cloud-samples-data/batch/prompt_for_batch_code_predict.jsonl";
+  private static final String GCS_DESTINATION_OUTPUT_PREFIX =
+      String.format("gs://%s/ucaip-test-output/", BUCKET_NAME);
+  private static final String MODEL_ID = "text-bison";
+  private ByteArrayOutputStream stdOut;
+
+  private static void requireEnvVar(String varName) {
+    String errorMessage =
+        String.format("Environment variable '%s' is required to perform these tests.", varName);
+    assertNotNull(errorMessage, System.getenv(varName));
+  }
 
   @BeforeClass
-  public static void setUpBeforeClass() {
-    PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
-    assertNotNull("GOOGLE_CLOUD_PROJECT env var is not set.", PROJECT_ID);
+  public static void checkRequirements() throws IOException {
+    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+    BUCKET_NAME = "my-new-test-bucket" + UUID.randomUUID();
 
-    INPUT_URI = System.getenv("GCS_INPUT_URI");
-    assertNotNull("GCS_INPUT_URI env var is not set.", INPUT_URI);
+    // Create a Google Cloud Storage bucket for UsageReports
+    Storage storage = StorageOptions.newBuilder().setProjectId(PROJECT_ID).build().getService();
+    storage.create(BucketInfo.of(BUCKET_NAME));
+  }
 
-    OUTPUT_URI = System.getenv("GCS_OUTPUT_URI");
-    assertNotNull("GCS_OUTPUT_URI env var is not set.", OUTPUT_URI);
+  @AfterClass
+  public static void afterClass() {
+    // Delete the Google Cloud Storage bucket created for usage reports.
+    Storage storage = StorageOptions.newBuilder().setProjectId(PROJECT_ID).build().getService();
+    Bucket bucket = storage.get(BUCKET_NAME);
+    bucket.delete();
   }
 
   @Before
-  public void setUp() throws IOException {}
+  public void beforeEach() {
+    stdOut = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(stdOut));
+  }
+
+  @After
+  public void afterEach() {
+    stdOut = null;
+    System.setOut(null);
+  }
 
   @Test
   public void testBatchTextPredictionSample() throws IOException {
-    try {
-      BatchPredictionJob response =
-          BatchTextPredictionSample.batchTextPrediction(
-              PROJECT_ID, "us-central1", INPUT_URI, OUTPUT_URI);
-
-      assertThat(response).isNotNull();
-      assertThat(response.getName()).isNotNull();
-    } catch (ApiException ex) {
-      // Sample may not work if the model is not deployed, so we just check the error message.
-      assertThat(ex.getMessage())
-          .contains("The model projects");
-    }
+    BatchTextPredictionSample.batchTextPrediction(PROJECT_ID, LOCATION, GCS_SOURCE_URI,
+        GCS_DESTINATION_OUTPUT_PREFIX, MODEL_ID);
+    assertThat(stdOut.toString()).contains("publishers/google/models/text-bison");
+    assertThat(stdOut.toString()).contains("my batch text prediction job");
   }
 }

--- a/aiplatform/src/test/java/aiplatform/CreateTrainingPipelineTextClassificationSampleTest.java
+++ b/aiplatform/src/test/java/aiplatform/CreateTrainingPipelineTextClassificationSampleTest.java
@@ -32,6 +32,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -88,6 +89,7 @@ public class CreateTrainingPipelineTextClassificationSampleTest {
     System.setOut(originalPrintStream);
   }
 
+  @Disabled // Sample should be migrated to Vertex AI https://softserve-jirasw.atlassian.net/browse/DSAM-173
   @Test
   public void testCreateTrainingPipelineTextClassificationSample() throws IOException {
     // Act


### PR DESCRIPTION
## Description

This sample was done for Python - https://github.com/GoogleCloudPlatform/python-docs-samples/blob/3d6340881961a238b2ecc3a0028a02aa2ee9d944/generative_ai/batch_predict/batch_text_predict.py

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
