### PR TITLE
feat(bigquery): add helper classes for cloud-client testing (1/3)

### DIFF
--- a/bigquery/cloud-client/snippets/pom.xml
+++ b/bigquery/cloud-client/snippets/pom.xml
@@ -1,0 +1,67 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Copyright 2025 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.bigquery</groupId>
+  <artifactId>cloud-client-snippets</artifactId>
+  <packaging>jar</packaging>
+  <name>Google Cloud BigQuery Cloud Client Snippets</name>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.2.0</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>21</maven.compiler.target>
+    <maven.compiler.source>21</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.32.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigquery</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.4.4</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/CreateDataset.java
+++ b/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/CreateDataset.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquery;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.Dataset;
+import com.google.cloud.bigquery.DatasetId;
+import com.google.cloud.bigquery.DatasetInfo;
+
+public class CreateDataset {
+  public static void main(String[] args) {
+    // TODO(developer): Replace these variables before running the sample.
+    // Project where to create the dataset.
+    String projectId = "MY_PROJECT_ID";
+    String datasetName = "MY_DATASET_NAME";
+    createDataset(projectId, datasetName);
+  }
+
+  public static void createDataset(String projectId, String datasetName) {
+    try {
+      // Initialize client that will be used to send requests. This client only needs
+      // to be created once, and can be reused for multiple requests.
+      BigQuery bigquery = BigQueryOptions.getDefaultInstance().getService();
+
+      String location = "US";
+
+      // Create datasetId with the projectId and the datasetName, and set it into the datasetInfo.
+      DatasetId datasetId = DatasetId.of(projectId, datasetName);
+      DatasetInfo datasetInfo = DatasetInfo.newBuilder(datasetId).setLocation(location).build();
+
+      // Create Dataset.
+      Dataset dataset = bigquery.create(datasetInfo);
+      System.out.println(
+          "Dataset \"" + dataset.getDatasetId().getDataset() + "\" created successfully");
+    } catch (BigQueryException e) {
+      System.out.println("Dataset was not created. \n" + e.toString());
+    }
+  }
+}

--- a/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/CreateTable.java
+++ b/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/CreateTable.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquery;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableDefinition;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
+
+public class CreateTable {
+
+  public static void main(String[] args) {
+    // TODO(developer): Replace these variables before running the sample.
+    // Project and dataset name to create a new table
+    String projectId = "MY_PROJECT_ID";
+    String datasetName = "MY_DATASET_NAME";
+    String tableName = "MY_TABLE_NAME";
+
+    // Schema for a Google BigQuery Table.
+    Schema schema =
+        Schema.of(
+            Field.of("stringField", StandardSQLTypeName.STRING),
+            Field.of("isBooleanField", StandardSQLTypeName.BOOL));
+    createTable(projectId, datasetName, tableName, schema);
+  }
+
+  public static void createTable(
+      String projectId, String datasetName, String tableName, Schema schema) {
+    try {
+      // Initialize client that will be used to send requests. This client only needs
+      // to be created once, and can be reused for multiple requests.
+      BigQuery bigquery = BigQueryOptions.getDefaultInstance().getService();
+
+      // Create table identity given the projectId, the datasetName and the tableName.
+      TableId tableId = TableId.of(projectId, datasetName, tableName);
+      // Create table definition to build the table information
+      TableDefinition tableDefinition = StandardTableDefinition.of(schema);
+      TableInfo tableInfo = TableInfo.newBuilder(tableId, tableDefinition).build();
+
+      // Create table
+      Table table = bigquery.create(tableInfo);
+      System.out.println("Table \"" + table.getTableId().getTable() + "\" created successfully");
+    } catch (BigQueryException e) {
+      System.out.println("Table was not created. \n" + e.toString());
+    }
+  }
+}

