### PR TITLE
Migrate java-11 sample app to use Java17

### DIFF
--- a/flexible/java-17/cloudstorage/README.md
+++ b/flexible/java-17/cloudstorage/README.md
@@ -1,0 +1,40 @@
+# Cloud Storage sample for App Engine Flex
+
+<a
+href="https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=flexible/cloudstorage/README.md">
+<img alt="Open in Cloud Shell" src
+="http://gstatic.com/cloudssh/images/open-btn.png"></a>
+
+This sample demonstrates how to use [Cloud
+Storage](https://cloud.google.com/storage/) on Google Managed VMs.
+
+## Setup
+
+Before you can run or deploy the sample, you will need to do the following:
+
+1. Enable the Cloud Storage API in the [Google Developers
+   Console](https://console.developers.google.com/project/_/apiui/apiview/storage/overview).
+1. Create a Cloud Storage Bucket. You can do this with the [Google Cloud
+   SDK](https://cloud.google.com/sdk) using the following command:
+
+  ```sh
+  gsutil mb gs://[your-bucket-name]
+  ```
+
+1. Set the default ACL on your bucket to public read in order to serve files
+   directly from Cloud Storage. You can do this with the [Google Cloud
+   SDK](https://cloud.google.com/sdk) using the following command:
+
+  ```sh
+  gsutil defacl set public-read gs://[your-bucket-name]
+  ```
+
+1. Update the bucket name in `src/main/appengine/app.yaml`. This makes the
+   bucket name an environment variable in deployment. You still need to set the
+   environment variable when running locally, as shown below.
+
+## Deploying
+
+    ```sh
+    mvn clean package appengine:deploy
+    ```

--- a/flexible/java-17/cloudstorage/pom.xml
+++ b/flexible/java-17/cloudstorage/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>com.google.cloud.samples</groupId>
     <artifactId>shared-configuration</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.2</version>
   </parent>
 
   <properties>
@@ -106,12 +106,6 @@
         <artifactId>byte-buddy</artifactId>
         <version>1.14.17</version>
     </dependency>
-    <dependency>
-      <groupId>org.jacoco</groupId>
-      <artifactId>jacoco-maven-plugin</artifactId>
-      <version>0.8.12</version>
-    </dependency>
-
   </dependencies>
   <!-- [END gae_flex_storage_dependencies] -->
   <build>

--- a/flexible/java-17/cloudstorage/pom.xml
+++ b/flexible/java-17/cloudstorage/pom.xml
@@ -1,0 +1,147 @@
+<!--
+  Copyright 2023 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <groupId>com.example.flexible</groupId>
+  <artifactId>flexible-cloudstorage</artifactId>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.2.0</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+
+    <failOnMissingWebXml>false</failOnMissingWebXml> <!-- REQUIRED -->
+
+    <appengine.maven.plugin>2.8.0</appengine.maven.plugin>
+
+    <spring.boot.version>2.7.18</spring.boot.version>
+  </properties>
+
+  <!-- [START gae_flex_storage_dependencies] -->
+  <!--  Using libraries-bom to manage versions.
+  See https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.45.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring.boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-storage</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <type>jar</type>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit-pioneer</groupId>
+      <artifactId>junit-pioneer</artifactId>
+      <version>2.2.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+  <!-- [END gae_flex_storage_dependencies] -->
+  <build>
+    <!-- for hot reload of the web application -->
+    <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes</outputDirectory>
+    <plugins>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>appengine-maven-plugin</artifactId>
+        <version>${appengine.maven.plugin}</version>
+        <configuration>
+          <projectId>GCLOUD_CONFIG</projectId>
+          <version>GCLOUD_CONFIG</version>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring.boot.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>**/*Test*.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/flexible/java-17/cloudstorage/pom.xml
+++ b/flexible/java-17/cloudstorage/pom.xml
@@ -34,7 +34,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.source>17</maven.compiler.source>
     <failOnMissingWebXml>false</failOnMissingWebXml> <!-- REQUIRED -->
-    <appengine.maven.plugin>2.8.0</appengine.maven.plugin>
+    <appengine.maven.plugin>2.8.1</appengine.maven.plugin>
     <spring.boot.version>2.7.18</spring.boot.version>
   </properties>
 

--- a/flexible/java-17/cloudstorage/pom.xml
+++ b/flexible/java-17/cloudstorage/pom.xml
@@ -31,13 +31,10 @@
   </parent>
 
   <properties>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.source>11</maven.compiler.source>
-
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
     <failOnMissingWebXml>false</failOnMissingWebXml> <!-- REQUIRED -->
-
     <appengine.maven.plugin>2.8.0</appengine.maven.plugin>
-
     <spring.boot.version>2.7.18</spring.boot.version>
   </properties>
 
@@ -90,15 +87,15 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <scope>test</scope>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-junit-jupiter</artifactId>
+        <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-inline</artifactId>
+        <scope>test</scope>
+    </dependency>   
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>

--- a/flexible/java-17/cloudstorage/pom.xml
+++ b/flexible/java-17/cloudstorage/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2023 Google LLC
+  Copyright 2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -100,6 +100,16 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy</artifactId>
+        <version>1.14.17</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>jacoco-maven-plugin</artifactId>
+      <version>0.8.12</version>
     </dependency>
 
   </dependencies>

--- a/flexible/java-17/cloudstorage/src/main/appengine/app.yaml
+++ b/flexible/java-17/cloudstorage/src/main/appengine/app.yaml
@@ -1,4 +1,4 @@
-#  Copyright 2023 Google LLC
+#  Copyright 2024 Google LLC
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/flexible/java-17/cloudstorage/src/main/appengine/app.yaml
+++ b/flexible/java-17/cloudstorage/src/main/appengine/app.yaml
@@ -1,0 +1,27 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# [START gae_flex_cloudstorage_yaml]
+runtime: java
+env: flex
+runtime_config:
+  operating_system: ubuntu22
+  runtime_version: 17
+handlers:
+- url: /.*
+  script: this field is required, but ignored
+
+env_variables:
+  BUCKET_NAME: YOUR-BUCKET-NAME
+# [END gae_flex_cloudstorage_yaml]

--- a/flexible/java-17/cloudstorage/src/main/java/com/example/cloudstorage/Main.java
+++ b/flexible/java-17/cloudstorage/src/main/java/com/example/cloudstorage/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flexible/java-17/cloudstorage/src/main/java/com/example/cloudstorage/Main.java
+++ b/flexible/java-17/cloudstorage/src/main/java/com/example/cloudstorage/Main.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.cloudstorage;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.ServletComponentScan;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@SpringBootApplication
+@ServletComponentScan("com.example.cloudstorage")
+public class Main {
+  public static void main(String[] args) throws Exception {
+    SpringApplication.run(Main.class, args);
+  }
+}

--- a/flexible/java-17/cloudstorage/src/main/java/com/example/cloudstorage/UploadServlet.java
+++ b/flexible/java-17/cloudstorage/src/main/java/com/example/cloudstorage/UploadServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flexible/java-17/cloudstorage/src/main/java/com/example/cloudstorage/UploadServlet.java
+++ b/flexible/java-17/cloudstorage/src/main/java/com/example/cloudstorage/UploadServlet.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.cloudstorage;
+
+import com.google.cloud.storage.Acl;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.MultipartConfig;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.Part;
+
+// [START gae_flex_storage_app]
+@SuppressWarnings("serial")
+@WebServlet(name = "upload", value = "/upload")
+@MultipartConfig()
+public class UploadServlet extends HttpServlet {
+
+  private static final String BUCKET_NAME =
+      System.getenv().getOrDefault("BUCKET_NAME", "my-test-bucket");
+  private static Storage storage = null;
+
+  public UploadServlet() {
+    storage = StorageOptions.getDefaultInstance().getService();
+  }
+
+  @Override
+  public void doPost(HttpServletRequest req, HttpServletResponse resp)
+      throws IOException, ServletException {
+    final Part filePart = req.getPart("file");
+    final String fileName = filePart.getSubmittedFileName();
+    // Modify access list to allow all users with link to read file
+    List<Acl> acls = new ArrayList<>();
+    acls.add(Acl.of(Acl.User.ofAllUsers(), Acl.Role.READER));
+    // the inputstream is closed by default, so we don't need to close it here
+    Blob blob =
+        storage.create(
+            BlobInfo.newBuilder(BUCKET_NAME, fileName).setAcl(acls).build(),
+            filePart.getInputStream());
+
+    // return the public download link
+    resp.getWriter().print(blob.getMediaLink());
+  }
+}
+// [END gae_flex_storage_app]

--- a/flexible/java-17/cloudstorage/src/main/webapp/index.html
+++ b/flexible/java-17/cloudstorage/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2023 Google LLC
+ Copyright 2024 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/flexible/java-17/cloudstorage/src/main/webapp/index.html
+++ b/flexible/java-17/cloudstorage/src/main/webapp/index.html
@@ -1,0 +1,25 @@
+<!--
+ Copyright 2023 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<html>
+  <title>App Engine Flex Cloud Storage Sample</title>
+  <body>
+    <p>Select a file to upload to your Google Cloud Storage bucket.</p>
+    <form method="POST" action="/upload" enctype="multipart/form-data">
+      <input type="file" name="file"> <input type="submit">
+    </form>
+  </body>
+</html>

--- a/flexible/java-17/cloudstorage/src/test/java/com/example/cloudstorage/UploadServletTest.java
+++ b/flexible/java-17/cloudstorage/src/test/java/com/example/cloudstorage/UploadServletTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/flexible/java-17/cloudstorage/src/test/java/com/example/cloudstorage/UploadServletTest.java
+++ b/flexible/java-17/cloudstorage/src/test/java/com/example/cloudstorage/UploadServletTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.cloudstorage;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.Part;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class UploadServletTest {
+
+  @Test
+  public void testPost() throws Exception {
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter writer = new PrintWriter(stringWriter);
+    when(response.getWriter()).thenReturn(writer);
+
+    try (BufferedReader reader = mock(BufferedReader.class)) {
+      when(request.getReader()).thenReturn(reader);
+    }
+    Part filePart = mock(Part.class);
+    when(filePart.getSubmittedFileName()).thenReturn("testfile.txt");
+    when(filePart.getInputStream()).thenReturn(mock(InputStream.class));
+    when(request.getPart("file")).thenReturn(filePart);
+    Storage mockStorage = mock(Storage.class);
+    Blob mockBlob = mock(Blob.class);
+    when(mockBlob.getMediaLink()).thenReturn("test blob data");
+    when(mockStorage.create(any(BlobInfo.class), any(InputStream.class))).thenReturn(mockBlob);
+
+    MockedStatic<StorageOptions> storageOptionsMock =
+        Mockito.mockStatic(StorageOptions.class, Mockito.RETURNS_DEEP_STUBS);
+    storageOptionsMock
+        .when(() -> StorageOptions.getDefaultInstance().getService())
+        .thenReturn(mockStorage);
+    UploadServlet servlet = new UploadServlet();
+
+    servlet.doPost(request, response);
+    assertTrue(stringWriter.toString().contains("test blob data"));
+  }
+}

--- a/flexible/java-17/cloudstorage/src/test/java/com/example/cloudstorage/UploadServletTest.java
+++ b/flexible/java-17/cloudstorage/src/test/java/com/example/cloudstorage/UploadServletTest.java
@@ -49,13 +49,11 @@ public class UploadServletTest {
     PrintWriter writer = new PrintWriter(stringWriter);
     when(response.getWriter()).thenReturn(writer);
 
-    try (BufferedReader reader = mock(BufferedReader.class)) {
-      when(request.getReader()).thenReturn(reader);
-    }
     Part filePart = mock(Part.class);
+    when(request.getPart("file")).thenReturn(filePart);
     when(filePart.getSubmittedFileName()).thenReturn("testfile.txt");
     when(filePart.getInputStream()).thenReturn(mock(InputStream.class));
-    when(request.getPart("file")).thenReturn(filePart);
+
     Storage mockStorage = mock(Storage.class);
     Blob mockBlob = mock(Blob.class);
     when(mockBlob.getMediaLink()).thenReturn("test blob data");
@@ -70,5 +68,9 @@ public class UploadServletTest {
 
     servlet.doPost(request, response);
     assertTrue(stringWriter.toString().contains("test blob data"));
+
+    if (writer != null) { 
+      writer.close();
+    }
   }
 }

--- a/flexible/java-17/datastore/README.md
+++ b/flexible/java-17/datastore/README.md
@@ -1,0 +1,22 @@
+# Datastore sample for App Engine Flex
+
+[Documentation](https://cloud.google.com/appengine/docs/flexible/using-firestore-in-datastore-mode?tab=java)
+
+## Setup
+
+Before you can run or deploy the sample, you will need to do the following:
+
+1. Enable the Cloud Storage API in the [Google Developers
+   Console](https://console.developers.google.com/project/_/apiui/apiview/storage/overview).
+1. Create a [new database](https://cloud.google.com/datastore/docs/store-query-data#create_a_database).
+   By default, your Database ID will be `(default)`. In this example, we will be using the "(default)" database.
+
+   Note: Choosing between Native Mode and Datastore Mode? Check [this document](https://cloud.google.com/datastore/docs/firestore-or-datastore)
+
+1. Ensure you assign the appropriate permissions/roles for your Application default service account to perfrom database creation and read & write
+
+## Deploying
+
+    ```sh
+    mvn clean package appengine:deploy
+    ```

--- a/flexible/java-17/datastore/pom.xml
+++ b/flexible/java-17/datastore/pom.xml
@@ -1,0 +1,147 @@
+<!--
+  Copyright 2024 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <groupId>com.example.flexible</groupId>
+  <artifactId>flexible-datastore</artifactId>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.2.2</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+
+    <failOnMissingWebXml>false</failOnMissingWebXml> <!-- REQUIRED -->
+
+    <appengine.maven.plugin>2.8.0</appengine.maven.plugin>
+
+    <spring.boot.version>2.7.18</spring.boot.version>
+  </properties>
+
+  <!-- [START gae_flex_datastore_config] -->
+  <!--  Using libraries-bom to manage versions.
+  See https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.32.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring.boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-datastore</artifactId>
+    </dependency>
+    <!-- [END gae_flex_datastore_config] -->
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <type>jar</type>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- [START gae_flex_datastore_config] -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy</artifactId>
+        <version>1.14.17</version>
+    </dependency>
+  </dependencies>
+  <!-- [END gae_flex_datastore_config] -->
+  <build>
+    <!-- for hot reload of the web application -->
+    <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes</outputDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.4.0</version>
+      </plugin>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>appengine-maven-plugin</artifactId>
+        <version>${appengine.maven.plugin}</version>
+        <configuration>
+          <projectId>GCLOUD_CONFIG</projectId>
+          <version>GCLOUD_CONFIG</version>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring.boot.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>**/*Test*.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/flexible/java-17/datastore/pom.xml
+++ b/flexible/java-17/datastore/pom.xml
@@ -36,7 +36,7 @@
 
     <failOnMissingWebXml>false</failOnMissingWebXml> <!-- REQUIRED -->
 
-    <appengine.maven.plugin>2.8.0</appengine.maven.plugin>
+    <appengine.maven.plugin>2.8.1</appengine.maven.plugin>
 
     <spring.boot.version>2.7.18</spring.boot.version>
   </properties>

--- a/flexible/java-17/datastore/src/main/appengine/app.yaml
+++ b/flexible/java-17/datastore/src/main/appengine/app.yaml
@@ -1,0 +1,23 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+runtime: java
+env: flex
+runtime_config:
+  operating_system: ubuntu22
+  runtime_version: 17  
+handlers:
+- url: /.*
+  script: this field is required, but ignored

--- a/flexible/java-17/datastore/src/main/java/com/example/datastore/DatastoreServlet.java
+++ b/flexible/java-17/datastore/src/main/java/com/example/datastore/DatastoreServlet.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.datastore;
+
+import com.google.cloud.Timestamp;
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreOptions;
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.FullEntity;
+import com.google.cloud.datastore.IncompleteKey;
+import com.google.cloud.datastore.KeyFactory;
+import com.google.cloud.datastore.Query;
+import com.google.cloud.datastore.QueryResults;
+import com.google.cloud.datastore.StructuredQuery;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+// [START gae_flex_datastore_app]
+@SuppressWarnings("serial")
+@WebServlet(name = "datastore", value = "")
+public class DatastoreServlet extends HttpServlet {
+
+  @Override
+  public void doGet(HttpServletRequest req, HttpServletResponse resp)
+      throws IOException, ServletException {
+    // store only the first two octets of a users ip address
+    String userIp = req.getRemoteAddr();
+    InetAddress address = InetAddress.getByName(userIp);
+    if (address instanceof Inet6Address) {
+      // nest indexOf calls to find the second occurrence of a character in a string
+      // an alternative is to use Apache Commons Lang: StringUtils.ordinalIndexOf()
+      userIp = userIp.substring(0, userIp.indexOf(":", userIp.indexOf(":") + 1)) + ":*:*:*:*:*:*";
+    } else if (address instanceof Inet4Address) {
+      userIp = userIp.substring(0, userIp.indexOf(".", userIp.indexOf(".") + 1)) + ".*.*";
+    }
+
+    Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
+    KeyFactory keyFactory = datastore.newKeyFactory();
+    keyFactory.setKind("visit");
+    IncompleteKey key = keyFactory.newKey();
+
+    // Record a visit to the datastore, storing the IP and timestamp.
+    FullEntity<IncompleteKey> curVisit =
+        FullEntity.newBuilder(key).set("user_ip", userIp).set("timestamp", Timestamp.now()).build();
+    datastore.add(curVisit);
+
+    // Retrieve the last 10 visits from the datastore, ordered by timestamp.
+    Query<Entity> query =
+        Query.newEntityQueryBuilder()
+            .setKind("visit")
+            .setOrderBy(StructuredQuery.OrderBy.desc("timestamp"))
+            .setLimit(10)
+            .build();
+    QueryResults<Entity> results = datastore.run(query);
+
+    resp.setContentType("text/plain");
+    PrintWriter out = resp.getWriter();
+    out.print("Last 10 visits:\n");
+    while (results.hasNext()) {
+      Entity entity = results.next();
+      out.format(
+          "Time: %s Addr: %s\n", entity.getTimestamp("timestamp"), entity.getString("user_ip"));
+    }
+  }
+}
+// [END gae_flex_datastore_app]

--- a/flexible/java-17/datastore/src/main/java/com/example/datastore/Main.java
+++ b/flexible/java-17/datastore/src/main/java/com/example/datastore/Main.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.datastore;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.ServletComponentScan;
+
+@SpringBootApplication
+@ServletComponentScan("com.example.datastore")
+public class Main {
+  public static void main(String[] args) throws Exception {
+    SpringApplication.run(Main.class, args);
+  }
+}

--- a/flexible/java-17/datastore/src/test/java/com/example/datastore/DatastoreServletTest.java
+++ b/flexible/java-17/datastore/src/test/java/com/example/datastore/DatastoreServletTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.datastore;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreOptions;
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.FullEntity;
+import com.google.cloud.datastore.IncompleteKey;
+import com.google.cloud.datastore.KeyFactory;
+import com.google.cloud.datastore.Query;
+import com.google.cloud.datastore.QueryResults;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+public class DatastoreServletTest {
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testget() throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter writer = new PrintWriter(stringWriter);
+    when(response.getWriter()).thenReturn(writer);
+
+    when(request.getRemoteAddr()).thenReturn("9.9.9.9");
+
+    Datastore mockdatastore = mock(Datastore.class);
+    KeyFactory mockKeyFactory = mock(KeyFactory.class);
+    when(mockdatastore.newKeyFactory()).thenReturn(mockKeyFactory);
+
+    IncompleteKey mockKey = mock(IncompleteKey.class);
+    when(mockKeyFactory.newKey()).thenReturn(mockKey);
+    QueryResults<Entity> results = mock(QueryResults.class);
+    when(results.hasNext()).thenReturn(false);
+    when(mockdatastore.run(any(Query.class))).thenReturn(results);
+
+    MockedStatic<DatastoreOptions> datastoreOptionsMock =
+        Mockito.mockStatic(DatastoreOptions.class, Mockito.RETURNS_DEEP_STUBS);
+
+    datastoreOptionsMock
+        .when(() -> DatastoreOptions.getDefaultInstance().getService())
+        .thenReturn(mockdatastore);
+    DatastoreServlet servlet = new DatastoreServlet();
+    servlet.doGet(request, response);
+    verify(mockdatastore).add(any(FullEntity.class));
+  }
+}

--- a/flexible/java-17/websocket-jetty/README.md
+++ b/flexible/java-17/websocket-jetty/README.md
@@ -1,0 +1,54 @@
+# App Engine Flexible Environment - Web Socket Example
+
+This sample demonstrates how to use
+[Websockets](https://tools.ietf.org/html/rfc6455) on [Google App Engine Flexible
+Environment](https://cloud.google.com/appengine/docs/flexible/java/) using Java.
+The sample uses the [native Jetty WebSocket Server
+API](http://www.eclipse.org/jetty/documentation/9.4.x/jetty-websocket-server-api.html)
+to create a server-side socket and the [native Jetty WebSocket Client
+API](http://www.eclipse.org/jetty/documentation/9.4.x/jetty-websocket-client-api.html).
+
+## Sample application workflow
+
+1. The sample application creates a server socket using the endpoint  `/echo`.
+1. The homepage (`/`) provides a form to submit a text message to the server
+socket. This creates a client-side socket and sends the message to the server.
+1. The server on receiving the message, echoes the message back to the client.
+1. The message received by the client is stored  in an in-memory cache and is
+   viewable on the homepage.
+
+The sample also provides a Javascript
+[client](src/main/webapp/js_client.jsp)(`/js_client.jsp`) that you can use to
+test against the Websocket server.
+
+## Setup
+
+- [Install](https://cloud.google.com/sdk/) and initialize GCloud SDK. This will
+
+ ```sh
+    gcloud init
+ ```
+
+- If this is your first time creating an app engine application
+
+  ```sh
+    gcloud appengine create
+  ```
+
+## Deploy
+
+The sample application is packaged as a war, and hence will be automatically run
+using the [Java 8/Jetty 9 with Servlet 3.1
+Runtime](https://cloud.google.com/appengine/docs/flexible/java/dev-jetty9).
+
+```sh
+mvn clean package appengine:deploy
+```
+
+You can then direct your browser to `https://YOUR_PROJECT_ID.appspot.com/`
+
+To test the Javascript client, access
+`https://YOUR_PROJECT_ID.appspot.com/js_client.jsp`
+
+Note: This application constructs a Web Socket URL using `getWebSocketAddress`
+in the [SendServlet Class](src/main/java/com/example/flexible/websocket/jettynative/SendServlet.java). The application assumes the latest version of the service.

--- a/flexible/java-17/websocket-jetty/pom.xml
+++ b/flexible/java-17/websocket-jetty/pom.xml
@@ -1,0 +1,208 @@
+<!--
+  Copyright 2024 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.eclipse.jetty.demo</groupId>
+  <artifactId>native-jetty-websocket-example</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <!--
+   The parent pom defines common style checks and testing strategies for our samples.
+   Removing or replacing it should not effect the execution of the samples in anyway.
+ -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.2.2</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <failOnMissingWebXml>false</failOnMissingWebXml> <!-- REQUIRED -->
+    <jetty.version>9.4.54.v20240208</jetty.version>
+    <spring.boot.version>2.7.18</spring.boot.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.32.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-webapp</artifactId>
+      <version>${jetty.version}</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-annotations</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <!-- extra explicit dependency needed because there is a JSP in the sample-->
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>apache-jsp</artifactId>
+      <version>${jetty.version}</version>
+      <classifier>nolog</classifier>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>4.0.1</version>
+      <type>jar</type>
+      <scope>provided</scope>
+    </dependency>
+    <!-- To run websockets client -->
+    <dependency>
+      <groupId>org.eclipse.jetty.websocket</groupId>
+      <artifactId>websocket-client</artifactId>
+      <version>${jetty.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.websocket</groupId>
+      <artifactId>websocket-server</artifactId>
+      <version>${jetty.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.websocket</groupId>
+      <artifactId>websocket-servlet</artifactId>
+      <version>${jetty.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.12</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>${basedir}/src/main/webapp</directory>
+        <filtering>false</filtering>
+      </resource>
+    </resources>
+    <!-- for hot reload of the web application -->
+    <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes
+    </outputDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.4.0</version>
+      </plugin>
+      <!-- for deployment of web application -->
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>appengine-maven-plugin</artifactId>
+        <version>2.8.0</version>
+        <configuration>
+          <projectId>GCLOUD_CONFIG</projectId>
+          <version>GCLOUD_CONFIG</version>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.1.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <mainClass>com.example.flexible.websocket.jettynative.Main</mainClass>
+        </configuration>
+      </plugin>
+      <!-- for local testing of web application -->
+      <plugin>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>${jetty.version}</version>
+        <configuration>
+          <supportedPackagings>jar</supportedPackagings>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+              <mainClass>com.example.flexible.websocket.jettynative.Main</mainClass>
+            </manifest>
+          </archive>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring.boot.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/flexible/java-17/websocket-jetty/src/main/appengine/app.yaml
+++ b/flexible/java-17/websocket-jetty/src/main/appengine/app.yaml
@@ -1,0 +1,33 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+runtime: java
+env: flex
+runtime_config:
+  operating_system: ubuntu22
+  runtime_version: 17
+manual_scaling:
+  instances: 1
+handlers:
+- url: /.*
+  script: this field is required, but ignored
+
+
+
+# For applications which can take advantage of session affinity
+# (where the load balancer will attempt to route multiple connections from
+# the same user to the same App Engine instance), uncomment the folowing:
+
+# network:
+#   session_affinity: true

--- a/flexible/java-17/websocket-jetty/src/main/java/com/example/flexible/websocket/jettynative/ClientSocket.java
+++ b/flexible/java-17/websocket-jetty/src/main/java/com/example/flexible/websocket/jettynative/ClientSocket.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.flexible.websocket.jettynative;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.logging.Logger;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
+
+/**
+ * Basic Echo Client Socket.
+ */
+@WebSocket(maxTextMessageSize = 64 * 1024)
+public class ClientSocket {
+  private Logger logger = Logger.getLogger(ClientSocket.class.getName());
+  private Session session;
+  // stores the messages in-memory.
+  // Note : this is currently an in-memory store for demonstration,
+  // not recommended for production use-cases.
+  private static Collection<String> messages = new ConcurrentLinkedDeque<>();
+
+  @OnWebSocketClose
+  public void onClose(int statusCode, String reason) {
+    logger.fine("Connection closed: " + statusCode + ":" + reason);
+    this.session = null;
+  }
+
+  @OnWebSocketConnect
+  public void onConnect(Session session) {
+    this.session = session;
+  }
+
+  @OnWebSocketMessage
+  public void onMessage(String msg) {
+    logger.fine("Message Received : " + msg);
+    messages.add(msg);
+  }
+
+  // Retrieve all received messages.
+  public static Collection<String> getReceivedMessages() {
+    return Collections.unmodifiableCollection(messages);
+  }
+}

--- a/flexible/java-17/websocket-jetty/src/main/java/com/example/flexible/websocket/jettynative/EchoServlet.java
+++ b/flexible/java-17/websocket-jetty/src/main/java/com/example/flexible/websocket/jettynative/EchoServlet.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.flexible.websocket.jettynative;
+
+import javax.servlet.annotation.WebServlet;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
+import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
+import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
+import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+
+/*
+ * Server-side WebSocket upgraded on /echo servlet.
+ */
+@SuppressWarnings("serial")
+@WebServlet(
+    name = "Echo WebSocket Servlet",
+    urlPatterns = {"/echo"})
+public class EchoServlet extends WebSocketServlet implements WebSocketCreator {
+  @Override
+  public void configure(WebSocketServletFactory factory) {
+    factory.setCreator(this);
+  }
+
+  @Override
+  public Object createWebSocket(
+      ServletUpgradeRequest servletUpgradeRequest, ServletUpgradeResponse servletUpgradeResponse) {
+    return new ServerSocket();
+  }
+}

--- a/flexible/java-17/websocket-jetty/src/main/java/com/example/flexible/websocket/jettynative/Main.java
+++ b/flexible/java-17/websocket-jetty/src/main/java/com/example/flexible/websocket/jettynative/Main.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.flexible.websocket.jettynative;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import org.apache.tomcat.util.scan.StandardJarScanFilter;
+import org.apache.tomcat.util.scan.StandardJarScanner;
+import org.eclipse.jetty.annotations.AnnotationConfiguration;
+import org.eclipse.jetty.apache.jsp.JettyJasperInitializer;
+import org.eclipse.jetty.jsp.JettyJspServlet;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.util.component.AbstractLifeCycle;
+import org.eclipse.jetty.webapp.Configuration;
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.webapp.WebInfConfiguration;
+
+/**
+ * Starts up the server, including a DefaultServlet that handles static files, and any servlet
+ * classes annotated with the @WebServlet annotation.
+ */
+public class Main {
+
+  public static void main(String[] args) throws Exception {
+
+    // Create a server that listens on port 8080.
+    Server server = new Server(8080);
+    WebAppContext webAppContext = new WebAppContext();
+    server.setHandler(webAppContext);
+
+    // Load static content from inside the jar file.
+    URL webAppDir = Main.class.getClassLoader().getResource("WEB-INF/");
+    System.out.println(webAppDir);
+    webAppContext.setResourceBase(webAppDir.toURI().toString());
+
+    // Enable annotations so the server sees classes annotated with @WebServlet.
+    webAppContext.setConfigurations(
+        new Configuration[] {
+          new AnnotationConfiguration(), new WebInfConfiguration(),
+        });
+
+    webAppContext.setAttribute(
+        "org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern",
+        ".*/target/classes/|.*\\.jar");
+    enableEmbeddedJspSupport(webAppContext);
+
+    ServletHolder holderAltMapping = new ServletHolder();
+    holderAltMapping.setName("index.jsp");
+    holderAltMapping.setForcedPath("/index.jsp");
+    webAppContext.addServlet(holderAltMapping, "/");
+
+    // Start the server! 🚀
+    server.start();
+    System.out.println("Server started!");
+
+    // Keep the main thread alive while the server is running.
+    server.join();
+  }
+
+  private static void enableEmbeddedJspSupport(ServletContextHandler servletContextHandler)
+      throws IOException {
+    // Establish Scratch directory for the servlet context (used by JSP compilation)
+    File tempDir = new File(System.getProperty("java.io.tmpdir"));
+    File scratchDir = new File(tempDir.toString(), "embedded-jetty-jsp");
+
+    if (!scratchDir.exists()) {
+      if (!scratchDir.mkdirs()) {
+        throw new IOException("Unable to create scratch directory: " + scratchDir);
+      }
+    }
+    servletContextHandler.setAttribute("javax.servlet.context.tempdir", scratchDir);
+
+    // Set Classloader of Context to be sane (needed for JSTL)
+    // JSP requires a non-System classloader, this simply wraps the
+    // embedded System classloader in a way that makes it suitable
+    // for JSP to use
+    ClassLoader jspClassLoader = new URLClassLoader(new URL[0], Main.class.getClassLoader());
+    servletContextHandler.setClassLoader(jspClassLoader);
+
+    // Manually call JettyJasperInitializer on context startup
+    servletContextHandler.addBean(new JspStarter(servletContextHandler));
+
+    // Create / Register JSP Servlet (must be named "jsp" per spec)
+    ServletHolder holderJsp = new ServletHolder("jsp", JettyJspServlet.class);
+    holderJsp.setInitOrder(0);
+    holderJsp.setInitParameter("logVerbosityLevel", "DEBUG");
+    holderJsp.setInitParameter("fork", "false");
+    holderJsp.setInitParameter("xpoweredBy", "false");
+    holderJsp.setInitParameter("compilerTargetVM", "1.8");
+    holderJsp.setInitParameter("compilerSourceVM", "1.8");
+    holderJsp.setInitParameter("keepgenerated", "true");
+    servletContextHandler.addServlet(holderJsp, "*.jsp");
+  }
+
+  /**
+   * JspStarter for embedded ServletContextHandlers
+   *
+   * <p>This is added as a bean that is a jetty LifeCycle on the ServletContextHandler. This bean's
+   * doStart method will be called as the ServletContextHandler starts, and will call the
+   * ServletContainerInitializer for the jsp engine.
+   */
+  public static class JspStarter extends AbstractLifeCycle
+      implements ServletContextHandler.ServletContainerInitializerCaller {
+    JettyJasperInitializer sci;
+    ServletContextHandler context;
+
+    public JspStarter(ServletContextHandler context) {
+      this.sci = new JettyJasperInitializer();
+      this.context = context;
+      String skip = "apache-*,ecj-*,jetty-*,asm-*,javax.servlet-*"
+          + "javax.annotation-*,taglibs-standard-spec-*,*.jar";
+      StandardJarScanner jarScanner = new StandardJarScanner();
+      StandardJarScanFilter jarScanFilter = new StandardJarScanFilter();
+      jarScanFilter.setTldSkip(skip);
+      jarScanner.setJarScanFilter(jarScanFilter);
+      this.context.setAttribute("org.apache.tomcat.JarScanner", jarScanner);
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+      ClassLoader old = Thread.currentThread().getContextClassLoader();
+      Thread.currentThread().setContextClassLoader(context.getClassLoader());
+      try {
+        sci.onStartup(null, context.getServletContext());
+        super.doStart();
+      } finally {
+        Thread.currentThread().setContextClassLoader(old);
+      }
+    }
+  }
+}

--- a/flexible/java-17/websocket-jetty/src/main/java/com/example/flexible/websocket/jettynative/SendServlet.java
+++ b/flexible/java-17/websocket-jetty/src/main/java/com/example/flexible/websocket/jettynative/SendServlet.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.flexible.websocket.jettynative;
+
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.Future;
+import java.util.logging.Logger;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+
+@WebServlet("/send")
+/** Servlet that sends the message sent over POST to over a websocket connection. */
+public class SendServlet extends HttpServlet {
+
+  private Logger logger = Logger.getLogger(SendServlet.class.getName());
+
+  private static final String ENDPOINT = "/echo";
+  private static final String WEBSOCKET_PROTOCOL_PREFIX = "ws://";
+  private static final String WEBSOCKET_HTTPS_PROTOCOL_PREFIX = "wss://";
+  private static final String APPENGINE_HOST_SUFFIX = ".appspot.com";
+
+  // GAE_INSTANCE environment is used to detect App Engine Flexible Environment
+  private static final String GAE_INSTANCE_VAR = "GAE_INSTANCE";
+  // GOOGLE_CLOUD_PROJECT environment variable is set to the GCP project ID on App Engine Flexible.
+  private static final String GOOGLE_CLOUD_PROJECT_ENV_VAR = "GOOGLE_CLOUD_PROJECT";
+  // GAE_SERVICE environment variable is set to the GCP service name.
+  private static final String GAE_SERVICE_ENV_VAR = "GAE_SERVICE";
+
+  private final HttpClient httpClient;
+  private final WebSocketClient webSocketClient;
+  private final ClientSocket clientSocket;
+
+  public SendServlet() {
+    this.httpClient = createHttpClient();
+    this.webSocketClient = createWebSocketClient();
+    this.clientSocket = new ClientSocket();
+  }
+
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String message = request.getParameter("message");
+    try {
+      sendMessageOverWebSocket(message);
+      response.sendRedirect("/");
+    } catch (Exception e) {
+      logger.severe("Error sending message over socket: " + e.getMessage());
+      e.printStackTrace(response.getWriter());
+      response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR_500);
+    }
+  }
+
+  private HttpClient createHttpClient() {
+    HttpClient httpClient;
+    if (System.getenv(GAE_INSTANCE_VAR) != null) {
+      // If on HTTPS, create client with SSL Context
+      SslContextFactory.Client sslContextFactory = new SslContextFactory.Client();
+      httpClient = new HttpClient(sslContextFactory);
+    } else {
+      // local testing on HTTP
+      httpClient = new HttpClient();
+    }
+    return httpClient;
+  }
+
+  private WebSocketClient createWebSocketClient() {
+    return new WebSocketClient(this.httpClient);
+  }
+
+  private void sendMessageOverWebSocket(String message) throws Exception {
+    if (!httpClient.isRunning()) {
+      try {
+        httpClient.start();
+      } catch (URISyntaxException e) {
+        e.printStackTrace();
+      }
+    }
+    if (!webSocketClient.isRunning()) {
+      try {
+        webSocketClient.start();
+      } catch (URISyntaxException e) {
+        e.printStackTrace();
+      }
+    }
+    ClientUpgradeRequest request = new ClientUpgradeRequest();
+    // Attempt connection
+    Future<Session> future =
+        webSocketClient.connect(clientSocket, new URI(getWebSocketAddress()), request);
+    // Wait for Connect
+    Session session = future.get();
+    // Send a message
+    session.getRemote().sendString(message);
+    // Close session
+    session.close();
+  }
+
+  /**
+   * Returns the host:port/echo address a client needs to use to communicate with the server. On App
+   * engine Flex environments, result will be in the form wss://project-id.appspot.com/echo
+   */
+  public static String getWebSocketAddress() {
+    // Use ws://127.0.0.1:8080/echo when testing locally
+    String webSocketHost = "127.0.0.1:8080";
+    String webSocketProtocolPrefix = WEBSOCKET_PROTOCOL_PREFIX;
+
+    // On App Engine flexible environment, use wss://project-id.appspot.com/echo
+    if (System.getenv(GAE_INSTANCE_VAR) != null) {
+      String projectId = System.getenv(GOOGLE_CLOUD_PROJECT_ENV_VAR);
+      if (projectId != null) {
+        String serviceName = System.getenv(GAE_SERVICE_ENV_VAR);
+        webSocketHost = serviceName + "-dot-" + projectId + APPENGINE_HOST_SUFFIX;
+      }
+      Preconditions.checkNotNull(webSocketHost);
+      // Use wss:// instead of ws:// protocol when connecting over https
+      webSocketProtocolPrefix = WEBSOCKET_HTTPS_PROTOCOL_PREFIX;
+    }
+    return webSocketProtocolPrefix + webSocketHost + ENDPOINT;
+  }
+}

--- a/flexible/java-17/websocket-jetty/src/main/java/com/example/flexible/websocket/jettynative/ServerSocket.java
+++ b/flexible/java-17/websocket-jetty/src/main/java/com/example/flexible/websocket/jettynative/ServerSocket.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.flexible.websocket.jettynative;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
+
+/*
+ * Server-side WebSocket : echoes received message back to client.
+ */
+@WebSocket(maxTextMessageSize = 64 * 1024)
+public class ServerSocket {
+  private Logger logger = Logger.getLogger(SendServlet.class.getName());
+  private Session session;
+
+  @OnWebSocketConnect
+  public void onWebSocketConnect(Session session) {
+    this.session = session;
+    logger.fine("Socket Connected: " + session);
+  }
+
+  @OnWebSocketMessage
+  public void onWebSocketText(String message) {
+    logger.fine("Received message: " + message);
+    try {
+      // echo message back to client
+      this.session.getRemote().sendString(message);
+    } catch (IOException e) {
+      logger.severe("Error echoing message: " + e.getMessage());
+    }
+  }
+
+  @OnWebSocketClose
+  public void onWebSocketClose(int statusCode, String reason) {
+    logger.fine("Socket Closed: [" + statusCode + "] " + reason);
+  }
+
+  @OnWebSocketError
+  public void onWebSocketError(Throwable cause) {
+    logger.severe("Websocket error : " + cause.getMessage());
+  }
+}

--- a/flexible/java-17/websocket-jetty/src/main/webapp/WEB-INF/index.jsp
+++ b/flexible/java-17/websocket-jetty/src/main/webapp/WEB-INF/index.jsp
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2024 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<%@ page import="com.example.flexible.websocket.jettynative.ClientSocket" %>
+<html>
+  <head>
+    <meta http-equiv="refresh" content="10">
+  </head>
+  <title>Send a message </title>
+  <body>
+    <h3> Publish a message </h3>
+    <form action="send" method="POST">
+      <label for="message">Message:</label>
+      <input id="message" type="input" name="message" />
+      <input id="send"  type="submit" value="Send" />
+    </form>
+    <h3> Last received messages </h3>
+    <%= ClientSocket.getReceivedMessages() %>
+  </body>
+</html>

--- a/flexible/java-17/websocket-jetty/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/flexible/java-17/websocket-jetty/src/main/webapp/WEB-INF/jetty-web.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2024 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+  <Set name="parentLoaderPriority">true</Set>
+  <Call name="prependServerClass">
+    <Arg>-org.eclipse.jetty.</Arg>
+  </Call>
+</Configure>

--- a/flexible/java-17/websocket-jetty/src/main/webapp/WEB-INF/js_client.jsp
+++ b/flexible/java-17/websocket-jetty/src/main/webapp/WEB-INF/js_client.jsp
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2024 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html>
+<%@ page import="com.example.flexible.websocket.jettynative.SendServlet" %>
+  <head>
+    <title>Google App Engine Flexible Environment - WebSocket Echo</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  </head>
+  <body>
+    <p>Echo demo</p>
+    <form id="echo-form">
+      <textarea id="echo-text" placeholder="Enter some text..."></textarea>
+      <button type="submit">Send</button>
+    </form>
+
+    <div>
+      <p>Messages:</p>
+      <ul id="echo-response"></ul>
+    </div>
+
+    <div>
+      <p>Status:</p>
+      <ul id="echo-status"></ul>
+    </div>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+    <script>
+    $(function() {
+      var webSocketUri =  "<%=SendServlet.getWebSocketAddress() %>";
+
+      /* Get elements from the page */
+      var form = $('#echo-form');
+      var textarea = $('#echo-text');
+      var output = $('#echo-response');
+      var status = $('#echo-status');
+
+      /* Helper to keep an activity log on the page. */
+      function log(text){
+        status.append($('<li>').text(text))
+      }
+
+      /* Establish the WebSocket connection and register event handlers. */
+      var websocket = new WebSocket(webSocketUri);
+
+      websocket.onopen = function() {
+        log('Connected : ' + webSocketUri);
+      };
+
+      websocket.onclose = function() {
+        log('Closed');
+      };
+
+      websocket.onmessage = function(e) {
+        log('Message received');
+        output.append($('<li>').text(e.data));
+      };
+
+      websocket.onerror = function(e) {
+        log('Error (see console)');
+        console.log(e);
+      };
+
+      /* Handle form submission and send a message to the websocket. */
+      form.submit(function(e) {
+        e.preventDefault();
+        var data = textarea.val();
+        websocket.send(data);
+      });
+    });
+    </script>
+  </body>
+</html>

--- a/flexible/java-17/websocket-jetty/src/test/java/com/example/flexible/websocket/jettynative/ClientSocketTest.java
+++ b/flexible/java-17/websocket-jetty/src/test/java/com/example/flexible/websocket/jettynative/ClientSocketTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.flexible.websocket.jettynative;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ClientSocketTest {
+  ClientSocket socket;
+
+  @Before
+  public void setUp() {
+    socket = new ClientSocket();
+  }
+
+  @Test
+  public void testOnMessage() {
+    assertEquals(ClientSocket.getReceivedMessages().size(), 0);
+    socket.onMessage("test");
+    assertEquals(ClientSocket.getReceivedMessages().size(), 1);
+  }
+}

--- a/flexible/java-17/websocket-jetty/src/test/java/com/example/flexible/websocket/jettynative/SendServletTest.java
+++ b/flexible/java-17/websocket-jetty/src/test/java/com/example/flexible/websocket/jettynative/SendServletTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.flexible.websocket.jettynative;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class SendServletTest {
+  @Test
+  public void testGetWebSocketAddress() {
+    assertTrue(SendServlet.getWebSocketAddress().contains("/echo"));
+  }
+}


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Migrate java-11 cloudstorage, websocket-jetty, datastore sample app to use Java 17 (and later). 
Java 20+ might have warning at compile but the app runs as expected

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [X] `pom.xml` parent set to latest `shared-configuration`
- [X] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [X] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/javniceea-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
