### PR TITLE
feat(dataplex): add code samples for Entry

### DIFF
--- a/dataplex/snippets/src/main/java/dataplex/CreateEntry.java
+++ b/dataplex/snippets/src/main/java/dataplex/CreateEntry.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataplex;
+
+// [START dataplex_create_entry]
+import com.google.cloud.dataplex.v1.Aspect;
+import com.google.cloud.dataplex.v1.CatalogServiceClient;
+import com.google.cloud.dataplex.v1.Entry;
+import com.google.cloud.dataplex.v1.EntryGroupName;
+import com.google.cloud.dataplex.v1.EntrySource;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.util.Map;
+
+public class CreateEntry {
+
+  public static void main(String[] args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    String location = "MY_LOCATION";
+    String entryGroupId = "MY_ENTRY_GROUP_ID";
+    String entryId = "MY_ENTRY_ID";
+
+    Entry createdEntry = createEntry(projectId, location, entryGroupId, entryId);
+    System.out.println("Successfully created entry: " + createdEntry.getName());
+  }
+
+  public static Entry createEntry(
+      String projectId, String location, String entryGroupId, String entryId) throws Exception {
+    EntryGroupName entryGroupName = EntryGroupName.of(projectId, location, entryGroupId);
+    Entry entry =
+        Entry.newBuilder()
+            // Example of system Entry Type.
+            // It is also possible to specify custom Entry Type.
+            .setEntryType("projects/dataplex-types/locations/global/entryTypes/generic")
+            .setEntrySource(
+                EntrySource.newBuilder().setDescription("description of the entry").build())
+            .putAllAspects(
+                Map.of(
+                    "dataplex-types.global.generic",
+                    Aspect.newBuilder()
+                        // This is required Aspect Type for "generic" Entry Type.
+                        // For custom Aspect Type required Entry Type would be different.
+                        .setAspectType(
+                            "projects/dataplex-types/locations/global/aspectTypes/generic")
+                        .setData(
+                            Struct.newBuilder()
+                                // "Generic" Aspect Type have fields called "type" and "system,
+                                // it is just illustration how to fill in the fields of the Aspect.
+                                .putFields(
+                                    "type",
+                                    Value.newBuilder().setStringValue("example value").build())
+                                .putFields(
+                                    "system",
+                                    Value.newBuilder().setStringValue("example system").build())
+                                .build())
+                        .build()))
+            .build();
+
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources,
+    // or use "try-with-close" statement to do this automatically.
+    try (CatalogServiceClient client = CatalogServiceClient.create()) {
+      return client.createEntry(entryGroupName, entry, entryId);
+    }
+  }
+}
+// [END dataplex_create_entry]

--- a/dataplex/snippets/src/main/java/dataplex/DeleteEntry.java
+++ b/dataplex/snippets/src/main/java/dataplex/DeleteEntry.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataplex;
+
+// [START dataplex_delete_entry]
+import com.google.cloud.dataplex.v1.CatalogServiceClient;
+import com.google.cloud.dataplex.v1.EntryName;
+
+public class DeleteEntry {
+
+  public static void main(String[] args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    String location = "MY_LOCATION";
+    String entryGroupId = "MY_ENTRY_GROUP_ID";
+    String entryId = "MY_ENTRY_ID";
+
+    deleteEntry(projectId, location, entryGroupId, entryId);
+    System.out.println("Successfully deleted entry");
+  }
+
+  public static void deleteEntry(
+      String projectId, String location, String entryGroupId, String entryId) throws Exception {
+    EntryName entryName = EntryName.of(projectId, location, entryGroupId, entryId);
+
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources,
+    // or use "try-with-close" statement to do this automatically.
+    try (CatalogServiceClient client = CatalogServiceClient.create()) {
+      client.deleteEntry(entryName);
+    }
+  }
+}
+// [END dataplex_delete_entry]

