### PR TITLE
chore: add region tags to appengine java 21 gradle file

### DIFF
--- a/appengine-java21/helloworld/build.gradle
+++ b/appengine-java21/helloworld/build.gradle
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+// [START gae_standard21_gradle]
 apply plugin: 'java'
 apply plugin: 'war'
 
@@ -64,3 +65,4 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:4.11.0'
 }
+// [END gae_standard21_gradle]


### PR DESCRIPTION
This build.gradle file will be referenced in https://cloud.google.com/appengine/docs/standard/java-gen2/using-gradle#linuxmacos (which currently references outdated Java 8 build.gradle settings)