### PR TITLE
feat(security-center): Add Resource v2 API Assets Security Marks Samples

### DIFF
--- a/security-command-center/snippets/src/main/java/vtwo/assets/AddDeleteSecurityMarks.java
+++ b/security-command-center/snippets/src/main/java/vtwo/assets/AddDeleteSecurityMarks.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vtwo.assets;
+
+import java.io.IOException;
+
+import com.google.cloud.securitycenter.v2.SecurityCenterClient;
+import com.google.cloud.securitycenter.v2.SecurityMarks;
+import com.google.cloud.securitycenter.v2.UpdateSecurityMarksRequest;
+import com.google.protobuf.FieldMask;
+
+//[START securitycenter_add_delete_security_marks_assets_v2]
+
+
+public class AddDeleteSecurityMarks {
+  public static void main(String[] args) throws IOException {
+    // organizationId: Google Cloud Organization id.
+    String organizationId = "{google-cloud-organization-id}";
+
+    // Specify the finding-id.
+    String assetId = "{asset-id}";
+
+    // Specify the location.
+    String location = "global";
+
+    addDeleteSecurityMarks(organizationId, location, assetId);
+  }
+
+  // Demonstrates adding/updating at the same time as deleting security
+  // marks from an asset.
+  // To add or change security marks, you must have an IAM role that includes permission:
+  public static SecurityMarks addDeleteSecurityMarks(String organizationId,
+      String location, String assetId) throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    SecurityCenterClient client = SecurityCenterClient.create();
+
+    // Specify the value of 'assetName' in one of the following formats:
+    //    String assetName = "organizations/{org-id}/assets/{asset-id}";
+    //    String assetName = "projects/{project-id}/assets/{asset-id}";
+    //    String assetName = "folders/{folder-id}/assets/{asset-id}";
+    String assetName = String.format("organizations/%s/assets/%s", organizationId, assetId);   
+
+    // Start setting up a request to clear and update security marks for an asset.
+    // Create security mark and field mask for clearing security marks.
+    SecurityMarks securityMarks = SecurityMarks.newBuilder()
+        .setName(assetName + "/securityMarks")
+        .putMarks("key_a", "new_value_for_a")
+        .build();
+
+    FieldMask updateMask = FieldMask.newBuilder()
+        .addPaths("marks.key_a")
+        .addPaths("marks.key_b")
+        .build();
+
+    UpdateSecurityMarksRequest request = UpdateSecurityMarksRequest.newBuilder()
+        .setSecurityMarks(securityMarks)
+        .setUpdateMask(updateMask)
+        .build();
+
+    // Call the API.
+    SecurityMarks response = client.updateSecurityMarks(request);
+
+    System.out.println("Security Marks updated and cleared::" + response);
+    return response;
+  }
+}
+
+//[END securitycenter_add_delete_security_marks_assets_v2]

--- a/security-command-center/snippets/src/main/java/vtwo/assets/AddSecurityMarksToAssets.java
+++ b/security-command-center/snippets/src/main/java/vtwo/assets/AddSecurityMarksToAssets.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vtwo.assets;
+
+// [START securitycenter_add_security_marks_assets_v2]
+
+import autovalue.shaded.com.google.common.collect.ImmutableMap;
+import com.google.cloud.securitycenter.v2.SecurityCenterClient;
+import com.google.cloud.securitycenter.v2.SecurityMarks;
+import com.google.cloud.securitycenter.v2.UpdateSecurityMarksRequest;
+import com.google.protobuf.FieldMask;
+import java.io.IOException;
+
+public class AddSecurityMarksToAssets {
+
+  public static void main(String[] args) throws IOException {
+    // organizationId: Google Cloud Organization id.
+    String organizationId = "{google-cloud-organization-id}";
+
+    // Specify the finding-id.
+    String assetId = "{asset-id}";
+
+    // Specify the location.
+    String location = "global";
+
+    addToAsset(organizationId, location, assetId);
+  }
+
+  // Demonstrates adding security marks to findings.
+  // To add or change security marks, you must have an IAM role that includes permission:
+  public static SecurityMarks addToAsset(String organizationId,
+	      String location, String assetId) throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    SecurityCenterClient client = SecurityCenterClient.create();
+
+    // Specify the value of 'assetName' in one of the following formats:
+    //    String assetName = "organizations/{org-id}/assets/{asset-id}";
+    //    String assetName = "projects/{project-id}/assets/{asset-id}";
+    //    String assetName = "folders/{folder-id}/assets/{asset-id}";
+    String assetName = String.format("organizations/%s/assets/%s", organizationId, assetId);
+    
+    // Start setting up a request to add security marks for a finding.
+    ImmutableMap markMap = ImmutableMap.of("key_a", "value_a", "key_b", "value_b");
+
+    // Add security marks and field mask for security marks.
+    SecurityMarks securityMarks = SecurityMarks.newBuilder()
+        .setName(assetName + "/securityMarks")
+        .putAllMarks(markMap)
+        .build();
+
+    // Set the update mask to specify which properties should be updated.
+    // If empty, all mutable fields will be updated.
+    // For more info on constructing field mask path, see the proto or:
+    // https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.FieldMask
+    FieldMask updateMask = FieldMask.newBuilder()
+        .addPaths("marks.key_a")
+        .addPaths("marks.key_b")
+        .build();
+
+    UpdateSecurityMarksRequest request = UpdateSecurityMarksRequest.newBuilder()
+        .setSecurityMarks(securityMarks)
+        .setUpdateMask(updateMask)
+        .build();
+
+    // Call the API.
+    SecurityMarks response = client.updateSecurityMarks(request);
+
+    System.out.println("Security Marks:" + response);
+    return response;
+  }	
+}
+
+
+// [END securitycenter_add_security_marks_assets_v2]