--- a/dataplex/snippets/src/main/java/dataplex/GetEntry.java
+++ b/dataplex/snippets/src/main/java/dataplex/GetEntry.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataplex;
+
+// [START dataplex_get_entry]
+import com.google.cloud.dataplex.v1.CatalogServiceClient;
+import com.google.cloud.dataplex.v1.Entry;
+import com.google.cloud.dataplex.v1.EntryName;
+import com.google.cloud.dataplex.v1.EntryView;
+import com.google.cloud.dataplex.v1.GetEntryRequest;
+import java.io.IOException;
+
+// Sample to get Entry
+public class GetEntry {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    String location = "MY_LOCATION";
+    String entryGroupId = "MY_ENTRY_GROUP_ID";
+    String entryId = "MY_ENTRY_ID";
+
+    Entry entry = getEntry(projectId, location, entryGroupId, entryId);
+    System.out.println("Entry retrieved successfully: " + entry.getName());
+    entry
+        .getAspectsMap()
+        .keySet()
+        .forEach(aspectKey -> System.out.println("Retrieved aspect for entry: " + aspectKey));
+  }
+
+  // When Entry is created in Dataplex for example for BigQuery table,
+  // access permissions might differ between Dataplex and source system.
+  // Get method checks permissions in Dataplex.
+  // Please also refer to LookupEntry code sample, which checks permissions in source system.
+  public static Entry getEntry(
+      String projectId, String location, String entryGroupId, String entryId) throws IOException {
+
+    GetEntryRequest getEntryRequest =
+        GetEntryRequest.newBuilder()
+            .setName(EntryName.of(projectId, location, entryGroupId, entryId).toString())
+            // View determines which Aspects are returned with the Entry, available options:
+            // not set - Defaults to FULL
+            // BASIC - Returns entry only, without aspects
+            // FULL - Returns all required aspects as well as the keys of all non-required aspects
+            // CUSTOM - Returns Aspects matching custom fields in GetEntryRequest (max 100)
+            // ALL - Returns all aspects (max 100)
+            .setView(EntryView.FULL)
+            // Following 2 lines will be ignored, because "View" is set to FULL.
+            // Their purpose is to demonstrate how to filter the Aspects returned for Entry
+            // when "View" is set to CUSTOM.
+            .addAspectTypes("projects/dataplex-types/locations/global/aspectTypes/generic")
+            .addPaths("generic")
+            .build();
+
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources,
+    // or use "try-with-close" statement to do this automatically.
+    try (CatalogServiceClient client = CatalogServiceClient.create()) {
+      return client.getEntry(getEntryRequest);
+    }
+  }
+}
+// [END dataplex_get_entry]

--- a/dataplex/snippets/src/main/java/dataplex/ListEntries.java
+++ b/dataplex/snippets/src/main/java/dataplex/ListEntries.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataplex;
+
+// [START dataplex_list_entries]
+import com.google.cloud.dataplex.v1.CatalogServiceClient;
+import com.google.cloud.dataplex.v1.Entry;
+import com.google.cloud.dataplex.v1.EntryGroupName;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.List;
+
+// Sample to list Entries
+public class ListEntries {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    String location = "MY_LOCATION";
+    String entryGroupId = "MY_ENTRY_GROUP_ID";
+
+    List<Entry> entries = listEntries(projectId, location, entryGroupId);
+    entries.forEach(aspectType -> System.out.println("Entry name: " + aspectType.getName()));
+  }
+
+  public static List<Entry> listEntries(String projectId, String location, String entryGroupId)
+      throws IOException {
+    EntryGroupName entryGroupName = EntryGroupName.of(projectId, location, entryGroupId);
+
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources,
+    // or use "try-with-close" statement to do this automatically.
+    try (CatalogServiceClient client = CatalogServiceClient.create()) {
+      CatalogServiceClient.ListEntriesPagedResponse listEntriesResponse =
+          client.listEntries(entryGroupName);
+      // Paging is implicitly handled by .iterateAll(), all results will be returned
+      return ImmutableList.copyOf(listEntriesResponse.iterateAll());
+    }
+  }
+}
+// [END dataplex_list_entries]