--- a/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/CreateView.java
+++ b/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/CreateView.java
@@ -35,7 +35,7 @@ public class CreateView {
     String tableName = "MY_TABLE_NAME";
     String viewName = "MY_VIEW_NAME";
     String query =
-        String.format("SELECT StringField, BooleanField FROM %s.%s", datasetName, tableName);
+        String.format("SELECT stringField, isBooleanField FROM %s.%s", datasetName, tableName);
     createView(projectId, datasetName, viewName, query);
   }
 

--- a/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/CreateView.java
+++ b/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/CreateView.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquery;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
+import com.google.cloud.bigquery.ViewDefinition;
+
+// Sample to create a view
+public class CreateView {
+
+  public static void main(String[] args) {
+    // TODO(developer): Replace these variables before running the sample.
+    // Project, dataset and table name to create a new view
+    String projectId = "MY_PROJECT_ID";
+    String datasetName = "MY_DATASET_NAME";
+    String tableName = "MY_TABLE_NAME";
+    String viewName = "MY_VIEW_NAME";
+    String query =
+        String.format("SELECT StringField, BooleanField FROM %s.%s", datasetName, tableName);
+    createView(projectId, datasetName, viewName, query);
+  }
+
+  public static void createView(
+      String projectId, String datasetName, String viewName, String query) {
+    try {
+      // Initialize client that will be used to send requests. This client only needs
+      // to be created once, and can be reused for multiple requests.
+      BigQuery bigquery = BigQueryOptions.getDefaultInstance().getService();
+
+      // Create table identity given the projectId, the datasetName and the viewName.
+      TableId tableId = TableId.of(projectId, datasetName, viewName);
+
+      // Create view definition to generate the table information.
+      ViewDefinition viewDefinition =
+          ViewDefinition.newBuilder(query).setUseLegacySql(false).build();
+      TableInfo tableInfo = TableInfo.of(tableId, viewDefinition);
+
+      // Create view.
+      Table view = bigquery.create(tableInfo);
+      System.out.println("View \"" + view.getTableId().getTable() + "\" created successfully");
+    } catch (BigQueryException e) {
+      System.out.println("View was not created. \n" + e.toString());
+    }
+  }
+}

--- a/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/DeleteDataset.java
+++ b/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/DeleteDataset.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquery;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQuery.DatasetDeleteOption;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.DatasetId;
+
+public class DeleteDataset {
+
+  public static void main(String[] args) {
+    // TODO(developer): Replace these variables before running the sample.
+    // Project from which to delete the dataset
+    String projectId = "MY_PROJECT_ID";
+    String datasetName = "MY_DATASET_NAME";
+    deleteDataset(projectId, datasetName);
+  }
+
+  public static void deleteDataset(String projectId, String datasetName) {
+    try {
+      // Initialize client that will be used to send requests. This client only needs
+      // to be created once, and can be reused for multiple requests.
+      BigQuery bigquery = BigQueryOptions.getDefaultInstance().getService();
+
+      // Create datasetId with the projectId and the datasetName.
+      DatasetId datasetId = DatasetId.of(projectId, datasetName);
+
+      // Delete dataset.
+      boolean success = bigquery.delete(datasetId, DatasetDeleteOption.deleteContents());
+      if (success) {
+        System.out.println("Dataset \"" + datasetName + "\" deleted successfully");
+      } else {
+        System.out.println("Dataset was not found");
+      }
+    } catch (BigQueryException e) {
+      System.out.println("Dataset was not deleted. \n" + e.toString());
+    }
+  }
+}

