### PR TITLE
feat(tpu): add  tpu queued resources create/delete/force delete/get/list samples

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,6 +44,7 @@
 /security-command-center         @GoogleCloudPlatform/java-samples-reviewers @yoshi-approver @GoogleCloudPlatform/cloud-samples-reviewers @GoogleCloudPlatform/dee-infra @GoogleCloudPlatform/gcp-security-command-center
 /servicedirectory                @GoogleCloudPlatform/java-samples-reviewers @yoshi-approver @GoogleCloudPlatform/cloud-samples-reviewers @GoogleCloudPlatform/dee-infra
 /webrisk                         @GoogleCloudPlatform/java-samples-reviewers @yoshi-approver @GoogleCloudPlatform/cloud-samples-reviewers @GoogleCloudPlatform/dee-infra
+/tpu                             @GoogleCloudPlatform/java-samples-reviewers @yoshi-approver @GoogleCloudPlatform/cloud-samples-reviewers @GoogleCloudPlatform/dee-infra
 
 # DEE Platform Ops (DEEPO)
 /errorreporting                  @GoogleCloudPlatform/java-samples-reviewers @yoshi-approver @GoogleCloudPlatform/cloud-samples-reviewers

--- a/tpu/pom.xml
+++ b/tpu/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2024 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.tpu</groupId>
+  <artifactId>gce-diregapic-samples</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <!--
+   The parent pom defines common style checks and testing strategies for our samples.
+   Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <artifactId>shared-configuration</artifactId>
+    <groupId>com.google.cloud.samples</groupId>
+    <version>1.2.0</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-tpu</artifactId>
+      <version>2.52.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <artifactId>google-cloud-storage</artifactId>
+      <groupId>com.google.cloud</groupId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <artifactId>truth</artifactId>
+      <groupId>com.google.truth</groupId>
+      <scope>test</scope>
+      <version>1.4.0</version>
+    </dependency>
+    <dependency>
+      <artifactId>junit</artifactId>
+      <groupId>junit</groupId>
+      <scope>test</scope>
+      <version>4.13.2</version>
+    </dependency>
+
+    <!--
+    JUnit Jupiter dependencies to run BeforeEach and AfterEach methods
+    (in tandem with mvn surefire) before every test.
+    Without these, mvn surefire skips these methods and leads to concurrency
+    issues.
+    -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.10.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <artifactId>libraries-bom</artifactId>
+        <groupId>com.google.cloud</groupId>
+        <scope>import</scope>
+        <type>pom</type>
+        <version>26.40.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+</project>

--- a/tpu/src/main/java/tpu/CreateQueuedResource.java
+++ b/tpu/src/main/java/tpu/CreateQueuedResource.java
@@ -81,6 +81,8 @@ public class CreateQueuedResource {
                               .setNodeId(nodeName)
                               .build())
                       .build())
+              // You can request a queued resource using a reservation by specifying it in code
+              //.setReservationName("projects/YOUR_PROJECT_ID/locations/YOUR_ZONE/reservations/YOUR_RESERVATION_NAME")
               .build();
 
       CreateQueuedResourceRequest request =

--- a/tpu/src/main/java/tpu/CreateQueuedResource.java
+++ b/tpu/src/main/java/tpu/CreateQueuedResource.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tpu;
+
+//[START tpu_queued_resources_create]
+
+import com.google.cloud.tpu.v2alpha1.CreateQueuedResourceRequest;
+import com.google.cloud.tpu.v2alpha1.Node;
+import com.google.cloud.tpu.v2alpha1.QueuedResource;
+import com.google.cloud.tpu.v2alpha1.TpuClient;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+public class CreateQueuedResource {
+  public static void main(String[] args)
+      throws IOException, ExecutionException, InterruptedException {
+    // TODO(developer): Replace these variables before running the sample.
+    // Project ID or project number of the Google Cloud project you want to create a node.
+    String projectId = "YOUR_PROJECT_ID";
+    // The zone in which to create the TPU.
+    // For more information about supported TPU types for specific zones,
+    // see https://cloud.google.com/tpu/docs/regions-zones
+    String zone = "europe-west4-a";
+    // The name for your TPU.
+    String nodeName = "YOUR_NODE_ID";
+    // The accelerator type that specifies the version and size of the Cloud TPU you want to create.
+    // For more information about supported accelerator types for each TPU version,
+    // see https://cloud.google.com/tpu/docs/system-architecture-tpu-vm#versions.
+    String tpuType = "v2-8";
+    // Software version that specifies the version of the TPU runtime to install.
+    // For more information see https://cloud.google.com/tpu/docs/runtimes
+    String tpuSoftwareVersion = "tpu-vm-tf-2.14.1";
+    // The name for your Queued Resource.
+    String queuedResourceId = "QUEUED_RESOURCE_ID";
+
+    createQueuedResource(
+        projectId, zone, queuedResourceId, nodeName, tpuType, tpuSoftwareVersion);
+  }
+
+  // Creates a Queued Resource
+  public static void createQueuedResource(String projectId, String zone,
+      String queuedResourceId, String nodeName, String tpuType, String tpuSoftwareVersion)
+      throws IOException, ExecutionException, InterruptedException {
+    try (TpuClient tpuClient = TpuClient.create()) {
+      String parent = String.format("projects/%s/locations/%s", projectId, zone);
+
+      Node node =
+          Node.newBuilder()
+              .setName(nodeName)
+              .setAcceleratorType(tpuType)
+              .setRuntimeVersion(tpuSoftwareVersion)
+              .setQueuedResource(
+                  String.format(
+                      "projects/%s/locations/%s/queuedResources/%s",
+                      projectId, zone, queuedResourceId))
+              .build();
+
+      QueuedResource queuedResource =
+          QueuedResource.newBuilder()
+              .setName(queuedResourceId)
+              .setTpu(
+                  QueuedResource.Tpu.newBuilder()
+                      .addNodeSpec(
+                          QueuedResource.Tpu.NodeSpec.newBuilder()
+                              .setParent(parent)
+                              .setNode(node)
+                              .setNodeId(nodeName)
+                              .build())
+                      .build())
+              .build();
+
+      CreateQueuedResourceRequest request =
+          CreateQueuedResourceRequest.newBuilder()
+              .setParent(parent)
+              .setQueuedResourceId(queuedResourceId)
+              .setQueuedResource(queuedResource)
+              .build();
+
+      QueuedResource response = tpuClient.createQueuedResourceAsync(request).get();
+      System.out.printf("Queued Resource created: %s\n", response.getName());
+    }
+  }
+}
+//[END tpu_queued_resources_create]

--- a/tpu/src/main/java/tpu/CreateQueuedResource.java
+++ b/tpu/src/main/java/tpu/CreateQueuedResource.java
@@ -55,7 +55,7 @@ public class CreateQueuedResource {
   }
 
   // Creates a Queued Resource
-  public static void createQueuedResource(String projectId, String zone,
+  public static QueuedResource createQueuedResource(String projectId, String zone,
       String queuedResourceId, String nodeName, String tpuType, String tpuSoftwareVersion)
       throws IOException, ExecutionException, InterruptedException {
     // With these settings the client library handles the Operation's polling mechanism
@@ -116,6 +116,7 @@ public class CreateQueuedResource {
       // You can wait until TPU Node is READY,
       // and check its status using getTpuVm() from "tpu_vm_get" sample.
       System.out.printf("Queued Resource created: %s\n", response.getName());
+      return response;
     }
   }
 }

--- a/tpu/src/main/java/tpu/CreateQueuedResource.java
+++ b/tpu/src/main/java/tpu/CreateQueuedResource.java
@@ -91,6 +91,8 @@ public class CreateQueuedResource {
               .build();
 
       QueuedResource response = tpuClient.createQueuedResourceAsync(request).get();
+      // You can wait until TPU Node is READY,
+      // and check its status using getTpuVm() from "tpu_vm_get" sample.
       System.out.printf("Queued Resource created: %s\n", response.getName());
     }
   }

--- a/tpu/src/main/java/tpu/CreateQueuedResource.java
+++ b/tpu/src/main/java/tpu/CreateQueuedResource.java
@@ -57,7 +57,6 @@ public class CreateQueuedResource {
       throws IOException, ExecutionException, InterruptedException {
     try (TpuClient tpuClient = TpuClient.create()) {
       String parent = String.format("projects/%s/locations/%s", projectId, zone);
-
       Node node =
           Node.newBuilder()
               .setName(nodeName)
@@ -82,7 +81,8 @@ public class CreateQueuedResource {
                               .build())
                       .build())
               // You can request a queued resource using a reservation by specifying it in code
-              //.setReservationName("projects/YOUR_PROJECT_ID/locations/YOUR_ZONE/reservations/YOUR_RESERVATION_NAME")
+              //.setReservationName(
+              // "projects/YOUR_PROJECT_ID/locations/YOUR_ZONE/reservations/YOUR_RESERVATION_NAME")
               .build();
 
       CreateQueuedResourceRequest request =

--- a/tpu/src/main/java/tpu/CreateTpuVm.java
+++ b/tpu/src/main/java/tpu/CreateTpuVm.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tpu;
+
+//[START tpu_vm_create]
+
+import com.google.cloud.tpu.v2.CreateNodeRequest;
+import com.google.cloud.tpu.v2.Node;
+import com.google.cloud.tpu.v2.TpuClient;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+public class CreateTpuVm {
+
+  public static void main(String[] args)
+      throws IOException, ExecutionException, InterruptedException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "YOUR_PROJECT_ID";
+    String zone = "europe-west4-a";
+    String tpuVmName = "YOUR_TPU_NAME";
+    String acceleratorType = "v2-8";
+    String version = "tpu-vm-tf-2.14.1";
+
+    createTpuVm(projectId, zone, tpuVmName, acceleratorType, version);
+  }
+
+  // Creates a TPU VM with the specified name, zone, accelerator type, and version.
+  public static void createTpuVm(
+      String projectId, String zone, String tpuVmName, String acceleratorType, String version)
+      throws IOException, ExecutionException, InterruptedException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    try (TpuClient tpuClient = TpuClient.create()) {
+      String parent = String.format("projects/%s/locations/%s", projectId, zone);
+
+      Node tpuVm = Node.newBuilder()
+              .setName(tpuVmName)
+              .setAcceleratorType(acceleratorType)
+              .setRuntimeVersion(version)
+              .build();
+
+      CreateNodeRequest request = CreateNodeRequest.newBuilder()
+              .setParent(parent)
+              .setNodeId(tpuVmName)
+              .setNode(tpuVm)
+              .build();
+
+      Node response = tpuClient.createNodeAsync(request).get();
+      System.out.printf("TPU VM created: %s\n", response.getName());
+    }
+  }
+}
+//[END tpu_vm_create]

