### PR TITLE
docs(memorystore): added valkey session snippets

### DIFF
--- a/memorystore/valkey/session/snippets/pom.xml
+++ b/memorystore/valkey/session/snippets/pom.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright 2020 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example.memorystore</groupId>
+  <artifactId>caching</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>Google Cloud Memorystore Sample</name>
+  <url>http://www.example.com</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>11</maven.compiler.release>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.11.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- Jedis Redis client library -->
+    <dependency>
+      <groupId>redis.clients</groupId>
+      <artifactId>jedis</artifactId>
+      <version>4.3.1</version>
+    </dependency>
+
+    <!-- Google Cloud Client Libraries -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-core</artifactId>
+      <version>2.16.0</version>
+    </dependency>
+
+    <!-- Unit testing libraries -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.4.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.3.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.13.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.3.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.4.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>3.1.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.1.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.12.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>3.6.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/memorystore/valkey/session/snippets/src/main/java/samples/MemorystoreAddItemToBasket.java
+++ b/memorystore/valkey/session/snippets/src/main/java/samples/MemorystoreAddItemToBasket.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR IMPLIED WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+public final class MemorystoreAddItemToBasket {
+
+    /** Replace the Memorystore instance ID. */
+    private static final String INSTANCE_ID = "INSTANCE_ID";
+
+    /** Replace the Memorystore port, if not the default port. */
+    private static final int PORT = 6379;
+
+    /** User ID for managing the basket. */
+    private static final String USER_ID = "USER_ID";
+
+    /** Item to be added to the user's basket. */
+    private static final String ITEM_ID = "ITEM_ID";
+
+    /** Set how many items to be added to the basket. */
+    private static final int ITEM_COUNT = 1;
+
+    private MemorystoreAddItemToBasket() {
+        // No-op constructor to prevent instantiation
+    }
+
+    /**
+     * Adds an item to a user's basket in Memorystore.
+     *
+     * @param args command-line arguments
+     */
+    public static void main(final String[] args) {
+        // Create a Jedis connection pool
+        try (JedisPool pool = new JedisPool(INSTANCE_ID, PORT);
+                Jedis jedis = pool.getResource()) {
+
+            String basketKey = "basket:" + USER_ID;
+
+            // Add items to the user's basket
+            jedis.hincrBy(basketKey, ITEM_ID, ITEM_COUNT);
+            System.out.printf("Added %d items to basket: %s%n", ITEM_COUNT, ITEM_ID);
+
+            // Verify the item is in the basket
+            boolean exists = jedis.hexists(basketKey, ITEM_ID);
+            if (exists) {
+                System.out.printf("Item successfully added: %s%n", ITEM_ID);
+            } else {
+                System.out.printf("Failed to add item: %s%n", ITEM_ID);
+            }
+        } catch (Exception e) {
+            System.err.printf("Error connecting to Redis: %s%n", e.getMessage());
+        }
+    }
+}

--- a/memorystore/valkey/session/snippets/src/main/java/samples/MemorystoreClearBasket.java
+++ b/memorystore/valkey/session/snippets/src/main/java/samples/MemorystoreClearBasket.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR IMPLIED WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+public final class MemorystoreClearBasket {
+
+    /** Replace the Memorystore instance ID. */
+    private static final String INSTANCE_ID = "INSTANCE_ID";
+
+    /** Replace the Memorystore port, if not the default port. */
+    private static final int PORT = 6379;
+
+    /** User ID for managing the basket */
+    private static final String USER_ID = "USER_ID";
+
+    private MemorystoreClearBasket() {
+        // No-op; won't be called
+    }
+
+    /**
+     * Clears a user's basket in Memorystore.
+     *
+     * @param args command-line arguments
+     */
+    public static void main(final String[] args) {
+        // Connect to the Memorystore instance
+        JedisPool pool = new JedisPool(INSTANCE_ID, PORT);
+
+        try (Jedis jedis = pool.getResource()) {
+            String basketKey = "basket:" + USER_ID;
+
+            // Delete the basket (remove all items)
+            long deleted = jedis.del(basketKey);
+
+            // Verify if the basket was cleared
+            if (deleted > 0) {
+                System.out.printf("Basket cleared successfully for user: %s%n", USER_ID);
+            } else {
+                System.out.printf("No basket found for user: %s%n", USER_ID);
+            }
+        } catch (Exception e) {
+            System.err.printf("Error connecting to Redis: %s%n", e.getMessage());
+        }
+    }
+}