--- a/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/DeleteTable.java
+++ b/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/DeleteTable.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquery;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.TableId;
+
+public class DeleteTable {
+
+  public static void main(String[] args) {
+    // TODO(developer): Replace these variables before running the sample.
+    // Project, dataset and table name to create a new table
+    String projectId = "MY_PROJECT_ID";
+    String datasetName = "MY_DATASET_NAME";
+    String tableName = "MY_TABLE_NAME";
+    deleteTable(projectId, datasetName, tableName);
+  }
+
+  public static void deleteTable(String projectId, String datasetName, String tableName) {
+    try {
+      // Initialize client that will be used to send requests. This client only needs
+      // to be created once, and can be reused for multiple requests.
+      BigQuery bigquery = BigQueryOptions.getDefaultInstance().getService();
+
+      // Create table identity given the projectId, the datasetName and the tableName.
+      TableId tableId = TableId.of(projectId, datasetName, tableName);
+
+      // Delete the table.
+      boolean success = bigquery.delete(tableId);
+      if (success) {
+        System.out.println("Table \"" + tableName + "\" deleted successfully");
+      } else {
+        System.out.println("Table was not found");
+      }
+    } catch (BigQueryException e) {
+      System.out.println("Table was not deleted. \n" + e.toString());
+    }
+  }
+}

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/CreateDatasetIT.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/CreateDatasetIT.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquery;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.testing.RemoteBigQueryHelper;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CreateDatasetIT {
+
+  private final Logger log = Logger.getLogger(this.getClass().getName());
+  private String datasetName;
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String GOOGLE_CLOUD_PROJECT = System.getenv("GOOGLE_CLOUD_PROJECT");
+
+  private static void requireEnvVar(String varName) {
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+
+    // Generate dataset name.
+    datasetName = RemoteBigQueryHelper.generateDatasetName();
+  }
+
+  @After
+  public void tearDown() {
+    // Clean up.
+    DeleteDataset.deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+
+    // Restores print statements to the original output stream.
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    log.log(Level.INFO, "\n" + bout.toString());
+  }
+
+  @Test
+  public void testCreateDataset() {
+    CreateDataset.createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+    assertThat(bout.toString()).contains(datasetName + "\" created successfully");
+  }
+}

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/CreateDatasetIT.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/CreateDatasetIT.java
@@ -64,7 +64,7 @@ public class CreateDatasetIT {
   @After
   public void tearDown() {
     // Clean up.
-    DeleteDataset.deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+    Util.tearDownTest_deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
 
     // Restores print statements to the original output stream.
     System.out.flush();

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/CreateTableIT.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/CreateTableIT.java
@@ -87,7 +87,7 @@ public class CreateTableIT {
     Schema schema =
         Schema.of(
             Field.of("stringField", StandardSQLTypeName.STRING),
-            Field.of("booleanField", StandardSQLTypeName.BOOL));
+            Field.of("isBooleanField", StandardSQLTypeName.BOOL));
     CreateTable.createTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName, schema);
     assertThat(bout.toString()).contains(tableName + "\" created successfully");
   }

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/CreateTableIT.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/CreateTableIT.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquery;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.testing.RemoteBigQueryHelper;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CreateTableIT {
+
+  private final Logger log = Logger.getLogger(this.getClass().getName());
+  private String datasetName;
+  private String tableName;
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String GOOGLE_CLOUD_PROJECT = System.getenv("GOOGLE_CLOUD_PROJECT");
+
+  private static void requireEnvVar(String varName) {
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+
+    // Create temporary dataset.
+    datasetName = RemoteBigQueryHelper.generateDatasetName();
+    CreateDataset.createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+
+    // Generate table name.
+    tableName = "table_test" + UUID.randomUUID().toString().substring(0, 8);
+  }
+
+  @After
+  public void tearDown() {
+    // Clean up
+    DeleteTable.deleteTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName);
+    DeleteDataset.deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+
+    // Restores print statements to the original output stream.
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    log.log(Level.INFO, "\n" + bout.toString());
+  }
+
+  @Test
+  public void testCreateTable() {
+    Schema schema =
+        Schema.of(
+            Field.of("stringField", StandardSQLTypeName.STRING),
+            Field.of("booleanField", StandardSQLTypeName.BOOL));
+    CreateTable.createTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName, schema);
+    assertThat(bout.toString()).contains(tableName + "\" created successfully");
+  }
+}

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/CreateTableIT.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/CreateTableIT.java
@@ -64,7 +64,7 @@ public class CreateTableIT {
 
     // Create temporary dataset.
     datasetName = RemoteBigQueryHelper.generateDatasetName();
-    CreateDataset.createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+    Util.setUpTest_createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
 
     // Generate table name.
     tableName = "table_test" + UUID.randomUUID().toString().substring(0, 8);
@@ -73,8 +73,8 @@ public class CreateTableIT {
   @After
   public void tearDown() {
     // Clean up
-    DeleteTable.deleteTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName);
-    DeleteDataset.deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+    Util.tearDownTest_deleteTableOrView(GOOGLE_CLOUD_PROJECT, datasetName, tableName);
+    Util.tearDownTest_deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
 
     // Restores print statements to the original output stream.
     System.out.flush();

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/CreateViewIT.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/CreateViewIT.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquery;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.testing.RemoteBigQueryHelper;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CreateViewIT {
+
+  private final Logger log = Logger.getLogger(this.getClass().getName());
+  private String datasetName;
+  private String tableName;
+  private String viewName;
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String GOOGLE_CLOUD_PROJECT = System.getenv("GOOGLE_CLOUD_PROJECT");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+
+    // Create temporary dataset.
+    datasetName = RemoteBigQueryHelper.generateDatasetName();
+    CreateDataset.createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+
+    // Create temporary table.
+    tableName = "table_test_" + UUID.randomUUID().toString().substring(0, 8);
+    Schema schema =
+        Schema.of(
+            Field.of("timestampField", StandardSQLTypeName.TIMESTAMP),
+            Field.of("stringField", StandardSQLTypeName.STRING),
+            Field.of("booleanField", StandardSQLTypeName.BOOL));
+    CreateTable.createTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName, schema);
+
+    // Generate view name.
+    viewName = "view_test_" + UUID.randomUUID().toString().substring(0, 8);
+  }
+
+  @After
+  public void tearDown() {
+    // Clean up.
+    DeleteTable.deleteTable(GOOGLE_CLOUD_PROJECT, datasetName, viewName);
+    DeleteTable.deleteTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName);
+    DeleteDataset.deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+
+    // Restores print statements to the original output stream.
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    log.log(Level.INFO, "\n" + bout.toString());
+  }
+
+  @Test
+  public void testCreateView() {
+    String query =
+        String.format("SELECT stringField, booleanField FROM %s.%s", datasetName, tableName);
+    CreateView.createView(GOOGLE_CLOUD_PROJECT, datasetName, viewName, query);
+    assertThat(bout.toString()).contains(viewName + "\" created successfully");
+  }
+}

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/CreateViewIT.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/CreateViewIT.java
@@ -73,9 +73,8 @@ public class CreateViewIT {
     tableName = "table_test_" + UUID.randomUUID().toString().substring(0, 8);
     Schema schema =
         Schema.of(
-            Field.of("timestampField", StandardSQLTypeName.TIMESTAMP),
             Field.of("stringField", StandardSQLTypeName.STRING),
-            Field.of("booleanField", StandardSQLTypeName.BOOL));
+            Field.of("isBooleanField", StandardSQLTypeName.BOOL));
     CreateTable.createTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName, schema);
 
     // Generate view name.
