### PR TITLE
feat(dataplex): add code samples for Entry Group

### DIFF
--- a/dataplex/snippets/src/main/java/dataplex/CreateEntryGroup.java
+++ b/dataplex/snippets/src/main/java/dataplex/CreateEntryGroup.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataplex;
+
+// [START dataplex_create_entry_group]
+import com.google.cloud.dataplex.v1.CatalogServiceClient;
+import com.google.cloud.dataplex.v1.EntryGroup;
+import com.google.cloud.dataplex.v1.LocationName;
+
+// Samples to create Entry Group
+public class CreateEntryGroup {
+
+  public static void main(String[] args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    // Available locations: https://cloud.google.com/dataplex/docs/locations
+    String location = "MY_LOCATION";
+    String entryGroupId = "MY_ENTRY_GROUP_ID";
+
+    LocationName locationName = LocationName.of(projectId, location);
+    EntryGroup createdEntryGroup = createEntryGroup(locationName, entryGroupId);
+    System.out.println("Successfully created entry group: " + createdEntryGroup.getName());
+  }
+
+  public static EntryGroup createEntryGroup(LocationName locationName, String entryGroupId)
+      throws Exception {
+    EntryGroup entryGroup =
+        EntryGroup.newBuilder().setDescription("description of the entry group").build();
+
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources,
+    // or use "try-with-close" statement to do this automatically.
+    try (CatalogServiceClient client = CatalogServiceClient.create()) {
+      return client.createEntryGroupAsync(locationName, entryGroup, entryGroupId).get();
+    }
+  }
+}
+// [END dataplex_create_entry_group]

--- a/dataplex/snippets/src/main/java/dataplex/CreateEntryGroup.java
+++ b/dataplex/snippets/src/main/java/dataplex/CreateEntryGroup.java
@@ -31,13 +31,13 @@ public class CreateEntryGroup {
     String location = "MY_LOCATION";
     String entryGroupId = "MY_ENTRY_GROUP_ID";
 
-    LocationName locationName = LocationName.of(projectId, location);
-    EntryGroup createdEntryGroup = createEntryGroup(locationName, entryGroupId);
+    EntryGroup createdEntryGroup = createEntryGroup(projectId, location, entryGroupId);
     System.out.println("Successfully created entry group: " + createdEntryGroup.getName());
   }
 
