### PR TITLE
chore(CODEOWNERS): Add cloud-samples-infra team to repo config ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,9 +16,9 @@
 
 # Repo owner. cloud-samples-reviewer is limited to samples ownership.
 * @GoogleCloudPlatform/java-samples-reviewers @yoshi-approver @GoogleCloudPlatform/cloud-samples-reviewers
-/* @GoogleCloudPlatform/java-samples-reviewers @yoshi-approver
-.github @GoogleCloudPlatform/java-samples-reviewers @yoshi-approver
-.kokoro @GoogleCloudPlatform/java-samples-reviewers @yoshi-approver
+/* @GoogleCloudPlatform/java-samples-reviewers @GoogleCloudPlatform/cloud-samples-infra @yoshi-approver
+.github @GoogleCloudPlatform/java-samples-reviewers @GoogleCloudPlatform/cloud-samples-infra @yoshi-approver
+.kokoro @GoogleCloudPlatform/java-samples-reviewers @GoogleCloudPlatform/cloud-samples-infra @yoshi-approver
 
 # Serverless, Orchestration, DevOps
 /container-registry              @GoogleCloudPlatform/java-samples-reviewers @yoshi-approver @GoogleCloudPlatform/cloud-samples-reviewers


### PR DESCRIPTION
## Description

Fixes b/368475378, parallels https://github.com/GoogleCloudPlatform/nodejs-docs-samples/pull/3870

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
