### PR TITLE
feat(dataplex): add code samples for Entry Type

### DIFF
--- a/dataplex/snippets/src/main/java/dataplex/CreateEntryType.java
+++ b/dataplex/snippets/src/main/java/dataplex/CreateEntryType.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataplex;
+
+// [START dataplex_create_entry_type]
+import com.google.cloud.dataplex.v1.CatalogServiceClient;
+import com.google.cloud.dataplex.v1.EntryType;
+import com.google.cloud.dataplex.v1.LocationName;
+
+// Samples to create Entry Type
+public class CreateEntryType {
+
+  public static void main(String[] args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    // Available locations: https://cloud.google.com/dataplex/docs/locations
+    String location = "MY_LOCATION";
+    String entryTypeId = "MY_ENTRY_TYPE_ID";
+
+    EntryType createdEntryType = createEntryType(projectId, location, entryTypeId);
+    System.out.println("Successfully created entry type: " + createdEntryType.getName());
+  }
+
+  public static EntryType createEntryType(String projectId, String location, String entryTypeId)
+      throws Exception {
+    LocationName locationName = LocationName.of(projectId, location);
+    EntryType entryType =
+        EntryType.newBuilder()
+            .setDescription("description of the entry type")
+            // Required aspects will need to be attached to every entry created for this entry type.
+            // You cannot change required aspects for entry type once it is created.
+            .addRequiredAspects(
+                EntryType.AspectInfo.newBuilder()
+                    // Example of system aspect type.
+                    // It is also possible to specify custom aspect type.
+                    .setType("projects/dataplex-types/locations/global/aspectTypes/schema")
+                    .build())
+            .build();
+
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources,
+    // or use "try-with-close" statement to do this automatically.
+    try (CatalogServiceClient client = CatalogServiceClient.create()) {
+      return client.createEntryTypeAsync(locationName, entryType, entryTypeId).get();
+    }
+  }
+}
+// [END dataplex_create_entry_type]

--- a/dataplex/snippets/src/main/java/dataplex/DeleteEntryType.java
+++ b/dataplex/snippets/src/main/java/dataplex/DeleteEntryType.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataplex;
+
+// [START dataplex_delete_entry_type]
+import com.google.cloud.dataplex.v1.CatalogServiceClient;
+import com.google.cloud.dataplex.v1.EntryTypeName;
+
+// Sample to delete Entry Type
+public class DeleteEntryType {
+
+  public static void main(String[] args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    // Available locations: https://cloud.google.com/dataplex/docs/locations
+    String location = "MY_LOCATION";
+    String entryTypeId = "MY_ENTRY_TYPE_ID";
+
+    deleteEntryType(projectId, location, entryTypeId);
+    System.out.println("Successfully deleted entry type");
+  }
+
+  public static void deleteEntryType(String projectId, String location, String entryTypeId)
+      throws Exception {
+    EntryTypeName entryTypeName = EntryTypeName.of(projectId, location, entryTypeId);
+
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources,
+    // or use "try-with-close" statement to do this automatically.
+    try (CatalogServiceClient client = CatalogServiceClient.create()) {
+      client.deleteEntryTypeAsync(entryTypeName).get();
+    }
+  }
+}
+// [END dataplex_delete_entry_type]

--- a/dataplex/snippets/src/main/java/dataplex/GetEntryType.java
+++ b/dataplex/snippets/src/main/java/dataplex/GetEntryType.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataplex;
+
+// [START dataplex_get_entry_type]
+import com.google.cloud.dataplex.v1.CatalogServiceClient;
+import com.google.cloud.dataplex.v1.EntryType;
+import com.google.cloud.dataplex.v1.EntryTypeName;
+import java.io.IOException;
+
+// Sample to get Entry Type
+public class GetEntryType {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    // Available locations: https://cloud.google.com/dataplex/docs/locations
+    String location = "MY_LOCATION";
+    String entryTypeId = "MY_ENTRY_TYPE_ID";
+
+    EntryType entryType = getEntryType(projectId, location, entryTypeId);
+    System.out.println("Entry type retrieved successfully: " + entryType.getName());
+  }
+
+  public static EntryType getEntryType(String projectId, String location, String entryTypeId)
+      throws IOException {
+    EntryTypeName entryTypeName = EntryTypeName.of(projectId, location, entryTypeId);
+
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources,
+    // or use "try-with-close" statement to do this automatically.
+    try (CatalogServiceClient client = CatalogServiceClient.create()) {
+      return client.getEntryType(entryTypeName);
+    }
+  }
+}
+// [END dataplex_get_entry_type]

--- a/dataplex/snippets/src/main/java/dataplex/ListEntryTypes.java
+++ b/dataplex/snippets/src/main/java/dataplex/ListEntryTypes.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataplex;
+
+// [START dataplex_list_entry_types]
+import com.google.cloud.dataplex.v1.CatalogServiceClient;
+import com.google.cloud.dataplex.v1.EntryType;
+import com.google.cloud.dataplex.v1.LocationName;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.List;
+
+// Sample to list Entry Types
+public class ListEntryTypes {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    // Available locations: https://cloud.google.com/dataplex/docs/locations
+    String location = "MY_LOCATION";
+
+    List<EntryType> entryTypes = listEntryTypes(projectId, location);
+    entryTypes.forEach(entryType -> System.out.println("Entry type name: " + entryType.getName()));
+  }
+
+  public static List<EntryType> listEntryTypes(String projectId, String location)
+      throws IOException {
+    LocationName locationName = LocationName.of(projectId, location);
+
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources,
+    // or use "try-with-close" statement to do this automatically.
+    try (CatalogServiceClient client = CatalogServiceClient.create()) {
+      CatalogServiceClient.ListEntryTypesPagedResponse listEntryTypesResponse =
+          client.listEntryTypes(locationName);
+      // Paging is implicitly handled by .iterateAll(), all results will be returned
+      return ImmutableList.copyOf(listEntryTypesResponse.iterateAll());
+    }
+  }
+}
+// [END dataplex_list_entry_types]

