### PR TITLE
chore: decouple Otel from CallLabels

### DIFF
--- a/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/core/CallLabels.java
+++ b/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/core/CallLabels.java
@@ -17,11 +17,9 @@
 package com.google.cloud.bigtable.examples.proxy.core;
 
 import com.google.auto.value.AutoValue;
-import com.google.cloud.bigtable.examples.proxy.metrics.MetricsImpl;
 import io.grpc.Metadata;
 import io.grpc.Metadata.Key;
 import io.grpc.MethodDescriptor;
-import io.opentelemetry.api.common.Attributes;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
@@ -70,15 +68,13 @@ public abstract class CallLabels {
     }
   }
 
-  abstract Optional<String> getApiClient();
+  public abstract Optional<String> getApiClient();
 
   public abstract Optional<String> getResourceName();
 
   public abstract Optional<String> getAppProfileId();
 
-  abstract String getMethodName();
-
-  public abstract Attributes getOtelAttributes();
+  public abstract String getMethodName();
 
   public static CallLabels create(MethodDescriptor<?, ?> method, Metadata headers) {
     Optional<String> apiClient = Optional.ofNullable(headers.get(API_CLIENT));
@@ -96,15 +92,9 @@ public abstract class CallLabels {
       Optional<String> apiClient,
       Optional<String> resourceName,
       Optional<String> appProfile) {
-    Attributes otelAttrs =
-        Attributes.builder()
-            .put(MetricsImpl.API_CLIENT_KEY, apiClient.orElse("<missing>"))
-            .put(MetricsImpl.RESOURCE_KEY, resourceName.orElse("<missing>"))
-            .put(MetricsImpl.APP_PROFILE_KEY, appProfile.orElse("<missing>"))
-            .put(MetricsImpl.METHOD_KEY, method.getFullMethodName())
-            .build();
+
     return new AutoValue_CallLabels(
-        apiClient, resourceName, appProfile, method.getFullMethodName(), otelAttrs);
+        apiClient, resourceName, appProfile, method.getFullMethodName());
   }
 
   private static Optional<ResourceName> extractResourceName(String[] encodedKvPairs) {

--- a/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/metrics/Metrics.java
+++ b/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/metrics/Metrics.java
@@ -17,26 +17,30 @@
 package com.google.cloud.bigtable.examples.proxy.metrics;
 
 import com.google.cloud.bigtable.examples.proxy.core.CallLabels;
+import com.google.cloud.bigtable.examples.proxy.metrics.Metrics.MetricsAttributes;
 import io.grpc.Status;
 import java.time.Duration;
 
 public interface Metrics {
+  MetricsAttributes createAttributes(CallLabels callLabels);
 
-  void recordCallStarted(CallLabels labels);
+  void recordCallStarted(MetricsAttributes attrs);
 
-  void recordCredLatency(CallLabels labels, Status status, Duration duration);
+  void recordCredLatency(MetricsAttributes attrs, Status status, Duration duration);
 
-  void recordQueueLatency(CallLabels labels, Duration duration);
+  void recordQueueLatency(MetricsAttributes attrs, Duration duration);
 
-  void recordRequestSize(CallLabels labels, long size);
+  void recordRequestSize(MetricsAttributes attrs, long size);
 
-  void recordResponseSize(CallLabels labels, long size);
+  void recordResponseSize(MetricsAttributes attrs, long size);
 
-  void recordGfeLatency(CallLabels labels, Duration duration);
+  void recordGfeLatency(MetricsAttributes attrs, Duration duration);
 
-  void recordGfeHeaderMissing(CallLabels labels);
+  void recordGfeHeaderMissing(MetricsAttributes attrs);
 
-  void recordCallLatency(CallLabels labels, Status status, Duration duration);
+  void recordCallLatency(MetricsAttributes attrs, Status status, Duration duration);
 
   void updateChannelCount(int delta);
+
+  interface MetricsAttributes {}
 }

--- a/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/metrics/NoopMetrics.java
+++ b/bigtable/bigtable-proxy/src/main/java/com/google/cloud/bigtable/examples/proxy/metrics/NoopMetrics.java
@@ -23,28 +23,33 @@ import java.time.Duration;
 public class NoopMetrics implements Metrics {
 
   @Override
-  public void recordCallStarted(CallLabels labels) {}
+  public MetricsAttributes createAttributes(CallLabels callLabels) {
+    return null;
+  }
 
   @Override
-  public void recordCredLatency(CallLabels labels, Status status, Duration duration) {}
+  public void recordCallStarted(MetricsAttributes attrs) {}
 
   @Override
-  public void recordQueueLatency(CallLabels labels, Duration duration) {}
+  public void recordCredLatency(MetricsAttributes attrs, Status status, Duration duration) {}
 
   @Override
-  public void recordRequestSize(CallLabels labels, long size) {}
+  public void recordQueueLatency(MetricsAttributes attrs, Duration duration) {}
 
   @Override
-  public void recordResponseSize(CallLabels labels, long size) {}
+  public void recordRequestSize(MetricsAttributes attrs, long size) {}
 
   @Override
-  public void recordGfeLatency(CallLabels labels, Duration duration) {}
+  public void recordResponseSize(MetricsAttributes attrs, long size) {}
 
   @Override
-  public void recordGfeHeaderMissing(CallLabels labels) {}
+  public void recordGfeLatency(MetricsAttributes attrs, Duration duration) {}
 
   @Override
-  public void recordCallLatency(CallLabels labels, Status status, Duration duration) {}
+  public void recordGfeHeaderMissing(MetricsAttributes attrs) {}
+
+  @Override
+  public void recordCallLatency(MetricsAttributes attrs, Status status, Duration duration) {}
 
   @Override
   public void updateChannelCount(int delta) {}

--- a/bigtable/bigtable-proxy/src/test/java/com/google/cloud/bigtable/examples/proxy/commands/ServeMetricsTest.java
+++ b/bigtable/bigtable-proxy/src/test/java/com/google/cloud/bigtable/examples/proxy/commands/ServeMetricsTest.java
@@ -21,6 +21,7 @@ import static org.mockito.AdditionalMatchers.geq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 
 import com.google.auth.Credentials;
@@ -31,6 +32,7 @@ import com.google.bigtable.v2.CheckAndMutateRowRequest;
 import com.google.bigtable.v2.CheckAndMutateRowResponse;
 import com.google.cloud.bigtable.examples.proxy.core.CallLabels;
 import com.google.cloud.bigtable.examples.proxy.metrics.Metrics;
+import com.google.cloud.bigtable.examples.proxy.metrics.Metrics.MetricsAttributes;
 import com.google.common.collect.Lists;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -71,7 +73,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -203,6 +204,9 @@ public class ServeMetricsTest {
                   }
                 });
 
