### PR TITLE
chore(datacatalog): ignore tests for deprecated Data Catalog

### DIFF
--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/CreateCustomConnectorIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/CreateCustomConnectorIT.java
@@ -41,6 +41,7 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -103,6 +104,7 @@ public class CreateCustomConnectorIT {
     log.log(Level.INFO, bout.toString());
   }
 
+  @Ignore
   @Test
   public void testCreateCustomConnector()
       throws IOException, ExecutionException, InterruptedException {

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/CreateCustomEntryIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/CreateCustomEntryIT.java
@@ -34,6 +34,7 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -93,6 +94,7 @@ public class CreateCustomEntryIT {
     log.log(Level.INFO, bout.toString());
   }
 
+  @Ignore
   @Test
   public void testCreateCustomEntry() throws IOException {
     CreateCustomEntry.createCustomEntry(PROJECT_ID, entryGroup, entry);

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/CreateEntryGroupIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/CreateEntryGroupIT.java
@@ -32,6 +32,7 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -85,6 +86,7 @@ public class CreateEntryGroupIT {
     log.log(Level.INFO, bout.toString());
   }
 
+  @Ignore
   @Test
   public void testCreateEntryGroup() throws IOException {
     CreateEntryGroup.createEntryGroup(PROJECT_ID, LOCATION, entryGroup);

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/CreateEntryIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/CreateEntryIT.java
@@ -34,6 +34,7 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -88,6 +89,7 @@ public class CreateEntryIT {
     log.log(Level.INFO, bout.toString());
   }
 
+  @Ignore
   @Test
   public void testCreateEntry() throws IOException {
     EntryGroupName entryGroupName = EntryGroupName.of(PROJECT_ID, LOCATION, entryGroupId);

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/CreateEntryTests.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/CreateEntryTests.java
@@ -33,6 +33,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -87,6 +88,7 @@ public class CreateEntryTests {
     }
   }
 
+  @Ignore
   @Test
   public void testCreateFilesetEntry() throws IOException {
     String entryGroupId = "fileset_entry_group_parent_" + getUuid8Chars();
@@ -111,6 +113,7 @@ public class CreateEntryTests {
         CoreMatchers.containsString(String.format(entryTemplate, expectedEntryName)));
   }
 
+  @Ignore
   @Test
   public void testCreateEntryGroup() throws IOException {
     String entryGroupId = "entry_group_no_children_" + getUuid8Chars();

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/CreateFilesetEntryIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/CreateFilesetEntryIT.java
@@ -34,6 +34,7 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -94,6 +95,7 @@ public class CreateFilesetEntryIT {
     log.log(Level.INFO, bout.toString());
   }
 
+  @Ignore
   @Test
   public void testCreateFilesetEntry() throws IOException {
     CreateFilesetEntry.createFilesetEntry(PROJECT_ID, entryGroup, entry);

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/CreateTagTemplateIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/CreateTagTemplateIT.java
@@ -34,6 +34,7 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -83,6 +84,7 @@ public class CreateTagTemplateIT {
     log.log(Level.INFO, bout.toString());
   }
 
+  @Ignore
   @Test
   public void testCreateTagTemplate() throws IOException {
     LocationName locationName = LocationName.of(PROJECT_ID, LOCATION);

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/DeleteEntryGroupIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/DeleteEntryGroupIT.java
@@ -30,6 +30,7 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -78,6 +79,7 @@ public class DeleteEntryGroupIT {
     log.log(Level.INFO, bout.toString());
   }
 
+  @Ignore
   @Test
   public void testDeleteEntryGroup() throws IOException {
     EntryGroupName name = EntryGroupName.of(PROJECT_ID, LOCATION, entryGroup);

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/DeleteEntryIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/DeleteEntryIT.java
@@ -34,6 +34,7 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -102,6 +103,7 @@ public class DeleteEntryIT {
     log.log(Level.INFO, bout.toString());
   }
 
+  @Ignore
   @Test
   public void testDeleteEntry() throws IOException {
     EntryName entryName = EntryName.of(PROJECT_ID, LOCATION, entryGroupId, entryId);

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/DeleteTagTemplateIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/DeleteTagTemplateIT.java
@@ -34,6 +34,7 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -88,6 +89,7 @@ public class DeleteTagTemplateIT {
     log.log(Level.INFO, bout.toString());
   }
 
+  @Ignore
   @Test
   public void testDeleteTagTemplate() throws IOException {
     TagTemplateName name = TagTemplateName.of(PROJECT_ID, LOCATION, tagTemplateId);

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/GetEntryGroupIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/GetEntryGroupIT.java
@@ -30,6 +30,7 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -81,6 +82,7 @@ public class GetEntryGroupIT {
     log.log(Level.INFO, bout.toString());
   }
 
+  @Ignore
   @Test
   public void testGetEntryGroup() throws IOException {
     EntryGroupName name = EntryGroupName.of(PROJECT_ID, LOCATION, entryGroup);

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/GetEntryIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/GetEntryIT.java
@@ -34,6 +34,7 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -103,6 +104,7 @@ public class GetEntryIT {
     log.log(Level.INFO, bout.toString());
   }
 
+  @Ignore
   @Test
   public void testGetEntry() throws IOException {
     EntryName entryName = EntryName.of(PROJECT_ID, LOCATION, entryGroupId, entryId);

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/GetImportEntriesStateIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/GetImportEntriesStateIT.java
@@ -45,6 +45,7 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -109,6 +110,7 @@ public class GetImportEntriesStateIT {
     log.log(Level.INFO, bout.toString());
   }
 
+  @Ignore
   @Test
   public void testGetImportEntriesState() throws IOException {
     WaitForImportEntries.queryImportEntriesState(operationName);

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/GetTagTemplateIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/GetTagTemplateIT.java
@@ -34,6 +34,7 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -91,6 +92,7 @@ public class GetTagTemplateIT {
     log.log(Level.INFO, bout.toString());
   }
 
+  @Ignore
   @Test
   public void testGetTagTemplate() throws IOException {
     TagTemplateName name = TagTemplateName.of(PROJECT_ID, LOCATION, tagTemplateId);

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/GrantTagTemplateUserRoleIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/GrantTagTemplateUserRoleIT.java
@@ -37,6 +37,7 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -105,6 +106,7 @@ public class GrantTagTemplateUserRoleIT {
     log.log(Level.INFO, bout.toString());
   }
 
+  @Ignore
   @Test
   public void testGrantTagTemplateUserRole() throws IOException {
     GrantTagTemplateUserRole.grantTagTemplateUserRole(PROJECT_ID, tagTemplateId);

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/ListEntriesIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/ListEntriesIT.java
@@ -34,6 +34,7 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -103,6 +104,7 @@ public class ListEntriesIT {
     log.log(Level.INFO, bout.toString());
   }
 
+  @Ignore
   @Test
   public void testListEntries() throws IOException {
     EntryGroupName entryGroupName = EntryGroupName.of(PROJECT_ID, LOCATION, entryGroupId);

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/ListEntryGroupsIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/ListEntryGroupsIT.java
@@ -31,6 +31,7 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -82,6 +83,7 @@ public class ListEntryGroupsIT {
     log.log(Level.INFO, bout.toString());
   }
 
+  @Ignore
   @Test
   public void testListEntryGroups() throws IOException {
     ListEntryGroups.listEntryGroups(LocationName.of(PROJECT_ID, LOCATION));

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/LookupEntryTests.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/LookupEntryTests.java
@@ -58,6 +58,7 @@ public class LookupEntryTests {
     System.setOut(null);
   }
 
+  @Ignore
   @Test
   public void testLookupEntryBigQueryDataset() {
     LookupEntryBigQueryDataset.lookupEntry(BIGQUERY_PROJECT, BIGQUERY_DATASET);
@@ -66,6 +67,7 @@ public class LookupEntryTests {
         "projects/" + BIGQUERY_PROJECT + "/locations/.+?/entryGroups/@bigquery/entries/.+?$");
   }
 
+  @Ignore
   @Test
   public void testLookupEntryBigQueryTable() {
     LookupEntryBigQueryTable.lookupEntry(BIGQUERY_PROJECT, BIGQUERY_DATASET, BIGQUERY_TABLE);
@@ -74,6 +76,7 @@ public class LookupEntryTests {
         "projects/" + BIGQUERY_PROJECT + "/locations/.+?/entryGroups/@bigquery/entries/.+?$");
   }
 
+  @Ignore
   @Test
   public void testLookupPubSubTopic() {
     LookupEntryPubSubTopic.lookupEntry(PUBSUB_PROJECT, PUBSUB_TOPIC);

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/QuickstartIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/QuickstartIT.java
@@ -32,6 +32,7 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -86,6 +87,7 @@ public class QuickstartIT {
     log.log(Level.INFO, bout.toString());
   }
 
+  @Ignore
   @Test
   public void testQuickstart() throws IOException {
     Quickstart.createTags(PROJECT_ID, tagTemplateId);

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/SearchAssetsIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/SearchAssetsIT.java
@@ -28,6 +28,7 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -70,6 +71,7 @@ public class SearchAssetsIT {
     log.log(Level.INFO, bout.toString());
   }
 
+  @Ignore
   @Test
   public void testSearchAssets() throws IOException {
     SearchAssets.searchCatalog(PROJECT_ID, "type=lake");

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/UpdateEntryGroupIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/UpdateEntryGroupIT.java
@@ -31,6 +31,7 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -82,6 +83,7 @@ public class UpdateEntryGroupIT {
     log.log(Level.INFO, bout.toString());
   }
 
+  @Ignore
   @Test
   public void testUpdateEntryGroup() throws IOException {
     EntryGroupName name = EntryGroupName.of(PROJECT_ID, LOCATION, entryGroup);

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/UpdateEntryIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/UpdateEntryIT.java
@@ -34,6 +34,7 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -103,6 +104,7 @@ public class UpdateEntryIT {
     log.log(Level.INFO, bout.toString());
   }
 
+  @Ignore
   @Test
   public void testUpdateEntry() throws IOException {
     EntryName entryName = EntryName.of(PROJECT_ID, LOCATION, entryGroupId, entryId);

--- a/datacatalog/snippets/src/test/java/com/example/datacatalog/UpdateTagTemplateIT.java
+++ b/datacatalog/snippets/src/test/java/com/example/datacatalog/UpdateTagTemplateIT.java
@@ -34,6 +34,7 @@ import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -91,6 +92,7 @@ public class UpdateTagTemplateIT {
     log.log(Level.INFO, bout.toString());
   }
 
+  @Ignore
   @Test
   public void testUpdateTagTemplate() throws IOException {
     TagTemplateName name = TagTemplateName.of(PROJECT_ID, LOCATION, tagTemplateId);


### PR DESCRIPTION
## Description

Fixes b/394006908

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [X] Please **merge** this PR for me once it is approved