@@ -98,7 +97,7 @@ public class CreateViewIT {
   @Test
   public void testCreateView() {
     String query =
-        String.format("SELECT stringField, booleanField FROM %s.%s", datasetName, tableName);
+        String.format("SELECT stringField, isBooleanField FROM %s.%s", datasetName, tableName);
     CreateView.createView(GOOGLE_CLOUD_PROJECT, datasetName, viewName, query);
     assertThat(bout.toString()).contains(viewName + "\" created successfully");
   }

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/CreateViewIT.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/CreateViewIT.java
@@ -67,7 +67,7 @@ public class CreateViewIT {
 
     // Create temporary dataset.
     datasetName = RemoteBigQueryHelper.generateDatasetName();
-    CreateDataset.createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+    Util.setUpTest_createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
 
     // Create temporary table.
     tableName = "table_test_" + UUID.randomUUID().toString().substring(0, 8);
@@ -75,7 +75,7 @@ public class CreateViewIT {
         Schema.of(
             Field.of("stringField", StandardSQLTypeName.STRING),
             Field.of("isBooleanField", StandardSQLTypeName.BOOL));
-    CreateTable.createTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName, schema);
+    Util.setUpTest_createTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName, schema);
 
     // Generate view name.
     viewName = "view_test_" + UUID.randomUUID().toString().substring(0, 8);
@@ -84,9 +84,9 @@ public class CreateViewIT {
   @After
   public void tearDown() {
     // Clean up.
-    DeleteTable.deleteTable(GOOGLE_CLOUD_PROJECT, datasetName, viewName);
-    DeleteTable.deleteTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName);
-    DeleteDataset.deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+    Util.tearDownTest_deleteTableOrView(GOOGLE_CLOUD_PROJECT, datasetName, viewName);
+    Util.tearDownTest_deleteTableOrView(GOOGLE_CLOUD_PROJECT, datasetName, tableName);
+    Util.tearDownTest_deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
 
     // Restores print statements to the original output stream.
     System.out.flush();

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/DeleteDatasetIT.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/DeleteDatasetIT.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquery;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.testing.RemoteBigQueryHelper;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DeleteDatasetIT {
+
+  private final Logger log = Logger.getLogger(this.getClass().getName());
+  private String datasetName;
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String GOOGLE_CLOUD_PROJECT = System.getenv("GOOGLE_CLOUD_PROJECT");
+
+  private static void requireEnvVar(String varName) {
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+
+    // Create temporary dataset.
+    datasetName = RemoteBigQueryHelper.generateDatasetName();
+    CreateDataset.createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+  }
+
+  @After
+  public void tearDown() {
+    // Restores print statements to the original output stream.
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    log.log(Level.INFO, "\n" + bout.toString());
+  }
+
+  @Test
+  public void deleteDataset() {
+    DeleteDataset.deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+
+    assertThat(bout.toString()).contains(datasetName + "\" deleted successfully");
+  }
+}

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/DeleteDatasetIT.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/DeleteDatasetIT.java
@@ -59,7 +59,7 @@ public class DeleteDatasetIT {
 
     // Create temporary dataset.
     datasetName = RemoteBigQueryHelper.generateDatasetName();
-    CreateDataset.createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+    Util.setUpTest_createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
   }
 
   @After

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/DeleteTableIT.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/DeleteTableIT.java
@@ -62,17 +62,17 @@ public class DeleteTableIT {
 
     // Create temporary dataset.
     datasetName = RemoteBigQueryHelper.generateDatasetName();
-    CreateDataset.createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+    Util.setUpTest_createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
 
     // Create temporary table to be deleted.
     tableName = "table_test_" + UUID.randomUUID().toString().substring(0, 8);
-    CreateTable.createTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName, Schema.of());
+    Util.setUpTest_createTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName, Schema.of());
   }
 
   @After
   public void tearDown() {
     // Clean up.
-    DeleteDataset.deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+    Util.tearDownTest_deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
 
     // Restores print statements to the original output stream.
     System.out.flush();

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/DeleteTableIT.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/DeleteTableIT.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquery;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.testing.RemoteBigQueryHelper;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DeleteTableIT {
+
+  private final Logger log = Logger.getLogger(this.getClass().getName());
+  private String datasetName;
+  private String tableName;
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String GOOGLE_CLOUD_PROJECT = System.getenv("GOOGLE_CLOUD_PROJECT");
+
+  private static void requireEnvVar(String varName) {
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+
+    // Create temporary dataset.
+    datasetName = RemoteBigQueryHelper.generateDatasetName();
+    CreateDataset.createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+
+    // Create temporary table to be deleted.
+    tableName = "table_test_" + UUID.randomUUID().toString().substring(0, 8);
+    CreateTable.createTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName, Schema.of());
+  }
+
+  @After
+  public void tearDown() {
+    // Clean up.
+    DeleteDataset.deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+
+    // Restores print statements to the original output stream.
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    log.log(Level.INFO, "\n" + bout.toString());
+  }
+
+  @Test
+  public void testDeleteTable() {
+    // Delete the table that was just created.
+    DeleteTable.deleteTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName);
+    assertThat(bout.toString()).contains(tableName + "\" deleted successfully");
+  }
+}

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/Util.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/Util.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquery;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQuery.DatasetDeleteOption;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.Dataset;
+import com.google.cloud.bigquery.DatasetId;
+import com.google.cloud.bigquery.DatasetInfo;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableDefinition;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
+import com.google.cloud.bigquery.ViewDefinition;
+
+public class Util {
+
+  private static BigQuery bigquery = BigQueryOptions.getDefaultInstance().getService();
+
+  public static Dataset setUpTest_createDataset(String projectId, String datasetName)
+      throws BigQueryException {
+    String location = "US";
+    DatasetId datasetId = DatasetId.of(projectId, datasetName);
+    DatasetInfo datasetInfo = DatasetInfo.newBuilder(datasetId).setLocation(location).build();
+    return bigquery.create(datasetInfo);
+  }
+
+  public static boolean tearDownTest_deleteDataset(String projectId, String datasetName) {
+    DatasetId datasetId = DatasetId.of(projectId, datasetName);
+    return bigquery.delete(datasetId, DatasetDeleteOption.deleteContents());
+  }
+
+  public static Table setUpTest_createTable(
+      String projectId, String datasetName, String tableName, Schema schema)
+      throws BigQueryException {
+    TableId tableId = TableId.of(projectId, datasetName, tableName);
+    TableDefinition tableDefinition = StandardTableDefinition.of(schema);
+    TableInfo tableInfo = TableInfo.newBuilder(tableId, tableDefinition).build();
+
+    return bigquery.create(tableInfo);
+  }
+
+  public static Table setUpTest_createView(
+      String projectId, String datasetName, String viewName, String query)
+      throws BigQueryException {
+    TableId tableId = TableId.of(projectId, datasetName, viewName);
+    ViewDefinition viewDefinition = ViewDefinition.newBuilder(query).setUseLegacySql(false).build();
+    TableInfo tableInfo = TableInfo.of(tableId, viewDefinition);
+
+    return bigquery.create(tableInfo);
+  }
+
+  public static boolean tearDownTest_deleteTableOrView(
+      String projectId, String datasetName, String tableName) throws BigQueryException {
+    TableId tableId = TableId.of(projectId, datasetName, tableName);
+    return bigquery.delete(tableId);
+  }
+}