+    MetricsAttributes fakeAttrs = new MetricsAttributes() {};
+
+    doReturn(fakeAttrs).when(mockMetrics).createAttributes(any());
     doAnswer(
             invocation -> {
               Thread.sleep(10);
@@ -217,7 +221,7 @@ public class ServeMetricsTest {
               return invocation.callRealMethod();
             })
         .when(fakeCredentials)
-        .getRequestMetadata(Mockito.any());
+        .getRequestMetadata(any());
 
     CheckAndMutateRowRequest request =
         CheckAndMutateRowRequest.newBuilder()
@@ -225,24 +229,22 @@ public class ServeMetricsTest {
             .build();
     CheckAndMutateRowResponse response = stub.checkAndMutateRow(request);
 
-    CallLabels expectedLabels =
-        CallLabels.create(
-            BigtableGrpc.getCheckAndMutateRowMethod(),
-            Optional.of("fake-client"),
-            Optional.of("projects/fake-project/instances/fake-instance/tables/fake-table"),
-            Optional.of("fake-app-profile"));
+    verify(mockMetrics)
+        .createAttributes(
+            eq(
+                CallLabels.create(
+                    BigtableGrpc.getCheckAndMutateRowMethod(),
+                    Optional.of("fake-client"),
+                    Optional.of("projects/fake-project/instances/fake-instance/tables/fake-table"),
+                    Optional.of("fake-app-profile"))));
 
-    verify(mockMetrics).recordCallStarted(eq(expectedLabels));
-    verify(mockMetrics)
-        .recordCredLatency(eq(expectedLabels), eq(Status.OK), geq(Duration.ofMillis(10)));
-    verify(mockMetrics).recordGfeLatency(eq(expectedLabels), eq(Duration.ofMillis(1234)));
-    verify(mockMetrics).recordQueueLatency(eq(expectedLabels), geq(Duration.ZERO));
-    verify(mockMetrics)
-        .recordRequestSize(eq(expectedLabels), eq((long) request.getSerializedSize()));
-    verify(mockMetrics)
-        .recordResponseSize(eq(expectedLabels), eq((long) response.getSerializedSize()));
-    verify(mockMetrics)
-        .recordCallLatency(eq(expectedLabels), eq(Status.OK), geq(Duration.ofMillis(20)));
+    verify(mockMetrics).recordCallStarted(eq(fakeAttrs));
+    verify(mockMetrics).recordCredLatency(eq(fakeAttrs), eq(Status.OK), geq(Duration.ofMillis(10)));
+    verify(mockMetrics).recordGfeLatency(eq(fakeAttrs), eq(Duration.ofMillis(1234)));
+    verify(mockMetrics).recordQueueLatency(eq(fakeAttrs), geq(Duration.ZERO));
+    verify(mockMetrics).recordRequestSize(eq(fakeAttrs), eq((long) request.getSerializedSize()));
+    verify(mockMetrics).recordResponseSize(eq(fakeAttrs), eq((long) response.getSerializedSize()));
+    verify(mockMetrics).recordCallLatency(eq(fakeAttrs), eq(Status.OK), geq(Duration.ofMillis(20)));
   }
 
   @Test
@@ -276,25 +278,30 @@ public class ServeMetricsTest {
                   }
                 });
 
