### PR TITLE
fix(storage): migrate old region all to storagetransfer_transfer_all step 1

### DIFF
--- a/storage-transfer/src/test/java/com/google/cloud/storage/storagetransfer/samples/test/util/TransferJobUtils.java
+++ b/storage-transfer/src/test/java/com/google/cloud/storage/storagetransfer/samples/test/util/TransferJobUtils.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+// [START storagetransfer_transfer_all]
 // [START all]
 
 package com.google.cloud.storage.storagetransfer.samples.test.util;
@@ -68,3 +69,4 @@ public final class TransferJobUtils {
   }
 }
 // [END all]
+// [END storagetransfer_transfer_all]


### PR DESCRIPTION
## Description
Migrate old region all to storagetransfer_transfer_all to associate it with official product and function

Fixes [b/347826316](https://b.corp.google.com/issues/347826316)

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
