### PR TITLE
Creating Java 17 version of CloudStorage sample with Gemini

### DIFF
--- a/flexible/java-17/cloudstorage/README.md
+++ b/flexible/java-17/cloudstorage/README.md
@@ -1,0 +1,40 @@
+# Cloud Storage sample for App Engine Flex
+
+<a
+href="https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=flexible/cloudstorage/README.md">
+<img alt="Open in Cloud Shell" src
+="http://gstatic.com/cloudssh/images/open-btn.png"></a>
+
+This sample demonstrates how to use [Cloud
+Storage](https://cloud.google.com/storage/) on Google Managed VMs.
+
+## Setup
+
+Before you can run or deploy the sample, you will need to do the following:
+
+1. Enable the Cloud Storage API in the [Google Developers
+   Console](https://console.developers.google.com/project/_/apiui/apiview/storage/overview).
+1. Create a Cloud Storage Bucket. You can do this with the [Google Cloud
+   SDK](https://cloud.google.com/sdk) using the following command:
+
+  ```sh
+  gsutil mb gs://[your-bucket-name]
+  ```
+
+1. Set the default ACL on your bucket to public read in order to serve files
+   directly from Cloud Storage. You can do this with the [Google Cloud
+   SDK](https://cloud.google.com/sdk) using the following command:
+
+  ```sh
+  gsutil defacl set public-read gs://[your-bucket-name]
+  ```
+
+1. Update the bucket name in `src/main/appengine/app.yaml`. This makes the
+   bucket name an environment variable in deployment. You still need to set the
+   environment variable when running locally, as shown below.
+
+## Deploying
+
+    ```sh
+    mvn clean package appengine:deploy
+    ```

--- a/flexible/java-17/cloudstorage/pom.xml
+++ b/flexible/java-17/cloudstorage/pom.xml
@@ -1,0 +1,147 @@
+<!--
+  Copyright 2023 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <groupId>com.example.flexible</groupId>
+  <artifactId>flexible-cloudstorage</artifactId>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.2.0</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+
+    <failOnMissingWebXml>false</failOnMissingWebXml> <!-- REQUIRED -->
+
+    <appengine.maven.plugin>2.8.0</appengine.maven.plugin>
+
+    <spring.boot.version>2.7.18</spring.boot.version>
+  </properties>
+
+  <!-- [START gae_flex_storage_dependencies] -->
+  <!--  Using libraries-bom to manage versions.
+  See https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.32.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring.boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-storage</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <type>jar</type>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit-pioneer</groupId>
+      <artifactId>junit-pioneer</artifactId>
+      <version>2.2.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+  <!-- [END gae_flex_storage_dependencies] -->
+  <build>
+    <!-- for hot reload of the web application -->
+    <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes</outputDirectory>
+    <plugins>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>appengine-maven-plugin</artifactId>
+        <version>${appengine.maven.plugin}</version>
+        <configuration>
+          <projectId>GCLOUD_CONFIG</projectId>
+          <version>GCLOUD_CONFIG</version>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring.boot.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>**/*Test*.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/flexible/java-17/cloudstorage/src/main/appengine/app.yaml
+++ b/flexible/java-17/cloudstorage/src/main/appengine/app.yaml
@@ -1,0 +1,27 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# [START gae_flex_cloudstorage_yaml]
+runtime: java
+env: flex
+runtime_config:
+  operating_system: ubuntu22
+  runtime_version: 17
+handlers:
+- url: /.*
+  script: this field is required, but ignored
+
+env_variables:
+  BUCKET_NAME: YOUR-BUCKET-NAME
+# [END gae_flex_cloudstorage_yaml]

--- a/flexible/java-17/cloudstorage/src/main/java/com/example/cloudstorage/Main.java
+++ b/flexible/java-17/cloudstorage/src/main/java/com/example/cloudstorage/Main.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.cloudstorage;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.ServletComponentScan;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@SpringBootApplication
+@ServletComponentScan("com.example.cloudstorage")
+public class Main {
+  public static void main(String[] args) throws Exception {
+    SpringApplication.run(Main.class, args);
+  }
+}

--- a/flexible/java-17/cloudstorage/src/main/java/com/example/cloudstorage/UploadServlet.java
+++ b/flexible/java-17/cloudstorage/src/main/java/com/example/cloudstorage/UploadServlet.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.cloudstorage;
+
+import com.google.cloud.storage.Acl;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.MultipartConfig;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.Part;
+
+// [START gae_flex_storage_app]
+@SuppressWarnings("serial")
+@WebServlet(name = "upload", value = "/upload")
+@MultipartConfig()
+public class UploadServlet extends HttpServlet {
+
+  private static final String BUCKET_NAME =
+      System.getenv().getOrDefault("BUCKET_NAME", "my-test-bucket");
+  private static Storage storage = null;
+
+  public UploadServlet() {
+    storage = StorageOptions.getDefaultInstance().getService();
+  }
+
+  @Override
+  public void doPost(HttpServletRequest req, HttpServletResponse resp)
+      throws IOException, ServletException {
+    final Part filePart = req.getPart("file");
+    final String fileName = filePart.getSubmittedFileName();
+    // Modify access list to allow all users with link to read file
+    List<Acl> acls = new ArrayList<>();
+    acls.add(Acl.of(Acl.User.ofAllUsers(), Acl.Role.READER));
+    // the inputstream is closed by default, so we don't need to close it here
+    Blob blob =
+        storage.create(
+            BlobInfo.newBuilder(BUCKET_NAME, fileName).setAcl(acls).build(),
+            filePart.getInputStream());
+
+    // return the public download link
+    resp.getWriter().print(blob.getMediaLink());
+  }
+}
+// [END gae_flex_storage_app]

--- a/flexible/java-17/cloudstorage/src/main/webapp/index.html
+++ b/flexible/java-17/cloudstorage/src/main/webapp/index.html
@@ -1,0 +1,25 @@
+<!--
+ Copyright 2023 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<html>
+  <title>App Engine Flex Cloud Storage Sample</title>
+  <body>
+    <p>Select a file to upload to your Google Cloud Storage bucket.</p>
+    <form method="POST" action="/upload" enctype="multipart/form-data">
+      <input type="file" name="file"> <input type="submit">
+    </form>
+  </body>
+</html>

--- a/flexible/java-17/cloudstorage/src/test/java/com/example/cloudstorage/UploadServletTest.java
+++ b/flexible/java-17/cloudstorage/src/test/java/com/example/cloudstorage/UploadServletTest.java
@@ -33,11 +33,11 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.Part;
 import org.junit.Test;
-import org.mockito.MockedStatic;
 import org.mockito.InjectMocks;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 @ExtendWith(MockitoExtension.class)

--- a/flexible/java-17/cloudstorage/src/test/java/com/example/cloudstorage/UploadServletTest.java
+++ b/flexible/java-17/cloudstorage/src/test/java/com/example/cloudstorage/UploadServletTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.cloudstorage;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.Part;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.InjectMocks;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+public class UploadServletTest {
+
+  @Mock private Storage mockStorage;
+  @Mock private Blob mockBlob;
+
+  @InjectMocks private UploadServlet servlet;
+
+  @Test
+  public void testPost() throws Exception {
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter writer = new PrintWriter(stringWriter);
+    when(response.getWriter()).thenReturn(writer);
+
+    try (BufferedReader reader = mock(BufferedReader.class)) {
+      when(request.getReader()).thenReturn(reader);
+    }
+    Part filePart = mock(Part.class);
+    when(filePart.getSubmittedFileName()).thenReturn("testfile.txt");
+    when(filePart.getInputStream()).thenReturn(mock(InputStream.class));
+    when(request.getPart("file")).thenReturn(filePart);
+    when(mockBlob.getMediaLink()).thenReturn("test blob data");
+    when(mockStorage.create(any(BlobInfo.class), any(InputStream.class))).thenReturn(mockBlob);
+
+    servlet.doPost(request, response);
+    assertTrue(stringWriter.toString().contains("test blob data"));
+  }
+}


### PR DESCRIPTION
This PR creates a Java 17 version of the Cloud Storage sample.
The sample was created with Gemini during a livestream, and contains a change to the test to use @ExtendsWith and MockitoExtension instead of the existing Mock approach for StorageOptions..