--- a/dataplex/snippets/src/main/java/dataplex/UpdateEntryType.java
+++ b/dataplex/snippets/src/main/java/dataplex/UpdateEntryType.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataplex;
+
+// [START dataplex_update_entry_type]
+import com.google.cloud.dataplex.v1.CatalogServiceClient;
+import com.google.cloud.dataplex.v1.EntryType;
+import com.google.cloud.dataplex.v1.EntryTypeName;
+import com.google.protobuf.FieldMask;
+
+// Sample to update Entry Type
+public class UpdateEntryType {
+
+  public static void main(String[] args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    // Available locations: https://cloud.google.com/dataplex/docs/locations
+    String location = "MY_LOCATION";
+    String entryTypeId = "MY_ENTRY_TYPE_ID";
+
+    EntryType updatedEntryType = updateEntryType(projectId, location, entryTypeId);
+    System.out.println("Successfully updated entry type: " + updatedEntryType.getName());
+  }
+
+  public static EntryType updateEntryType(String projectId, String location, String entryTypeId)
+      throws Exception {
+    EntryType entryType =
+        EntryType.newBuilder()
+            .setName(EntryTypeName.of(projectId, location, entryTypeId).toString())
+            .setDescription("updated description of the entry type")
+            .build();
+
+    // Update mask specifies which fields will be updated.
+    // If empty mask is given, all modifiable fields from the request will be used for update.
+    // If update mask is specified as "*" it is treated as full update,
+    // that means fields not present in the request will be emptied.
+    FieldMask updateMask = FieldMask.newBuilder().addPaths("description").build();
+
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources,
+    // or use "try-with-close" statement to do this automatically.
+    try (CatalogServiceClient client = CatalogServiceClient.create()) {
+      return client.updateEntryTypeAsync(entryType, updateMask).get();
+    }
+  }
+}
+// [END dataplex_update_entry_type]

--- a/dataplex/snippets/src/test/java/dataplex/EntryTypeIT.java
+++ b/dataplex/snippets/src/test/java/dataplex/EntryTypeIT.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataplex;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.dataplex.v1.EntryType;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class EntryTypeIT {
+  private static final String ID = UUID.randomUUID().toString().substring(0, 8);
+  private static final String LOCATION = "us-central1";
+  private static final String entryTypeId = "test-entry-type" + ID;
+  private static String expectedEntryType;
+
+  private static final String PROJECT_ID = requireProjectIdEnvVar();
+
+  private static String requireProjectIdEnvVar() {
+    String value = System.getenv("GOOGLE_CLOUD_PROJECT");
+    assertNotNull(
+        "Environment variable GOOGLE_CLOUD_PROJECT is required to perform these tests.", value);
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireProjectIdEnvVar();
+  }
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    expectedEntryType =
+        String.format("projects/%s/locations/%s/entryTypes/%s", PROJECT_ID, LOCATION, entryTypeId);
+    // Create Entry Type resource that will be used in tests for "get", "list" and "update" methods
+    CreateEntryType.createEntryType(PROJECT_ID, LOCATION, entryTypeId);
+  }
+
+  @Test
+  public void testListEntryTypes() throws IOException {
+    List<EntryType> entryTypes = ListEntryTypes.listEntryTypes(PROJECT_ID, LOCATION);
+    assertThat(entryTypes.stream().map(EntryType::getName)).contains(expectedEntryType);
+  }
+
+  @Test
+  public void testGetEntryType() throws IOException {
+    EntryType entryType = GetEntryType.getEntryType(PROJECT_ID, LOCATION, entryTypeId);
+    assertThat(entryType.getName()).isEqualTo(expectedEntryType);
+  }
+
+  @Test
+  public void testUpdateEntryType() throws Exception {
+    EntryType entryType = UpdateEntryType.updateEntryType(PROJECT_ID, LOCATION, entryTypeId);
+    assertThat(entryType.getName()).contains(expectedEntryType);
+  }
+
+  @Test
+  public void testCreateEntryType() throws Exception {
+    String entryTypeIdToCreate = "test-entry-type" + UUID.randomUUID().toString().substring(0, 8);
+    String expectedEntryTypeToCreate =
+        String.format(
+            "projects/%s/locations/%s/entryTypes/%s", PROJECT_ID, LOCATION, entryTypeIdToCreate);
+
+    EntryType entryType =
+        CreateEntryType.createEntryType(PROJECT_ID, LOCATION, entryTypeIdToCreate);
+    // Clean-up created Entry Type
+    DeleteEntryType.deleteEntryType(PROJECT_ID, LOCATION, entryTypeIdToCreate);
+
+    assertThat(entryType.getName()).contains(expectedEntryTypeToCreate);
+  }
+
+  @Test
+  public void testDeleteEntryType() throws Exception {
+    String entryTypeIdToDelete = "test-entry-type" + UUID.randomUUID().toString().substring(0, 8);
+    // Create Entry Group to be deleted
+    CreateEntryType.createEntryType(PROJECT_ID, LOCATION, entryTypeIdToDelete);
+
+    // No exception means successful call.
+    DeleteEntryType.deleteEntryType(PROJECT_ID, LOCATION, entryTypeIdToDelete);
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    // Clean-up Entry Group resource created in setUp()
+    DeleteEntryType.deleteEntryType(PROJECT_ID, LOCATION, entryTypeId);
+  }
+}


### PR DESCRIPTION
## Description

Fixes b/368503059

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [X] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [X] **Tests** pass:   `mvn clean verify` **required**
- [X] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
