### PR TITLE
docs(samples): Dynamic destinations in Iceberg I/O for Dataflow 

### DIFF
--- a/dataflow/snippets/pom.xml
+++ b/dataflow/snippets/pom.xml
@@ -37,7 +37,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <apache_beam.version>2.58.0</apache_beam.version>
+    <apache_beam.version>2.60.0</apache_beam.version>
     <slf4j.version>2.0.12</slf4j.version>
     <parquet.version>1.14.0</parquet.version>
     <iceberg.version>1.4.2</iceberg.version>

--- a/dataflow/snippets/src/main/java/com/example/dataflow/ApacheIcebergWrite.java
+++ b/dataflow/snippets/src/main/java/com/example/dataflow/ApacheIcebergWrite.java
@@ -33,9 +33,9 @@ import org.apache.beam.sdk.values.PCollectionRowTuple;
 
 public class ApacheIcebergWrite {
   static final List<String> TABLE_ROWS = Arrays.asList(
-      "{\"id\":0, \"name\":\"Alice\"}",
-      "{\"id\":1, \"name\":\"Bob\"}",
-      "{\"id\":2, \"name\":\"Charles\"}"
+      "{\"id\":0, \"name\":\"Alice\", \"extra_field\": \"field1\" }",
+      "{\"id\":1, \"name\":\"Bob\", \"extra_field\": \"field2\" }",
+      "{\"id\":2, \"name\":\"Charles\", \"extra_field\": \"field3\" }"
   );
 
   static final String CATALOG_TYPE = "hadoop";
@@ -44,6 +44,7 @@ public class ApacheIcebergWrite {
   public static final Schema SCHEMA = new Schema.Builder()
       .addStringField("name")
       .addInt64Field("id")
+      .addStringField("extra_field")
       .build();
 
   public interface Options extends PipelineOptions {
@@ -82,6 +83,8 @@ public class ApacheIcebergWrite {
         .put("table", options.getTableName())
         .put("catalog_name", options.getCatalogName())
         .put("catalog_properties", catalogConfig)
+        // Specify which fields to keep from the input data.
+        .put("keep", Arrays.asList("name", "id"))
         .build();
 
     // Build the pipeline.


### PR DESCRIPTION
## Description

Update the Apache Iceberg write sample to show the use of [dynamic destinations](https://github.com/apache/beam/issues/32365), which is a new feature in [Beam 2.60](https://github.com/apache/beam/releases/tag/v2.60.0).

Relevant doc bug: b/371047621

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
