### PR TITLE
feat(managedkafka): increase LRO timeout to 1 hour in client samples

### DIFF
--- a/managedkafka/examples/pom.xml
+++ b/managedkafka/examples/pom.xml
@@ -29,7 +29,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>26.40.0</version>
+                <version>26.50.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -40,13 +40,7 @@
     <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-managedkafka</artifactId>
-        <version>0.1.0</version>
     </dependency>
-        <dependency>
-            <groupId>com.google.api.grpc</groupId>
-            <artifactId>proto-google-cloud-managedkafka-v1</artifactId>
-            <version>0.1.0</version>
-        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/managedkafka/examples/src/main/java/examples/CreateCluster.java
+++ b/managedkafka/examples/src/main/java/examples/CreateCluster.java
@@ -76,13 +76,7 @@ public class CreateCluster {
     ManagedKafkaSettings.Builder settingsBuilder = ManagedKafkaSettings.newBuilder();
     TimedRetryAlgorithm timedRetryAlgorithm = OperationTimedPollAlgorithm.create(
         RetrySettings.newBuilder()
-            .setInitialRetryDelayDuration(Duration.ofSeconds(5L))
-            .setRetryDelayMultiplier(1.5)
-            .setMaxRetryDelayDuration(Duration.ofSeconds(30L))
-            .setInitialRpcTimeoutDuration(Duration.ZERO) // ignored for LROs
-            .setRpcTimeoutMultiplier(1.0) // ignored for LROs
-            .setMaxRpcTimeoutDuration(Duration.ZERO) // ignored for LROs
-            .setTotalTimeoutDuration(Duration.ofHours(1L)) // set polling timeout to 1 hour
+            .setTotalTimeoutDuration(Duration.ofHours(1L))
             .build());
     settingsBuilder.createClusterOperationSettings()
         .setPollingAlgorithm(timedRetryAlgorithm);

--- a/managedkafka/examples/src/main/java/examples/CreateCluster.java
+++ b/managedkafka/examples/src/main/java/examples/CreateCluster.java
@@ -17,7 +17,13 @@
 package examples;
 
 // [START managedkafka_create_cluster]
+
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.api.gax.longrunning.OperationSnapshot;
+import com.google.api.gax.longrunning.OperationTimedPollAlgorithm;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.retrying.RetryingFuture;
+import com.google.api.gax.retrying.TimedRetryAlgorithm;
 import com.google.cloud.managedkafka.v1.AccessConfig;
 import com.google.cloud.managedkafka.v1.CapacityConfig;
 import com.google.cloud.managedkafka.v1.Cluster;
@@ -25,9 +31,11 @@ import com.google.cloud.managedkafka.v1.CreateClusterRequest;
 import com.google.cloud.managedkafka.v1.GcpConfig;
 import com.google.cloud.managedkafka.v1.LocationName;
 import com.google.cloud.managedkafka.v1.ManagedKafkaClient;
+import com.google.cloud.managedkafka.v1.ManagedKafkaSettings;
 import com.google.cloud.managedkafka.v1.NetworkConfig;
 import com.google.cloud.managedkafka.v1.OperationMetadata;
 import com.google.cloud.managedkafka.v1.RebalanceConfig;
+import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 
 public class CreateCluster {
@@ -64,17 +72,53 @@ public class CreateCluster {
             .setRebalanceConfig(rebalanceConfig)
             .build();
 
-    try (ManagedKafkaClient managedKafkaClient = ManagedKafkaClient.create()) {
+    // Create the settings to configure the timeout for polling operations
+    ManagedKafkaSettings.Builder settingsBuilder = ManagedKafkaSettings.newBuilder();
+    TimedRetryAlgorithm timedRetryAlgorithm = OperationTimedPollAlgorithm.create(
+        RetrySettings.newBuilder()
+            .setInitialRetryDelayDuration(Duration.ofSeconds(5L))
+            .setRetryDelayMultiplier(1.5)
+            .setMaxRetryDelayDuration(Duration.ofSeconds(30L))
+            .setInitialRpcTimeoutDuration(Duration.ZERO) // ignored for LROs
+            .setRpcTimeoutMultiplier(1.0) // ignored for LROs
+            .setMaxRpcTimeoutDuration(Duration.ZERO) // ignored for LROs
+            .setTotalTimeoutDuration(Duration.ofHours(1L)) // set polling timeout to 1 hour
+            .build());
+    settingsBuilder.createClusterOperationSettings()
+        .setPollingAlgorithm(timedRetryAlgorithm);
+
+    try (ManagedKafkaClient managedKafkaClient = ManagedKafkaClient.create(
+        settingsBuilder.build())) {
+
       CreateClusterRequest request =
           CreateClusterRequest.newBuilder()
               .setParent(LocationName.of(projectId, region).toString())
               .setClusterId(clusterId)
               .setCluster(cluster)
               .build();
+
       // The duration of this operation can vary considerably, typically taking between 10-40
       // minutes.
       OperationFuture<Cluster, OperationMetadata> future =
           managedKafkaClient.createClusterOperationCallable().futureCall(request);
+
+      // Get the initial LRO and print details.
+      OperationSnapshot operation = future.getInitialFuture().get();
+      System.out.printf("Cluster creation started. Operation name: %s\nDone: %s\nMetadata: %s\n",
+          operation.getName(),
+          operation.isDone(),
+          future.getMetadata().get().toString());
+
+      while (!future.isDone()) {
+        // The pollingFuture gives us the most recent status of the operation
+        RetryingFuture<OperationSnapshot> pollingFuture = future.getPollingFuture();
+        OperationSnapshot currentOp = pollingFuture.getAttemptResult().get();
+        System.out.printf("Polling Operation:\nName: %s\n Done: %s\n",
+            currentOp.getName(),
+            currentOp.isDone());
+      }
+
+      // NOTE: future.get() blocks completion until the operation is complete (isDone =  True)
       Cluster response = future.get();
       System.out.printf("Created cluster: %s\n", response.getName());
     } catch (ExecutionException e) {

--- a/managedkafka/examples/src/main/java/examples/DeleteCluster.java
+++ b/managedkafka/examples/src/main/java/examples/DeleteCluster.java
@@ -17,14 +17,21 @@
 package examples;
 
 // [START managedkafka_delete_cluster]
+
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.api.gax.longrunning.OperationSnapshot;
+import com.google.api.gax.longrunning.OperationTimedPollAlgorithm;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.retrying.TimedRetryAlgorithm;
 import com.google.api.gax.rpc.ApiException;
 import com.google.cloud.managedkafka.v1.ClusterName;
 import com.google.cloud.managedkafka.v1.DeleteClusterRequest;
 import com.google.cloud.managedkafka.v1.ManagedKafkaClient;
+import com.google.cloud.managedkafka.v1.ManagedKafkaSettings;
 import com.google.cloud.managedkafka.v1.OperationMetadata;
 import com.google.protobuf.Empty;
 import java.io.IOException;
+import java.time.Duration;
 
 public class DeleteCluster {
 
@@ -38,13 +45,38 @@ public class DeleteCluster {
 
   public static void deleteCluster(String projectId, String region, String clusterId)
       throws Exception {
-    try (ManagedKafkaClient managedKafkaClient = ManagedKafkaClient.create()) {
+
+    // Create the settings to configure the timeout for polling operations
+    ManagedKafkaSettings.Builder settingsBuilder = ManagedKafkaSettings.newBuilder();
+    TimedRetryAlgorithm timedRetryAlgorithm = OperationTimedPollAlgorithm.create(
+        RetrySettings.newBuilder()
+            .setInitialRetryDelayDuration(Duration.ofSeconds(5L))
+            .setRetryDelayMultiplier(1.5)
+            .setMaxRetryDelayDuration(Duration.ofSeconds(30L))
+            .setInitialRpcTimeoutDuration(Duration.ZERO) // ignored for LROs
+            .setRpcTimeoutMultiplier(1.0) // ignored for LROs
+            .setMaxRpcTimeoutDuration(Duration.ZERO) // ignored for LROs
+            .setTotalTimeoutDuration(Duration.ofHours(1L))  // set polling timeout to 1 hour
+            .build());
+    settingsBuilder.deleteClusterOperationSettings()
+        .setPollingAlgorithm(timedRetryAlgorithm);
+
+    try (ManagedKafkaClient managedKafkaClient = ManagedKafkaClient.create(
+        settingsBuilder.build())) {
       DeleteClusterRequest request =
           DeleteClusterRequest.newBuilder()
               .setName(ClusterName.of(projectId, region, clusterId).toString())
               .build();
       OperationFuture<Empty, OperationMetadata> future =
           managedKafkaClient.deleteClusterOperationCallable().futureCall(request);
+
+      // Get the initial LRO and print details. CreateCluster contains sample code for polling logs.
+      OperationSnapshot operation = future.getInitialFuture().get();
+      System.out.printf("Cluster deletion started. Operation name: %s\nDone: %s\nMetadata: %s\n",
+          operation.getName(),
+          operation.isDone(),
+          future.getMetadata().get().toString());
+
       future.get();
       System.out.println("Deleted cluster");
     } catch (IOException | ApiException e) {

--- a/managedkafka/examples/src/main/java/examples/DeleteCluster.java
+++ b/managedkafka/examples/src/main/java/examples/DeleteCluster.java
@@ -50,13 +50,7 @@ public class DeleteCluster {
     ManagedKafkaSettings.Builder settingsBuilder = ManagedKafkaSettings.newBuilder();
     TimedRetryAlgorithm timedRetryAlgorithm = OperationTimedPollAlgorithm.create(
         RetrySettings.newBuilder()
-            .setInitialRetryDelayDuration(Duration.ofSeconds(5L))
-            .setRetryDelayMultiplier(1.5)
-            .setMaxRetryDelayDuration(Duration.ofSeconds(30L))
-            .setInitialRpcTimeoutDuration(Duration.ZERO) // ignored for LROs
-            .setRpcTimeoutMultiplier(1.0) // ignored for LROs
-            .setMaxRpcTimeoutDuration(Duration.ZERO) // ignored for LROs
-            .setTotalTimeoutDuration(Duration.ofHours(1L))  // set polling timeout to 1 hour
+            .setTotalTimeoutDuration(Duration.ofHours(1L))
             .build());
     settingsBuilder.deleteClusterOperationSettings()
         .setPollingAlgorithm(timedRetryAlgorithm);

--- a/managedkafka/examples/src/main/java/examples/UpdateCluster.java
+++ b/managedkafka/examples/src/main/java/examples/UpdateCluster.java
@@ -17,14 +17,21 @@
 package examples;
 
 // [START managedkafka_update_cluster]
+
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.api.gax.longrunning.OperationSnapshot;
+import com.google.api.gax.longrunning.OperationTimedPollAlgorithm;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.retrying.TimedRetryAlgorithm;
 import com.google.cloud.managedkafka.v1.CapacityConfig;
 import com.google.cloud.managedkafka.v1.Cluster;
 import com.google.cloud.managedkafka.v1.ClusterName;
 import com.google.cloud.managedkafka.v1.ManagedKafkaClient;
+import com.google.cloud.managedkafka.v1.ManagedKafkaSettings;
 import com.google.cloud.managedkafka.v1.OperationMetadata;
 import com.google.cloud.managedkafka.v1.UpdateClusterRequest;
 import com.google.protobuf.FieldMask;
+import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 
 public class UpdateCluster {
@@ -48,11 +55,35 @@ public class UpdateCluster {
             .build();
     FieldMask updateMask = FieldMask.newBuilder().addPaths("capacity_config.memory_bytes").build();
 
-    try (ManagedKafkaClient managedKafkaClient = ManagedKafkaClient.create()) {
+    // Create the settings to configure the timeout for polling operations
+    ManagedKafkaSettings.Builder settingsBuilder = ManagedKafkaSettings.newBuilder();
+    TimedRetryAlgorithm timedRetryAlgorithm = OperationTimedPollAlgorithm.create(
+        RetrySettings.newBuilder()
+            .setInitialRetryDelayDuration(Duration.ofSeconds(5L))
+            .setRetryDelayMultiplier(1.5)
+            .setMaxRetryDelayDuration(Duration.ofSeconds(30L))
+            .setInitialRpcTimeoutDuration(Duration.ZERO) // ignored for LROs
+            .setRpcTimeoutMultiplier(1.0) // ignored for LROs
+            .setMaxRpcTimeoutDuration(Duration.ZERO) // ignored for LROs
+            .setTotalTimeoutDuration(Duration.ofHours(1L))  // set polling timeout to 1 hour
+            .build());
+    settingsBuilder.updateClusterOperationSettings()
+        .setPollingAlgorithm(timedRetryAlgorithm);
+
+    try (ManagedKafkaClient managedKafkaClient = ManagedKafkaClient.create(
+        settingsBuilder.build())) {
       UpdateClusterRequest request =
           UpdateClusterRequest.newBuilder().setUpdateMask(updateMask).setCluster(cluster).build();
       OperationFuture<Cluster, OperationMetadata> future =
           managedKafkaClient.updateClusterOperationCallable().futureCall(request);
+
+      // Get the initial LRO and print details. CreateCluster contains sample code for polling logs.
+      OperationSnapshot operation = future.getInitialFuture().get();
+      System.out.printf("Cluster update started. Operation name: %s\nDone: %s\nMetadata: %s\n",
+          operation.getName(),
+          operation.isDone(),
+          future.getMetadata().get().toString());
+
       Cluster response = future.get();
       System.out.printf("Updated cluster: %s\n", response.getName());
     } catch (ExecutionException e) {

--- a/managedkafka/examples/src/main/java/examples/UpdateCluster.java
+++ b/managedkafka/examples/src/main/java/examples/UpdateCluster.java
@@ -59,13 +59,7 @@ public class UpdateCluster {
     ManagedKafkaSettings.Builder settingsBuilder = ManagedKafkaSettings.newBuilder();
     TimedRetryAlgorithm timedRetryAlgorithm = OperationTimedPollAlgorithm.create(
         RetrySettings.newBuilder()
-            .setInitialRetryDelayDuration(Duration.ofSeconds(5L))
-            .setRetryDelayMultiplier(1.5)
-            .setMaxRetryDelayDuration(Duration.ofSeconds(30L))
-            .setInitialRpcTimeoutDuration(Duration.ZERO) // ignored for LROs
-            .setRpcTimeoutMultiplier(1.0) // ignored for LROs
-            .setMaxRpcTimeoutDuration(Duration.ZERO) // ignored for LROs
-            .setTotalTimeoutDuration(Duration.ofHours(1L))  // set polling timeout to 1 hour
+            .setTotalTimeoutDuration(Duration.ofHours(1L))
             .build());
     settingsBuilder.updateClusterOperationSettings()
         .setPollingAlgorithm(timedRetryAlgorithm);

--- a/managedkafka/examples/src/test/java/examples/ClustersTest.java
+++ b/managedkafka/examples/src/test/java/examples/ClustersTest.java
@@ -24,10 +24,21 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.api.core.ApiFuture;
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.api.gax.longrunning.OperationSnapshot;
+import com.google.api.gax.retrying.RetryingFuture;
+import com.google.api.gax.rpc.OperationCallable;
 import com.google.cloud.managedkafka.v1.Cluster;
 import com.google.cloud.managedkafka.v1.ClusterName;
+import com.google.cloud.managedkafka.v1.CreateClusterRequest;
+import com.google.cloud.managedkafka.v1.DeleteClusterRequest;
 import com.google.cloud.managedkafka.v1.LocationName;
 import com.google.cloud.managedkafka.v1.ManagedKafkaClient;
+import com.google.cloud.managedkafka.v1.ManagedKafkaSettings;
+import com.google.cloud.managedkafka.v1.OperationMetadata;
+import com.google.cloud.managedkafka.v1.UpdateClusterRequest;
+import com.google.protobuf.Empty;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -58,11 +69,54 @@ public class ClustersTest {
   @Test
   public void createClusterTest() throws Exception {
     ManagedKafkaClient managedKafkaClient = mock(ManagedKafkaClient.class);
+    OperationCallable<CreateClusterRequest, Cluster, OperationMetadata> operationCallable =
+        mock(OperationCallable.class);
+    OperationFuture<Cluster, OperationMetadata> operationFuture =
+        mock(OperationFuture.class);
+
     try (MockedStatic<ManagedKafkaClient> mockedStatic =
         Mockito.mockStatic(ManagedKafkaClient.class)) {
-      mockedStatic.when(() -> create()).thenReturn(managedKafkaClient);
+
+      // client creation
+      mockedStatic.when(() -> create(any(ManagedKafkaSettings.class)))
+          .thenReturn(managedKafkaClient);
+
+      // operation callable
       when(managedKafkaClient.createClusterOperationCallable())
-          .thenReturn(MockOperationFuture.getOperableCallable());
+          .thenReturn(operationCallable);
+      when(operationCallable.futureCall(any(CreateClusterRequest.class)))
+          .thenReturn(operationFuture);
+
+      // initial future
+      ApiFuture<OperationSnapshot> initialFuture = mock(ApiFuture.class);
+      when(operationFuture.getInitialFuture()).thenReturn(initialFuture);
+
+      // Metadata
+      ApiFuture<OperationMetadata> metadataFuture = mock(ApiFuture.class);
+      OperationMetadata metadata = mock(OperationMetadata.class);
+      when(operationFuture.getMetadata()).thenReturn(metadataFuture);
+      when(metadataFuture.get()).thenReturn(metadata);
+
+      // operation snapshot
+      OperationSnapshot operationSnapshot = mock(OperationSnapshot.class);
+      when(operationFuture.getInitialFuture().get()).thenReturn(operationSnapshot);
+      when(operationSnapshot.getName())
+          .thenReturn("projects/test-project/locations/test-location/operations/test-operation");
+      when(operationSnapshot.isDone()).thenReturn(false, false, true);
+
+      // polling future
+      RetryingFuture<OperationSnapshot> pollingFuture = mock(RetryingFuture.class);
+      when(operationFuture.getPollingFuture()).thenReturn(pollingFuture);
+      when(operationFuture.isDone()).thenReturn(false, false, true);
+      ApiFuture<OperationSnapshot> attemptResult = mock(ApiFuture.class);
+      when(pollingFuture.getAttemptResult()).thenReturn(attemptResult);
+      when(attemptResult.get()).thenReturn(operationSnapshot);
+
+      // Setup final result
+      Cluster resultCluster = mock(Cluster.class);
+      when(operationFuture.get()).thenReturn(resultCluster);
+      when(resultCluster.getName()).thenReturn(clusterName);
+
       String subnet = "test-subnet";
       int cpu = 3;
       long memory = 3221225472L;
@@ -71,6 +125,10 @@ public class ClustersTest {
       assertThat(output).contains("Created cluster");
       assertThat(output).contains(clusterName);
       verify(managedKafkaClient, times(1)).createClusterOperationCallable();
+      verify(operationCallable, times(1)).futureCall(any(CreateClusterRequest.class));
+      verify(operationFuture, times(2)).getPollingFuture();  // Verify 2 polling attempts
+      verify(pollingFuture, times(2)).getAttemptResult();    // Verify 2 attempt results
+      verify(operationSnapshot, times(3)).isDone();          // 2 polls + 1 initial check
     }
   }
 
@@ -122,32 +180,104 @@ public class ClustersTest {
   @Test
   public void updateClusterTest() throws Exception {
     ManagedKafkaClient managedKafkaClient = mock(ManagedKafkaClient.class);
+    OperationCallable<UpdateClusterRequest, Cluster, OperationMetadata> operationCallable =
+        mock(OperationCallable.class);
+    OperationFuture<Cluster, OperationMetadata> operationFuture =
+        mock(OperationFuture.class);
+
     try (MockedStatic<ManagedKafkaClient> mockedStatic =
         Mockito.mockStatic(ManagedKafkaClient.class)) {
-      mockedStatic.when(() -> create()).thenReturn(managedKafkaClient);
+
+      // client creation
+      mockedStatic.when(() -> create(any(ManagedKafkaSettings.class)))
+          .thenReturn(managedKafkaClient);
+
+      // operation callable
       when(managedKafkaClient.updateClusterOperationCallable())
-          .thenReturn(MockOperationFuture.getOperableCallable());
+          .thenReturn(operationCallable);
+      when(operationCallable.futureCall(any(UpdateClusterRequest.class)))
+          .thenReturn(operationFuture);
+
+      // initial future
+      ApiFuture<OperationSnapshot> initialFuture = mock(ApiFuture.class);
+      when(operationFuture.getInitialFuture()).thenReturn(initialFuture);
+
+      // Metadata
+      ApiFuture<OperationMetadata> metadataFuture = mock(ApiFuture.class);
+      OperationMetadata metadata = mock(OperationMetadata.class);
+      when(operationFuture.getMetadata()).thenReturn(metadataFuture);
+      when(metadataFuture.get()).thenReturn(metadata);
+
+      // operation snapshot
+      OperationSnapshot operationSnapshot = mock(OperationSnapshot.class);
+      when(operationFuture.getInitialFuture().get()).thenReturn(operationSnapshot);
+      when(operationSnapshot.getName())
+          .thenReturn("projects/test-project/locations/test-location/operations/test-operation");
+      when(operationSnapshot.isDone()).thenReturn(false, false, true);
+
+      // Setup final result
+      Cluster resultCluster = mock(Cluster.class);
+      when(operationFuture.get()).thenReturn(resultCluster);
+      when(resultCluster.getName()).thenReturn(clusterName);
+
       long updatedMemory = 4221225472L;
       UpdateCluster.updateCluster(projectId, region, projectId, updatedMemory);
       String output = bout.toString();
       assertThat(output).contains("Updated cluster");
       assertThat(output).contains(clusterName);
       verify(managedKafkaClient, times(1)).updateClusterOperationCallable();
+      verify(operationCallable, times(1)).futureCall(any(UpdateClusterRequest.class));
     }
   }
 
   @Test
   public void deleteClusterTest() throws Exception {
     ManagedKafkaClient managedKafkaClient = mock(ManagedKafkaClient.class);
+    OperationCallable<DeleteClusterRequest, Empty, OperationMetadata> operationCallable =
+        mock(OperationCallable.class);
+    OperationFuture<Empty, OperationMetadata> operationFuture =
+        mock(OperationFuture.class);
     try (MockedStatic<ManagedKafkaClient> mockedStatic =
         Mockito.mockStatic(ManagedKafkaClient.class)) {
-      mockedStatic.when(() -> create()).thenReturn(managedKafkaClient);
+
+      // client creation
+      mockedStatic.when(() -> create(any(ManagedKafkaSettings.class)))
+          .thenReturn(managedKafkaClient);
+
+      // operation callable
       when(managedKafkaClient.deleteClusterOperationCallable())
-          .thenReturn(MockDeleteOperationFuture.getOperableCallable());
+          .thenReturn(operationCallable);
+      when(operationCallable.futureCall(any(DeleteClusterRequest.class)))
+          .thenReturn(operationFuture);
+
+      // initial future
+      ApiFuture<OperationSnapshot> initialFuture = mock(ApiFuture.class);
+      when(operationFuture.getInitialFuture()).thenReturn(initialFuture);
+
+      // Metadata
+      ApiFuture<OperationMetadata> metadataFuture = mock(ApiFuture.class);
+      OperationMetadata metadata = mock(OperationMetadata.class);
+      when(operationFuture.getMetadata()).thenReturn(metadataFuture);
+      when(metadataFuture.get()).thenReturn(metadata);
+
+      // operation snapshot
+      OperationSnapshot operationSnapshot = mock(OperationSnapshot.class);
+      when(operationFuture.getInitialFuture().get()).thenReturn(operationSnapshot);
+      when(operationSnapshot.getName())
+          .thenReturn("projects/test-project/locations/test-location/operations/test-operation");
+      when(operationSnapshot.isDone()).thenReturn(false, false, true);
+
+      // Setup final result
+      Cluster resultCluster = mock(Cluster.class);
+      when(operationFuture.get()).thenReturn(Empty.getDefaultInstance());
+      when(resultCluster.getName()).thenReturn(clusterName);
+
       DeleteCluster.deleteCluster(projectId, region, clusterId);
       String output = bout.toString();
       assertThat(output).contains("Deleted cluster");
+
       verify(managedKafkaClient, times(1)).deleteClusterOperationCallable();
+      verify(operationCallable, times(1)).futureCall(any(DeleteClusterRequest.class));
     }
   }
 }


### PR DESCRIPTION
* feat(managedkafka): increase timeouts to 1 hour for Create/Update/Delete cluster 
* feat(managedkafka): added code sample for polling logs in CreateCluster 