--- a/dataplex/snippets/src/main/java/dataplex/LookupEntry.java
+++ b/dataplex/snippets/src/main/java/dataplex/LookupEntry.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataplex;
+
+// [START dataplex_lookup_entry]
+import com.google.cloud.dataplex.v1.CatalogServiceClient;
+import com.google.cloud.dataplex.v1.Entry;
+import com.google.cloud.dataplex.v1.EntryName;
+import com.google.cloud.dataplex.v1.EntryView;
+import com.google.cloud.dataplex.v1.LookupEntryRequest;
+import java.io.IOException;
+
+// Sample to lookup Entry
+public class LookupEntry {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    String location = "MY_LOCATION";
+    String entryGroupId = "MY_ENTRY_GROUP_ID";
+    String entryId = "MY_ENTRY_ID";
+
+    Entry entry = lookupEntry(projectId, location, entryGroupId, entryId);
+    System.out.println("Entry retrieved successfully: " + entry.getName());
+    entry
+        .getAspectsMap()
+        .keySet()
+        .forEach(aspectKey -> System.out.println("Retrieved aspect for entry: " + aspectKey));
+  }
+
+  // When Entry is created in Dataplex for example for BigQuery table,
+  // access permissions might differ between Dataplex and source system.
+  // Lookup method checks permissions in source system.
+  // Please also refer to GetEntry code sample, which checks permissions in Dataplex.
+  public static Entry lookupEntry(
+      String projectId, String location, String entryGroupId, String entryId) throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources,
+    // or use "try-with-close" statement to do this automatically.
+    try (CatalogServiceClient client = CatalogServiceClient.create()) {
+      String projectLocation = String.format("projects/%s/locations/%s", projectId, location);
+      LookupEntryRequest lookupEntryRequest =
+          LookupEntryRequest.newBuilder()
+              // The project to which the request should be attributed
+              .setName(projectLocation)
+              // The resource name of the Entry
+              .setEntry(EntryName.of(projectId, location, entryGroupId, entryId).toString())
+              // View determines which Aspects are returned with the Entry, available options:
+              // not set - Defaults to FULL
+              // BASIC - Returns entry only, without aspects
+              // FULL - Returns all required aspects as well as the keys of all non-required aspects
+              // CUSTOM - Returns Aspects matching custom fields in GetEntryRequest (max 100)
+              // ALL - Returns all aspects (max 100)
+              .setView(EntryView.FULL)
+              // Following 2 lines will be ignored, because "View" is set to FULL.
+              // Their purpose is to demonstrate how to filter the Aspects returned for Entry
+              // when "View" is set to CUSTOM.
+              .addAspectTypes("projects/dataplex-types/locations/global/aspectTypes/generic")
+              .addPaths("generic")
+              .build();
+      return client.lookupEntry(lookupEntryRequest);
+    }
+  }
+}
+// [END dataplex_lookup_entry]

--- a/dataplex/snippets/src/main/java/dataplex/UpdateEntry.java
+++ b/dataplex/snippets/src/main/java/dataplex/UpdateEntry.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataplex;
+
+// [START dataplex_update_entry]
+import com.google.cloud.dataplex.v1.Aspect;
+import com.google.cloud.dataplex.v1.CatalogServiceClient;
+import com.google.cloud.dataplex.v1.Entry;
+import com.google.cloud.dataplex.v1.EntryName;
+import com.google.cloud.dataplex.v1.EntrySource;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.util.Map;
+
+public class UpdateEntry {
+
+  public static void main(String[] args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "MY_PROJECT_ID";
+    String location = "MY_LOCATION";
+    String entryGroupId = "MY_ENTRY_GROUP_ID";
+    String entryId = "MY_ENTRY_ID";
+
+    Entry createdEntry = updateEntry(projectId, location, entryGroupId, entryId);
+    System.out.println("Successfully updated entry: " + createdEntry.getName());
+  }
+
+  public static Entry updateEntry(
+      String projectId, String location, String entryGroupId, String entryId) throws Exception {
+    Entry entry =
+        Entry.newBuilder()
+            .setName(EntryName.of(projectId, location, entryGroupId, entryId).toString())
+            .setEntrySource(
+                EntrySource.newBuilder().setDescription("updated description of the entry").build())
+            .putAllAspects(
+                Map.of(
+                    "dataplex-types.global.generic",
+                    Aspect.newBuilder()
+                        // This is required Aspect Type for "generic" Entry Type.
+                        // For custom Aspect Type required Entry Type would be different.
+                        .setAspectType(
+                            "projects/dataplex-types/locations/global/aspectTypes/generic")
+                        .setData(
+                            Struct.newBuilder()
+                                // "Generic" Aspect Type have fields called "type" and "system,
+                                // it is just illustration how to fill in the fields of the Aspect.
+                                .putFields(
+                                    "type",
+                                    Value.newBuilder()
+                                        .setStringValue("updated example value")
+                                        .build())
+                                .putFields(
+                                    "system",
+                                    Value.newBuilder()
+                                        .setStringValue("updated example system")
+                                        .build())
+                                .build())
+                        .build()))
+            .build();
+
+    // Update mask specifies which fields will be updated.
+    // If empty mask is given, all modifiable fields from the request will be used for update.
+    // If update mask is specified as "*" it is treated as full update,
+    // that means fields not present in the request will be emptied.
+    FieldMask updateMask =
+        FieldMask.newBuilder().addPaths("aspects").addPaths("entry_source.description").build();
+
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources,
+    // or use "try-with-close" statement to do this automatically.
+    try (CatalogServiceClient client = CatalogServiceClient.create()) {
+      return client.updateEntry(entry, updateMask);
+    }
+  }
+}
+// [END dataplex_update_entry]

