### PR TITLE
feat(bigquery): add table/view samples to cloud-client (3/3)

### DIFF
--- a/bigquery/cloud-client/snippets/pom.xml
+++ b/bigquery/cloud-client/snippets/pom.xml
@@ -1,0 +1,70 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.bigquery</groupId>
+  <artifactId>cloud-client-snippets</artifactId>
+  <packaging>jar</packaging>
+  <name>Google Cloud BigQuery Cloud Client Snippets</name>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.2.0</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>21</maven.compiler.target>
+    <maven.compiler.source>21</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.32.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigquery</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.4.4</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/GetTableOrViewAccessPolicy.java
+++ b/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/GetTableOrViewAccessPolicy.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquery;
+
+// [START bigquery_view_table_or_view_access_policy]
+
+import com.google.cloud.Policy;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.TableId;
+
+public class GetTableOrViewAccessPolicy {
+
+  public static void main(String[] args) {
+    // TODO(developer): Replace these variables before running the sample.
+    // Project, dataset and resource (table or view) from which to get the access policy.
+    String projectId = "MY_PROJECT_ID";
+    String datasetName = "MY_DATASET_NAME";
+    String resourceName = "MY_RESOURCE_NAME";
+    getTableOrViewAccessPolicy(projectId, datasetName, resourceName);
+  }
+
+  public static void getTableOrViewAccessPolicy(
+      String projectId, String datasetName, String resourceName) {
+    try {
+      // Initialize client that will be used to send requests. This client only needs
+      // to be created once, and can be reused for multiple requests.
+      BigQuery bigquery = BigQueryOptions.getDefaultInstance().getService();
+
+      // Create table identity given the projectId, the datasetName and the resourceName.
+      TableId tableId = TableId.of(projectId, datasetName, resourceName);
+
+      // Get the table IAM policy.
+      Policy policy = bigquery.getIamPolicy(tableId);
+
+      // Show policy details.
+      // Find more information about the Policy Class here:
+      // https://cloud.google.com/java/docs/reference/google-cloud-core/latest/com.google.cloud.Policy
+      System.out.println(
+          "IAM policy info of resource \"" + resourceName + "\" retrieved succesfully");
+      System.out.println();
+      System.out.println("IAM policy info: " + policy.toString());
+    } catch (BigQueryException e) {
+      System.out.println("IAM policy info not retrieved. \n" + e.toString());
+    }
+  }
+}
+ // [END bigquery_view_table_or_view_access_policy]

--- a/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/GrantAccessToTableOrView.java
+++ b/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/GrantAccessToTableOrView.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquery;
+
+// [START bigquery_grant_access_to_table_or_view]
+import com.google.cloud.Identity;
+import com.google.cloud.Policy;
+import com.google.cloud.Role;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.TableId;
+
+public class GrantAccessToTableOrView {
+
+  public static void main(String[] args) {
+    // TODO(developer): Replace these variables before running the sample.
+    // Project, dataset and resource (table or view) from which to get the access policy.
+    String projectId = "MY_PROJECT_ID";
+    String datasetName = "MY_DATASET_NAME";
+    String resourceName = "MY_TABLE_NAME";
+    // Role to add to the policy access
+    Role role = Role.of("roles/bigquery.dataViewer");
+    // Identity to add to the policy access
+    Identity identity = Identity.user("user-add@example.com");
+    grantAccessToTableOrView(projectId, datasetName, resourceName, role, identity);
+  }
+
+  public static void grantAccessToTableOrView(
+      String projectId, String datasetName, String resourceName, Role role, Identity identity) {
+    try {
+      // Initialize client that will be used to send requests. This client only needs
+      // to be created once, and can be reused for multiple requests.
+      BigQuery bigquery = BigQueryOptions.getDefaultInstance().getService();
+
+      // Create table identity given the projectId, the datasetName and the resourceName.
+      TableId tableId = TableId.of(projectId, datasetName, resourceName);
+
+      // Add new user identity to current IAM policy.
+      Policy policy = bigquery.getIamPolicy(tableId);
+      policy = policy.toBuilder().addIdentity(role, identity).build();
+
+      // Update the IAM policy by setting the new one.
+      bigquery.setIamPolicy(tableId, policy);
+
+      System.out.println("IAM policy of resource \"" + resourceName + "\" updated successfully");
+    } catch (BigQueryException e) {
+      System.out.println("IAM policy was not updated. \n" + e.toString());
+    }
+  }
+}
+ // [END bigquery_grant_access_to_table_or_view]