### PR DESCRIPTION
## Description

Part of internal b/394478489

#### First part of bigquery cloud-client (1/3).
(**https://github.com/GoogleCloudPlatform/java-docs-samples/pull/10034**, https://github.com/GoogleCloudPlatform/java-docs-samples/pull/10035, https://github.com/GoogleCloudPlatform/java-docs-samples/pull/10036)

**Create[Dataset,Table,View]** and **Delete[Dataset,Table]** are required for testing the following samples (samples will be added in part 2 and 3).

### Samples
1. [bigquery_view_dataset_access policy](https://cloud.google.com/bigquery/docs/control-access-to-resources-iam#view_the_access_policy_of_a_dataset)
2. [bigquery_view_table_or_view_access_policy](https://cloud.google.com/bigquery/docs/control-access-to-resources-iam#view_the_access_policy_of_a_table_or_view)
3. [bigquery_grant_access_to_dataset](https://cloud.google.com/bigquery/docs/control-access-to-resources-iam#grant_access_to_a_dataset)
4. [bigquery_grant_access_to_table_or_view](https://cloud.google.com/bigquery/docs/control-access-to-resources-iam#grant_access_to_a_table_or_view)
5. [bigquery_revoke_dataset_access](https://cloud.google.com/bigquery/docs/control-access-to-resources-iam#revoke_access_to_a_dataset)
6. [bigquery_revoke_access_to_table_or_view](https://cloud.google.com/bigquery/docs/control-access-to-resources-iam#revoke_access_to_a_table_or_view)

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