--- a/tpu/src/main/java/tpu/CreateTpuVm.java
+++ b/tpu/src/main/java/tpu/CreateTpuVm.java
@@ -29,18 +29,28 @@ public class CreateTpuVm {
   public static void main(String[] args)
       throws IOException, ExecutionException, InterruptedException {
     // TODO(developer): Replace these variables before running the sample.
+    // Project ID or project number of the Google Cloud project you want to create a node.
     String projectId = "YOUR_PROJECT_ID";
+    // The zone in which to create the TPU.
+    // For more information about supported TPU types for specific zones,
+    // see https://cloud.google.com/tpu/docs/regions-zones
     String zone = "europe-west4-a";
-    String tpuVmName = "YOUR_TPU_NAME";
-    String acceleratorType = "v2-8";
-    String version = "tpu-vm-tf-2.14.1";
+    // The name for your TPU.
+    String nodeName = "YOUR_TPY_NAME";
+    // The accelerator type that specifies the version and size of the Cloud TPU you want to create.
+    // For more information about supported accelerator types for each TPU version,
+    // see https://cloud.google.com/tpu/docs/system-architecture-tpu-vm#versions.
+    String tpuType = "v2-8";
+    // Software version that specifies the version of the TPU runtime to install.
+    // For more information see https://cloud.google.com/tpu/docs/runtimes
+    String tpuSoftwareVersion = "tpu-vm-tf-2.14.1";
 
-    createTpuVm(projectId, zone, tpuVmName, acceleratorType, version);
+    createTpuVm(projectId, zone, nodeName, tpuType, tpuSoftwareVersion);
   }
 
   // Creates a TPU VM with the specified name, zone, accelerator type, and version.
   public static void createTpuVm(
-      String projectId, String zone, String tpuVmName, String acceleratorType, String version)
+      String projectId, String zone, String nodeName, String tpuType, String tpuSoftwareVersion)
       throws IOException, ExecutionException, InterruptedException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests.
