### PR TITLE
chore: bigtable-proxy move CallLabels to core

### DIFF
--- a/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/channelpool/DataChannel.java
+++ b/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/channelpool/DataChannel.java
@@ -19,7 +19,7 @@ package com.google.cloud.bigtable.examples.proxy.channelpool;
 import com.google.bigtable.v2.BigtableGrpc;
 import com.google.bigtable.v2.PingAndWarmRequest;
 import com.google.bigtable.v2.PingAndWarmResponse;
-import com.google.cloud.bigtable.examples.proxy.metrics.CallLabels;
+import com.google.cloud.bigtable.examples.proxy.core.CallLabels;
 import com.google.cloud.bigtable.examples.proxy.metrics.Metrics;
 import com.google.cloud.bigtable.examples.proxy.metrics.Tracer;
 import com.google.common.util.concurrent.ListenableFuture;

--- a/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/channelpool/ResourceCollector.java
+++ b/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/channelpool/ResourceCollector.java
@@ -17,7 +17,7 @@
 package com.google.cloud.bigtable.examples.proxy.channelpool;
 
 import com.google.bigtable.v2.PingAndWarmRequest;
-import com.google.cloud.bigtable.examples.proxy.metrics.CallLabels;
+import com.google.cloud.bigtable.examples.proxy.core.CallLabels;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;

--- a/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/commands/Verify.java
+++ b/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/commands/Verify.java
@@ -58,7 +58,6 @@ import io.opentelemetry.sdk.metrics.internal.data.ImmutableGaugeData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableLongPointData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
 import io.opentelemetry.sdk.resources.Resource;
-import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -189,7 +188,6 @@ public class Verify implements Callable<Void> {
   void checkMetrics(Credentials creds) {
     Instant end = Instant.now().truncatedTo(ChronoUnit.MINUTES);
     Instant start = end.minus(Duration.ofMinutes(1));
-
 
     GCPResourceProvider resourceProvider = new GCPResourceProvider();
     Resource resource = Resource.create(resourceProvider.getAttributes());

--- a/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/core/CallLabels.java
+++ b/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/core/CallLabels.java
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package com.google.cloud.bigtable.examples.proxy.metrics;
+package com.google.cloud.bigtable.examples.proxy.core;
 
 import com.google.auto.value.AutoValue;
+import com.google.cloud.bigtable.examples.proxy.metrics.MetricsImpl;
 import io.grpc.Metadata;
 import io.grpc.Metadata.Key;
 import io.grpc.MethodDescriptor;

--- a/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/core/ProxyHandler.java
+++ b/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/core/ProxyHandler.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.bigtable.examples.proxy.core;
 
-import com.google.cloud.bigtable.examples.proxy.metrics.CallLabels;
 import com.google.cloud.bigtable.examples.proxy.metrics.Metrics;
 import com.google.cloud.bigtable.examples.proxy.metrics.Tracer;
 import io.grpc.CallCredentials;

--- a/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/metrics/Metrics.java
+++ b/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/metrics/Metrics.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.bigtable.examples.proxy.metrics;
 
+import com.google.cloud.bigtable.examples.proxy.core.CallLabels;
 import io.grpc.Status;
 import java.time.Duration;
 

--- a/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/metrics/MetricsImpl.java
+++ b/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/metrics/MetricsImpl.java
@@ -17,6 +17,7 @@
 package com.google.cloud.bigtable.examples.proxy.metrics;
 
 import com.google.auth.Credentials;
+import com.google.cloud.bigtable.examples.proxy.core.CallLabels;
 import com.google.cloud.opentelemetry.metric.GoogleCloudMetricExporter;
 import com.google.cloud.opentelemetry.metric.MetricConfiguration;
 import io.grpc.Status;
@@ -45,11 +46,11 @@ public class MetricsImpl implements Closeable, Metrics {
 
   public static final String METRIC_PREFIX = "bigtableproxy.";
 
-  static final AttributeKey<String> API_CLIENT_KEY = AttributeKey.stringKey("api_client");
-  static final AttributeKey<String> RESOURCE_KEY = AttributeKey.stringKey("resource");
-  static final AttributeKey<String> APP_PROFILE_KEY = AttributeKey.stringKey("app_profile");
-  static final AttributeKey<String> METHOD_KEY = AttributeKey.stringKey("method");
-  static final AttributeKey<String> STATUS_KEY = AttributeKey.stringKey("status");
+  public static final AttributeKey<String> API_CLIENT_KEY = AttributeKey.stringKey("api_client");
+  public static final AttributeKey<String> RESOURCE_KEY = AttributeKey.stringKey("resource");
+  public static final AttributeKey<String> APP_PROFILE_KEY = AttributeKey.stringKey("app_profile");
+  public static final AttributeKey<String> METHOD_KEY = AttributeKey.stringKey("method");
+  public static final AttributeKey<String> STATUS_KEY = AttributeKey.stringKey("status");
 
   public static final String METRIC_PRESENCE_NAME = METRIC_PREFIX + "presence";
   public static final String METRIC_PRESENCE_DESC = "Number of proxy processes";

--- a/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/metrics/NoopMetrics.java
+++ b/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/metrics/NoopMetrics.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.bigtable.examples.proxy.metrics;
 
+import com.google.cloud.bigtable.examples.proxy.core.CallLabels;
 import io.grpc.Status;
 import java.time.Duration;
 

--- a/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/metrics/Tracer.java
+++ b/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/metrics/Tracer.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.bigtable.examples.proxy.metrics;
 
+import com.google.cloud.bigtable.examples.proxy.core.CallLabels;
 import com.google.common.base.Stopwatch;
 import io.grpc.CallOptions;
 import io.grpc.CallOptions.Key;

--- a/bigtable/bigtable-proxy/src/test/java/com/google/cloud/bigtable/examples/proxy/commands/ServeMetricsTest.java
+++ b/bigtable/bigtable-proxy/src/test/java/com/google/cloud/bigtable/examples/proxy/commands/ServeMetricsTest.java
@@ -29,7 +29,7 @@ import com.google.bigtable.v2.BigtableGrpc.BigtableBlockingStub;
 import com.google.bigtable.v2.BigtableGrpc.BigtableImplBase;
 import com.google.bigtable.v2.CheckAndMutateRowRequest;
 import com.google.bigtable.v2.CheckAndMutateRowResponse;
-import com.google.cloud.bigtable.examples.proxy.metrics.CallLabels;
+import com.google.cloud.bigtable.examples.proxy.core.CallLabels;
 import com.google.cloud.bigtable.examples.proxy.metrics.Metrics;
 import com.google.common.collect.Lists;
 import io.grpc.CallOptions;

--- a/bigtable/bigtable-proxy/src/test/java/com/google/cloud/bigtable/examples/proxy/core/CallLabelsTest.java
+++ b/bigtable/bigtable-proxy/src/test/java/com/google/cloud/bigtable/examples/proxy/core/CallLabelsTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.bigtable.examples.proxy.metrics;
+package com.google.cloud.bigtable.examples.proxy.core;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.common.truth.Truth.assertThat;


### PR DESCRIPTION
CallLabels apply to more than just metrics, this is the first part of generalizing them. 