--- a/dataplex/snippets/src/test/java/dataplex/EntryIT.java
+++ b/dataplex/snippets/src/test/java/dataplex/EntryIT.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataplex;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.dataplex.v1.Entry;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class EntryIT {
+  private static final String ID = UUID.randomUUID().toString().substring(0, 8);
+  private static final String LOCATION = "us-central1";
+  private static final String entryGroupId = "test-entry-group-" + ID;
+  private static final String entryId = "test-entry-" + ID;
+  private static String expectedEntry;
+
+  private static final String PROJECT_ID = requireProjectIdEnvVar();
+
+  private static String requireProjectIdEnvVar() {
+    String value = System.getenv("GOOGLE_CLOUD_PROJECT");
+    assertNotNull(
+        "Environment variable GOOGLE_CLOUD_PROJECT is required to perform these tests.", value);
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireProjectIdEnvVar();
+  }
+
+  @BeforeClass
+  // Set-up code that will be executed before all tests
+  public static void setUp() throws Exception {
+    expectedEntry =
+        String.format(
+            "projects/%s/locations/%s/entryGroups/%s/entries/%s",
+            PROJECT_ID, LOCATION, entryGroupId, entryId);
+    // Create Entry Group resource that will be used for creating Entry
+    CreateEntryGroup.createEntryGroup(PROJECT_ID, LOCATION, entryGroupId);
+    // Create Entry that will be used in tests for "get", "lookup", "list" and "update" methods
+    CreateEntry.createEntry(PROJECT_ID, LOCATION, entryGroupId, entryId);
+  }
+
+  @Test
+  public void testListEntries() throws IOException {
+    List<Entry> entries = ListEntries.listEntries(PROJECT_ID, LOCATION, entryGroupId);
+    assertThat(entries.stream().map(Entry::getName)).contains(expectedEntry);
+  }
+
+  @Test
+  public void testGetEntry() throws IOException {
+    Entry entry = GetEntry.getEntry(PROJECT_ID, LOCATION, entryGroupId, entryId);
+    assertThat(entry.getName()).isEqualTo(expectedEntry);
+  }
+
+  @Test
+  public void testLookupEntry() throws IOException {
+    Entry entry = LookupEntry.lookupEntry(PROJECT_ID, LOCATION, entryGroupId, entryId);
+    assertThat(entry.getName()).isEqualTo(expectedEntry);
+  }
+
+  @Test
+  public void testUpdateEntry() throws Exception {
+    Entry entry = UpdateEntry.updateEntry(PROJECT_ID, LOCATION, entryGroupId, entryId);
+    assertThat(entry.getName()).isEqualTo(expectedEntry);
+  }
+
+  @Test
+  public void testCreateEntry() throws Exception {
+    String entryIdToCreate = "test-entry-" + UUID.randomUUID().toString().substring(0, 8);
+    String expectedEntryToCreate =
+        String.format(
+            "projects/%s/locations/%s/entryGroups/%s/entries/%s",
+            PROJECT_ID, LOCATION, entryGroupId, entryIdToCreate);
+
+    Entry entry = CreateEntry.createEntry(PROJECT_ID, LOCATION, entryGroupId, entryIdToCreate);
+    // Clean-up created Entry Group
+    DeleteEntry.deleteEntry(PROJECT_ID, LOCATION, entryGroupId, entryIdToCreate);
+
+    assertThat(entry.getName()).isEqualTo(expectedEntryToCreate);
+  }
+
+  @Test
+  public void testDeleteEntry() throws Exception {
+    String entryIdToDelete = "test-entry-" + UUID.randomUUID().toString().substring(0, 8);
+    // Create Entry Group to be deleted
+    CreateEntry.createEntry(PROJECT_ID, LOCATION, entryGroupId, entryIdToDelete);
+
+    // No exception means successful call
+    DeleteEntry.deleteEntry(PROJECT_ID, LOCATION, entryGroupId, entryIdToDelete);
+  }
+
+  @AfterClass
+  // Clean-up code that will be executed after all tests
+  public static void tearDown() throws Exception {
+    // Clean-up Entry Group resource created in setUp()
+    // Entry inside this Entry Group will be deleted automatically
+    DeleteEntryGroup.deleteEntryGroup(PROJECT_ID, LOCATION, entryGroupId);
+  }
+}


### PR DESCRIPTION
## Description

Fixes b/287183421

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [X] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [X] **Tests** pass:   `mvn clean verify` **required**
- [X] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