--- a/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/RevokeAccessToTableOrView.java
+++ b/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/RevokeAccessToTableOrView.java
@@ -57,7 +57,7 @@ public class RevokeAccessToTableOrView {
       // Remove either identities or roles, or both from bindings and replace it in
       // the current IAM policy.
       Policy policy = bigquery.getIamPolicy(tableId);
-      // Create a copy of a inmutable map.
+      // Create a copy of an immutable map.
       Map<Role, Set<Identity>> bindings = new HashMap<>(policy.getBindings());
 
       // Remove all identities with a specific role.

--- a/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/RevokeAccessToTableOrView.java
+++ b/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/RevokeAccessToTableOrView.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquery;
+
+// [START bigquery_revoke_access_to_table_or_view]
+import com.google.cloud.Identity;
+import com.google.cloud.Policy;
+import com.google.cloud.Role;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.TableId;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class RevokeAccessToTableOrView {
+
+  public static void main(String[] args) {
+    // TODO(developer): Replace these variables before running the sample.
+    // Project, dataset and resource (table or view) from which to get the access policy
+    String projectId = "MY_PROJECT_ID";
+    String datasetName = "MY_DATASET_NAME";
+    String resourceName = "MY_RESOURCE_NAME";
+    // Role to remove from the access policy
+    Role role = Role.of("roles/bigquery.dataViewer");
+    // Identity to remove from the access policy
+    Identity user = Identity.user("user-add@example.com");
+    revokeAccessToTableOrView(projectId, datasetName, resourceName, role, user);
+  }
+
+  public static void revokeAccessToTableOrView(
+      String projectId, String datasetName, String resourceName, Role role, Identity identity) {
+    try {
+      // Initialize client that will be used to send requests. This client only needs
+      // to be created once, and can be reused for multiple requests.
+      BigQuery bigquery = BigQueryOptions.getDefaultInstance().getService();
+
+      // Create table identity given the projectId, the datasetName and the resourceName.
+      TableId tableId = TableId.of(projectId, datasetName, resourceName);
+
+      // Remove either identities or roles, or both from bindings and replace it in
+      // the current IAM policy.
+      Policy policy = bigquery.getIamPolicy(tableId);
+      // Create a copy of a inmutable map.
+      Map<Role, Set<Identity>> bindings = new HashMap<>(policy.getBindings());
+
+      // Remove all identities with a specific role.
+      bindings.remove(role);
+      // Update bindings.
+      policy = policy.toBuilder().setBindings(bindings).build();
+
+      // Remove one identity in all the existing roles.
+      for (Role roleKey : bindings.keySet()) {
+        if (bindings.get(roleKey).contains(identity)) {
+          // Create a copy of a inmutable set if the identity is present in the role.
+          Set<Identity> identities = new HashSet<>(bindings.get(roleKey));
+          // Remove identity.
+          identities.remove(identity);
+          bindings.put(roleKey, identities);
+          if (bindings.get(roleKey).isEmpty()) {
+            // Remove the role if it has no identities.
+            bindings.remove(roleKey);
+          }
+        }
+      }
+      // Update bindings.
+      policy = policy.toBuilder().setBindings(bindings).build();
+
+      // Update the IAM policy by setting the new one.
+      bigquery.setIamPolicy(tableId, policy);
+
+      System.out.println("IAM policy of resource \"" + resourceName + "\" updated successfully");
+    } catch (BigQueryException e) {
+      System.out.println("IAM policy was not updated. \n" + e.toString());
+    }
+  }
+}
+ // [END bigquery_revoke_access_to_table_or_view]

--- a/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/RevokeAccessToTableOrView.java
+++ b/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/RevokeAccessToTableOrView.java
@@ -68,7 +68,7 @@ public class RevokeAccessToTableOrView {
       // Remove one identity in all the existing roles.
       for (Role roleKey : bindings.keySet()) {
         if (bindings.get(roleKey).contains(identity)) {
-          // Create a copy of a inmutable set if the identity is present in the role.
+          // Create a copy of an immutable set if the identity is present in the role.
           Set<Identity> identities = new HashSet<>(bindings.get(roleKey));
           // Remove identity.
           identities.remove(identity);

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/GetTableOrViewAccessPolicyIT.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/GetTableOrViewAccessPolicyIT.java
@@ -67,7 +67,7 @@ public class GetTableOrViewAccessPolicyIT {
 
     // Create temporary dataset.
     datasetName = RemoteBigQueryHelper.generateDatasetName();
-    CreateDataset.createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+    Util.setUpTest_createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
 
     // Create temporary table.
     tableName = "get_access_policy_table_test_" + UUID.randomUUID().toString().substring(0, 8);
@@ -75,21 +75,21 @@ public class GetTableOrViewAccessPolicyIT {
         Schema.of(
             Field.of("stringField", StandardSQLTypeName.STRING),
             Field.of("isBooleanField", StandardSQLTypeName.BOOL));
-    CreateTable.createTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName, schema);
+    Util.setUpTest_createTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName, schema);
 
     // Create a temporary view.
     viewName = "get_access_policy_view_test_" + UUID.randomUUID().toString().substring(0, 8);
     String query =
         String.format("SELECT stringField, isBooleanField FROM %s.%s", datasetName, tableName);
-    CreateView.createView(GOOGLE_CLOUD_PROJECT, datasetName, viewName, query);
+    Util.setUpTest_createView(GOOGLE_CLOUD_PROJECT, datasetName, viewName, query);
   }
 
   @After
   public void tearDown() {
     // Clean up.
-    DeleteTable.deleteTable(GOOGLE_CLOUD_PROJECT, datasetName, viewName);
-    DeleteTable.deleteTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName);
-    DeleteDataset.deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+    Util.tearDownTest_deleteTableOrView(GOOGLE_CLOUD_PROJECT, datasetName, viewName);
+    Util.tearDownTest_deleteTableOrView(GOOGLE_CLOUD_PROJECT, datasetName, tableName);
+    Util.tearDownTest_deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
 
     // Restores print statements to the original output stream.
     System.out.flush();

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/GetTableOrViewAccessPolicyIT.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/GetTableOrViewAccessPolicyIT.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquery;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.testing.RemoteBigQueryHelper;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class GetTableOrViewAccessPolicyIT {
+
+  private final Logger log = Logger.getLogger(this.getClass().getName());
+  private String datasetName;
+  private String tableName;
+  private String viewName;
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String GOOGLE_CLOUD_PROJECT = System.getenv("GOOGLE_CLOUD_PROJECT");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+
+    // Create temporary dataset.
+    datasetName = RemoteBigQueryHelper.generateDatasetName();
+    CreateDataset.createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+
+    // Create temporary table.
+    tableName = "get_access_policy_table_test_" + UUID.randomUUID().toString().substring(0, 8);
+    Schema schema =
+        Schema.of(
+            Field.of("stringField", StandardSQLTypeName.STRING),
+            Field.of("isBooleanField", StandardSQLTypeName.BOOL));
+    CreateTable.createTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName, schema);
+
+    // Create a temporary view.
+    viewName = "get_access_policy_view_test_" + UUID.randomUUID().toString().substring(0, 8);
+    String query =
+        String.format("SELECT stringField, isBooleanField FROM %s.%s", datasetName, tableName);
+    CreateView.createView(GOOGLE_CLOUD_PROJECT, datasetName, viewName, query);
+  }
+
+  @After
+  public void tearDown() {
+    // Clean up.
+    DeleteTable.deleteTable(GOOGLE_CLOUD_PROJECT, datasetName, viewName);
+    DeleteTable.deleteTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName);
+    DeleteDataset.deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+
+    // Restores print statements to the original output stream.
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    log.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testGetTableOrViewAccessPolicy_getTableAccessPolicy() {
+    GetTableOrViewAccessPolicy.getTableOrViewAccessPolicy(
+        GOOGLE_CLOUD_PROJECT, datasetName, tableName);
+    assertThat(bout.toString())
+        .contains("IAM policy info of resource \"" + tableName + "\" retrieved succesfully");
+  }
+
+  @Test
+  public void testGetTableOrViewAccessPolicy_getViewAccessPolicy() {
+    GetTableOrViewAccessPolicy.getTableOrViewAccessPolicy(
+        GOOGLE_CLOUD_PROJECT, datasetName, viewName);
+    assertThat(bout.toString())
+        .contains("IAM policy info of resource \"" + viewName + "\" retrieved succesfully");
+  }
+}

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/GrantAccessToTableOrViewIT.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/GrantAccessToTableOrViewIT.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquery;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.Identity;
+import com.google.cloud.Role;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.testing.RemoteBigQueryHelper;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class GrantAccessToTableOrViewIT {
+
+  private final Logger log = Logger.getLogger(this.getClass().getName());
+  private String datasetName;
+  private String tableName;
+  private String viewName;
+  private Role role;
+  private Identity identity;
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String GOOGLE_CLOUD_PROJECT = System.getenv("GOOGLE_CLOUD_PROJECT");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+
+    // Create temporary dataset.
+    datasetName = RemoteBigQueryHelper.generateDatasetName();
+    CreateDataset.createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+
+    // Create temporary table.
+    tableName = "grant_access_to_table_test_" + UUID.randomUUID().toString().substring(0, 8);
+    Schema schema =
+        Schema.of(
+            Field.of("stringField", StandardSQLTypeName.STRING),
+            Field.of("isBooleanField", StandardSQLTypeName.BOOL));
+    CreateTable.createTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName, schema);
+
+    // Create a temporary view.
+    viewName = "grant_access_to_view_test_" + UUID.randomUUID().toString().substring(0, 8);
+    String query =
+        String.format("SELECT stringField, isBooleanField FROM %s.%s", datasetName, tableName);
+    CreateView.createView(GOOGLE_CLOUD_PROJECT, datasetName, viewName, query);
+
+    // Role and identity to add to policy.
+    role = Role.of("roles/bigquery.dataViewer");
+    identity = Identity.group("cloud-developer-relations@google.com");
+  }
+
+  @After
+  public void tearDown() {
+    // Clean up.
+    DeleteTable.deleteTable(GOOGLE_CLOUD_PROJECT, datasetName, viewName);
+    DeleteTable.deleteTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName);
+    DeleteDataset.deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+
+    // Restores print statements to the original output stream.
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    log.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testGrantAccessToTableOrView_grantAccessToTable() {
+    GrantAccessToTableOrView.grantAccessToTableOrView(
+        GOOGLE_CLOUD_PROJECT, datasetName, tableName, role, identity);
+    assertThat(bout.toString())
+        .contains("IAM policy of resource \"" + tableName + "\" updated successfully");
+  }
+
+  @Test
+  public void testGrantAccessToTableOrView_grantAccessToView() {
+    GrantAccessToTableOrView.grantAccessToTableOrView(
+        GOOGLE_CLOUD_PROJECT, datasetName, viewName, role, identity);
+    assertThat(bout.toString())
+        .contains("IAM policy of resource \"" + viewName + "\" updated successfully");
+  }
+}

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/GrantAccessToTableOrViewIT.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/GrantAccessToTableOrViewIT.java
@@ -71,7 +71,7 @@ public class GrantAccessToTableOrViewIT {
 
     // Create temporary dataset.
     datasetName = RemoteBigQueryHelper.generateDatasetName();
-    CreateDataset.createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+    Util.setUpTest_createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
 
     // Create temporary table.
     tableName = "grant_access_to_table_test_" + UUID.randomUUID().toString().substring(0, 8);
@@ -79,13 +79,13 @@ public class GrantAccessToTableOrViewIT {
         Schema.of(
             Field.of("stringField", StandardSQLTypeName.STRING),
             Field.of("isBooleanField", StandardSQLTypeName.BOOL));
-    CreateTable.createTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName, schema);
+    Util.setUpTest_createTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName, schema);
 
     // Create a temporary view.
     viewName = "grant_access_to_view_test_" + UUID.randomUUID().toString().substring(0, 8);
     String query =
         String.format("SELECT stringField, isBooleanField FROM %s.%s", datasetName, tableName);