--- a/memorystore/valkey/session/snippets/src/main/java/samples/MemorystoreLoginUser.java
+++ b/memorystore/valkey/session/snippets/src/main/java/samples/MemorystoreLoginUser.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR IMPLIED WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import java.util.UUID;
+
+public final class MemorystoreLoginUser {
+
+    /** Replace the Memorystore instance id. */
+    private static final String INSTANCE_ID = "INSTANCE_ID";
+
+    /** Replace the Memorystore port, if not the default port. */
+    private static final int PORT = 6379;
+
+    /** User ID for login */
+    private static final String USER_ID = "USER_ID";
+
+    /** Session expiration time in seconds (30 minutes) */
+    private static final int SESSION_TIMEOUT = 1800;
+
+    private MemorystoreLoginUser() {
+        // No-op; won't be called
+    }
+
+    /**
+     * Logs in a user by creating a session in Memorystore.
+     *
+     * @param args command-line arguments
+     */
+    public static void main(final String[] args) {
+        // Connect to the Memorystore instance
+        JedisPool pool = new JedisPool(INSTANCE_ID, PORT);
+
+        try (Jedis jedis = pool.getResource()) {
+
+            // Generate a session token
+            String sessionToken = UUID.randomUUID().toString();
+
+            // Store the session token in Redis with an expiration time
+            jedis.setex(sessionToken, SESSION_TIMEOUT, USER_ID);
+            System.out.printf("User %s logged in with session: %s%n", USER_ID, sessionToken);
+        } catch (Exception e) {
+            System.err.printf("Error connecting to Redis: %s%n", e.getMessage());
+        }
+    }
+}

--- a/memorystore/valkey/session/snippets/src/main/java/samples/MemorystoreLogoutUser.java
+++ b/memorystore/valkey/session/snippets/src/main/java/samples/MemorystoreLogoutUser.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR IMPLIED WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+public final class MemorystoreLogoutUser {
+
+    /** Replace the Memorystore instance id. */
+    private static final String INSTANCE_ID = "INSTANCE_ID";
+
+    /** Replace the Memorystore port, if not the default port. */
+    private static final int PORT = 6379;
+
+    /** User ID token for logout */
+    private static final String TOKEN = "TOKEN";
+
+    private MemorystoreLogoutUser() {
+        // No-op; won't be called
+    }
+
+    /**
+     * Logs out a user by deleting their session from Memorystore.
+     *
+     * @param args command-line arguments
+     */
+    public static void main(final String[] args) {
+        // Connect to the Memorystore instance
+        try (JedisPool pool = new JedisPool(INSTANCE_ID, PORT);
+                Jedis jedis = pool.getResource()) {
+
+            // Check if the session exists
+            if (!jedis.exists(TOKEN)) {
+                System.out.printf("User %s is not logged in.%n", TOKEN);
+                return;
+            }
+
+            // Remove the session from Redis
+            jedis.del(TOKEN);
+            System.out.printf("User %s has been logged out.%n", TOKEN);
+        } catch (Exception e) {
+            System.err.printf("Error connecting to Redis: %s%n", e.getMessage());
+        }
+    }
+}

--- a/memorystore/valkey/session/snippets/src/main/java/samples/MemorystoreRemoveItemFromBasket.java
+++ b/memorystore/valkey/session/snippets/src/main/java/samples/MemorystoreRemoveItemFromBasket.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR IMPLIED WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+public final class MemorystoreRemoveItemFromBasket {
+
+    /** Replace the Memorystore instance id. */
+    private static final String INSTANCE_ID = "INSTANCE_ID";
+
+    /** Replace the Memorystore port, if not the default port. */
+    private static final int PORT = 6379;
+
+    /** User ID for managing the basket */
+    private static final String USER_ID = "USER_ID";
+
+    /** Item to be removed from the user's basket */
+    private static final String ITEM_ID = "ITEM_ID";
+
+    /** Quantity of items to be removed */
+    private static final Integer REMOVE_QUANTITY = -1;
+
+    private MemorystoreRemoveItemFromBasket() {
+        // No-op; won't be called
+    }
+
+    /**
+     * Removes an item from a user's basket in Memorystore.
+     *
+     * @param args command-line arguments
+     */
+    public static void main(final String[] args) {
+        // Connect to the Memorystore instance
+        JedisPool pool = new JedisPool(INSTANCE_ID, PORT);
+
+        try (Jedis jedis = pool.getResource()) {
+            String basketKey = "basket:" + USER_ID;
+
+            // Remove the item from the user's basket
+            long newQty = jedis.hincrBy(basketKey, ITEM_ID, REMOVE_QUANTITY);
+
+            // Print the item removed
+            System.out.printf("Removed %d items from basket: %s%n", REMOVE_QUANTITY, ITEM_ID);
+
+            // Remove the item if the quanitity is less than or equal to 0
+            if (newQty <= 0) {
+                // Remove the item from the basket
+                jedis.hdel(basketKey, ITEM_ID);
+
+                // print the item removed
+                System.out.printf("Removed item from basket: %s%n", ITEM_ID);
+            }
+        } catch (Exception e) {
+            System.err.printf("Error connecting to Redis: %s%n", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