+    MetricsAttributes fakeAttrs = new MetricsAttributes() {};
+    doReturn(fakeAttrs).when(mockMetrics).createAttributes(any());
+
     CheckAndMutateRowRequest request =
         CheckAndMutateRowRequest.newBuilder()
             .setTableName("project/fake-project/instances/fake-instance/tables/fake-table")
             .build();
     CheckAndMutateRowResponse response = stub.checkAndMutateRow(request);
 
-    CallLabels expectedLabels =
-        CallLabels.create(
-            BigtableGrpc.getCheckAndMutateRowMethod(),
-            Optional.of("fake-client"),
-            Optional.of("projects/fake-project/instances/fake-instance/tables/fake-table"),
-            Optional.of("fake-app-profile"));
+    verify(mockMetrics)
+        .createAttributes(
+            eq(
+                CallLabels.create(
+                    BigtableGrpc.getCheckAndMutateRowMethod(),
+                    Optional.of("fake-client"),
+                    Optional.of("projects/fake-project/instances/fake-instance/tables/fake-table"),
+                    Optional.of("fake-app-profile"))));
 
-    verify(mockMetrics).recordGfeHeaderMissing(eq(expectedLabels));
+    verify(mockMetrics).recordGfeHeaderMissing(eq(fakeAttrs));
   }
 
   @Test
   public void testError() throws IOException {
-    BigtableBlockingStub stub =
+    final BigtableBlockingStub stub =
         BigtableGrpc.newBlockingStub(proxyChannel)
             .withInterceptors(
                 new ClientInterceptor() {
@@ -329,7 +336,7 @@ public class ServeMetricsTest {
               return invocation.callRealMethod();
             })
         .when(fakeCredentials)
-        .getRequestMetadata(Mockito.any());
+        .getRequestMetadata(any());
 
     doAnswer(
             invocation -> {
@@ -342,28 +349,31 @@ public class ServeMetricsTest {
         .when(dataService)
         .checkAndMutateRow(any(), any());
 
+    MetricsAttributes fakeAttrs = new MetricsAttributes() {};
+    doReturn(fakeAttrs).when(mockMetrics).createAttributes(any());
+
     CheckAndMutateRowRequest request =
         CheckAndMutateRowRequest.newBuilder()
             .setTableName("project/fake-project/instances/fake-instance/tables/fake-table")
             .build();
     assertThrows(StatusRuntimeException.class, () -> stub.checkAndMutateRow(request));
 
-    CallLabels expectedLabels =
-        CallLabels.create(
-            BigtableGrpc.getCheckAndMutateRowMethod(),
-            Optional.of("fake-client"),
-            Optional.of("projects/fake-project/instances/fake-instance/tables/fake-table"),
-            Optional.of("fake-app-profile"));
+    verify(mockMetrics)
+        .createAttributes(
+            eq(
+                CallLabels.create(
+                    BigtableGrpc.getCheckAndMutateRowMethod(),
+                    Optional.of("fake-client"),
+                    Optional.of("projects/fake-project/instances/fake-instance/tables/fake-table"),
+                    Optional.of("fake-app-profile"))));
 
-    verify(mockMetrics).recordCallStarted(eq(expectedLabels));
+    verify(mockMetrics).recordCallStarted(eq(fakeAttrs));
+    verify(mockMetrics).recordCredLatency(eq(fakeAttrs), eq(Status.OK), geq(Duration.ofMillis(10)));
+    verify(mockMetrics).recordQueueLatency(eq(fakeAttrs), geq(Duration.ZERO));
+    verify(mockMetrics).recordRequestSize(eq(fakeAttrs), eq((long) request.getSerializedSize()));
+    verify(mockMetrics).recordResponseSize(eq(fakeAttrs), eq(0L));
     verify(mockMetrics)
-        .recordCredLatency(eq(expectedLabels), eq(Status.OK), geq(Duration.ofMillis(10)));
-    verify(mockMetrics).recordQueueLatency(eq(expectedLabels), geq(Duration.ZERO));
-    verify(mockMetrics)
-        .recordRequestSize(eq(expectedLabels), eq((long) request.getSerializedSize()));
-    verify(mockMetrics).recordResponseSize(eq(expectedLabels), eq(0L));
-    verify(mockMetrics)
-        .recordCallLatency(eq(expectedLabels), eq(Status.INTERNAL), geq(Duration.ofMillis(20)));
+        .recordCallLatency(eq(fakeAttrs), eq(Status.INTERNAL), geq(Duration.ofMillis(20)));
   }
 
   static class MetadataInterceptor implements ServerInterceptor {

--- a/bigtable/bigtable-proxy/src/test/java/com/google/cloud/bigtable/examples/proxy/core/CallLabelsTest.java
+++ b/bigtable/bigtable-proxy/src/test/java/com/google/cloud/bigtable/examples/proxy/core/CallLabelsTest.java
@@ -21,11 +21,9 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.bigtable.v2.BigtableGrpc;
 import com.google.common.truth.FailureMetadata;
-import com.google.common.truth.MapSubject;
 import com.google.common.truth.Subject;
 import io.grpc.Metadata;
 import io.grpc.Metadata.Key;
-import io.opentelemetry.api.common.AttributeKey;
 import java.util.Optional;
 import org.jspecify.annotations.Nullable;
 import org.junit.Test;
@@ -50,14 +48,6 @@ public class CallLabelsTest {
     assertThat(callLabels.getAppProfileId()).isEqualTo(Optional.of("a"));
     assertThat(callLabels.getResourceName())
         .isEqualTo(Optional.of("projects/p/instances/i/tables/t"));
-
-    CallLabelsSubject.assertThat(callLabels)
-        .hasOtelAttributesThat()
-        .containsAtLeast(
-            AttributeKey.stringKey("api_client"), "some-client",
-            AttributeKey.stringKey("resource"), "projects/p/instances/i/tables/t",
-            AttributeKey.stringKey("app_profile"), "a",
-            AttributeKey.stringKey("method"), "google.bigtable.v2.Bigtable/MutateRow");
   }
 
   @Test
@@ -68,9 +58,6 @@ public class CallLabelsTest {
 
     assertThat(callLabels.getResourceName())
         .isEqualTo(Optional.of("projects/p/instances/i/tables/t"));
-    CallLabelsSubject.assertThat(callLabels)
-        .hasOtelAttributesThat()
-        .containsAtLeast(AttributeKey.stringKey("resource"), "projects/p/instances/i/tables/t");
   }
 
   @Test
@@ -79,13 +66,6 @@ public class CallLabelsTest {
     CallLabels callLabels = CallLabels.create(BigtableGrpc.getMutateRowMethod(), md);
 
     assertThat(callLabels.getResourceName()).isEqualTo(Optional.empty());
-    CallLabelsSubject.assertThat(callLabels)
-        .hasOtelAttributesThat()
-        .containsAtLeast(
-            AttributeKey.stringKey("api_client"), "<missing>",
-            AttributeKey.stringKey("resource"), "<missing>",
-            AttributeKey.stringKey("app_profile"), "<missing>",
-            AttributeKey.stringKey("method"), "google.bigtable.v2.Bigtable/MutateRow");
   }
 
   @Test
@@ -95,9 +75,6 @@ public class CallLabelsTest {
     CallLabels callLabels = CallLabels.create(BigtableGrpc.getMutateRowMethod(), md);
 
     assertThat(callLabels.getResourceName()).isEqualTo(Optional.empty());
-    CallLabelsSubject.assertThat(callLabels)
-        .hasOtelAttributesThat()
-        .containsAtLeast(AttributeKey.stringKey("resource"), "<missing>");
   }
 
   @Test
@@ -107,9 +84,6 @@ public class CallLabelsTest {
     CallLabels callLabels = CallLabels.create(BigtableGrpc.getMutateRowMethod(), md);
 
     assertThat(callLabels.getResourceName()).isEqualTo(Optional.empty());
-    CallLabelsSubject.assertThat(callLabels)
-        .hasOtelAttributesThat()
-        .containsAtLeast(AttributeKey.stringKey("resource"), "<missing>");
   }
 
   @Test
@@ -119,9 +93,6 @@ public class CallLabelsTest {
     CallLabels callLabels = CallLabels.create(BigtableGrpc.getMutateRowMethod(), md);
 
     assertThat(callLabels.getResourceName()).isEqualTo(Optional.empty());
-    CallLabelsSubject.assertThat(callLabels)
-        .hasOtelAttributesThat()
-        .containsAtLeast(AttributeKey.stringKey("resource"), "<missing>");
   }
 
   private static class CallLabelsSubject extends Subject {
@@ -138,10 +109,6 @@ public class CallLabelsTest {
 
     public static CallLabelsSubject assertThat(CallLabels callLabels) {
       return assertAbout(callLabels()).that(callLabels);
-    }
-
-    public MapSubject hasOtelAttributesThat() {
-      return check("getOtelAttributes()").that(actual.getOtelAttributes().asMap());
     }
 
     public void hasMethodName(String method) {

--- a/bigtable/bigtable-proxy/src/test/java/com/google/cloud/bigtable/examples/proxy/metrics/MetricsImplTest.java
+++ b/bigtable/bigtable-proxy/src/test/java/com/google/cloud/bigtable/examples/proxy/metrics/MetricsImplTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigtable.examples.proxy.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.bigtable.v2.BigtableGrpc;
+import com.google.cloud.bigtable.examples.proxy.core.CallLabels;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.MeterProvider;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public class MetricsImplTest {
+  @Rule public final MockitoRule mockitoTestRule = MockitoJUnit.rule();
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  MeterProvider mockMeterProvider;
+
+  private MetricsImpl metrics;
+
+  @Before
+  public void setUp() throws Exception {
+    metrics = new MetricsImpl(mockMeterProvider);
+  }
+
+  @Test
+  public void testBasic() {
+    CallLabels callLabels =
+        CallLabels.create(
+            BigtableGrpc.getMutateRowMethod(),
+            Optional.of("some-client"),
+            Optional.of("projects/p/instances/i/tables/t"),
+            Optional.of("a"));
+    Attributes attrs = metrics.createAttributes(callLabels).getAttributes();
+    assertThat(attrs.asMap())
+        .containsAtLeast(
+            AttributeKey.stringKey("api_client"), "some-client",
+            AttributeKey.stringKey("resource"), "projects/p/instances/i/tables/t",
+            AttributeKey.stringKey("app_profile"), "a",
+            AttributeKey.stringKey("method"), "google.bigtable.v2.Bigtable/MutateRow");
+  }
+
+  @Test
+  public void testMissing() {
+    CallLabels callLabels =
+        CallLabels.create(
+            BigtableGrpc.getMutateRowMethod(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    Attributes attrs = metrics.createAttributes(callLabels).getAttributes();
+    assertThat(attrs.asMap())
+        .containsAtLeast(
+            AttributeKey.stringKey("api_client"), "<missing>",
+            AttributeKey.stringKey("resource"), "<missing>",
+            AttributeKey.stringKey("app_profile"), "<missing>",
+            AttributeKey.stringKey("method"), "google.bigtable.v2.Bigtable/MutateRow");
+  }
+}


### PR DESCRIPTION
NOTE: this is depends on and includes #9746

Metric labels are derived from CallLabels, but they are not the same thing