@@ -48,14 +58,14 @@ public class CreateTpuVm {
       String parent = String.format("projects/%s/locations/%s", projectId, zone);
 
       Node tpuVm = Node.newBuilder()
-              .setName(tpuVmName)
-              .setAcceleratorType(acceleratorType)
-              .setRuntimeVersion(version)
+              .setName(nodeName)
+              .setAcceleratorType(tpuType)
+              .setRuntimeVersion(tpuSoftwareVersion)
               .build();
 
       CreateNodeRequest request = CreateNodeRequest.newBuilder()
               .setParent(parent)
-              .setNodeId(tpuVmName)
+              .setNodeId(nodeName)
               .setNode(tpuVm)
               .build();
 

--- a/tpu/src/main/java/tpu/CreateTpuVm.java
+++ b/tpu/src/main/java/tpu/CreateTpuVm.java
@@ -18,11 +18,15 @@ package tpu;
 
 //[START tpu_vm_create]
 
+import com.google.api.gax.longrunning.OperationTimedPollAlgorithm;
+import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.tpu.v2.CreateNodeRequest;
 import com.google.cloud.tpu.v2.Node;
 import com.google.cloud.tpu.v2.TpuClient;
+import com.google.cloud.tpu.v2.TpuSettings;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
+import org.threeten.bp.Duration;
 
 public class CreateTpuVm {
 
@@ -52,9 +56,27 @@ public class CreateTpuVm {
   public static void createTpuVm(
       String projectId, String zone, String nodeName, String tpuType, String tpuSoftwareVersion)
       throws IOException, ExecutionException, InterruptedException {
+    // With these settings the client library handles the Operation's polling mechanism
+    // and prevent CancellationException error
+    TpuSettings.Builder clientSettings =
+        TpuSettings.newBuilder();
+    clientSettings
+        .createNodeOperationSettings()
+        .setPollingAlgorithm(
+            OperationTimedPollAlgorithm.create(
+                RetrySettings.newBuilder()
+                    .setInitialRetryDelay(Duration.ofMillis(5000L))
+                    .setRetryDelayMultiplier(1.5)
+                    .setMaxRetryDelay(Duration.ofMillis(45000L))
+                    .setInitialRpcTimeout(Duration.ZERO)
+                    .setRpcTimeoutMultiplier(1.0)
+                    .setMaxRpcTimeout(Duration.ZERO)
+                    .setTotalTimeout(Duration.ofHours(24L))
+                    .build()));
+
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests.
-    try (TpuClient tpuClient = TpuClient.create()) {
+    try (TpuClient tpuClient = TpuClient.create(clientSettings.build())) {
       String parent = String.format("projects/%s/locations/%s", projectId, zone);
 
       Node tpuVm = Node.newBuilder()

--- a/tpu/src/main/java/tpu/DeleteForceQueuedResource.java
+++ b/tpu/src/main/java/tpu/DeleteForceQueuedResource.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tpu;
+
+//[START tpu_queued_resources_delete_force]
+
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.cloud.tpu.v2alpha1.DeleteQueuedResourceRequest;
+import com.google.cloud.tpu.v2alpha1.TpuClient;
+import com.google.cloud.tpu.v2alpha1.TpuSettings;
+import org.threeten.bp.Duration;
+
+public class DeleteForceQueuedResource {
+  public static void main(String[] args) {
+    // TODO(developer): Replace these variables before running the sample.
+    // Project ID or project number of the Google Cloud project.
+    String projectId = "YOUR_PROJECT_ID";
+    // The zone in which the TPU was created.
+    String zone = "europe-west4-a";
+    // The name for your Queued Resource.
+    String queuedResourceId = "QUEUED_RESOURCE_ID";
+
+    deleteForceQueuedResource(projectId, zone, queuedResourceId);
+  }
+
+  // Deletes a Queued Resource asynchronously with force=true flag.
+  public static void deleteForceQueuedResource(
+      String projectId, String zone, String queuedResourceId) {
+    String name = String.format("projects/%s/locations/%s/queuedResources/%s",
+              projectId, zone, queuedResourceId);
+    // With these settings the client library handles the Operation's polling mechanism
+    // and prevent CancellationException error
+    TpuSettings.Builder clientSettings =
+        TpuSettings.newBuilder();
+    clientSettings
+        .deleteQueuedResourceSettings()
+        .setRetrySettings(
+            RetrySettings.newBuilder()
+                .setInitialRetryDelay(Duration.ofMillis(5000L))
+                .setRetryDelayMultiplier(2.0)
+                .setInitialRpcTimeout(Duration.ZERO)
+                .setRpcTimeoutMultiplier(1.0)
+                .setMaxRetryDelay(Duration.ofMillis(45000L))
+                .setTotalTimeout(Duration.ofHours(24L))
+                .build());
+
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    try (TpuClient tpuClient = TpuClient.create(clientSettings.build())) {
+      DeleteQueuedResourceRequest request =
+          DeleteQueuedResourceRequest.newBuilder().setName(name).setForce(true).build();
+
+      tpuClient.deleteQueuedResourceAsync(request).get();
+
+    } catch (Exception e) {
+      System.out.println("Error unpacking QueuedResource: " + e.getMessage());
+    }
+    System.out.printf("Deleted Queued Resource: %s\n", name);
+  }
+}
+//[END tpu_queued_resources_delete_force]

--- a/tpu/src/main/java/tpu/DeleteForceQueuedResource.java
+++ b/tpu/src/main/java/tpu/DeleteForceQueuedResource.java
@@ -19,9 +19,12 @@ package tpu;
 //[START tpu_queued_resources_delete_force]
 
 import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.UnknownException;
 import com.google.cloud.tpu.v2alpha1.DeleteQueuedResourceRequest;
 import com.google.cloud.tpu.v2alpha1.TpuClient;
 import com.google.cloud.tpu.v2alpha1.TpuSettings;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 import org.threeten.bp.Duration;
 
 public class DeleteForceQueuedResource {
@@ -37,7 +40,7 @@ public class DeleteForceQueuedResource {
     deleteForceQueuedResource(projectId, zone, queuedResourceId);
   }
 
-  // Deletes a Queued Resource asynchronously with force=true flag.
+  // Deletes a Queued Resource asynchronously with --force flag.
   public static void deleteForceQueuedResource(
       String projectId, String zone, String queuedResourceId) {
     String name = String.format("projects/%s/locations/%s/queuedResources/%s",
@@ -66,8 +69,8 @@ public class DeleteForceQueuedResource {
 
       tpuClient.deleteQueuedResourceAsync(request).get();
 
-    } catch (Exception e) {
-      System.out.println("Error unpacking QueuedResource: " + e.getMessage());
+    } catch (UnknownException | InterruptedException | ExecutionException | IOException e) {
+      System.out.println(e.getMessage());
     }
     System.out.printf("Deleted Queued Resource: %s\n", name);
   }

--- a/tpu/src/main/java/tpu/DeleteQueuedResource.java
+++ b/tpu/src/main/java/tpu/DeleteQueuedResource.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tpu;
+
+//[START tpu_queued_resources_delete]
+
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.cloud.tpu.v2alpha1.DeleteQueuedResourceRequest;
+import com.google.cloud.tpu.v2alpha1.TpuClient;
+import com.google.cloud.tpu.v2alpha1.TpuSettings;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import org.threeten.bp.Duration;
+
+public class DeleteQueuedResource {
+  public static void main(String[] args)
+      throws IOException, ExecutionException, InterruptedException {
+    // TODO(developer): Replace these variables before running the sample.
+    // Project ID or project number of the Google Cloud project.
+    String projectId = "YOUR_PROJECT_ID";
+    // The zone in which the TPU was created.
+    String zone = "europe-west4-a";
+    // The name for your Queued Resource.
+    String queuedResourceId = "QUEUED_RESOURCE_ID";
+
+    deleteQueuedResource(projectId, zone, queuedResourceId);
+  }
+
+  // Deletes a Queued Resource asynchronously.
+  public static void deleteQueuedResource(String projectId, String zone, String queuedResourceId)
+      throws ExecutionException, InterruptedException {
+    String name = String.format("projects/%s/locations/%s/queuedResources/%s",
+            projectId, zone, queuedResourceId);
+    // With these settings the client library handles the Operation's polling mechanism
+    // and prevent CancellationException error
+    TpuSettings.Builder clientSettings =
+        TpuSettings.newBuilder();
+    clientSettings
+        .deleteQueuedResourceSettings()
+        .setRetrySettings(
+            RetrySettings.newBuilder()
+                .setInitialRetryDelay(Duration.ofMillis(5000L))
+                .setRetryDelayMultiplier(2.0)
+                .setInitialRpcTimeout(Duration.ZERO)
+                .setRpcTimeoutMultiplier(1.0)
+                .setMaxRetryDelay(Duration.ofMillis(45000L))
+                .setTotalTimeout(Duration.ofHours(24L))
+                .build());
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    try (TpuClient tpuClient = TpuClient.create(clientSettings.build())) {
+      DeleteQueuedResourceRequest request =
+          DeleteQueuedResourceRequest.newBuilder().setName(name).build();
+
+      tpuClient.deleteQueuedResourceAsync(request).get();
+
+    } catch (Exception e) {
+      System.out.println("Error unpacking QueuedResource: " + e.getMessage());
+    }
+    System.out.printf("Deleted Queued Resource: %s\n", name);
+  }
+}
+//[END tpu_queued_resources_delete]

--- a/tpu/src/main/java/tpu/DeleteQueuedResource.java
+++ b/tpu/src/main/java/tpu/DeleteQueuedResource.java
@@ -27,6 +27,7 @@ import com.google.cloud.tpu.v2alpha1.TpuClient;
 import com.google.cloud.tpu.v2alpha1.TpuSettings;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.threeten.bp.Duration;
 
 public class DeleteQueuedResource {
@@ -71,6 +72,8 @@ public class DeleteQueuedResource {
       String nodeName = queuedResource.getTpu().getNodeSpec(0).getNode().getName();
       // Before deleting the queued resource it is required to delete the TPU VM.
       DeleteTpuVm.deleteTpuVm(projectId, zone, nodeName);
+      // Wait until TpuVm is deleted
+      TimeUnit.MINUTES.sleep(3);
 
       DeleteQueuedResourceRequest request =
           DeleteQueuedResourceRequest.newBuilder().setName(name).build();

--- a/tpu/src/main/java/tpu/DeleteTpuVm.java
+++ b/tpu/src/main/java/tpu/DeleteTpuVm.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tpu;
+
+//[START tpu_vm_delete]
+
+import com.google.cloud.tpu.v2.DeleteNodeRequest;
+import com.google.cloud.tpu.v2.NodeName;
+import com.google.cloud.tpu.v2.TpuClient;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+public class DeleteTpuVm {
+
+  public static void main(String[] args)
+      throws IOException, ExecutionException, InterruptedException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "YOUR_PROJECT_ID";
+    String zone = "europe-west4-a";
+    String tpuVmName = "YOUR_TPU_NAME";
+
+    deleteTpuVm(projectId, zone, tpuVmName);
+  }
+
+  // Deletes a TPU VM with the specified name in the given project and zone.
+  public static void deleteTpuVm(String projectId, String zone, String tpuVmName)
+      throws IOException, ExecutionException, InterruptedException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    try (TpuClient tpuClient = TpuClient.create()) {
+      String nodeName = NodeName.of(projectId, zone, tpuVmName).toString();
+
+      DeleteNodeRequest request = DeleteNodeRequest.newBuilder().setName(nodeName).build();
+      tpuClient.deleteNodeAsync(request).get();
+
+      System.out.println("TPU VM deleted");
+    }
+  }
+}
+//[END tpu_vm_delete]

--- a/tpu/src/main/java/tpu/DeleteTpuVm.java
+++ b/tpu/src/main/java/tpu/DeleteTpuVm.java
@@ -48,6 +48,8 @@ public class DeleteTpuVm {
   // Deletes a TPU VM with the specified name in the given project and zone.
   public static void deleteTpuVm(String projectId, String zone, String nodeName)
       throws IOException, ExecutionException, InterruptedException {
+    // With these settings the client library handles the Operation's polling mechanism
+    // and prevent CancellationException error
     TpuSettings.Builder clientSettings =
         TpuSettings.newBuilder();
     clientSettings

--- a/tpu/src/main/java/tpu/GetQueuedResource.java
+++ b/tpu/src/main/java/tpu/GetQueuedResource.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tpu;
+
+//[START tpu_queued_resources_get]
+
+import com.google.cloud.tpu.v2alpha1.GetQueuedResourceRequest;
+import com.google.cloud.tpu.v2alpha1.QueuedResource;
+import com.google.cloud.tpu.v2alpha1.TpuClient;
+import java.io.IOException;
+
+public class GetQueuedResource {
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    // Project ID or project number of the Google Cloud project.
+    String projectId = "YOUR_PROJECT_ID";
+    // The zone in which the TPU was created.
+    String zone = "europe-west4-a";
+    // The name for your Queued Resource.
+    String queuedResourceId = "QUEUED_RESOURCE_ID";
+
+    getQueuedResource(projectId, zone, queuedResourceId);
+  }
+
+  // Get a Queued Resource.
+  public static QueuedResource getQueuedResource(
+      String projectId, String zone, String queuedResourceId) throws IOException {
+    String name = String.format("projects/%s/locations/%s/queuedResources/%s",
+              projectId, zone, queuedResourceId);
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    try (TpuClient tpuClient = TpuClient.create()) {
+      GetQueuedResourceRequest request =
+          GetQueuedResourceRequest.newBuilder().setName(name).build();
+
+      return tpuClient.getQueuedResource(request);
+    }
+  }
+}
+//[END tpu_queued_resources_get]

--- a/tpu/src/main/java/tpu/GetTpuVm.java
+++ b/tpu/src/main/java/tpu/GetTpuVm.java
@@ -28,23 +28,28 @@ public class GetTpuVm {
 
   public static void main(String[] args) throws IOException {
     // TODO(developer): Replace these variables before running the sample.
+    // Project ID or project number of the Google Cloud project you want to create a node.
     String projectId = "YOUR_PROJECT_ID";
+    // The zone in which to create the TPU.
+    // For more information about supported TPU types for specific zones,
+    // see https://cloud.google.com/tpu/docs/regions-zones
     String zone = "europe-west4-a";
-    String tpuVmName = "YOUR_TPU_NAME";
+    // The name for your TPU.
+    String nodeName = "YOUR_TPY_NAME";
 
-    getTpuVm(projectId, zone, tpuVmName);
+    getTpuVm(projectId, zone, nodeName);
   }
 
   // Describes a TPU VM with the specified name in the given project and zone.
-  public static Node getTpuVm(String projectId, String zone, String tpuVmName)
+  public static Node getTpuVm(String projectId, String zone, String nodeName)
       throws IOException {
     Node node;
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests.
     try (TpuClient tpuClient = TpuClient.create()) {
-      String nodeName = NodeName.of(projectId, zone, tpuVmName).toString();
+      String name = NodeName.of(projectId, zone, nodeName).toString();
 
-      GetNodeRequest request = GetNodeRequest.newBuilder().setName(nodeName).build();
+      GetNodeRequest request = GetNodeRequest.newBuilder().setName(name).build();
       node = tpuClient.getNode(request);
     }
     return node;

--- a/tpu/src/main/java/tpu/GetTpuVm.java
+++ b/tpu/src/main/java/tpu/GetTpuVm.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tpu;
+
+//[START tpu_vm_get]
+
+import com.google.cloud.tpu.v2.GetNodeRequest;
+import com.google.cloud.tpu.v2.Node;
+import com.google.cloud.tpu.v2.NodeName;
+import com.google.cloud.tpu.v2.TpuClient;
+import java.io.IOException;
+
+public class GetTpuVm {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "YOUR_PROJECT_ID";
+    String zone = "europe-west4-a";
+    String tpuVmName = "YOUR_TPU_NAME";
+
+    getTpuVm(projectId, zone, tpuVmName);
+  }
+
+  // Describes a TPU VM with the specified name in the given project and zone.
+  public static Node getTpuVm(String projectId, String zone, String tpuVmName)
+      throws IOException {
+    Node node;
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    try (TpuClient tpuClient = TpuClient.create()) {
+      String nodeName = NodeName.of(projectId, zone, tpuVmName).toString();
+
+      GetNodeRequest request = GetNodeRequest.newBuilder().setName(nodeName).build();
+      node = tpuClient.getNode(request);
+    }
+    return node;
+  }
+}
+//[END tpu_vm_get]

--- a/tpu/src/main/java/tpu/ListQueuedResources.java
+++ b/tpu/src/main/java/tpu/ListQueuedResources.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tpu;
+
+import com.google.cloud.tpu.v2alpha1.ListQueuedResourcesRequest;
+import com.google.cloud.tpu.v2alpha1.TpuClient;
+import java.io.IOException;
+
+public class ListQueuedResources {
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    // Project ID or project number of the Google Cloud project.
+    String projectId = "YOUR_PROJECT_ID";
+    // The zone in which the TPU was created.
+    String zone = "europe-west4-a";
+
+    listQueuedResources(projectId, zone);
+  }
+
+  // List Queued Resources.
+  public static TpuClient.ListQueuedResourcesPagedResponse listQueuedResources(
+      String projectId, String zone) throws IOException {
+    String parent = String.format("projects/%s/locations/%s", projectId, zone);
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    try (TpuClient tpuClient = TpuClient.create()) {
+      ListQueuedResourcesRequest request =
+          ListQueuedResourcesRequest.newBuilder().setParent(parent).build();
+
+      return tpuClient.listQueuedResources(request);
+    }
+  }
+}

--- a/tpu/src/main/java/tpu/ListQueuedResources.java
+++ b/tpu/src/main/java/tpu/ListQueuedResources.java
@@ -16,6 +16,8 @@
 
 package tpu;
 
+//[START tpu_queued_resources_list]
+
 import com.google.cloud.tpu.v2alpha1.ListQueuedResourcesRequest;
 import com.google.cloud.tpu.v2alpha1.TpuClient;
 import java.io.IOException;
@@ -45,3 +47,4 @@ public class ListQueuedResources {
     }
   }
 }
+//[END tpu_queued_resources_list]

--- a/tpu/src/main/java/tpu/ListTpuVms.java
+++ b/tpu/src/main/java/tpu/ListTpuVms.java
@@ -27,7 +27,11 @@ public class ListTpuVms {
 
   public static void main(String[] args) throws IOException {
     // TODO(developer): Replace these variables before running the sample.
+    // Project ID or project number of the Google Cloud project you want to create a node.
     String projectId = "YOUR_PROJECT_ID";
+    // The zone in which to create the TPU.
+    // For more information about supported TPU types for specific zones,
+    // see https://cloud.google.com/tpu/docs/regions-zones
     String zone = "europe-west4-a";
 
     listTpuVms(projectId, zone);

--- a/tpu/src/main/java/tpu/ListTpuVms.java
+++ b/tpu/src/main/java/tpu/ListTpuVms.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tpu;
+
+//[START tpu_vm_list]
+
+import com.google.cloud.tpu.v2.ListNodesRequest;
+import com.google.cloud.tpu.v2.TpuClient;
+import com.google.cloud.tpu.v2.TpuClient.ListNodesPagedResponse;
+import java.io.IOException;
+
+public class ListTpuVms {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "YOUR_PROJECT_ID";
+    String zone = "europe-west4-a";
+
+    listTpuVms(projectId, zone);
+  }
+
+  // Lists TPU VMs in the specified zone.
+  public static ListNodesPagedResponse listTpuVms(String projectId, String zone)
+      throws IOException {
+    ListNodesPagedResponse response;
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    try (TpuClient tpuClient = TpuClient.create()) {
+      String parent = String.format("projects/%s/locations/%s", projectId, zone);
+
+      ListNodesRequest request = ListNodesRequest.newBuilder().setParent(parent).build();
+      response = tpuClient.listNodes(request);
+    }
+    return response;
+  }
+}
+//[END tpu_vm_list]

--- a/tpu/src/main/java/tpu/StartTpuVm.java
+++ b/tpu/src/main/java/tpu/StartTpuVm.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tpu;
+
+//[START tpu_vm_start]
+
+import com.google.cloud.tpu.v2.Node;
+import com.google.cloud.tpu.v2.NodeName;
+import com.google.cloud.tpu.v2.StartNodeRequest;
+import com.google.cloud.tpu.v2.TpuClient;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+public class StartTpuVm {
+
+  public static void main(String[] args)
+      throws IOException, ExecutionException, InterruptedException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "YOUR_PROJECT_ID";
+    String zone = "europe-west4-a";
+    String tpuVmName = "YOUR_TPU_NAME";
+
+    startTpuVm(projectId, zone, tpuVmName);
+  }
+
+  // Starts a TPU VM with the specified name in the given project and zone.
+  public static void startTpuVm(String projectId, String zone, String tpuVmName)
+      throws IOException, ExecutionException, InterruptedException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    try (TpuClient tpuClient = TpuClient.create()) {
+      String nodeName = NodeName.of(projectId, zone, tpuVmName).toString();
+
+      StartNodeRequest request = StartNodeRequest.newBuilder().setName(nodeName).build();
+      Node response = tpuClient.startNodeAsync(request).get();
+
+      System.out.printf("TPU VM started: %s\n", response.getName());
+    }
+  }
+}
+//[END tpu_vm_start]

--- a/tpu/src/main/java/tpu/StartTpuVm.java
+++ b/tpu/src/main/java/tpu/StartTpuVm.java
@@ -30,22 +30,27 @@ public class StartTpuVm {
   public static void main(String[] args)
       throws IOException, ExecutionException, InterruptedException {
     // TODO(developer): Replace these variables before running the sample.
+    // Project ID or project number of the Google Cloud project you want to create a node.
     String projectId = "YOUR_PROJECT_ID";
+    // The zone in which to create the TPU.
+    // For more information about supported TPU types for specific zones,
+    // see https://cloud.google.com/tpu/docs/regions-zones
     String zone = "europe-west4-a";
-    String tpuVmName = "YOUR_TPU_NAME";
+    // The name for your TPU.
+    String nodeName = "YOUR_TPY_NAME";
 
-    startTpuVm(projectId, zone, tpuVmName);
+    startTpuVm(projectId, zone, nodeName);
   }
 
   // Starts a TPU VM with the specified name in the given project and zone.
-  public static void startTpuVm(String projectId, String zone, String tpuVmName)
+  public static void startTpuVm(String projectId, String zone, String nodeName)
       throws IOException, ExecutionException, InterruptedException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests.
     try (TpuClient tpuClient = TpuClient.create()) {
-      String nodeName = NodeName.of(projectId, zone, tpuVmName).toString();
+      String name = NodeName.of(projectId, zone, nodeName).toString();
 
-      StartNodeRequest request = StartNodeRequest.newBuilder().setName(nodeName).build();
+      StartNodeRequest request = StartNodeRequest.newBuilder().setName(name).build();
       Node response = tpuClient.startNodeAsync(request).get();
 
       System.out.printf("TPU VM started: %s\n", response.getName());

--- a/tpu/src/main/java/tpu/StopTpuVm.java
+++ b/tpu/src/main/java/tpu/StopTpuVm.java
@@ -30,22 +30,27 @@ public class StopTpuVm {
   public static void main(String[] args)
       throws IOException, ExecutionException, InterruptedException {
     // TODO(developer): Replace these variables before running the sample.
+    // Project ID or project number of the Google Cloud project you want to create a node.
     String projectId = "YOUR_PROJECT_ID";
+    // The zone in which to create the TPU.
+    // For more information about supported TPU types for specific zones,
+    // see https://cloud.google.com/tpu/docs/regions-zones
     String zone = "europe-west4-a";
-    String tpuVmName = "YOUR_TPU_NAME";
+    // The name for your TPU.
+    String nodeName = "YOUR_TPY_NAME";
 
-    stopTpuVm(projectId, zone, tpuVmName);
+    stopTpuVm(projectId, zone, nodeName);
   }
 
   // Stops a TPU VM with the specified name in the given project and zone.
-  public static void stopTpuVm(String projectId, String zone, String tpuVmName)
+  public static void stopTpuVm(String projectId, String zone, String nodeName)
       throws IOException, ExecutionException, InterruptedException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests.
     try (TpuClient tpuClient = TpuClient.create()) {
-      String nodeName = NodeName.of(projectId, zone, tpuVmName).toString();
+      String name = NodeName.of(projectId, zone, nodeName).toString();
 
-      StopNodeRequest request = StopNodeRequest.newBuilder().setName(nodeName).build();
+      StopNodeRequest request = StopNodeRequest.newBuilder().setName(name).build();
       Node response = tpuClient.stopNodeAsync(request).get();
 
       System.out.printf("TPU VM stopped: %s\n", response.getName());

--- a/tpu/src/main/java/tpu/StopTpuVm.java
+++ b/tpu/src/main/java/tpu/StopTpuVm.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tpu;
+
+//[START tpu_vm_stop]
+
+import com.google.cloud.tpu.v2.Node;
+import com.google.cloud.tpu.v2.NodeName;
+import com.google.cloud.tpu.v2.StopNodeRequest;
+import com.google.cloud.tpu.v2.TpuClient;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+public class StopTpuVm {
+
+  public static void main(String[] args)
+      throws IOException, ExecutionException, InterruptedException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "YOUR_PROJECT_ID";
+    String zone = "europe-west4-a";
+    String tpuVmName = "YOUR_TPU_NAME";
+
+    stopTpuVm(projectId, zone, tpuVmName);
+  }
+
+  // Stops a TPU VM with the specified name in the given project and zone.
+  public static void stopTpuVm(String projectId, String zone, String tpuVmName)
+      throws IOException, ExecutionException, InterruptedException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    try (TpuClient tpuClient = TpuClient.create()) {
+      String nodeName = NodeName.of(projectId, zone, tpuVmName).toString();
+
+      StopNodeRequest request = StopNodeRequest.newBuilder().setName(nodeName).build();
+      Node response = tpuClient.stopNodeAsync(request).get();
+
+      System.out.printf("TPU VM stopped: %s\n", response.getName());
+    }
+  }
+}
+//[END tpu_vm_stop]

--- a/tpu/src/main/java/tpu/StopTpuVm.java
+++ b/tpu/src/main/java/tpu/StopTpuVm.java
@@ -18,12 +18,16 @@ package tpu;
 
 //[START tpu_vm_stop]
 
+import com.google.api.gax.longrunning.OperationTimedPollAlgorithm;
+import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.tpu.v2.Node;
 import com.google.cloud.tpu.v2.NodeName;
 import com.google.cloud.tpu.v2.StopNodeRequest;
 import com.google.cloud.tpu.v2.TpuClient;
+import com.google.cloud.tpu.v2.TpuSettings;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
+import org.threeten.bp.Duration;
 
 public class StopTpuVm {
 
@@ -45,9 +49,27 @@ public class StopTpuVm {
   // Stops a TPU VM with the specified name in the given project and zone.
   public static void stopTpuVm(String projectId, String zone, String nodeName)
       throws IOException, ExecutionException, InterruptedException {
+    // With these settings the client library handles the Operation's polling mechanism
+    // and prevent CancellationException error
+    TpuSettings.Builder clientSettings =
+        TpuSettings.newBuilder();
+    clientSettings
+        .stopNodeOperationSettings()
+        .setPollingAlgorithm(
+            OperationTimedPollAlgorithm.create(
+                RetrySettings.newBuilder()
+                    .setInitialRetryDelay(Duration.ofMillis(5000L))
+                    .setRetryDelayMultiplier(1.5)
+                    .setMaxRetryDelay(Duration.ofMillis(45000L))
+                    .setInitialRpcTimeout(Duration.ZERO)
+                    .setRpcTimeoutMultiplier(1.0)
+                    .setMaxRpcTimeout(Duration.ZERO)
+                    .setTotalTimeout(Duration.ofHours(24L))
+                    .build()));
+
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests.
-    try (TpuClient tpuClient = TpuClient.create()) {
+    try (TpuClient tpuClient = TpuClient.create(clientSettings.build())) {
       String name = NodeName.of(projectId, zone, nodeName).toString();
 
       StopNodeRequest request = StopNodeRequest.newBuilder().setName(name).build();

--- a/tpu/src/test/java/tpu/QueuedResourcesIT.java
+++ b/tpu/src/test/java/tpu/QueuedResourcesIT.java
@@ -46,12 +46,12 @@ import org.junit.runners.JUnit4;
 @TestMethodOrder(MethodOrderer. OrderAnnotation. class)
 public class QueuedResourcesIT {
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
-  private static final String ZONE = "asia-east1-c";
+  private static final String ZONE = "us-central1-f";
   static String javaVersion = System.getProperty("java.version").substring(0, 2);
   private static final String NODE_NAME = "test-tpu-queued-resource-" + javaVersion + "-"
       + UUID.randomUUID().toString().substring(0, 8);
   private static final String TPU_TYPE = "v2-8";
-  private static final String TPU_SOFTWARE_VERSION = "tpu-vm-base";
+  private static final String TPU_SOFTWARE_VERSION = "tpu-vm-tf-2.17.0-pjrt";
   private static final String QUEUED_RESOURCE_NAME = "queued-resource-" + javaVersion + "-"
       + UUID.randomUUID().toString().substring(0, 8);
   private static final String QUEUED_RESOURCE_PATH_NAME =
@@ -98,7 +98,6 @@ public class QueuedResourcesIT {
     System.setOut(new PrintStream(stdOut));
     CreateQueuedResource.createQueuedResource(PROJECT_ID, ZONE,
         QUEUED_RESOURCE_NAME, NODE_NAME, TPU_TYPE, TPU_SOFTWARE_VERSION);
-    TimeUnit.MINUTES.sleep(15);
 
     assertThat(stdOut.toString()).contains("Queued Resource created: " + QUEUED_RESOURCE_PATH_NAME);
     stdOut.close();

--- a/tpu/src/test/java/tpu/QueuedResourcesIT.java
+++ b/tpu/src/test/java/tpu/QueuedResourcesIT.java
@@ -46,12 +46,12 @@ import org.junit.runners.JUnit4;
 @TestMethodOrder(MethodOrderer. OrderAnnotation. class)
 public class QueuedResourcesIT {
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
-  private static final String ZONE = "europe-west4-a";
+  private static final String ZONE = "asia-east1-c";
   static String javaVersion = System.getProperty("java.version").substring(0, 2);
   private static final String NODE_NAME = "test-tpu-queued-resource-" + javaVersion + "-"
       + UUID.randomUUID().toString().substring(0, 8);
   private static final String TPU_TYPE = "v2-8";
-  private static final String TPU_SOFTWARE_VERSION = "tpu-vm-tf-2.14.1";
+  private static final String TPU_SOFTWARE_VERSION = "tpu-vm-base";
   private static final String QUEUED_RESOURCE_NAME = "queued-resource-" + javaVersion + "-"
       + UUID.randomUUID().toString().substring(0, 8);
   private static final String QUEUED_RESOURCE_PATH_NAME =
@@ -64,26 +64,25 @@ public class QueuedResourcesIT {
   }
 
   @BeforeAll
-  public static void setUp()
-      throws IOException, ExecutionException, InterruptedException {
+  public static void setUp() throws IOException {
     requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
     requireEnvVar("GOOGLE_CLOUD_PROJECT");
 
     // Cleanup existing stale resources.
-    Util.cleanUpExistingTpu("test-tpu-queued-resource-" + javaVersion, PROJECT_ID, ZONE);
-    TimeUnit.MINUTES.sleep(5);
     Util.cleanUpExistingQueuedResources("queued-resource-", PROJECT_ID, ZONE);
   }
 
   @AfterAll
-  public static void cleanup() throws InterruptedException {
-    DeleteForceQueuedResource.deleteForceQueuedResource(PROJECT_ID, ZONE, QUEUED_RESOURCE_NAME);
-    TimeUnit.MINUTES.sleep(7);
+  public static void cleanup() {
+    DeleteQueuedResource.deleteQueuedResource(PROJECT_ID, ZONE, QUEUED_RESOURCE_NAME);
 
-    // Test that Queued Resource is deleted
+    // Test that resources are deleted
     Assertions.assertThrows(
         NotFoundException.class,
         () -> GetQueuedResource.getQueuedResource(PROJECT_ID, ZONE, QUEUED_RESOURCE_NAME));
+    Assertions.assertThrows(
+        NotFoundException.class,
+        () -> GetTpuVm.getTpuVm(PROJECT_ID, ZONE, NODE_NAME));
   }
 
   @Test
@@ -95,6 +94,7 @@ public class QueuedResourcesIT {
     System.setOut(new PrintStream(stdOut));
     CreateQueuedResource.createQueuedResource(PROJECT_ID, ZONE,
         QUEUED_RESOURCE_NAME, NODE_NAME, TPU_TYPE, TPU_SOFTWARE_VERSION);
+    TimeUnit.MINUTES.sleep(10);
 
     assertThat(stdOut.toString()).contains("Queued Resource created: " + QUEUED_RESOURCE_PATH_NAME);
     stdOut.close();

--- a/tpu/src/test/java/tpu/QueuedResourcesIT.java
+++ b/tpu/src/test/java/tpu/QueuedResourcesIT.java
@@ -56,7 +56,6 @@ public class QueuedResourcesIT {
       + UUID.randomUUID().toString().substring(0, 8);
   private static final String QUEUED_RESOURCE_PATH_NAME =
       String.format("projects/%s/locations/%s/queuedResources/%s",
-
           PROJECT_ID, ZONE, QUEUED_RESOURCE_NAME);
 
   public static void requireEnvVar(String envVarName) {
@@ -72,13 +71,14 @@ public class QueuedResourcesIT {
 
     // Cleanup existing stale resources.
     Util.cleanUpExistingTpu("test-tpu-queued-resource-" + javaVersion, PROJECT_ID, ZONE);
-    TimeUnit.MINUTES.sleep(3);
+    TimeUnit.MINUTES.sleep(5);
     Util.cleanUpExistingQueuedResources("queued-resource-", PROJECT_ID, ZONE);
   }
 
   @AfterAll
-  public static void cleanup() {
+  public static void cleanup() throws InterruptedException {
     DeleteForceQueuedResource.deleteForceQueuedResource(PROJECT_ID, ZONE, QUEUED_RESOURCE_NAME);
+    TimeUnit.MINUTES.sleep(5);
 
     // Test that Queued Resource is deleted
     Assertions.assertThrows(

--- a/tpu/src/test/java/tpu/QueuedResourcesIT.java
+++ b/tpu/src/test/java/tpu/QueuedResourcesIT.java
@@ -78,7 +78,7 @@ public class QueuedResourcesIT {
   @AfterAll
   public static void cleanup() throws InterruptedException {
     DeleteForceQueuedResource.deleteForceQueuedResource(PROJECT_ID, ZONE, QUEUED_RESOURCE_NAME);
-    TimeUnit.MINUTES.sleep(5);
+    TimeUnit.MINUTES.sleep(7);
 
     // Test that Queued Resource is deleted
     Assertions.assertThrows(

--- a/tpu/src/test/java/tpu/QueuedResourcesIT.java
+++ b/tpu/src/test/java/tpu/QueuedResourcesIT.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tpu;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.Assert.assertNotNull;
+
+import com.google.api.gax.rpc.NotFoundException;
+import com.google.cloud.tpu.v2alpha1.QueuedResource;
+import com.google.cloud.tpu.v2alpha1.TpuClient;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+@Timeout(value = 25, unit = TimeUnit.MINUTES)
+@TestMethodOrder(MethodOrderer. OrderAnnotation. class)
+public class QueuedResourcesIT {
+  private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static final String ZONE = "europe-west4-a";
+  static String javaVersion = System.getProperty("java.version").substring(0, 2);
+  private static final String NODE_NAME = "test-tpu-queued-resource-" + javaVersion + "-"
+      + UUID.randomUUID().toString().substring(0, 8);
+  private static final String TPU_TYPE = "v2-8";
+  private static final String TPU_SOFTWARE_VERSION = "tpu-vm-tf-2.14.1";
+  private static final String QUEUED_RESOURCE_NAME = "queued-resource-" + javaVersion + "-"
+      + UUID.randomUUID().toString().substring(0, 8);
+  private static final String QUEUED_RESOURCE_PATH_NAME =
+      String.format("projects/%s/locations/%s/queuedResources/%s",
+
+          PROJECT_ID, ZONE, QUEUED_RESOURCE_NAME);
+
+  public static void requireEnvVar(String envVarName) {
+    assertWithMessage(String.format("Missing environment variable '%s' ", envVarName))
+        .that(System.getenv(envVarName)).isNotEmpty();
+  }
+
+  @BeforeAll
+  public static void setUp()
+      throws IOException, ExecutionException, InterruptedException {
+    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+
+    // Cleanup existing stale resources.
+    Util.cleanUpExistingTpu("test-tpu-queued-resource-" + javaVersion, PROJECT_ID, ZONE);
+    TimeUnit.MINUTES.sleep(3);
+    Util.cleanUpExistingQueuedResources("queued-resource-", PROJECT_ID, ZONE);
+  }
+
+  @AfterAll
+  public static void cleanup() {
+    DeleteForceQueuedResource.deleteForceQueuedResource(PROJECT_ID, ZONE, QUEUED_RESOURCE_NAME);
+
+    // Test that Queued Resource is deleted
+    Assertions.assertThrows(
+        NotFoundException.class,
+        () -> GetQueuedResource.getQueuedResource(PROJECT_ID, ZONE, QUEUED_RESOURCE_NAME));
+  }
+
+  @Test
+  @Order(1)
+  public void testCreateQueuedResource()
+      throws IOException, ExecutionException, InterruptedException {
+    final PrintStream out = System.out;
+    ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(stdOut));
+    CreateQueuedResource.createQueuedResource(PROJECT_ID, ZONE,
+        QUEUED_RESOURCE_NAME, NODE_NAME, TPU_TYPE, TPU_SOFTWARE_VERSION);
+
+    assertThat(stdOut.toString()).contains("Queued Resource created: " + QUEUED_RESOURCE_PATH_NAME);
+    stdOut.close();
+    System.setOut(out);
+  }
+
+  @Test
+  @Order(2)
+  public void testGetQueuedResource() throws IOException {
+    QueuedResource queuedResource = GetQueuedResource.getQueuedResource(
+        PROJECT_ID, ZONE, QUEUED_RESOURCE_NAME);
+
+    assertNotNull(queuedResource);
+    assertThat(queuedResource.getName()).isEqualTo(QUEUED_RESOURCE_PATH_NAME);
+  }
+
+  @Test
+  @Order(2)
+  public void testListQueuedResources() throws IOException {
+    TpuClient.ListQueuedResourcesPagedResponse listQueuedResources =
+        ListQueuedResources.listQueuedResources(PROJECT_ID, ZONE);
+
+    assertNotNull(listQueuedResources);
+    for (QueuedResource queuedResource : listQueuedResources.iterateAll()) {
+      Assert.assertTrue((queuedResource.getName()
+          .substring(queuedResource.getName().lastIndexOf("/") + 1))
+          .contains("queued-resource-"));
+    }
+  }
+}

--- a/tpu/src/test/java/tpu/QueuedResourcesIT.java
+++ b/tpu/src/test/java/tpu/QueuedResourcesIT.java
@@ -73,16 +73,20 @@ public class QueuedResourcesIT {
   }
 
   @AfterAll
-  public static void cleanup() {
+  public static void cleanup() throws IOException {
+    final PrintStream out = System.out;
+    ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(stdOut));
     DeleteQueuedResource.deleteQueuedResource(PROJECT_ID, ZONE, QUEUED_RESOURCE_NAME);
 
     // Test that resources are deleted
-    Assertions.assertThrows(
-        NotFoundException.class,
-        () -> GetQueuedResource.getQueuedResource(PROJECT_ID, ZONE, QUEUED_RESOURCE_NAME));
+    assertThat(stdOut.toString()).contains("Deleted Queued Resource:");
     Assertions.assertThrows(
         NotFoundException.class,
         () -> GetTpuVm.getTpuVm(PROJECT_ID, ZONE, NODE_NAME));
+
+    stdOut.close();
+    System.setOut(out);
   }
 
   @Test
@@ -94,7 +98,7 @@ public class QueuedResourcesIT {
     System.setOut(new PrintStream(stdOut));
     CreateQueuedResource.createQueuedResource(PROJECT_ID, ZONE,
         QUEUED_RESOURCE_NAME, NODE_NAME, TPU_TYPE, TPU_SOFTWARE_VERSION);
-    TimeUnit.MINUTES.sleep(10);
+    TimeUnit.MINUTES.sleep(15);
 
     assertThat(stdOut.toString()).contains("Queued Resource created: " + QUEUED_RESOURCE_PATH_NAME);
     stdOut.close();

--- a/tpu/src/test/java/tpu/QueuedResourcesIT.java
+++ b/tpu/src/test/java/tpu/QueuedResourcesIT.java
@@ -93,15 +93,11 @@ public class QueuedResourcesIT {
   @Order(1)
   public void testCreateQueuedResource()
       throws IOException, ExecutionException, InterruptedException {
-    final PrintStream out = System.out;
-    ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(stdOut));
-    CreateQueuedResource.createQueuedResource(PROJECT_ID, ZONE,
+    QueuedResource queuedResource = CreateQueuedResource.createQueuedResource(PROJECT_ID, ZONE,
         QUEUED_RESOURCE_NAME, NODE_NAME, TPU_TYPE, TPU_SOFTWARE_VERSION);
 
-    assertThat(stdOut.toString()).contains("Queued Resource created: " + QUEUED_RESOURCE_PATH_NAME);
-    stdOut.close();
-    System.setOut(out);
+    assertThat(queuedResource.getName()).isEqualTo(QUEUED_RESOURCE_PATH_NAME);
+    assertThat(queuedResource.getTpu().getNodeSpec(0).getNode().getName()).isEqualTo(NODE_NAME);
   }
 
   @Test

--- a/tpu/src/test/java/tpu/TpuVmIT.java
+++ b/tpu/src/test/java/tpu/TpuVmIT.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tpu;
+
+import static com.google.cloud.tpu.v2.Node.State.READY;
+import static com.google.cloud.tpu.v2.Node.State.STOPPED;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.Assert.assertNotNull;
+
+import com.google.api.gax.rpc.NotFoundException;
+import com.google.cloud.tpu.v2.Node;
+import com.google.cloud.tpu.v2.TpuClient;
+import com.google.protobuf.Timestamp;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+@Timeout(value = 25, unit = TimeUnit.MINUTES)
+@TestMethodOrder(MethodOrderer. OrderAnnotation. class)
+public class TpuVmIT {
+  private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static final String ZONE = "europe-west4-b";
+  static String javaVersion = System.getProperty("java.version").substring(0, 2);
+  private static final String TPU_VM_NAME = "test-tpu-" + javaVersion + "-"
+      + UUID.randomUUID().toString().substring(0, 8);
+  private static final String ACCELERATOR_TYPE = "v5litepod-1";
+  private static final String VERSION = "tpu-vm-cos-stable";
+  private static final String TPU_VM_PATH_NAME =
+      String.format("projects/%s/locations/%s/nodes/%s", PROJECT_ID, ZONE, TPU_VM_NAME);
+
+  public static void requireEnvVar(String envVarName) {
+    assertWithMessage(String.format("Missing environment variable '%s' ", envVarName))
+        .that(System.getenv(envVarName)).isNotEmpty();
+  }
+
+  @BeforeAll
+  public static void setUp()
+      throws IOException, ExecutionException, InterruptedException {
+    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+
+    // Cleanup existing stale resources.
+    cleanUpExistingTpu("test-tpu-" + javaVersion, PROJECT_ID, ZONE);
+  }
+
+  @AfterAll
+  public static void cleanup() throws Exception {
+    DeleteTpuVm.deleteTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
+    TimeUnit.MINUTES.sleep(5);
+
+    // Test that TPUs is deleted
+    Assertions.assertThrows(
+        NotFoundException.class,
+        () -> GetTpuVm.getTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME));
+  }
+
+  @Test
+  @Order(1)
+  public void testCreateTpuVm() throws IOException, ExecutionException, InterruptedException {
+    final PrintStream out = System.out;
+    ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(stdOut));
+    CreateTpuVm.createTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME, ACCELERATOR_TYPE, VERSION);
+
+    assertThat(stdOut.toString()).contains("TPU VM created: " + TPU_VM_PATH_NAME);
+    stdOut.close();
+    System.setOut(out);
+  }
+
+  @Test
+  @Order(2)
+  public void testGetTpuVm() throws IOException {
+    Node node = GetTpuVm.getTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
+    assertNotNull(node);
+    assertThat(node.getName()).isEqualTo(TPU_VM_PATH_NAME);
+  }
+
+  @Test
+  @Order(2)
+  public void testListTpuVm() throws IOException {
+    TpuClient.ListNodesPagedResponse nodesList = ListTpuVms.listTpuVms(PROJECT_ID, ZONE);
+    assertNotNull(nodesList);
+    for (Node node : nodesList.iterateAll()) {
+      Assert.assertTrue(node.getName().contains("test-tpu"));
+    }
+  }
+
+  @Test
+  @Order(2)
+  public void testStopTpuVm() throws IOException, ExecutionException, InterruptedException {
+    StopTpuVm.stopTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
+    Node node = GetTpuVm.getTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
+    assertThat(node.getState()).isEqualTo(STOPPED);
+  }
+
+  @Test
+  @Order(3)
+  public void testStartTpuVm() throws IOException, ExecutionException, InterruptedException {
+    StartTpuVm.startTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
+    Node node = GetTpuVm.getTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
+    assertThat(node.getState()).isEqualTo(READY);
+  }
+
+  public static void cleanUpExistingTpu(String prefixToDelete, String projectId, String zone)
+      throws IOException, ExecutionException, InterruptedException {
+    try (TpuClient tpuClient = TpuClient.create()) {
+      String parent = String.format("projects/%s/locations/%s", projectId, zone);
+      for (Node node : tpuClient.listNodes(parent).iterateAll()) {
+        String creationTime = formatTimestamp(node.getCreateTime());
+        String name = node.getName().substring(node.getName().lastIndexOf("/") + 1);
+        if (containPrefixToDeleteAndZone(node, prefixToDelete, zone)
+            && isCreatedBeforeThresholdTime(creationTime)) {
+          DeleteTpuVm.deleteTpuVm(projectId, zone, name);
+        }
+      }
+    }
+  }
+
+  public static boolean containPrefixToDeleteAndZone(
+      Node node, String prefixToDelete, String zone) {
+    boolean containPrefixAndZone = false;
+    try {
+      containPrefixAndZone = node.getName().contains(prefixToDelete)
+          && node.getName().split("/")[3].contains(zone);
+
+    } catch (NullPointerException e) {
+      System.out.println("Resource not found, skipping deletion:");
+    }
+    return containPrefixAndZone;
+  }
+
+  public static boolean isCreatedBeforeThresholdTime(String timestamp) {
+    return OffsetDateTime.parse(timestamp).toInstant()
+        .isBefore(Instant.now().minus(5, ChronoUnit.MINUTES));
+  }
+
+  private static String formatTimestamp(Timestamp timestamp) {
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+    OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(
+        Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanos()),
+        ZoneOffset.UTC);
+    return formatter.format(offsetDateTime);
+  }
+}

--- a/tpu/src/test/java/tpu/TpuVmIT.java
+++ b/tpu/src/test/java/tpu/TpuVmIT.java
@@ -22,7 +22,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.Assert.assertNotNull;
 
-import com.google.api.gax.rpc.NotFoundException;
 import com.google.cloud.tpu.v2.Node;
 import com.google.cloud.tpu.v2.TpuClient;
 import java.io.ByteArrayOutputStream;
@@ -33,8 +32,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -70,20 +69,23 @@ public class TpuVmIT {
 
     // Cleanup existing stale resources.
     Util.cleanUpExistingTpu("test-tpu-" + javaVersion, PROJECT_ID, ZONE);
+    Util.cleanUpExistingTpu("test-tpu-" + javaVersion, PROJECT_ID, "asia-east1-c");
+    Util.cleanUpExistingTpu("test-tpu-" + javaVersion, PROJECT_ID, "europe-west4-a");
   }
 
   @AfterAll
-  public static void cleanup() throws Exception {
-    DeleteTpuVm.deleteTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
+  public static void cleanup() {
+    //DeleteTpuVm.deleteTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
 
     // Test that TPUs is deleted
-    Assertions.assertThrows(
-        NotFoundException.class,
-        () -> GetTpuVm.getTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME));
+    //Assertions.assertThrows(
+    //    NotFoundException.class,
+    //    () -> GetTpuVm.getTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME));
   }
 
   @Test
   @Order(1)
+  @Disabled
   public void testCreateTpuVm() throws IOException, ExecutionException, InterruptedException {
     final PrintStream out = System.out;
     ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
@@ -97,6 +99,7 @@ public class TpuVmIT {
 
   @Test
   @Order(2)
+  @Disabled
   public void testGetTpuVm() throws IOException {
     Node node = GetTpuVm.getTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
 
@@ -106,6 +109,7 @@ public class TpuVmIT {
 
   @Test
   @Order(2)
+  @Disabled
   public void testListTpuVm() throws IOException {
     TpuClient.ListNodesPagedResponse nodesList = ListTpuVms.listTpuVms(PROJECT_ID, ZONE);
 
@@ -117,6 +121,7 @@ public class TpuVmIT {
 
   @Test
   @Order(2)
+  @Disabled
   public void testStopTpuVm() throws IOException, ExecutionException, InterruptedException {
     StopTpuVm.stopTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
     Node node = GetTpuVm.getTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
@@ -126,6 +131,7 @@ public class TpuVmIT {
 
   @Test
   @Order(3)
+  @Disabled
   public void testStartTpuVm() throws IOException, ExecutionException, InterruptedException {
     StartTpuVm.startTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
     Node node = GetTpuVm.getTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);

--- a/tpu/src/test/java/tpu/TpuVmIT.java
+++ b/tpu/src/test/java/tpu/TpuVmIT.java
@@ -22,6 +22,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.Assert.assertNotNull;
 
+import com.google.api.gax.rpc.NotFoundException;
 import com.google.cloud.tpu.v2.Node;
 import com.google.cloud.tpu.v2.TpuClient;
 import java.io.ByteArrayOutputStream;
@@ -32,8 +33,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -69,23 +70,20 @@ public class TpuVmIT {
 
     // Cleanup existing stale resources.
     Util.cleanUpExistingTpu("test-tpu-" + javaVersion, PROJECT_ID, ZONE);
-    Util.cleanUpExistingTpu("test-tpu-" + javaVersion, PROJECT_ID, "asia-east1-c");
-    Util.cleanUpExistingTpu("test-tpu-" + javaVersion, PROJECT_ID, "europe-west4-a");
   }
 
   @AfterAll
-  public static void cleanup() {
-    //DeleteTpuVm.deleteTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
+  public static void cleanup() throws IOException, ExecutionException, InterruptedException {
+    DeleteTpuVm.deleteTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
 
     // Test that TPUs is deleted
-    //Assertions.assertThrows(
-    //    NotFoundException.class,
-    //    () -> GetTpuVm.getTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME));
+    Assertions.assertThrows(
+        NotFoundException.class,
+        () -> GetTpuVm.getTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME));
   }
 
   @Test
   @Order(1)
-  @Disabled
   public void testCreateTpuVm() throws IOException, ExecutionException, InterruptedException {
     final PrintStream out = System.out;
     ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
@@ -99,7 +97,6 @@ public class TpuVmIT {
 
   @Test
   @Order(2)
-  @Disabled
   public void testGetTpuVm() throws IOException {
     Node node = GetTpuVm.getTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
 
@@ -109,7 +106,6 @@ public class TpuVmIT {
 
   @Test
   @Order(2)
-  @Disabled
   public void testListTpuVm() throws IOException {
     TpuClient.ListNodesPagedResponse nodesList = ListTpuVms.listTpuVms(PROJECT_ID, ZONE);
 
@@ -121,7 +117,6 @@ public class TpuVmIT {
 
   @Test
   @Order(2)
-  @Disabled
   public void testStopTpuVm() throws IOException, ExecutionException, InterruptedException {
     StopTpuVm.stopTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
     Node node = GetTpuVm.getTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
@@ -131,7 +126,6 @@ public class TpuVmIT {
 
   @Test
   @Order(3)
-  @Disabled
   public void testStartTpuVm() throws IOException, ExecutionException, InterruptedException {
     StartTpuVm.startTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
     Node node = GetTpuVm.getTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);

--- a/tpu/src/test/java/tpu/TpuVmIT.java
+++ b/tpu/src/test/java/tpu/TpuVmIT.java
@@ -48,7 +48,7 @@ import org.junit.runners.JUnit4;
 @TestMethodOrder(MethodOrderer. OrderAnnotation. class)
 public class TpuVmIT {
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
-  private static final String ZONE = "europe-west4-a";
+  private static final String ZONE = "us-central1-c";
   static String javaVersion = System.getProperty("java.version").substring(0, 2);
   private static final String TPU_VM_NAME = "test-tpu-" + javaVersion + "-"
       + UUID.randomUUID().toString().substring(0, 8);

--- a/tpu/src/test/java/tpu/TpuVmIT.java
+++ b/tpu/src/test/java/tpu/TpuVmIT.java
@@ -54,12 +54,12 @@ import org.junit.runners.JUnit4;
 @TestMethodOrder(MethodOrderer. OrderAnnotation. class)
 public class TpuVmIT {
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
-  private static final String ZONE = "europe-west4-b";
+  private static final String ZONE = "europe-west4-a";
   static String javaVersion = System.getProperty("java.version").substring(0, 2);
   private static final String TPU_VM_NAME = "test-tpu-" + javaVersion + "-"
       + UUID.randomUUID().toString().substring(0, 8);
-  private static final String ACCELERATOR_TYPE = "v5litepod-1";
-  private static final String VERSION = "tpu-vm-cos-stable";
+  private static final String ACCELERATOR_TYPE = "v2-8";
+  private static final String VERSION = "tpu-vm-tf-2.14.1";
   private static final String TPU_VM_PATH_NAME =
       String.format("projects/%s/locations/%s/nodes/%s", PROJECT_ID, ZONE, TPU_VM_NAME);
 
@@ -171,7 +171,7 @@ public class TpuVmIT {
 
   public static boolean isCreatedBeforeThresholdTime(String timestamp) {
     return OffsetDateTime.parse(timestamp).toInstant()
-        .isBefore(Instant.now().minus(5, ChronoUnit.MINUTES));
+        .isBefore(Instant.now().minus(30, ChronoUnit.MINUTES));
   }
 
   private static String formatTimestamp(Timestamp timestamp) {

--- a/tpu/src/test/java/tpu/TpuVmIT.java
+++ b/tpu/src/test/java/tpu/TpuVmIT.java
@@ -96,6 +96,7 @@ public class TpuVmIT {
     ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
     System.setOut(new PrintStream(stdOut));
     CreateTpuVm.createTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME, ACCELERATOR_TYPE, VERSION);
+    TimeUnit.MINUTES.sleep(3);
 
     assertThat(stdOut.toString()).contains("TPU VM created: " + TPU_VM_PATH_NAME);
     stdOut.close();
@@ -106,6 +107,7 @@ public class TpuVmIT {
   @Order(2)
   public void testGetTpuVm() throws IOException {
     Node node = GetTpuVm.getTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
+
     assertNotNull(node);
     assertThat(node.getName()).isEqualTo(TPU_VM_PATH_NAME);
   }
@@ -114,6 +116,7 @@ public class TpuVmIT {
   @Order(2)
   public void testListTpuVm() throws IOException {
     TpuClient.ListNodesPagedResponse nodesList = ListTpuVms.listTpuVms(PROJECT_ID, ZONE);
+
     assertNotNull(nodesList);
     for (Node node : nodesList.iterateAll()) {
       Assert.assertTrue(node.getName().contains("test-tpu"));
@@ -125,6 +128,7 @@ public class TpuVmIT {
   public void testStopTpuVm() throws IOException, ExecutionException, InterruptedException {
     StopTpuVm.stopTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
     Node node = GetTpuVm.getTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
+
     assertThat(node.getState()).isEqualTo(STOPPED);
   }
 
@@ -133,6 +137,7 @@ public class TpuVmIT {
   public void testStartTpuVm() throws IOException, ExecutionException, InterruptedException {
     StartTpuVm.startTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
     Node node = GetTpuVm.getTpuVm(PROJECT_ID, ZONE, TPU_VM_NAME);
+
     assertThat(node.getState()).isEqualTo(READY);
   }
 

--- a/tpu/src/test/java/tpu/Util.java
+++ b/tpu/src/test/java/tpu/Util.java
@@ -18,6 +18,7 @@ package tpu;
 
 import com.google.cloud.tpu.v2.Node;
 import com.google.cloud.tpu.v2.TpuClient;
+import com.google.cloud.tpu.v2alpha1.QueuedResource;
 import com.google.protobuf.Timestamp;
 import java.io.IOException;
 import java.time.Instant;
@@ -28,7 +29,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.concurrent.ExecutionException;
 
 public class Util {
-  private static final int DELETION_THRESHOLD_TIME_MINUTES = 30;
+  private static final int DELETION_THRESHOLD_TIME_MINUTES = 10;
 
   // Delete TPU VMs which starts with the given prefixToDelete and
   // has creation timestamp >30 minutes.
@@ -47,13 +48,42 @@ public class Util {
     }
   }
 
+  // Delete TPU VMs which starts with the given prefixToDelete and
+  // has creation timestamp >30 minutes.
+  public static void cleanUpExistingQueuedResources(
+      String prefixToDelete, String projectId, String zone)
+      throws IOException {
+    try (com.google.cloud.tpu.v2alpha1.TpuClient tpuClient =
+             com.google.cloud.tpu.v2alpha1.TpuClient.create()) {
+      String parent = String.format("projects/%s/locations/%s", projectId, zone);
+
+      for (QueuedResource queuedResource : tpuClient.listQueuedResources(parent).iterateAll()) {
+
+        com.google.cloud.tpu.v2alpha1.Node node = queuedResource.getTpu().getNodeSpec(0).getNode();
+        String creationTime = formatTimestamp(node.getCreateTime());
+        String name = queuedResource.getName().substring(node.getName().lastIndexOf("/") + 1);
+        if (containPrefixToDeleteAndZone(queuedResource, prefixToDelete, zone)
+            && isCreatedBeforeThresholdTime(creationTime)) {
+          DeleteQueuedResource.deleteQueuedResource(projectId, zone, name);
+        }
+      }
+    } catch (ExecutionException | InterruptedException e) {
+      System.out.println("Exception for deleting QueuedResource: " + e.getMessage());
+    }
+  }
+
   public static boolean containPrefixToDeleteAndZone(
-      Node node, String prefixToDelete, String zone) {
+      Object resource, String prefixToDelete, String zone) {
     boolean containPrefixAndZone = false;
     try {
-      containPrefixAndZone = node.getName().contains(prefixToDelete)
-          && node.getName().split("/")[3].contains(zone);
-
+      if (resource instanceof Node) {
+        containPrefixAndZone = ((Node) resource).getName().contains(prefixToDelete)
+            && ((Node) resource).getName().split("/")[3].contains(zone);
+      }
+      if (resource instanceof QueuedResource) {
+        containPrefixAndZone = ((QueuedResource) resource).getName().contains(prefixToDelete)
+            && ((QueuedResource) resource).getName().split("/")[3].contains(zone);
+      }
     } catch (NullPointerException e) {
       System.out.println("Resource not found, skipping deletion:");
     }

--- a/tpu/src/test/java/tpu/Util.java
+++ b/tpu/src/test/java/tpu/Util.java
@@ -29,7 +29,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.concurrent.ExecutionException;
 
 public class Util {
-  private static final int DELETION_THRESHOLD_TIME_MINUTES = 10;
+  private static final int DELETION_THRESHOLD_TIME_MINUTES = 30;
 
   // Delete TPU VMs which starts with the given prefixToDelete and
   // has creation timestamp >30 minutes.
@@ -65,7 +65,7 @@ public class Util {
             .substring(queuedResource.getName().lastIndexOf("/") + 1);
         if (containPrefixToDeleteAndZone(queuedResource, prefixToDelete, zone)
             && isCreatedBeforeThresholdTime(creationTime)) {
-          DeleteQueuedResource.deleteQueuedResource(projectId, zone, name);
+          DeleteForceQueuedResource.deleteForceQueuedResource(projectId, zone, name);
         }
       }
     }

--- a/tpu/src/test/java/tpu/Util.java
+++ b/tpu/src/test/java/tpu/Util.java
@@ -61,14 +61,13 @@ public class Util {
 
         com.google.cloud.tpu.v2alpha1.Node node = queuedResource.getTpu().getNodeSpec(0).getNode();
         String creationTime = formatTimestamp(node.getCreateTime());
-        String name = queuedResource.getName().substring(node.getName().lastIndexOf("/") + 1);
+        String name = queuedResource.getName()
+            .substring(queuedResource.getName().lastIndexOf("/") + 1);
         if (containPrefixToDeleteAndZone(queuedResource, prefixToDelete, zone)
             && isCreatedBeforeThresholdTime(creationTime)) {
           DeleteQueuedResource.deleteQueuedResource(projectId, zone, name);
         }
       }
-    } catch (ExecutionException | InterruptedException e) {
-      System.out.println("Exception for deleting QueuedResource: " + e.getMessage());
     }
   }
 

--- a/tpu/src/test/java/tpu/Util.java
+++ b/tpu/src/test/java/tpu/Util.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tpu;
+
+import com.google.cloud.tpu.v2.Node;
+import com.google.cloud.tpu.v2.TpuClient;
+import com.google.protobuf.Timestamp;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.ExecutionException;
+
+public class Util {
+  private static final int DELETION_THRESHOLD_TIME_MINUTES = 30;
+
+  // Delete TPU VMs which starts with the given prefixToDelete and
+  // has creation timestamp >30 minutes.
+  public static void cleanUpExistingTpu(String prefixToDelete, String projectId, String zone)
+      throws IOException, ExecutionException, InterruptedException {
+    try (TpuClient tpuClient = TpuClient.create()) {
+      String parent = String.format("projects/%s/locations/%s", projectId, zone);
+      for (Node node : tpuClient.listNodes(parent).iterateAll()) {
+        String creationTime = formatTimestamp(node.getCreateTime());
+        String name = node.getName().substring(node.getName().lastIndexOf("/") + 1);
+        if (containPrefixToDeleteAndZone(node, prefixToDelete, zone)
+            && isCreatedBeforeThresholdTime(creationTime)) {
+          DeleteTpuVm.deleteTpuVm(projectId, zone, name);
+        }
+      }
+    }
+  }
+
+  public static boolean containPrefixToDeleteAndZone(
+      Node node, String prefixToDelete, String zone) {
+    boolean containPrefixAndZone = false;
+    try {
+      containPrefixAndZone = node.getName().contains(prefixToDelete)
+          && node.getName().split("/")[3].contains(zone);
+
+    } catch (NullPointerException e) {
+      System.out.println("Resource not found, skipping deletion:");
+    }
+    return containPrefixAndZone;
+  }
+
+  public static boolean isCreatedBeforeThresholdTime(String timestamp) {
+    return OffsetDateTime.parse(timestamp).toInstant()
+        .isBefore(Instant.now().minus(DELETION_THRESHOLD_TIME_MINUTES, ChronoUnit.MINUTES));
+  }
+
+  private static String formatTimestamp(Timestamp timestamp) {
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+    OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(
+        Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanos()),
+        ZoneOffset.UTC);
+    return formatter.format(offsetDateTime);
+  }
+}


### PR DESCRIPTION
## Description
Issue with Deleting operation in google.cloud.tpu_v2alpha1
1. When running on macOS, the user will encounter an IllegalStateException, which is better handled at the library level and not delegated to the user, as it does not affect the delete method, since it is successful.
![Screenshot 2024-10-23 at 13 08 56 (2)](https://github.com/user-attachments/assets/a0bce2a9-3bc3-45f9-9de1-8600551539fd)

2.We are using the v2alpha1 library to delete Queued Resources and we faced an issue with the unpack operation even though it still succeeds. I have handled this in a catch block, but I believe that this is not a very good way to pass this exception to the end user.
![Screenshot 2024-10-23 at 13 15 37 (2)](https://github.com/user-attachments/assets/05aaacc9-538a-4bf0-8c10-b557b8923982)

Log file -  [log.txt](https://github.com/user-attachments/files/17491663/log.txt)

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
