### PR TITLE
docs(pull request template): mark shared-configuration step as required

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ Note: Before submitting a pull request, please open an issue for discussion if y
 ## Checklist
 
 - [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
-- [ ] `pom.xml` parent set to latest `shared-configuration`
+- [ ] `pom.xml` parent set to latest `shared-configuration` **required**
 - [ ] Appropriate changes to README are included in PR
 - [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
 - [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)


### PR DESCRIPTION
This PR marks adding the shared config to the pom.xml as a required step in the pull request template. As I understand, it affects later required steps like linting?

