### PR TITLE
fix(spanner): opentelemetry metrics documentation

### DIFF
--- a/spanner/opentelemetry/pom.xml
+++ b/spanner/opentelemetry/pom.xml
@@ -25,6 +25,7 @@
     <version>1.2.0</version>
   </parent>
 
+  <!-- [START spanner_opentelemetry_dependencies] -->
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -45,7 +46,6 @@
   </dependencyManagement>
 
   <dependencies>
-  <!-- [START spanner_opentelemetry_dependencies] -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
@@ -66,7 +66,7 @@
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-exporter-otlp</artifactId>
     </dependency>
-  <!-- [END spanner_opentelemetry_dependencies] -->
   </dependencies>
+  <!-- [END spanner_opentelemetry_dependencies] -->
 
 </project>

--- a/spanner/opentelemetry/src/main/java/com/example/spanner/OpenTelemetryUsage.java
+++ b/spanner/opentelemetry/src/main/java/com/example/spanner/OpenTelemetryUsage.java
@@ -77,14 +77,16 @@ public class OpenTelemetryUsage {
         .build();
     Spanner spanner = options.getService();
 
-    // [END spanner_opentelemetry_usage]
     DatabaseClient dbClient = spanner
         .getDatabaseClient(DatabaseId.of(projectId, instanceId, databaseId));
 
     captureGfeMetric(dbClient);
     captureQueryStatsMetric(openTelemetry, dbClient);
-    sdkMeterProvider.forceFlush();
-    sdkTracerProvider.forceFlush();
+
+    // Close the providers to free up the resources and export the data. */
+    sdkMeterProvider.close();
+    sdkTracerProvider.close();
+    // [END spanner_opentelemetry_usage]
   }
 
 


### PR DESCRIPTION
This PR fixes the OpenTelemetry metrics documentation to include the bom details and add meterProvider.close() in the sample [here](https://cloud.google.com/spanner/docs/capture-custom-metrics-opentelemetry#before-you-begin)
