### PR TITLE
docs: add ja4 to CreateAssessment code snippet used in recaptcha docs

### DIFF
--- a/recaptcha_enterprise/snippets/src/main/java/recaptcha/CreateAssessment.java
+++ b/recaptcha_enterprise/snippets/src/main/java/recaptcha/CreateAssessment.java
@@ -36,9 +36,10 @@ public class CreateAssessment {
     String recaptchaAction = "action-name";
     String userIpAddress = "user-ip-address";
     String userAgent = "user-agent";
-    String ja3 = "ja3"
+    String ja3 = "ja3";
+    String ja4 = "ja4";
 
-    createAssessment(projectID, recaptchaSiteKey, token, recaptchaAction, userIpAddress, userAgent, ja3);
+    createAssessment(projectID, recaptchaSiteKey, token, recaptchaAction, userIpAddress, userAgent, ja3, ja4);
   }
 
   /**
@@ -53,9 +54,10 @@ public class CreateAssessment {
    * @param userIpAddress: IP address of the user sending a request.
    * @param userAgent: User agent is included in the HTTP request in the request header. 
    * @param ja3: JA3 associated with the request.
+   * @param ja4: JA4 associated with the request.
    */
   public static void createAssessment(
-      String projectID, String recaptchaSiteKey, String token, String recaptchaAction, String userIpAddress, String userAgent, String ja3)
+      String projectID, String recaptchaSiteKey, String token, String recaptchaAction, String userIpAddress, String userAgent, String ja3, String ja4)
       throws IOException {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
@@ -69,6 +71,7 @@ public class CreateAssessment {
           .setToken(token)
           .setUserIpAddress(userIpAddress)
           .setJa3(ja3)
+          .setJa4(ja4)
           .setUserAgent(userAgent)
           .build();
 


### PR DESCRIPTION
Add ja4 to CreateAssessment code snippet used in recaptcha docs

## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
