### PR TITLE
feat(auth): add apikeys undelete api key sample.

### DIFF
--- a/auth/src/main/java/UndeleteApiKey.java
+++ b/auth/src/main/java/UndeleteApiKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google Inc.
+ * Copyright 2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/src/main/java/UndeleteApiKey.java
+++ b/auth/src/main/java/UndeleteApiKey.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START apikeys_undelete_api_key]
+import com.google.api.apikeys.v2.ApiKeysClient;
+import com.google.api.apikeys.v2.Key;
+import com.google.api.apikeys.v2.UndeleteKeyRequest;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class UndeleteApiKey {
+
+  public static void main(String[] args)
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    // TODO(developer): Replace these variables before running the sample.
+    // Project ID or project number of the Google Cloud project.
+    String projectId = "YOUR_PROJECT_ID";
+    // The API key id to undelete.
+    String keyId = "YOUR_KEY_ID";
+
+    undeleteApiKey(projectId, keyId);
+  }
+
+  // Undeletes an API key.
+  public static void undeleteApiKey(String projectId, String keyId)
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    try (ApiKeysClient apiKeysClient = ApiKeysClient.create()) {
+
+      // Initialize the undelete request and set the argument.
+      UndeleteKeyRequest undeleteKeyRequest = UndeleteKeyRequest.newBuilder()
+          .setName(String.format("projects/%s/locations/global/keys/%s", projectId, keyId))
+          .build();
+
+      // Make the request and wait for the operation to complete.
+      Key undeletedKey = apiKeysClient.undeleteKeyAsync(undeleteKeyRequest)
+          .get(3, TimeUnit.MINUTES);
+
+      System.out.printf("Successfully undeleted the API key: %s", undeletedKey.getName());
+    }
+  }
+}
+// [END apikeys_undelete_api_key]

--- a/auth/src/test/java/ApiKeySnippetsIT.java
+++ b/auth/src/test/java/ApiKeySnippetsIT.java
@@ -36,7 +36,6 @@ import org.junit.runners.JUnit4;
 public class ApiKeySnippetsIT {
 
   private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
-  private static final String CREDENTIALS = System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
   private static Key API_KEY;
   private static String API_KEY_STRING;
   private ByteArrayOutputStream stdOut;
@@ -79,8 +78,15 @@ public class ApiKeySnippetsIT {
 
     String apiKeyId = getApiKeyId(API_KEY);
     DeleteApiKey.deleteApiKey(PROJECT_ID, apiKeyId);
-    String goal = String.format("Successfully deleted the API key: %s", API_KEY.getName());
-    assertThat(stdOut.toString()).contains(goal);
+
+    UndeleteApiKey.undeleteApiKey(PROJECT_ID, apiKeyId);
+    String undeletedKey = String.format("Successfully undeleted the API key: %s",
+        API_KEY.getName());
+    assertThat(stdOut.toString()).contains(undeletedKey);
+
+    DeleteApiKey.deleteApiKey(PROJECT_ID, apiKeyId);
+    String deletedKey = String.format("Successfully deleted the API key: %s", API_KEY.getName());
+    assertThat(stdOut.toString()).contains(deletedKey);
 
     stdOut.close();
     System.setOut(out);


### PR DESCRIPTION
## Description
Documentation - https://cloud.google.com/docs/authentication/api-keys#java_6
Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