--- a/security-command-center/snippets/src/main/java/vtwo/assets/DeleteAssetsSecurityMarks.java
+++ b/security-command-center/snippets/src/main/java/vtwo/assets/DeleteAssetsSecurityMarks.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vtwo.assets;
+
+import java.io.IOException;
+
+import com.google.cloud.securitycenter.v2.SecurityCenterClient;
+import com.google.cloud.securitycenter.v2.SecurityMarks;
+import com.google.cloud.securitycenter.v2.UpdateSecurityMarksRequest;
+import com.google.protobuf.FieldMask;
+
+//[START securitycenter_delete_security_marks_assets_v2]
+
+public class DeleteAssetsSecurityMarks {
+  public static void main(String[] args) throws IOException {
+    // organizationId: Google Cloud Organization id.
+    String organizationId = "{google-cloud-organization-id}";
+
+    // Specify the asset-id.
+    String assetId = "{asset-id}";
+
+    // Specify the location.
+    String location = "global";
+
+    deleteSecurityMarks(organizationId, location, assetId);
+  }
+
+  // Demonstrates deleting security marks on an asset.
+  // To add or change security marks, you must have an IAM role that includes permission:
+  public static SecurityMarks deleteSecurityMarks(String organizationId,
+      String location, String assetId) throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    SecurityCenterClient client = SecurityCenterClient.create();
+
+    // Specify the value of 'assetName' in one of the following formats:
+    //    String assetName = "organizations/{org-id}/assets/{asset-id}";
+    //    String assetName = "projects/{project-id}/assets/{asset-id}";
+    //    String assetName = "folders/{folder-id}/assets/{asset-id}";
+    String assetName = String.format("organizations/%s/assets/%s", organizationId, assetId);   
+
+    // Start setting up a request to clear and update security marks for an asset.
+    // Create security mark and field mask for clearing security marks.
+    SecurityMarks securityMarks = SecurityMarks.newBuilder()
+        .setName(assetName + "/securityMarks")
+        .build();
+
+    FieldMask updateMask = FieldMask.newBuilder()
+        .addPaths("marks.key_a")
+        .addPaths("marks.key_b")
+        .build();
+
+    UpdateSecurityMarksRequest request = UpdateSecurityMarksRequest.newBuilder()
+        .setSecurityMarks(securityMarks)
+        .setUpdateMask(updateMask)
+        .build();
+
+    // Call the API.
+    SecurityMarks response = client.updateSecurityMarks(request);
+
+    System.out.println("Security Marks cleared::" + response);
+    return response;
+  }
+}
+
+//[END securitycenter_delete_security_marks_assets_v2]
+

