### PR TITLE
feat(cloud sql): add lazy refresh property for postgres, sql server and mysql

### DIFF
--- a/cloud-sql/mysql/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
+++ b/cloud-sql/mysql/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
@@ -73,9 +73,9 @@ public class ConnectorConnectionPoolFactory extends ConnectionPoolFactory {
     config.addDataSourceProperty("ipTypes", "PUBLIC,PRIVATE");
     // [START cloud_sql_mysql_servlet_connect_unix]
 
-    // setting the refresh strategy to LAZY
-    // to refresh the tokens when they are needed, rather than on a regular interval
-    // this is recommended for serverless environments to 
+    // Setting cloudSqlRefreshStrategy to lazy
+    // to refresh the tokens when they are needed, rather than on a scheduled interval.
+    // This is recommended for serverless environments to
     // avoid background refreshes from throttling CPU.
     config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy");
     

--- a/cloud-sql/mysql/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
+++ b/cloud-sql/mysql/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
@@ -73,6 +73,12 @@ public class ConnectorConnectionPoolFactory extends ConnectionPoolFactory {
     config.addDataSourceProperty("ipTypes", "PUBLIC,PRIVATE");
     // [START cloud_sql_mysql_servlet_connect_unix]
 
+    // setting the refresh strategy to LAZY
+    // to refresh the tokens when they are needed, rather than on a regular interval
+    // this is recommended for serverless environments to 
+    // avoid background refreshes from throttling CPU.
+    config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy")
+    
     // ... Specify additional connection properties here.
     // [START_EXCLUDE]
     configureConnectionPool(config);

--- a/cloud-sql/mysql/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
+++ b/cloud-sql/mysql/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
@@ -77,7 +77,7 @@ public class ConnectorConnectionPoolFactory extends ConnectionPoolFactory {
     // to refresh the tokens when they are needed, rather than on a regular interval
     // this is recommended for serverless environments to 
     // avoid background refreshes from throttling CPU.
-    config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy")
+    config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy");
     
     // ... Specify additional connection properties here.
     // [START_EXCLUDE]

--- a/cloud-sql/mysql/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
+++ b/cloud-sql/mysql/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
@@ -73,8 +73,8 @@ public class ConnectorConnectionPoolFactory extends ConnectionPoolFactory {
     config.addDataSourceProperty("ipTypes", "PUBLIC,PRIVATE");
     // [START cloud_sql_mysql_servlet_connect_unix]
 
-    // Setting cloudSqlRefreshStrategy to lazy
-    // to refresh the tokens when they are needed, rather than on a scheduled interval.
+    // cloudSqlRefreshStrategy set to "lazy" is used to perform a
+    // refresh when needed, rather than on a scheduled interval.
     // This is recommended for serverless environments to
     // avoid background refreshes from throttling CPU.
     config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy");

--- a/cloud-sql/mysql/servlet/src/main/java/com/example/cloudsql/ConnectorIamAuthnConnectionPoolFactory.java
+++ b/cloud-sql/mysql/servlet/src/main/java/com/example/cloudsql/ConnectorIamAuthnConnectionPoolFactory.java
@@ -60,8 +60,8 @@ public class ConnectorIamAuthnConnectionPoolFactory extends ConnectionPoolFactor
     // The Java Connector will handle SSL so it is unneccesary to enable it at the driver level.
     config.addDataSourceProperty("sslmode", "disable");
 
-    // Setting cloudSqlRefreshStrategy to lazy
-    // to refresh the tokens when they are needed, rather than on a scheduled interval.
+    // cloudSqlRefreshStrategy set to "lazy" is used to perform a
+    // refresh when needed, rather than on a scheduled interval.
     // This is recommended for serverless environments to
     // avoid background refreshes from throttling CPU.
     config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy");

--- a/cloud-sql/mysql/servlet/src/main/java/com/example/cloudsql/ConnectorIamAuthnConnectionPoolFactory.java
+++ b/cloud-sql/mysql/servlet/src/main/java/com/example/cloudsql/ConnectorIamAuthnConnectionPoolFactory.java
@@ -60,6 +60,12 @@ public class ConnectorIamAuthnConnectionPoolFactory extends ConnectionPoolFactor
     // The Java Connector will handle SSL so it is unneccesary to enable it at the driver level.
     config.addDataSourceProperty("sslmode", "disable");
 
+    // setting the refresh strategy to LAZY
+    // to refresh the tokens when they are needed, rather than on a regular interval
+    // this is recommended for serverless environments to 
+    // avoid background refreshes from throttling CPU.
+    config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy")
+
 
     // ... Specify additional connection properties here.
     // [START_EXCLUDE]

--- a/cloud-sql/mysql/servlet/src/main/java/com/example/cloudsql/ConnectorIamAuthnConnectionPoolFactory.java
+++ b/cloud-sql/mysql/servlet/src/main/java/com/example/cloudsql/ConnectorIamAuthnConnectionPoolFactory.java
@@ -64,7 +64,7 @@ public class ConnectorIamAuthnConnectionPoolFactory extends ConnectionPoolFactor
     // to refresh the tokens when they are needed, rather than on a regular interval
     // this is recommended for serverless environments to 
     // avoid background refreshes from throttling CPU.
-    config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy")
+    config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy");
 
 
     // ... Specify additional connection properties here.

--- a/cloud-sql/mysql/servlet/src/main/java/com/example/cloudsql/ConnectorIamAuthnConnectionPoolFactory.java
+++ b/cloud-sql/mysql/servlet/src/main/java/com/example/cloudsql/ConnectorIamAuthnConnectionPoolFactory.java
@@ -60,9 +60,9 @@ public class ConnectorIamAuthnConnectionPoolFactory extends ConnectionPoolFactor
     // The Java Connector will handle SSL so it is unneccesary to enable it at the driver level.
     config.addDataSourceProperty("sslmode", "disable");
 
-    // setting the refresh strategy to LAZY
-    // to refresh the tokens when they are needed, rather than on a regular interval
-    // this is recommended for serverless environments to 
+    // Setting cloudSqlRefreshStrategy to lazy
+    // to refresh the tokens when they are needed, rather than on a scheduled interval.
+    // This is recommended for serverless environments to
     // avoid background refreshes from throttling CPU.
     config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy");
 

--- a/cloud-sql/postgres/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
+++ b/cloud-sql/postgres/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
@@ -72,9 +72,9 @@ public class ConnectorConnectionPoolFactory extends ConnectionPoolFactory {
     config.addDataSourceProperty("ipTypes", "PUBLIC,PRIVATE");
     // [START cloud_sql_postgres_servlet_connect_unix]
 
-    // setting the refresh strategy to LAZY
-    // to refresh the tokens when they are needed, rather than on a regular interval
-    // this is recommended for serverless environments to 
+    // Setting cloudSqlRefreshStrategy to lazy
+    // to refresh the tokens when they are needed, rather than on a scheduled interval.
+    // This is recommended for serverless environments to
     // avoid background refreshes from throttling CPU.
     config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy");
 

--- a/cloud-sql/postgres/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
+++ b/cloud-sql/postgres/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
@@ -72,6 +72,11 @@ public class ConnectorConnectionPoolFactory extends ConnectionPoolFactory {
     config.addDataSourceProperty("ipTypes", "PUBLIC,PRIVATE");
     // [START cloud_sql_postgres_servlet_connect_unix]
 
+    // setting the refresh strategy to LAZY
+    // to refresh the tokens when they are needed, rather than on a regular interval
+    // this is recommended for serverless environments to 
+    // avoid background refreshes from throttling CPU.
+    config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy")
 
     // ... Specify additional connection properties here.
     // [START_EXCLUDE]

--- a/cloud-sql/postgres/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
+++ b/cloud-sql/postgres/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
@@ -76,7 +76,7 @@ public class ConnectorConnectionPoolFactory extends ConnectionPoolFactory {
     // to refresh the tokens when they are needed, rather than on a regular interval
     // this is recommended for serverless environments to 
     // avoid background refreshes from throttling CPU.
-    config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy")
+    config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy");
 
     // ... Specify additional connection properties here.
     // [START_EXCLUDE]

--- a/cloud-sql/postgres/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
+++ b/cloud-sql/postgres/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
@@ -72,8 +72,8 @@ public class ConnectorConnectionPoolFactory extends ConnectionPoolFactory {
     config.addDataSourceProperty("ipTypes", "PUBLIC,PRIVATE");
     // [START cloud_sql_postgres_servlet_connect_unix]
 
-    // Setting cloudSqlRefreshStrategy to lazy
-    // to refresh the tokens when they are needed, rather than on a scheduled interval.
+    // cloudSqlRefreshStrategy set to "lazy" is used to perform a
+    // refresh when needed, rather than on a scheduled interval.
     // This is recommended for serverless environments to
     // avoid background refreshes from throttling CPU.
     config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy");

--- a/cloud-sql/postgres/servlet/src/main/java/com/example/cloudsql/ConnectorIamAuthnConnectionPoolFactory.java
+++ b/cloud-sql/postgres/servlet/src/main/java/com/example/cloudsql/ConnectorIamAuthnConnectionPoolFactory.java
@@ -65,7 +65,7 @@ public class ConnectorIamAuthnConnectionPoolFactory extends ConnectionPoolFactor
     // to refresh the tokens when they are needed, rather than on a regular interval
     // this is recommended for serverless environments to 
     // avoid background refreshes from throttling CPU.
-    config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy")
+    config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy");
 
     // ... Specify additional connection properties here.
     // [START_EXCLUDE]

--- a/cloud-sql/postgres/servlet/src/main/java/com/example/cloudsql/ConnectorIamAuthnConnectionPoolFactory.java
+++ b/cloud-sql/postgres/servlet/src/main/java/com/example/cloudsql/ConnectorIamAuthnConnectionPoolFactory.java
@@ -61,9 +61,9 @@ public class ConnectorIamAuthnConnectionPoolFactory extends ConnectionPoolFactor
     // The Java Connector will handle SSL so it is unneccesary to enable it at the driver level.
     config.addDataSourceProperty("sslmode", "disable");
 
-    // setting the refresh strategy to LAZY
-    // to refresh the tokens when they are needed, rather than on a regular interval
-    // this is recommended for serverless environments to 
+    // Setting cloudSqlRefreshStrategy to lazy
+    // to refresh the tokens when they are needed, rather than on a scheduled interval.
+    // This is recommended for serverless environments to
     // avoid background refreshes from throttling CPU.
     config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy");
 

--- a/cloud-sql/postgres/servlet/src/main/java/com/example/cloudsql/ConnectorIamAuthnConnectionPoolFactory.java
+++ b/cloud-sql/postgres/servlet/src/main/java/com/example/cloudsql/ConnectorIamAuthnConnectionPoolFactory.java
@@ -61,8 +61,8 @@ public class ConnectorIamAuthnConnectionPoolFactory extends ConnectionPoolFactor
     // The Java Connector will handle SSL so it is unneccesary to enable it at the driver level.
     config.addDataSourceProperty("sslmode", "disable");
 
-    // Setting cloudSqlRefreshStrategy to lazy
-    // to refresh the tokens when they are needed, rather than on a scheduled interval.
+    // cloudSqlRefreshStrategy set to "lazy" is used to perform a
+    // refresh when needed, rather than on a scheduled interval.
     // This is recommended for serverless environments to
     // avoid background refreshes from throttling CPU.
     config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy");

--- a/cloud-sql/postgres/servlet/src/main/java/com/example/cloudsql/ConnectorIamAuthnConnectionPoolFactory.java
+++ b/cloud-sql/postgres/servlet/src/main/java/com/example/cloudsql/ConnectorIamAuthnConnectionPoolFactory.java
@@ -61,6 +61,11 @@ public class ConnectorIamAuthnConnectionPoolFactory extends ConnectionPoolFactor
     // The Java Connector will handle SSL so it is unneccesary to enable it at the driver level.
     config.addDataSourceProperty("sslmode", "disable");
 
+    // setting the refresh strategy to LAZY
+    // to refresh the tokens when they are needed, rather than on a regular interval
+    // this is recommended for serverless environments to 
+    // avoid background refreshes from throttling CPU.
+    config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy")
 
     // ... Specify additional connection properties here.
     // [START_EXCLUDE]

--- a/cloud-sql/sqlserver/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
+++ b/cloud-sql/sqlserver/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
@@ -61,6 +61,12 @@ public class ConnectorConnectionPoolFactory extends ConnectionPoolFactory {
     // at the driver level.
     config.addDataSourceProperty("encrypt", "false");
 
+    // setting the refresh strategy to LAZY
+    // to refresh the tokens when they are needed, rather than on a regular interval
+    // this is recommended for serverless environments to 
+    // avoid background refreshes from throttling CPU.
+    config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy")
+
     // ... Specify additional connection properties here.
     // [START_EXCLUDE]
     configureConnectionPool(config);

--- a/cloud-sql/sqlserver/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
+++ b/cloud-sql/sqlserver/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
@@ -61,9 +61,9 @@ public class ConnectorConnectionPoolFactory extends ConnectionPoolFactory {
     // at the driver level.
     config.addDataSourceProperty("encrypt", "false");
 
-    // setting the refresh strategy to LAZY
-    // to refresh the tokens when they are needed, rather than on a regular interval
-    // this is recommended for serverless environments to 
+    // Setting cloudSqlRefreshStrategy to lazy
+    // to refresh the tokens when they are needed, rather than on a scheduled interval.
+    // This is recommended for serverless environments to
     // avoid background refreshes from throttling CPU.
     config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy");
 

--- a/cloud-sql/sqlserver/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
+++ b/cloud-sql/sqlserver/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
@@ -65,7 +65,7 @@ public class ConnectorConnectionPoolFactory extends ConnectionPoolFactory {
     // to refresh the tokens when they are needed, rather than on a regular interval
     // this is recommended for serverless environments to 
     // avoid background refreshes from throttling CPU.
-    config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy")
+    config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy");
 
     // ... Specify additional connection properties here.
     // [START_EXCLUDE]

--- a/cloud-sql/sqlserver/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
+++ b/cloud-sql/sqlserver/servlet/src/main/java/com/example/cloudsql/ConnectorConnectionPoolFactory.java
@@ -61,8 +61,8 @@ public class ConnectorConnectionPoolFactory extends ConnectionPoolFactory {
     // at the driver level.
     config.addDataSourceProperty("encrypt", "false");
 
-    // Setting cloudSqlRefreshStrategy to lazy
-    // to refresh the tokens when they are needed, rather than on a scheduled interval.
+    // cloudSqlRefreshStrategy set to "lazy" is used to perform a
+    // refresh when needed, rather than on a scheduled interval.
     // This is recommended for serverless environments to
     // avoid background refreshes from throttling CPU.
     config.addDataSourceProperty("cloudSqlRefreshStrategy", "lazy");


### PR DESCRIPTION
Fixes #388034268

Enabled lazy refresh for the Java Cloud SQL connector (Postgres, MySQL, and SQL Server).