### PR TITLE
fix(auth): AuthExampleIT flaky test

### DIFF
--- a/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
+++ b/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
@@ -61,12 +61,10 @@ public class AuthExampleIT {
     assertTrue(output.contains("Buckets:"));
   }
 
-  @Ignore("Temporarily disabled due to failing test (Issue #10023).")
   @Test
   public void testAuthApiKey() throws IOException, IllegalStateException {
-    //TODO: Re-enable this test after fixing issue #10023.
     String projectId = ServiceOptions.getDefaultProjectId();
-    String keyDisplayName = "Test API Key";
+    String keyDisplayName = "Test API Key " + System.currentTimeMillis();;
     String service = "language.googleapis.com";
     String method = "google.cloud.language.v2.LanguageService.AnalyzeSentiment";
     Key apiKey = null;

--- a/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
+++ b/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
@@ -20,9 +20,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.api.apikeys.v2.Key;
+import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.cloud.ServiceOptions;
 import io.grpc.StatusRuntimeException;
-import com.google.api.gax.rpc.InvalidArgumentException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -66,15 +66,12 @@ public class AuthExampleIT {
   @Test
   public void testAuthApiKey() throws IOException, IllegalStateException {
     String projectId = ServiceOptions.getDefaultProjectId();
-    java.util.Random random = new java.util.Random();
-    String keyDisplayName = "Test API Key " + random.nextInt();
+    String keyDisplayName = "Test API Key";
     String service = "language.googleapis.com";
     String method = "google.cloud.language.v2.LanguageService.AnalyzeSentiment";
     Key apiKey = null;
     try {
       apiKey = AuthTestUtils.createTestApiKey(projectId, keyDisplayName, service, method);
-      assertNotNull(apiKey);
-      System.out.println("key string " + apiKey.getKeyString());
       String output = authenticateUsingApiKeyWithRetry(apiKey.getKeyString());
       assertTrue(output.contains("magnitude:"));
     } finally {
@@ -92,7 +89,7 @@ public class AuthExampleIT {
     for (int i = 0; i < retries; i++) {
       try {
         return ApiKeyAuthExample.authenticateUsingApiKey(apiKey);
-      } catch (StatusRuntimeException | InvalidArgumentException e ) {
+      } catch (StatusRuntimeException | InvalidArgumentException e) {
         if (e.getMessage().contains("API key expired")) {
           System.out.println("API key not yet active, retrying...");
           try {

--- a/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
+++ b/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
@@ -95,7 +95,7 @@ public class AuthExampleIT {
           System.out.println("API key not yet active, retrying...");
           try {
             Thread.sleep(delay);
-          } catch (InterruptedException ignored) {}
+          } catch (InterruptedException ignored) { }
         } else {
           throw e;
         }

--- a/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
+++ b/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
@@ -72,12 +72,13 @@ public class AuthExampleIT {
     try {
       apiKey = AuthTestUtils.createTestApiKey(projectId, keyDisplayName, service, method);
       assertNotNull(apiKey);
+      assert
       String output = ApiKeyAuthExample.authenticateUsingApiKey(apiKey.getKeyString());
 
       assertTrue(output.contains("magnitude:"));
     } finally {
       if (apiKey != null) {
-        AuthTestUtils.deleteTestApiKey(apiKey.getName());
+       // AuthTestUtils.deleteTestApiKey(apiKey.getName());
       }
     }
   }

--- a/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
+++ b/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
@@ -72,11 +72,12 @@ public class AuthExampleIT {
     Key apiKey = null;
     try {
       apiKey = AuthTestUtils.createTestApiKey(projectId, keyDisplayName, service, method);
+
       String output = authenticateUsingApiKeyWithRetry(apiKey.getKeyString());
+
       assertTrue(output.contains("magnitude:"));
     } finally {
       if (apiKey != null) {
-        System.out.println("trying to delete " + apiKey.getKeyString());
         AuthTestUtils.deleteTestApiKey(apiKey.getName());
       }
     }

--- a/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
+++ b/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 import com.google.api.apikeys.v2.Key;
 import com.google.cloud.ServiceOptions;
 import io.grpc.StatusRuntimeException;
+import com.google.api.gax.rpc.InvalidArgumentException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -91,12 +92,14 @@ public class AuthExampleIT {
     for (int i = 0; i < retries; i++) {
       try {
         return ApiKeyAuthExample.authenticateUsingApiKey(apiKey);
-      } catch (StatusRuntimeException e) {
+      } catch (StatusRuntimeException | InvalidArgumentException e ) {
         if (e.getMessage().contains("API key expired")) {
           System.out.println("API key not yet active, retrying...");
           try {
             Thread.sleep(delay);
-          } catch (InterruptedException ignored) { }
+          } catch (InterruptedException ignored) {
+            // ignore iterrupted exception and retry test
+          }
         } else {
           throw e;
         }

--- a/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
+++ b/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
@@ -71,13 +71,11 @@ public class AuthExampleIT {
     try {
       apiKey = AuthTestUtils.createTestApiKey(projectId, keyDisplayName, service, method);
       assertNotNull(apiKey);
-      System.out.println("created key " + apiKey.getKeyString());
       String output = ApiKeyAuthExample.authenticateUsingApiKey(apiKey.getKeyString());
 
       assertTrue(output.contains("magnitude:"));
     } finally {
       if (apiKey != null) {
-        System.out.println("deleting key " + apiKey.getKeyString());
         AuthTestUtils.deleteTestApiKey(apiKey.getName());
       }
     }

--- a/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
+++ b/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
@@ -70,12 +70,13 @@ public class AuthExampleIT {
     Key apiKey = null;
     try {
       apiKey = AuthTestUtils.createTestApiKey(projectId, keyDisplayName, service, method);
-
+      System.out.println("created key " + apiKey.getKeyString());
       String output = ApiKeyAuthExample.authenticateUsingApiKey(apiKey.getKeyString());
 
       assertTrue(output.contains("magnitude:"));
     } finally {
       if (apiKey != null) {
+        System.out.println("deleting key " + apiKey.getKeyString());
         AuthTestUtils.deleteTestApiKey(apiKey.getName());
       }
     }

--- a/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
+++ b/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
@@ -70,7 +70,7 @@ public class AuthExampleIT {
     Key apiKey = null;
     try {
       apiKey = AuthTestUtils.createTestApiKey(projectId, keyDisplayName, service, method);
-      assertNotNull(apiKey)
+      assertNotNull(apiKey);
       System.out.println("created key " + apiKey.getKeyString());
       String output = ApiKeyAuthExample.authenticateUsingApiKey(apiKey.getKeyString());
 

--- a/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
+++ b/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
@@ -64,7 +64,8 @@ public class AuthExampleIT {
   @Test
   public void testAuthApiKey() throws IOException, IllegalStateException {
     String projectId = ServiceOptions.getDefaultProjectId();
-    String keyDisplayName = "Test API Key " + System.currentTimeMillis();;
+    java.util.Random random = new java.util.Random();
+    String keyDisplayName = "Test API Key " + random.nextInt();
     String service = "language.googleapis.com";
     String method = "google.cloud.language.v2.LanguageService.AnalyzeSentiment";
     Key apiKey = null;

--- a/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
+++ b/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
@@ -70,6 +70,7 @@ public class AuthExampleIT {
     Key apiKey = null;
     try {
       apiKey = AuthTestUtils.createTestApiKey(projectId, keyDisplayName, service, method);
+      assertNotNull(apiKey)
       System.out.println("created key " + apiKey.getKeyString());
       String output = ApiKeyAuthExample.authenticateUsingApiKey(apiKey.getKeyString());
 

--- a/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
+++ b/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
@@ -72,12 +72,12 @@ public class AuthExampleIT {
     try {
       apiKey = AuthTestUtils.createTestApiKey(projectId, keyDisplayName, service, method);
       assertNotNull(apiKey);
-      assert
+      System.out.println("key string " + apiKey.getKeyString());
       String output = ApiKeyAuthExample.authenticateUsingApiKey(apiKey.getKeyString());
-
       assertTrue(output.contains("magnitude:"));
     } finally {
       if (apiKey != null) {
+        System.out.println("trying to delete " + apiKey.getKeyString());
        // AuthTestUtils.deleteTestApiKey(apiKey.getName());
       }
     }

--- a/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
+++ b/auth/src/test/java/com/google/cloud/auth/samples/AuthExampleIT.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.api.apikeys.v2.Key;
 import com.google.cloud.ServiceOptions;
+import io.grpc.StatusRuntimeException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -90,7 +91,7 @@ public class AuthExampleIT {
     for (int i = 0; i < retries; i++) {
       try {
         return ApiKeyAuthExample.authenticateUsingApiKey(apiKey);
-      } catch (IOException e) {
+      } catch (StatusRuntimeException e) {
         if (e.getMessage().contains("API key expired")) {
           System.out.println("API key not yet active, retrying...");
           try {


### PR DESCRIPTION
There can be a delay after creating an API key where its not available yet, so in the case the operation fails with API authentication issue, retry operation again with a delay 5.x

Fixes #10023 

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