--- a/security-command-center/snippets/src/test/java/vtwo/AssetSecurityMarksIT.java
+++ b/security-command-center/snippets/src/test/java/vtwo/AssetSecurityMarksIT.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vtwo;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.api.gax.rpc.InvalidArgumentException;
+import com.google.cloud.securitycenter.v1.Asset;
+import com.google.cloud.securitycenter.v1.ListAssetsRequest;
+import com.google.cloud.securitycenter.v1.SecurityCenterClient;
+import com.google.cloud.securitycenter.v2.OrganizationName;
+import com.google.cloud.securitycenter.v2.SecurityMarks;
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
+
+import vtwo.assets.AddDeleteSecurityMarks;
+import vtwo.assets.AddSecurityMarksToAssets;
+import vtwo.assets.DeleteAssetsSecurityMarks;
+
+@RunWith(JUnit4.class)
+public class AssetSecurityMarksIT {
+
+  private static final String ORGANIZATION_ID = System.getenv("SCC_PROJECT_ORG_ID");
+  private static final String LOCATION = "global";
+  private static String assetId, assetName;
+  private static ByteArrayOutputStream stdOut;
+
+  @Rule
+  public final MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(3, 120000); // 2 minutes
+
+  // Check if the required environment variables are set.
+  public static void requireEnvVar(String envVarName) {
+    assertThat(System.getenv(envVarName)).isNotEmpty();
+  }
+
+  // Extracts the asset ID from a full resource name.
+  private static String extractAssetId(String assetPath) {
+    // Pattern to match the asset ID at the end of the resource name.
+    Pattern pattern = Pattern.compile("assets/(\\d+)$");
+    Matcher matcher = pattern.matcher(assetPath);
+    if (matcher.find()) {
+      return matcher.group(1);
+    }
+    return assetPath;
+  }
+  
+@SuppressWarnings("deprecation")
+@BeforeClass
+  public static void setUp() throws IOException, InterruptedException {
+    final PrintStream out = System.out;
+    stdOut = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(stdOut));
+
+    requireEnvVar("GOOGLE_APPLICATION_CREDENTIALS");
+
+    // Fetch a valid asset ID dynamically
+    try (SecurityCenterClient client = SecurityCenterClient.create()) {
+        OrganizationName orgName = OrganizationName.of(ORGANIZATION_ID);
+        ListAssetsRequest request = ListAssetsRequest.newBuilder()
+            .setParent(orgName.toString())
+            .setPageSize(1)
+            .build();
+
+        Asset asset = client.listAssets(request).iterateAll().iterator().next().getAsset();
+        assetName = asset.getName(); // Get the full resource name for the asset
+        assetId = extractAssetId(assetName);
+    } catch (InvalidArgumentException e) {
+        System.err.println("Error retrieving asset ID: " + e.getMessage());
+        throw e;
+    }
+    
+    stdOut = null;
+    System.setOut(out);
+    TimeUnit.MINUTES.sleep(1);
+  }
+
+  @Before
+  public void beforeEach() {
+    stdOut = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(stdOut));
+  }
+
+  @After
+  public void afterEach() {
+    stdOut = null;
+    System.setOut(null);
+  }
+
+  @AfterClass
+  public static void cleanUp() {
+    System.setOut(System.out);
+  }
+
+  @Test
+  public void testAddSecurityMarksToAsset() throws IOException {
+    SecurityMarks response = AddSecurityMarksToAssets.addToAsset(
+    		ORGANIZATION_ID, LOCATION, assetId);
+
+    assertTrue(response.getMarksOrThrow("key_a").contains("value_a"));
+    assertTrue(response.getMarksOrThrow("key_b").contains("value_b"));
+  }
+
+  @Test
+  public void testDeleteSecurityMarksOnAsset() throws IOException {
+    SecurityMarks response = DeleteAssetsSecurityMarks.deleteSecurityMarks(
+        ORGANIZATION_ID, LOCATION, assetId);
+
+    assertFalse(response.containsMarks("key_a"));
+    assertFalse(response.containsMarks("key_b"));
+  }
+
+  @Test
+  public void testAddAndDeleteSecurityMarks() throws IOException {
+    SecurityMarks response = AddDeleteSecurityMarks.addDeleteSecurityMarks(
+        ORGANIZATION_ID, LOCATION, assetId);
+
+    // Assert update for key_a
+    assertTrue(response.getMarksOrThrow("key_a").contains("new_value_for_a"));
+
+    // Assert deletion for key_b
+    assertFalse(response.getMarksMap().containsKey("key_b"));
+  }
+}
+


### PR DESCRIPTION
## Description

This PR adds v2 API Assets Security Marks Java client samples to Add Security Marks, Delete Security Marks, Add Delete Security Marks.

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
