### PR TITLE
fix(eventarc): sets protojson to ignoreUnknownFields

### DIFF
--- a/eventarc/storage-handler/src/main/java/com/example/cloudrun/CloudEventController.java
+++ b/eventarc/storage-handler/src/main/java/com/example/cloudrun/CloudEventController.java
@@ -46,7 +46,12 @@ public class CloudEventController {
 
     String json = new String(cloudEvent.getData().toBytes());
     StorageObjectData.Builder builder = StorageObjectData.newBuilder();
-    JsonFormat.parser().merge(json, builder);
+
+    // If you do not ignore unknown fields, then JsonFormat.Parser returns an
+    // error when encountering a new or unknown field. Note that you might lose
+    // some event data in the unmarshaling process by ignoring unknown fields.
+    JsonFormat.Parser parser = JsonFormat.parser().ignoringUnknownFields();
+    parser.merge(json, builder);
     StorageObjectData data = builder.build();
 
     // Convert protobuf timestamp to java Instant
@@ -54,7 +59,7 @@ public class CloudEventController {
     Instant updated = Instant.ofEpochSecond(ts.getSeconds(), ts.getNanos());
     String msg =
         String.format(
-            "Cloud Storage object changed: %s/%s modified at %s\n",
+            "Cloud Storage object changed: %s/%s modified at %s%n",
             data.getBucket(), data.getName(), updated);
 
     System.out.println(msg);

--- a/functions/v2/firebase/firestore-reactive/src/main/java/functions/FirebaseFirestoreReactive.java
+++ b/functions/v2/firebase/firestore-reactive/src/main/java/functions/FirebaseFirestoreReactive.java
@@ -59,8 +59,15 @@ public class FirebaseFirestoreReactive implements CloudEventsFunction {
       return;
     }
 
-    DocumentEventData firestoreEventData = DocumentEventData
-        .parseFrom(event.getData().toBytes());
+    DocumentEventData.Builder builder = DocumentEventData.newBuilder();
+    String json = new String(event.getData().toBytes());
+
+    // If you do not ignore unknown fields, then JsonFormat.Parser returns an
+    // error when encountering a new or unknown field. Note that you might lose
+    // some event data in the unmarshaling process by ignoring unknown fields.
+    JsonFormat.Parser parser = JsonFormat.parser().ignoringUnknownFields();
+    parser.merge(json, builder);
+    DocumentEventData firestoreEventData = builder.build();
 
     // Get the fields from the post-operation document snapshot
     // https://firebase.google.com/docs/firestore/reference/rest/v1/projects.databases.documents#Document

--- a/functions/v2/firebase/firestore-reactive/src/main/java/functions/FirebaseFirestoreReactive.java
+++ b/functions/v2/firebase/firestore-reactive/src/main/java/functions/FirebaseFirestoreReactive.java
@@ -24,6 +24,7 @@ import com.google.cloud.functions.CloudEventsFunction;
 import com.google.events.cloud.firestore.v1.DocumentEventData;
 import com.google.events.cloud.firestore.v1.Value;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
 import io.cloudevents.CloudEvent;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;

--- a/functions/v2/firebase/firestore-reactive/src/main/java/functions/FirebaseFirestoreReactive.java
+++ b/functions/v2/firebase/firestore-reactive/src/main/java/functions/FirebaseFirestoreReactive.java
@@ -60,15 +60,8 @@ public class FirebaseFirestoreReactive implements CloudEventsFunction {
       return;
     }
 
-    DocumentEventData.Builder builder = DocumentEventData.newBuilder();
-    String json = new String(event.getData().toBytes());
-
-    // If you do not ignore unknown fields, then JsonFormat.Parser returns an
-    // error when encountering a new or unknown field. Note that you might lose
-    // some event data in the unmarshaling process by ignoring unknown fields.
-    JsonFormat.Parser parser = JsonFormat.parser().ignoringUnknownFields();
-    parser.merge(json, builder);
-    DocumentEventData firestoreEventData = builder.build();
+    DocumentEventData firestoreEventData = DocumentEventData
+        .parseFrom(event.getData().toBytes());
 
     // Get the fields from the post-operation document snapshot
     // https://firebase.google.com/docs/firestore/reference/rest/v1/projects.databases.documents#Document

--- a/functions/v2/firebase/firestore-reactive/src/main/java/functions/FirebaseFirestoreReactive.java
+++ b/functions/v2/firebase/firestore-reactive/src/main/java/functions/FirebaseFirestoreReactive.java
@@ -24,7 +24,6 @@ import com.google.cloud.functions.CloudEventsFunction;
 import com.google.events.cloud.firestore.v1.DocumentEventData;
 import com.google.events.cloud.firestore.v1.Value;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.util.JsonFormat;
 import io.cloudevents.CloudEvent;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;

--- a/functions/v2/firebase/firestore/src/main/java/functions/FirebaseFirestore.java
+++ b/functions/v2/firebase/firestore/src/main/java/functions/FirebaseFirestore.java
@@ -20,6 +20,8 @@ package functions;
 import com.google.cloud.functions.CloudEventsFunction;
 import com.google.events.cloud.firestore.v1.DocumentEventData;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+
 import io.cloudevents.CloudEvent;
 import java.util.logging.Logger;
 
@@ -28,16 +30,24 @@ public class FirebaseFirestore implements CloudEventsFunction {
 
   @Override
   public void accept(CloudEvent event) throws InvalidProtocolBufferException {
-    DocumentEventData firestorEventData = DocumentEventData.parseFrom(event.getData().toBytes());
+    DocumentEventData.Builder builder = DocumentEventData.newBuilder();
+    String json = new String(event.getData().toBytes());
+
+    // If you do not ignore unknown fields, then JsonFormat.Parser returns an
+    // error when encountering a new or unknown field. Note that you might lose
+    // some event data in the unmarshaling process by ignoring unknown fields.
+    JsonFormat.Parser parser = JsonFormat.parser().ignoringUnknownFields();
+    parser.merge(json, builder);
+    DocumentEventData firestoreEventData = builder.build();
 
     logger.info("Function triggered by event on: " + event.getSource());
     logger.info("Event type: " + event.getType());
 
     logger.info("Old value:");
-    logger.info(firestorEventData.getOldValue().toString());
+    logger.info(firestoreEventData.getOldValue().toString());
 
     logger.info("New value:");
-    logger.info(firestorEventData.getValue().toString());
+    logger.info(firestoreEventData.getValue().toString());
   }
 }
 

--- a/functions/v2/firebase/firestore/src/main/java/functions/FirebaseFirestore.java
+++ b/functions/v2/firebase/firestore/src/main/java/functions/FirebaseFirestore.java
@@ -21,7 +21,6 @@ import com.google.cloud.functions.CloudEventsFunction;
 import com.google.events.cloud.firestore.v1.DocumentEventData;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
-
 import io.cloudevents.CloudEvent;
 import java.util.logging.Logger;
 

--- a/functions/v2/firebase/firestore/src/main/java/functions/FirebaseFirestore.java
+++ b/functions/v2/firebase/firestore/src/main/java/functions/FirebaseFirestore.java
@@ -20,7 +20,6 @@ package functions;
 import com.google.cloud.functions.CloudEventsFunction;
 import com.google.events.cloud.firestore.v1.DocumentEventData;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.util.JsonFormat;
 import io.cloudevents.CloudEvent;
 import java.util.logging.Logger;
 
@@ -29,15 +28,8 @@ public class FirebaseFirestore implements CloudEventsFunction {
 
   @Override
   public void accept(CloudEvent event) throws InvalidProtocolBufferException {
-    DocumentEventData.Builder builder = DocumentEventData.newBuilder();
-    String json = new String(event.getData().toBytes());
-
-    // If you do not ignore unknown fields, then JsonFormat.Parser returns an
-    // error when encountering a new or unknown field. Note that you might lose
-    // some event data in the unmarshaling process by ignoring unknown fields.
-    JsonFormat.Parser parser = JsonFormat.parser().ignoringUnknownFields();
-    parser.merge(json, builder);
-    DocumentEventData firestoreEventData = builder.build();
+    DocumentEventData firestoreEventData = DocumentEventData
+        .parseFrom(event.getData().toBytes());
 
     logger.info("Function triggered by event on: " + event.getSource());
     logger.info("Event type: " + event.getType());

--- a/functions/v2/hello-gcs/src/main/java/functions/HelloGcs.java
+++ b/functions/v2/hello-gcs/src/main/java/functions/HelloGcs.java
@@ -40,7 +40,12 @@ public class HelloGcs implements CloudEventsFunction {
 
     String cloudEventData = new String(event.getData().toBytes(), StandardCharsets.UTF_8);
     StorageObjectData.Builder builder = StorageObjectData.newBuilder();
-    JsonFormat.parser().merge(cloudEventData, builder);
+
+    // If you do not ignore unknown fields, then JsonFormat.Parser returns an
+    // error when encountering a new or unknown field. Note that you might lose
+    // some event data in the unmarshaling process by ignoring unknown fields.
+    JsonFormat.Parser parser = JsonFormat.parser().ignoringUnknownFields();
+    parser.merge(cloudEventData, builder);
     StorageObjectData data = builder.build();
 
     logger.info("Bucket: " + data.getBucket());

--- a/functions/v2/imagemagick/src/main/java/functions/ImageMagick.java
+++ b/functions/v2/imagemagick/src/main/java/functions/ImageMagick.java
@@ -156,7 +156,12 @@ public class ImageMagick implements CloudEventsFunction {
     // Extract Cloud Event data and convert to StorageObjectData
     String cloudEventData = new String(event.getData().toBytes(), StandardCharsets.UTF_8);
     StorageObjectData.Builder builder = StorageObjectData.newBuilder();
-    JsonFormat.parser().merge(cloudEventData, builder);
+    
+    // If you do not ignore unknown fields, then JsonFormat.Parser returns an
+    // error when encountering a new or unknown field. Note that you might lose
+    // some event data in the unmarshaling process by ignoring unknown fields.
+    JsonFormat.Parser parser = JsonFormat.parser().ignoringUnknownFields();
+    parser.merge(cloudEventData, builder);
     return builder.build();
   }
   // [START functions_imagemagick_setup]

--- a/functions/v2/ocr/ocr-process-image/src/main/java/functions/OcrProcessImage.java
+++ b/functions/v2/ocr/ocr-process-image/src/main/java/functions/OcrProcessImage.java
@@ -71,7 +71,12 @@ public class OcrProcessImage implements CloudEventsFunction {
     // Unmarshal data from CloudEvent
     String cloudEventData = new String(event.getData().toBytes(), StandardCharsets.UTF_8);
     StorageObjectData.Builder builder = StorageObjectData.newBuilder();
-    JsonFormat.parser().merge(cloudEventData, builder);
+    
+    // If you do not ignore unknown fields, then JsonFormat.Parser returns an
+    // error when encountering a new or unknown field. Note that you might lose
+    // some event data in the unmarshaling process by ignoring unknown fields.
+    JsonFormat.Parser parser = JsonFormat.parser().ignoringUnknownFields();
+    parser.merge(cloudEventData, builder);
     StorageObjectData gcsEvent = builder.build();
 
     String bucket = gcsEvent.getBucket();


### PR DESCRIPTION
## Description

This PR sets all of the calls to protojson.Unmarshal() to DiscardUnknown fields. This will reduce the likelihood of customers encountering errors in their deployed functions. This PR also adds a comment explaining the usage of the DiscardUnknown field.