-    CreateView.createView(GOOGLE_CLOUD_PROJECT, datasetName, viewName, query);
+    Util.setUpTest_createView(GOOGLE_CLOUD_PROJECT, datasetName, viewName, query);
 
     // Role and identity to add to policy.
     role = Role.of("roles/bigquery.dataViewer");
@@ -95,9 +95,9 @@ public class GrantAccessToTableOrViewIT {
   @After
   public void tearDown() {
     // Clean up.
-    DeleteTable.deleteTable(GOOGLE_CLOUD_PROJECT, datasetName, viewName);
-    DeleteTable.deleteTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName);
-    DeleteDataset.deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+    Util.tearDownTest_deleteTableOrView(GOOGLE_CLOUD_PROJECT, datasetName, viewName);
+    Util.tearDownTest_deleteTableOrView(GOOGLE_CLOUD_PROJECT, datasetName, tableName);
+    Util.tearDownTest_deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
 
     // Restores print statements to the original output stream.
     System.out.flush();

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/RevokeAccessToTableOrViewIT.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/RevokeAccessToTableOrViewIT.java
@@ -91,18 +91,18 @@ public class RevokeAccessToTableOrViewIT {
     identity = Identity.group("cloud-developer-relations@google.com");
 
     // Grant access to table and view.
-    GrantAccessToTableOrView.grantAccessToTableOrView(
+    Util.setUpTest_grantAccessToTableOrView(
         GOOGLE_CLOUD_PROJECT, datasetName, tableName, firstRole, identity);
-    GrantAccessToTableOrView.grantAccessToTableOrView(
+    Util.setUpTest_grantAccessToTableOrView(
         GOOGLE_CLOUD_PROJECT, datasetName, viewName, firstRole, identity);
 
     // Add a second role for identity.
     secondRole = Role.of("roles/bigquery.dataEditor");
 
     // Grant access to table and view.
-    GrantAccessToTableOrView.grantAccessToTableOrView(
+    Util.setUpTest_grantAccessToTableOrView(
         GOOGLE_CLOUD_PROJECT, datasetName, tableName, secondRole, identity);
-    GrantAccessToTableOrView.grantAccessToTableOrView(
+    Util.setUpTest_grantAccessToTableOrView(
         GOOGLE_CLOUD_PROJECT, datasetName, viewName, secondRole, identity);
   }
 

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/RevokeAccessToTableOrViewIT.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/RevokeAccessToTableOrViewIT.java
@@ -72,7 +72,7 @@ public class RevokeAccessToTableOrViewIT {
 
     // Create temporary dataset.
     datasetName = RemoteBigQueryHelper.generateDatasetName();
-    CreateDataset.createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+    Util.setUpTest_createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
 
     // Create temporary table and view.
     tableName = "revoke_access_to_table_test_" + UUID.randomUUID().toString().substring(0, 8);
@@ -80,11 +80,11 @@ public class RevokeAccessToTableOrViewIT {
         Schema.of(
             Field.of("stringField", StandardSQLTypeName.STRING),
             Field.of("isBooleanField", StandardSQLTypeName.BOOL));
-    CreateTable.createTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName, schema);
+    Util.setUpTest_createTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName, schema);
     viewName = "revoke_access_to_view_test_" + UUID.randomUUID().toString().substring(0, 8);
     String query =
         String.format("SELECT stringField, isBooleanField FROM %s.%s", datasetName, tableName);
-    CreateView.createView(GOOGLE_CLOUD_PROJECT, datasetName, viewName, query);
+    Util.setUpTest_createView(GOOGLE_CLOUD_PROJECT, datasetName, viewName, query);
 
     // Role and identity to add to policy.
     firstRole = Role.of("roles/bigquery.dataViewer");
@@ -109,8 +109,9 @@ public class RevokeAccessToTableOrViewIT {
   @After
   public void tearDown() {
     // Clean up.
-    DeleteTable.deleteTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName);
-    DeleteDataset.deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+    Util.tearDownTest_deleteTableOrView(GOOGLE_CLOUD_PROJECT, datasetName, viewName);
+    Util.tearDownTest_deleteTableOrView(GOOGLE_CLOUD_PROJECT, datasetName, tableName);
+    Util.tearDownTest_deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
 
     // Restores print statements to the original output stream.
     System.out.flush();

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/RevokeAccessToTableOrViewIT.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/RevokeAccessToTableOrViewIT.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquery;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.cloud.Identity;
+import com.google.cloud.Role;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.testing.RemoteBigQueryHelper;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class RevokeAccessToTableOrViewIT {
+
+  private final Logger log = Logger.getLogger(this.getClass().getName());
+  private String datasetName;
+  private String tableName;
+  private String viewName;
+  private Role firstRole;
+  private Role secondRole;
+  private Identity identity;
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  private static final String GOOGLE_CLOUD_PROJECT = System.getenv("GOOGLE_CLOUD_PROJECT");
+
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+
+    // Create temporary dataset.
+    datasetName = RemoteBigQueryHelper.generateDatasetName();
+    CreateDataset.createDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+
+    // Create temporary table and view.
+    tableName = "revoke_access_to_table_test_" + UUID.randomUUID().toString().substring(0, 8);
+    Schema schema =
+        Schema.of(
+            Field.of("stringField", StandardSQLTypeName.STRING),
+            Field.of("isBooleanField", StandardSQLTypeName.BOOL));
+    CreateTable.createTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName, schema);
+    viewName = "revoke_access_to_view_test_" + UUID.randomUUID().toString().substring(0, 8);
+    String query =
+        String.format("SELECT stringField, isBooleanField FROM %s.%s", datasetName, tableName);
+    CreateView.createView(GOOGLE_CLOUD_PROJECT, datasetName, viewName, query);
+
+    // Role and identity to add to policy.
+    firstRole = Role.of("roles/bigquery.dataViewer");
+    identity = Identity.group("cloud-developer-relations@google.com");
+
+    // Grant access to table and view.
+    GrantAccessToTableOrView.grantAccessToTableOrView(
+        GOOGLE_CLOUD_PROJECT, datasetName, tableName, firstRole, identity);
+    GrantAccessToTableOrView.grantAccessToTableOrView(
+        GOOGLE_CLOUD_PROJECT, datasetName, viewName, firstRole, identity);
+
+    // Add a second role for identity.
+    secondRole = Role.of("roles/bigquery.dataEditor");
+
+    // Grant access to table and view.
+    GrantAccessToTableOrView.grantAccessToTableOrView(
+        GOOGLE_CLOUD_PROJECT, datasetName, tableName, secondRole, identity);
+    GrantAccessToTableOrView.grantAccessToTableOrView(
+        GOOGLE_CLOUD_PROJECT, datasetName, viewName, secondRole, identity);
+  }
+
+  @After
+  public void tearDown() {
+    // Clean up.
+    DeleteTable.deleteTable(GOOGLE_CLOUD_PROJECT, datasetName, tableName);
+    DeleteDataset.deleteDataset(GOOGLE_CLOUD_PROJECT, datasetName);
+
+    // Restores print statements to the original output stream.
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    log.log(Level.INFO, bout.toString());
+  }
+
+  @Test
+  public void testRevokeAccessToTableOrView_revokeAccessToTable() {
+    RevokeAccessToTableOrView.revokeAccessToTableOrView(
+        GOOGLE_CLOUD_PROJECT, datasetName, tableName, firstRole, identity);
+    assertThat(bout.toString())
+        .contains("IAM policy of resource \"" + tableName + "\" updated successfully");
+  }
+
+  @Test
+  public void testRevokeAccessToTableOrView_revokeAccessToView() {
+    RevokeAccessToTableOrView.revokeAccessToTableOrView(
+        GOOGLE_CLOUD_PROJECT, datasetName, viewName, firstRole, identity);
+    assertThat(bout.toString())
+        .contains("IAM policy of resource \"" + viewName + "\" updated successfully");
+  }
+}

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/Util.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/Util.java
@@ -16,6 +16,9 @@
 
 package com.example.bigquery;
 
+import com.google.cloud.Identity;
+import com.google.cloud.Policy;
+import com.google.cloud.Role;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQuery.DatasetDeleteOption;
 import com.google.cloud.bigquery.BigQueryException;
@@ -72,5 +75,15 @@ public class Util {
       String projectId, String datasetName, String tableName) throws BigQueryException {
     TableId tableId = TableId.of(projectId, datasetName, tableName);
     return bigquery.delete(tableId);
+  }
+
+  public static Policy setUpTest_grantAccessToTableOrView(
+      String projectId, String datasetName, String resourceName, Role role, Identity identity)
+      throws BigQueryException {
+    TableId tableId = TableId.of(projectId, datasetName, resourceName);
+    Policy policy = bigquery.getIamPolicy(tableId);
+    policy = policy.toBuilder().addIdentity(role, identity).build();
+
+    return bigquery.setIamPolicy(tableId, policy);
   }
 }


### PR DESCRIPTION
## Description

Part of internal b/394478489

#### Third part of bigquery cloud-client (3/3).
(https://github.com/GoogleCloudPlatform/java-docs-samples/pull/10034, https://github.com/GoogleCloudPlatform/java-docs-samples/pull/10035, **https://github.com/GoogleCloudPlatform/java-docs-samples/pull/10036**)

This part adds samples 2, 4 and 6 from the following list:

### Samples
1. [bigquery_view_dataset_access policy](https://cloud.google.com/bigquery/docs/control-access-to-resources-iam#view_the_access_policy_of_a_dataset)
2. [bigquery_view_table_or_view_access_policy](https://cloud.google.com/bigquery/docs/control-access-to-resources-iam#view_the_access_policy_of_a_table_or_view)
3. [bigquery_grant_access_to_dataset](https://cloud.google.com/bigquery/docs/control-access-to-resources-iam#grant_access_to_a_dataset)
4. [bigquery_grant_access_to_table_or_view](https://cloud.google.com/bigquery/docs/control-access-to-resources-iam#grant_access_to_a_table_or_view)
5. [bigquery_revoke_dataset_access](https://cloud.google.com/bigquery/docs/control-access-to-resources-iam#revoke_access_to_a_dataset)
6. [bigquery_revoke_access_to_table_or_view](https://cloud.google.com/bigquery/docs/control-access-to-resources-iam#revoke_access_to_a_table_or_view)

Some of the samples are part of [java-bigquery/.../bigquery](https://github.com/googleapis/java-bigquery/tree/main/samples/snippets/src/main/java/com/example/bigquery) repo, but are deprecated or the content does not match the docs.


## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