-  public static EntryGroup createEntryGroup(LocationName locationName, String entryGroupId)
+  public static EntryGroup createEntryGroup(String projectId, String location, String entryGroupId)
       throws Exception {
+    LocationName locationName = LocationName.of(projectId, location);
     EntryGroup entryGroup =
         EntryGroup.newBuilder().setDescription("description of the entry group").build();
 

--- a/dataplex/snippets/src/main/java/dataplex/DeleteEntryGroup.java
+++ b/dataplex/snippets/src/main/java/dataplex/DeleteEntryGroup.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataplex;
+
+// [START dataplex_delete_entry_group]
+import com.google.cloud.dataplex.v1.CatalogServiceClient;
+import com.google.cloud.dataplex.v1.EntryGroupName;
+
+// Sample to delete Entry Group
+public class DeleteEntryGroup {
+
+  public static void main(String[] args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    // Available locations: https://cloud.google.com/dataplex/docs/locations
+    String location = "MY_LOCATION";
+    String entryGroupId = "MY_ENTRY_GROUP_ID";
+
+    EntryGroupName entryGroupName = EntryGroupName.of(projectId, location, entryGroupId);
+    deleteEntryGroup(entryGroupName);
+    System.out.println("Successfully deleted entry group");
+  }
+
+  public static void deleteEntryGroup(EntryGroupName entryGroupName) throws Exception {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources,
+    // or use "try-with-close" statement to do this automatically.
+    try (CatalogServiceClient client = CatalogServiceClient.create()) {
+      client.deleteEntryGroupAsync(entryGroupName).get();
+    }
+  }
+}
+// [END dataplex_delete_entry_group]

--- a/dataplex/snippets/src/main/java/dataplex/DeleteEntryGroup.java
+++ b/dataplex/snippets/src/main/java/dataplex/DeleteEntryGroup.java
@@ -30,12 +30,14 @@ public class DeleteEntryGroup {
     String location = "MY_LOCATION";
     String entryGroupId = "MY_ENTRY_GROUP_ID";
 
-    EntryGroupName entryGroupName = EntryGroupName.of(projectId, location, entryGroupId);
-    deleteEntryGroup(entryGroupName);
+    deleteEntryGroup(projectId, location, entryGroupId);
     System.out.println("Successfully deleted entry group");
   }
 
-  public static void deleteEntryGroup(EntryGroupName entryGroupName) throws Exception {
+  public static void deleteEntryGroup(String projectId, String location, String entryGroupId)
+      throws Exception {
+    EntryGroupName entryGroupName = EntryGroupName.of(projectId, location, entryGroupId);
+
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources,

--- a/dataplex/snippets/src/main/java/dataplex/GetEntryGroup.java
+++ b/dataplex/snippets/src/main/java/dataplex/GetEntryGroup.java
@@ -32,12 +32,14 @@ public class GetEntryGroup {
     String location = "MY_LOCATION";
     String entryGroupId = "MY_ENTRY_GROUP_ID";
 
-    EntryGroupName entryGroupName = EntryGroupName.of(projectId, location, entryGroupId);
-    EntryGroup entryGroup = getEntryGroup(entryGroupName);
+    EntryGroup entryGroup = getEntryGroup(projectId, location, entryGroupId);
     System.out.println("Entry group retrieved successfully: " + entryGroup.getName());
   }
 
-  public static EntryGroup getEntryGroup(EntryGroupName entryGroupName) throws IOException {
+  public static EntryGroup getEntryGroup(String projectId, String location, String entryGroupId)
+      throws IOException {
+    EntryGroupName entryGroupName = EntryGroupName.of(projectId, location, entryGroupId);
+
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources,

--- a/dataplex/snippets/src/main/java/dataplex/GetEntryGroup.java
+++ b/dataplex/snippets/src/main/java/dataplex/GetEntryGroup.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataplex;
+
+// [START dataplex_get_entry_group]
+import com.google.cloud.dataplex.v1.CatalogServiceClient;
+import com.google.cloud.dataplex.v1.EntryGroup;
+import com.google.cloud.dataplex.v1.EntryGroupName;
+import java.io.IOException;
+
+// Sample to get Entry Group
+public class GetEntryGroup {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    // Available locations: https://cloud.google.com/dataplex/docs/locations
+    String location = "MY_LOCATION";
+    String entryGroupId = "MY_ENTRY_GROUP_ID";
+
+    EntryGroupName entryGroupName = EntryGroupName.of(projectId, location, entryGroupId);
+    EntryGroup entryGroup = getEntryGroup(entryGroupName);
+    System.out.println("Entry group retrieved successfully: " + entryGroup.getName());
+  }
+
+  public static EntryGroup getEntryGroup(EntryGroupName entryGroupName) throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources,
+    // or use "try-with-close" statement to do this automatically.
+    try (CatalogServiceClient client = CatalogServiceClient.create()) {
+      return client.getEntryGroup(entryGroupName);
+    }
+  }
+}
+// [END dataplex_get_entry_group]

--- a/dataplex/snippets/src/main/java/dataplex/ListEntryGroups.java
+++ b/dataplex/snippets/src/main/java/dataplex/ListEntryGroups.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataplex;
+
+// [START dataplex_list_entry_groups]
+import com.google.cloud.dataplex.v1.CatalogServiceClient;
+import com.google.cloud.dataplex.v1.EntryGroup;
+import com.google.cloud.dataplex.v1.LocationName;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.List;
+
+// Sample to list Entry Groups
+public class ListEntryGroups {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    // Available locations: https://cloud.google.com/dataplex/docs/locations
+    String location = "MY_LOCATION";
+
+    LocationName locationName = LocationName.of(projectId, location);
+    List<EntryGroup> entryGroups = listEntryGroups(locationName);
+    entryGroups.forEach(
+        entryGroup -> System.out.println("Entry group name: " + entryGroup.getName()));
+  }
+
+  public static List<EntryGroup> listEntryGroups(LocationName locationName) throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources,
+    // or use "try-with-close" statement to do this automatically.
+    try (CatalogServiceClient client = CatalogServiceClient.create()) {
+      CatalogServiceClient.ListEntryGroupsPagedResponse listEntryGroupsResponse =
+          client.listEntryGroups(locationName);
+      return ImmutableList.copyOf(listEntryGroupsResponse.iterateAll());
+    }
+  }
+}
+// [END dataplex_list_entry_groups]

--- a/dataplex/snippets/src/main/java/dataplex/ListEntryGroups.java
+++ b/dataplex/snippets/src/main/java/dataplex/ListEntryGroups.java
@@ -33,13 +33,15 @@ public class ListEntryGroups {
     // Available locations: https://cloud.google.com/dataplex/docs/locations
     String location = "MY_LOCATION";
 
-    LocationName locationName = LocationName.of(projectId, location);
-    List<EntryGroup> entryGroups = listEntryGroups(locationName);
+    List<EntryGroup> entryGroups = listEntryGroups(projectId, location);
     entryGroups.forEach(
         entryGroup -> System.out.println("Entry group name: " + entryGroup.getName()));
   }
 
-  public static List<EntryGroup> listEntryGroups(LocationName locationName) throws IOException {
+  public static List<EntryGroup> listEntryGroups(String projectId, String location)
+      throws IOException {
+    LocationName locationName = LocationName.of(projectId, location);
+
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources,

--- a/dataplex/snippets/src/main/java/dataplex/ListEntryGroups.java
+++ b/dataplex/snippets/src/main/java/dataplex/ListEntryGroups.java
@@ -49,6 +49,7 @@ public class ListEntryGroups {
     try (CatalogServiceClient client = CatalogServiceClient.create()) {
       CatalogServiceClient.ListEntryGroupsPagedResponse listEntryGroupsResponse =
           client.listEntryGroups(locationName);
+      // Paging is implicitly handled by .iterateAll(), all results will be returned
       return ImmutableList.copyOf(listEntryGroupsResponse.iterateAll());
     }
   }

--- a/dataplex/snippets/src/main/java/dataplex/UpdateEntryGroup.java
+++ b/dataplex/snippets/src/main/java/dataplex/UpdateEntryGroup.java
@@ -32,15 +32,15 @@ public class UpdateEntryGroup {
     String location = "MY_LOCATION";
     String entryGroupId = "MY_ENTRY_GROUP_ID";
 
-    EntryGroupName entryGroupName = EntryGroupName.of(projectId, location, entryGroupId);
-    EntryGroup updatedEntryGroup = updateEntryGroup(entryGroupName);
+    EntryGroup updatedEntryGroup = updateEntryGroup(projectId, location, entryGroupId);
     System.out.println("Successfully updated entry group: " + updatedEntryGroup.getName());
   }
 
-  public static EntryGroup updateEntryGroup(EntryGroupName entryGroupName) throws Exception {
+  public static EntryGroup updateEntryGroup(String projectId, String location, String entryGroupId)
+      throws Exception {
     EntryGroup entryGroup =
         EntryGroup.newBuilder()
-            .setName(entryGroupName.toString())
+            .setName(EntryGroupName.of(projectId, location, entryGroupId).toString())
             .setDescription("updated description of the entry group")
             .build();
 

--- a/dataplex/snippets/src/main/java/dataplex/UpdateEntryGroup.java
+++ b/dataplex/snippets/src/main/java/dataplex/UpdateEntryGroup.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataplex;
+
+// [START dataplex_update_entry_group]
+import com.google.cloud.dataplex.v1.CatalogServiceClient;
+import com.google.cloud.dataplex.v1.EntryGroup;
+import com.google.cloud.dataplex.v1.EntryGroupName;
+import com.google.protobuf.FieldMask;
+
+// Sample to update Entry Group
+public class UpdateEntryGroup {
+
+  public static void main(String[] args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    // Available locations: https://cloud.google.com/dataplex/docs/locations
+    String location = "MY_LOCATION";
+    String entryGroupId = "MY_ENTRY_GROUP_ID";
+
+    EntryGroupName entryGroupName = EntryGroupName.of(projectId, location, entryGroupId);
+    EntryGroup updatedEntryGroup = updateEntryGroup(entryGroupName);
+    System.out.println("Successfully updated entry group: " + updatedEntryGroup.getName());
+  }
+
+  public static EntryGroup updateEntryGroup(EntryGroupName entryGroupName) throws Exception {
+    EntryGroup entryGroup =
+        EntryGroup.newBuilder()
+            .setName(entryGroupName.toString())
+            .setDescription("updated description of the entry group")
+            .build();
+
+    // Update mask specifies which fields will be updated.
+    // If empty mask is given, all modifiable fields from the request will be used for update.
+    // If update mask is specified as "*" it is treated as full update,
+    // that means fields not present in the request will be emptied.
+    FieldMask updateMask = FieldMask.newBuilder().addPaths("description").build();
+
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources,
+    // or use "try-with-close" statement to do this automatically.
+    try (CatalogServiceClient client = CatalogServiceClient.create()) {
+      return client.updateEntryGroupAsync(entryGroup, updateMask).get();
+    }
+  }
+}
+// [END dataplex_update_entry_group]

--- a/dataplex/snippets/src/test/java/dataplex/EntryGroupIT.java
+++ b/dataplex/snippets/src/test/java/dataplex/EntryGroupIT.java
@@ -20,8 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.TestCase.assertNotNull;
 
 import com.google.cloud.dataplex.v1.EntryGroup;
-import com.google.cloud.dataplex.v1.EntryGroupName;
-import com.google.cloud.dataplex.v1.LocationName;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
@@ -32,8 +30,7 @@ import org.junit.Test;
 public class EntryGroupIT {
   private static final String ID = UUID.randomUUID().toString().substring(0, 8);
   private static final String LOCATION = "us-central1";
-  private static LocationName locationName;
-  private static EntryGroupName entryGroupName;
+  private static final String entryGroupId = "test-entry-group" + ID;
   private static String expectedEntryGroup;
 
   private static final String PROJECT_ID = requireProjectIdEnvVar();
@@ -53,46 +50,42 @@ public class EntryGroupIT {
   @BeforeClass
   // Set-up code that will be executed before all tests
   public static void setUp() throws Exception {
-    String entryGroupId = "test-entry-group" + ID;
-    locationName = LocationName.of(PROJECT_ID, LOCATION);
-    entryGroupName = EntryGroupName.of(PROJECT_ID, LOCATION, entryGroupId);
     expectedEntryGroup =
         String.format(
             "projects/%s/locations/%s/entryGroups/%s", PROJECT_ID, LOCATION, entryGroupId);
     // Create Entry Group resource that will be used in tests for "get", "list" and "update" methods
-    CreateEntryGroup.createEntryGroup(locationName, entryGroupId);
+    CreateEntryGroup.createEntryGroup(PROJECT_ID, LOCATION, entryGroupId);
   }
 
   @Test
   public void listEntryGroups_returnsListContainingEntryGroupCreatedInSetUp() throws IOException {
-    List<EntryGroup> entryGroups = ListEntryGroups.listEntryGroups(locationName);
+    List<EntryGroup> entryGroups = ListEntryGroups.listEntryGroups(PROJECT_ID, LOCATION);
     assertThat(entryGroups.stream().map(EntryGroup::getName)).contains(expectedEntryGroup);
   }
 
   @Test
   public void getEntryGroup_returnsEntryGroupCreatedInSetUp() throws IOException {
-    EntryGroup entryGroup = GetEntryGroup.getEntryGroup(entryGroupName);
+    EntryGroup entryGroup = GetEntryGroup.getEntryGroup(PROJECT_ID, LOCATION, entryGroupId);
     assertThat(entryGroup.getName()).isEqualTo(expectedEntryGroup);
   }
 
   @Test
   public void updateEntryGroup_returnsUpdatedEntryGroup() throws Exception {
-    EntryGroup entryGroup = UpdateEntryGroup.updateEntryGroup(entryGroupName);
+    EntryGroup entryGroup = UpdateEntryGroup.updateEntryGroup(PROJECT_ID, LOCATION, entryGroupId);
     assertThat(entryGroup.getName()).isEqualTo(expectedEntryGroup);
   }
 
   @Test
   public void createEntryGroup_returnsCreatedEntryGroup() throws Exception {
     String entryGroupIdToCreate = "test-entry-group" + UUID.randomUUID().toString().substring(0, 8);
-    EntryGroupName entryGroupNameToCreate =
-        EntryGroupName.of(PROJECT_ID, LOCATION, entryGroupIdToCreate);
     String expectedEntryGroupToCreate =
         String.format(
             "projects/%s/locations/%s/entryGroups/%s", PROJECT_ID, LOCATION, entryGroupIdToCreate);
 
-    EntryGroup entryGroup = CreateEntryGroup.createEntryGroup(locationName, entryGroupIdToCreate);
+    EntryGroup entryGroup =
+        CreateEntryGroup.createEntryGroup(PROJECT_ID, LOCATION, entryGroupIdToCreate);
     // Clean-up created Entry Group
-    DeleteEntryGroup.deleteEntryGroup(entryGroupNameToCreate);
+    DeleteEntryGroup.deleteEntryGroup(PROJECT_ID, LOCATION, entryGroupIdToCreate);
 
     assertThat(entryGroup.getName()).isEqualTo(expectedEntryGroupToCreate);
   }
@@ -100,19 +93,17 @@ public class EntryGroupIT {
   @Test
   public void deleteEntryGroup_executesTheCallWithoutException() throws Exception {
     String entryGroupIdToDelete = "test-entry-group" + UUID.randomUUID().toString().substring(0, 8);
-    EntryGroupName entryGroupNameToDelete =
-        EntryGroupName.of(PROJECT_ID, LOCATION, entryGroupIdToDelete);
     // Create Entry Group to be deleted
-    CreateEntryGroup.createEntryGroup(locationName, entryGroupIdToDelete);
+    CreateEntryGroup.createEntryGroup(PROJECT_ID, LOCATION, entryGroupIdToDelete);
 
     // No exception means successful call
-    DeleteEntryGroup.deleteEntryGroup(entryGroupNameToDelete);
+    DeleteEntryGroup.deleteEntryGroup(PROJECT_ID, LOCATION, entryGroupIdToDelete);
   }
 
   @AfterClass
   // Clean-up code that will be executed after all tests
   public static void tearDown() throws Exception {
     // Clean-up Entry Group resource created in setUp()
-    DeleteEntryGroup.deleteEntryGroup(entryGroupName);
+    DeleteEntryGroup.deleteEntryGroup(PROJECT_ID, LOCATION, entryGroupId);
   }
 }

--- a/dataplex/snippets/src/test/java/dataplex/EntryGroupIT.java
+++ b/dataplex/snippets/src/test/java/dataplex/EntryGroupIT.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataplex;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.dataplex.v1.EntryGroup;
+import com.google.cloud.dataplex.v1.EntryGroupName;
+import com.google.cloud.dataplex.v1.LocationName;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class EntryGroupIT {
+  private static final String ID = UUID.randomUUID().toString().substring(0, 8);
+  private static final String LOCATION = "us-central1";
+  private static LocationName locationName;
+  private static EntryGroupName entryGroupName;
+  private static String expectedEntryGroup;
+
+  private static final String PROJECT_ID = requireProjectIdEnvVar();
+
+  private static String requireProjectIdEnvVar() {
+    String value = System.getenv("GOOGLE_CLOUD_PROJECT");
+    assertNotNull(
+        "Environment variable GOOGLE_CLOUD_PROJECT is required to perform these tests.", value);
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireProjectIdEnvVar();
+  }
+
+  @BeforeClass
+  // Set-up code that will be executed before all tests
+  public static void setUp() throws Exception {
+    String entryGroupId = "test-entry-group" + ID;
+    locationName = LocationName.of(PROJECT_ID, LOCATION);
+    entryGroupName = EntryGroupName.of(PROJECT_ID, LOCATION, entryGroupId);
+    expectedEntryGroup =
+        String.format(
+            "projects/%s/locations/%s/entryGroups/%s", PROJECT_ID, LOCATION, entryGroupId);
+    // Create Entry Group resource that will be used in tests for "get", "list" and "update" methods
+    CreateEntryGroup.createEntryGroup(locationName, entryGroupId);
+  }
+
+  @Test
+  public void listEntryGroups_returnsListContainingEntryGroupCreatedInSetUp() throws IOException {
+    List<EntryGroup> entryGroups = ListEntryGroups.listEntryGroups(locationName);
+    assertThat(entryGroups.stream().map(EntryGroup::getName)).contains(expectedEntryGroup);
+  }
+
+  @Test
+  public void getEntryGroup_returnsEntryGroupCreatedInSetUp() throws IOException {
+    EntryGroup entryGroup = GetEntryGroup.getEntryGroup(entryGroupName);
+    assertThat(entryGroup.getName()).isEqualTo(expectedEntryGroup);
+  }
+
+  @Test
+  public void updateEntryGroup_returnsUpdatedEntryGroup() throws Exception {
+    EntryGroup entryGroup = UpdateEntryGroup.updateEntryGroup(entryGroupName);
+    assertThat(entryGroup.getName()).isEqualTo(expectedEntryGroup);
+  }
+
+  @Test
+  public void createEntryGroup_returnsCreatedEntryGroup() throws Exception {
+    String entryGroupIdToCreate = "test-entry-group" + UUID.randomUUID().toString().substring(0, 8);
+    EntryGroupName entryGroupNameToCreate =
+        EntryGroupName.of(PROJECT_ID, LOCATION, entryGroupIdToCreate);
+    String expectedEntryGroupToCreate =
+        String.format(
+            "projects/%s/locations/%s/entryGroups/%s", PROJECT_ID, LOCATION, entryGroupIdToCreate);
+
+    EntryGroup entryGroup = CreateEntryGroup.createEntryGroup(locationName, entryGroupIdToCreate);
+    // Clean-up created Entry Group
+    DeleteEntryGroup.deleteEntryGroup(entryGroupNameToCreate);
+
+    assertThat(entryGroup.getName()).isEqualTo(expectedEntryGroupToCreate);
+  }
+
+  @Test
+  public void deleteEntryGroup_executesTheCallWithoutException() throws Exception {
+    String entryGroupIdToDelete = "test-entry-group" + UUID.randomUUID().toString().substring(0, 8);
+    EntryGroupName entryGroupNameToDelete =
+        EntryGroupName.of(PROJECT_ID, LOCATION, entryGroupIdToDelete);
+    // Create Entry Group to be deleted
+    CreateEntryGroup.createEntryGroup(locationName, entryGroupIdToDelete);
+
+    // No exception means successful call
+    DeleteEntryGroup.deleteEntryGroup(entryGroupNameToDelete);
+  }
+
+  @AfterClass
+  // Clean-up code that will be executed after all tests
+  public static void tearDown() throws Exception {
+    // Clean-up Entry Group resource created in setUp()
+    DeleteEntryGroup.deleteEntryGroup(entryGroupName);
+  }
+}

--- a/dataplex/snippets/src/test/java/dataplex/EntryGroupIT.java
+++ b/dataplex/snippets/src/test/java/dataplex/EntryGroupIT.java
@@ -58,25 +58,25 @@ public class EntryGroupIT {
   }
 
   @Test
-  public void listEntryGroups_returnsListContainingEntryGroupCreatedInSetUp() throws IOException {
+  public void testListEntryGroups() throws IOException {
     List<EntryGroup> entryGroups = ListEntryGroups.listEntryGroups(PROJECT_ID, LOCATION);
     assertThat(entryGroups.stream().map(EntryGroup::getName)).contains(expectedEntryGroup);
   }
 
   @Test
-  public void getEntryGroup_returnsEntryGroupCreatedInSetUp() throws IOException {
+  public void testGetEntryGroup() throws IOException {
     EntryGroup entryGroup = GetEntryGroup.getEntryGroup(PROJECT_ID, LOCATION, entryGroupId);
     assertThat(entryGroup.getName()).isEqualTo(expectedEntryGroup);
   }
 
   @Test
-  public void updateEntryGroup_returnsUpdatedEntryGroup() throws Exception {
+  public void testUpdateEntryGroup() throws Exception {
     EntryGroup entryGroup = UpdateEntryGroup.updateEntryGroup(PROJECT_ID, LOCATION, entryGroupId);
     assertThat(entryGroup.getName()).isEqualTo(expectedEntryGroup);
   }
 
   @Test
-  public void createEntryGroup_returnsCreatedEntryGroup() throws Exception {
+  public void testCreateEntryGroup() throws Exception {
     String entryGroupIdToCreate = "test-entry-group" + UUID.randomUUID().toString().substring(0, 8);
     String expectedEntryGroupToCreate =
         String.format(
@@ -91,7 +91,7 @@ public class EntryGroupIT {
   }
 
   @Test
-  public void deleteEntryGroup_executesTheCallWithoutException() throws Exception {
+  public void testDeleteEntryGroup() throws Exception {
     String entryGroupIdToDelete = "test-entry-group" + UUID.randomUUID().toString().substring(0, 8);
     // Create Entry Group to be deleted
     CreateEntryGroup.createEntryGroup(PROJECT_ID, LOCATION, entryGroupIdToDelete);


### PR DESCRIPTION
## Description

Fixes b/368503059

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [X] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [X] **Tests** pass:   `mvn clean verify` **required**
- [X] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
