### PR TITLE
fix(compute): migrate old region "dependecies" to "compute_sendgrid_dependecies_java"

### DIFF
--- a/compute/sendgrid/pom.xml
+++ b/compute/sendgrid/pom.xml
@@ -37,6 +37,7 @@
   </properties>
 
   <dependencies>
+    <!-- [START compute_sendgrid_dependecies_java] -->
     <!-- [START dependencies] -->
     <dependency>
       <groupId>com.sendgrid</groupId>
@@ -44,6 +45,7 @@
       <version>4.10.1</version>
     </dependency>
     <!-- [END dependencies] -->
+    <!-- [END compute_sendgrid_dependecies_java] -->
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
## Description
Migrate old region "dependecies" to "compute_sendgrid_dependecies" associating it with an official GCP product and adding the "_java" suffix.

Fixes [b/347825311](https://b.corp.google.com/issues/347825311)

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
