### PR TITLE
fix(compute): migrate region 'example' to 'compute_sendgrid'

### DIFF
--- a/compute/sendgrid/pom.xml
+++ b/compute/sendgrid/pom.xml
@@ -37,6 +37,7 @@
   </properties>
 
   <dependencies>
+    <!-- [START compute_sendgrid_dependecies_java] -->
     <!-- [START dependencies] -->
     <dependency>
       <groupId>com.sendgrid</groupId>
@@ -44,6 +45,7 @@
       <version>4.10.1</version>
     </dependency>
     <!-- [END dependencies] -->
+    <!-- [END compute_sendgrid_dependecies_java] -->
   </dependencies>
   <build>
     <plugins>

--- a/compute/sendgrid/pom.xml
+++ b/compute/sendgrid/pom.xml
@@ -37,7 +37,7 @@
   </properties>
 
   <dependencies>
-    <!-- [START compute_sendgrid_dependecies_java] -->
+    <!-- [START compute_sendgrid_dependencies_java] -->
     <!-- [START dependencies] -->
     <dependency>
       <groupId>com.sendgrid</groupId>
@@ -45,7 +45,7 @@
       <version>4.10.1</version>
     </dependency>
     <!-- [END dependencies] -->
-    <!-- [END compute_sendgrid_dependecies_java] -->
+    <!-- [END compute_sendgrid_dependencies_java] -->
   </dependencies>
   <build>
     <plugins>

--- a/compute/sendgrid/src/main/java/com/example/compute/sendgrid/SendEmailServlet.java
+++ b/compute/sendgrid/src/main/java/com/example/compute/sendgrid/SendEmailServlet.java
@@ -25,6 +25,7 @@ import com.sendgrid.helpers.mail.objects.Content;
 import com.sendgrid.helpers.mail.objects.Email;
 import java.io.IOException;
 
+// [START compute_sendgrid]
 // [START example]
 public class SendEmailServlet {
   static final String SENDGRID_API_KEY = "YOUR-SENDGRID-API-KEY";
@@ -65,3 +66,4 @@ public class SendEmailServlet {
 
 }
 // [END example]
+// [END compute_sendgrid]


### PR DESCRIPTION
## Description
Migrate old 'example' region to 'compute_sendgrid' to officially associate it with a product.

Fixes [b/386956670](https://b.corp.google.com/issues/386956670)

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
