### PR TITLE
feat(parametermanager): Added quickstart samples for parametermanager

### DIFF
--- a/parametermanager/README.md
+++ b/parametermanager/README.md
@@ -1,0 +1,49 @@
+# Google Parameter Manager
+
+<a href="https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/java-docs-samples&page=editor&open_in_editor=secretmanager/README.md">
+<img alt="Open in Cloud Shell" src ="http://gstatic.com/cloudssh/images/open-btn.png"></a>
+
+Google [Parameter Manager](https://cloud.google.com/secret-manager/parameter-manager/docs/overview)
+provides a centralized storage for all configuration parameters related to your workload deployments.
+Parameters are variables, often in the form of key-value pairs, which customize how an application functions.
+These sample Java applications demonstrate how to access
+the Parameter Manager API using the Google Java API Client Libraries.
+
+## Prerequisites
+
+### Enable the API
+
+You
+must [enable the Parameter Manager API](https://console.cloud.google.com/apis/enableflow?apiid=parametermanager.googleapis.com)
+for your project in order to use these samples
+
+### Set Environment Variables
+
+You must set your project ID in order to run the tests
+
+```text
+$ export GOOGLE_CLOUD_PROJECT=<your-project-id-here>
+```
+
+You must set your Location in order to run the regional tests
+
+```text
+$ export GOOGLE_CLOUD_PROJECT_LOCATION=<your-location-id-here>
+```
+
+### Grant Permissions
+
+You must ensure that
+the [user account or service account](https://cloud.google.com/iam/docs/service-accounts#differences_between_a_service_account_and_a_user_account)
+you used to authorize your gcloud session has the proper permissions to edit Parameter Manager resources for your project.
+In the Cloud Console under IAM, add the following roles to the project whose service account you're using to test:
+
+* Parameter Manager Admin (`roles/parametermanager.admin`)
+* Parameter Manager Parameter Accessor (`roles/parametermanager.parameterAccessor`)
+* Parameter Manager Parameter Version Adder (`roles/parametermanager.parameterVersionAdder`)
+
+To use the rendering of secret through parameter manager add the following role also:
+*  Secret Manager Secret Accessor (`roles/secretmanager.secretAccessor`)
+
+More information can be found in
+the [Parameter Manager Docs](https://cloud.google.com/secret-manager/parameter-manager/docs/access-control)

--- a/parametermanager/pom.xml
+++ b/parametermanager/pom.xml
@@ -1,0 +1,116 @@
+<!--
+ Copyright 2025 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>parametermanager</groupId>
+    <artifactId>parametermanager-samples</artifactId>
+    <packaging>jar</packaging>
+
+    <!--
+      The parent pom defines common style checks and testing strategies for our samples.
+      Removing or replacing it should not affect the execution of the samples in any way.
+    -->
+    <parent>
+        <groupId>com.google.cloud.samples</groupId>
+        <artifactId>shared-configuration</artifactId>
+        <version>1.2.0</version>
+    </parent>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>libraries-bom</artifactId>
+                <version>26.54.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-parametermanager</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.30</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.truth</groupId>
+            <artifactId>truth</artifactId>
+            <version>1.4.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-secretmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-iam-policy</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.12.1</version>
+                <configuration>
+                    <source>11</source> <!-- depending on your project -->
+                    <target>11</target> <!-- depending on your project -->
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.30</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/parametermanager/src/main/java/parametermanager/Quickstart.java
+++ b/parametermanager/src/main/java/parametermanager/Quickstart.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parametermanager;
+
+// [START parametermanager_quickstart]
+
+import com.google.cloud.parametermanager.v1.LocationName;
+import com.google.cloud.parametermanager.v1.Parameter;
+import com.google.cloud.parametermanager.v1.ParameterFormat;
+import com.google.cloud.parametermanager.v1.ParameterManagerClient;
+import com.google.cloud.parametermanager.v1.ParameterName;
+import com.google.cloud.parametermanager.v1.ParameterVersion;
+import com.google.cloud.parametermanager.v1.ParameterVersionName;
+import com.google.cloud.parametermanager.v1.ParameterVersionPayload;
+import com.google.protobuf.ByteString;
+
+public class Quickstart {
+
+  public static void main(String[] args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String parameterId = "your-parameter-id";
+    String versionId = "your-version-id";
+
+    // Run the quickstart method
+    quickstart(projectId, parameterId, versionId);
+  }
+
+  // This is an example snippet of how to use the basic capabilities in the Parameter Manager API.
+  public static void quickstart(
+      String projectId, String parameterId, String versionId) throws Exception {
+
+    // Initialize the client that will be used to send requests. This client only needs to be
+    // created once, and can be reused for multiple requests.
+    try (ParameterManagerClient client = ParameterManagerClient.create()) {
+      String locationId = "global";
+
+      // Step 1: Create a parameter.
+      // Build the parent name from the project.
+      LocationName location = LocationName.of(projectId, locationId);
+
+      // Specify the parameter format.
+      ParameterFormat format = ParameterFormat.JSON;
+      // Build the parameter to create.
+      Parameter parameter = Parameter.newBuilder().setFormat(format).build();
+
+      // Create the parameter.
+      Parameter createdParameter =
+          client.createParameter(location.toString(), parameter, parameterId);
+      System.out.printf(
+          "Created parameter %s with format %s\n",
+          createdParameter.getName(), createdParameter.getFormat());
+
+      // Step 2: Create a parameter version with JSON payload containing a secret reference.
+      // Build the parameter name.
+      ParameterName parameterName = ParameterName.of(projectId, locationId, parameterId);
+
+      String jsonPayload = "{\"username\": \"test-user\", \"host\": \"localhost\"}";
+      // Convert the JSON payload string to ByteString.
+      ByteString byteStringPayload = ByteString.copyFromUtf8(jsonPayload);
+
+      // Create the parameter version payload.
+      ParameterVersionPayload parameterVersionPayload =
+          ParameterVersionPayload.newBuilder().setData(byteStringPayload).build();
+
+      // Create the parameter version with the JSON payload.
+      ParameterVersion parameterVersion =
+          ParameterVersion.newBuilder().setPayload(parameterVersionPayload).build();
+
+      // Create the parameter version in the Parameter Manager.
+      ParameterVersion createdParameterVersion =
+          client.createParameterVersion(parameterName.toString(), parameterVersion, versionId);
+      System.out.printf("Created parameter version %s\n", createdParameterVersion.getName());
+
+      // Step 3: Render the parameter version to fetch and print both simple and rendered payloads.
+      // Build the parameter version name.
+      ParameterVersionName parameterVersionName =
+          ParameterVersionName.of(projectId, locationId, parameterId, versionId);
+
+      // Render the parameter version.
+      ParameterVersion response = client.getParameterVersion(parameterVersionName.toString());
+      System.out.printf(
+          "Parameter version %s with payload: %s\n",
+          response.getName(), response.getPayload().getData().toStringUtf8());
+    }
+  }
+}
+// [END parametermanager_quickstart]

--- a/parametermanager/src/main/java/parametermanager/regionalsamples/RegionalQuickstart.java
+++ b/parametermanager/src/main/java/parametermanager/regionalsamples/RegionalQuickstart.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parametermanager.regionalsamples;
+
+// [START parametermanager_regional_quickstart]
+import com.google.cloud.parametermanager.v1.LocationName;
+import com.google.cloud.parametermanager.v1.Parameter;
+import com.google.cloud.parametermanager.v1.ParameterFormat;
+import com.google.cloud.parametermanager.v1.ParameterManagerClient;
+import com.google.cloud.parametermanager.v1.ParameterManagerSettings;
+import com.google.cloud.parametermanager.v1.ParameterName;
+import com.google.cloud.parametermanager.v1.ParameterVersion;
+import com.google.cloud.parametermanager.v1.ParameterVersionName;
+import com.google.cloud.parametermanager.v1.ParameterVersionPayload;
+import com.google.protobuf.ByteString;
+
+/** Demonstrates basic capabilities in the regional Parameter Manager API. */
+public class RegionalQuickstart {
+
+  public static void main(String[] args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String locationId = "your-location-id";
+    String parameterId = "your-parameter-id";
+    String versionId = "your-version-id";
+
+    // Run the quickstart method
+    regionalQuickstart(projectId, locationId, parameterId, versionId);
+  }
+
+  // This is an example snippet that demonstrates basic capabilities in the regional Parameter
+  // Manager API
+  public static void regionalQuickstart(
+      String projectId, String locationId, String parameterId, String versionId)
+      throws Exception {
+    // Endpoint to call the regional parameter manager server
+    String apiEndpoint = String.format("parametermanager.%s.rep.googleapis.com:443", locationId);
+    ParameterManagerSettings parameterManagerSettings =
+        ParameterManagerSettings.newBuilder().setEndpoint(apiEndpoint).build();
+
+    // Initialize the client that will be used to send requests. This client only needs to be
+    // created once, and can be reused for multiple requests.
+    try (ParameterManagerClient client = ParameterManagerClient.create(parameterManagerSettings)) {
+
+      // Step 1: Create a regional parameter.
+      // Build the parent name from the project.
+      LocationName location = LocationName.of(projectId, locationId);
+
+      // Specify the parameter format.
+      ParameterFormat format = ParameterFormat.JSON;
+      // Build the regional parameter to create.
+      Parameter parameter = Parameter.newBuilder().setFormat(format).build();
+
+      // Create the regional parameter.
+      Parameter createdParameter =
+          client.createParameter(location.toString(), parameter, parameterId);
+      System.out.printf(
+          "Created regional parameter %s with format %s\n",
+          createdParameter.getName(), createdParameter.getFormat());
+
+      // Step 2: Create a parameter version with JSON payload containing a secret reference.
+      // Build the parameter name.
+      ParameterName parameterName = ParameterName.of(projectId, locationId, parameterId);
+
+      String jsonPayload = "{\"username\": \"test-user\", \"host\": \"localhost\"}";
+      // Convert the JSON payload string to ByteString.
+      ByteString byteStringPayload = ByteString.copyFromUtf8(jsonPayload);
+
+      // Create the parameter version payload.
+      ParameterVersionPayload parameterVersionPayload =
+          ParameterVersionPayload.newBuilder().setData(byteStringPayload).build();
+
+      // Create the parameter version with the JSON payload.
+      ParameterVersion parameterVersion =
+          ParameterVersion.newBuilder().setPayload(parameterVersionPayload).build();
+
+      // Create the parameter version in the Parameter Manager.
+      ParameterVersion createdParameterVersion =
+          client.createParameterVersion(parameterName.toString(), parameterVersion, versionId);
+      System.out.printf(
+          "Created regional parameter version %s\n", createdParameterVersion.getName());
+
+      // Step 3: Render the parameter version to fetch and print both simple and rendered payloads.
+      // Build the parameter version name.
+      ParameterVersionName parameterVersionName =
+          ParameterVersionName.of(projectId, locationId, parameterId, versionId);
+
+      // Render the parameter version.
+      ParameterVersion response = client.getParameterVersion(parameterVersionName.toString());
+      System.out.printf(
+          "Retrieved regional parameter version %s with rendered payload: %s\n",
+          response.getName(), response.getPayload().getData().toStringUtf8());
+    }
+  }
+}
+// [END parametermanager_regional_quickstart]

--- a/parametermanager/src/test/java/parametermanager/QuickstartIT.java
+++ b/parametermanager/src/test/java/parametermanager/QuickstartIT.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parametermanager;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.client.util.Strings;
+import com.google.cloud.parametermanager.v1.ParameterManagerClient;
+import com.google.cloud.parametermanager.v1.ParameterName;
+import com.google.cloud.parametermanager.v1.ParameterVersionName;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.UUID;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+public class QuickstartIT {
+  private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static final String PARAMETER_ID = "java-quickstart-" + UUID.randomUUID();
+  private static final String VERSION_ID = "java-quickstart-" + UUID.randomUUID();
+
+  @BeforeClass
+  public static void beforeAll() {
+    Assert.assertFalse("missing GOOGLE_CLOUD_PROJECT", Strings.isNullOrEmpty(PROJECT_ID));
+  }
+
+  @AfterClass
+  public static void afterAll() throws Exception {
+    Assert.assertFalse("missing GOOGLE_CLOUD_PROJECT", Strings.isNullOrEmpty(PROJECT_ID));
+
+    try (ParameterManagerClient client = ParameterManagerClient.create()) {
+      ParameterVersionName parameterVersionName =
+          ParameterVersionName.of(PROJECT_ID, "global", PARAMETER_ID, VERSION_ID);
+      ParameterName parameterName = ParameterName.of(PROJECT_ID, "global", PARAMETER_ID);
+      client.deleteParameterVersion(parameterVersionName.toString());
+      client.deleteParameter(parameterName.toString());
+    } catch (com.google.api.gax.rpc.NotFoundException e) {
+      // Ignore not found error - parameter was already deleted
+    } catch (io.grpc.StatusRuntimeException e) {
+      if (e.getStatus().getCode() != io.grpc.Status.Code.NOT_FOUND) {
+        throw e;
+      }
+    }
+  }
+
+  @Test
+  public void quickstart_test() throws Exception {
+    PrintStream originalOut = System.out;
+    ByteArrayOutputStream redirected = new ByteArrayOutputStream();
+
+    System.setOut(new PrintStream(redirected));
+
+    try {
+      Quickstart.quickstart(PROJECT_ID, PARAMETER_ID, VERSION_ID);
+      assertThat(redirected.toString()).contains(
+              "{\"username\": \"test-user\", \"host\": \"localhost\"}");
+    } finally {
+      System.setOut(originalOut);
+    }
+  }
+}

--- a/parametermanager/src/test/java/parametermanager/regionalsamples/QuickstartIT.java
+++ b/parametermanager/src/test/java/parametermanager/regionalsamples/QuickstartIT.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parametermanager.regionalsamples;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.client.util.Strings;
+import com.google.cloud.parametermanager.v1.ParameterManagerClient;
+import com.google.cloud.parametermanager.v1.ParameterManagerSettings;
+import com.google.cloud.parametermanager.v1.ParameterName;
+import com.google.cloud.parametermanager.v1.ParameterVersionName;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.UUID;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+public class QuickstartIT {
+  private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static final String LOCATION_ID =
+          System.getenv().getOrDefault("GOOGLE_CLOUD_PROJECT_LOCATION", "us-central1");
+  private static final String PARAMETER_ID = "java-quickstart-" + UUID.randomUUID();
+  private static final String VERSION_ID = "java-quickstart-" + UUID.randomUUID();
+
+  @BeforeClass
+  public static void beforeAll() {
+    Assert.assertFalse("missing GOOGLE_CLOUD_PROJECT", Strings.isNullOrEmpty(PROJECT_ID));
+    Assert.assertFalse("missing GOOGLE_CLOUD_PROJECT_LOCATION", Strings.isNullOrEmpty(LOCATION_ID));
+  }
+
+  @AfterClass
+  public static void afterAll() throws Exception {
+    Assert.assertFalse("missing GOOGLE_CLOUD_PROJECT", Strings.isNullOrEmpty(PROJECT_ID));
+    Assert.assertFalse("missing GOOGLE_CLOUD_PROJECT_LOCATION", Strings.isNullOrEmpty(LOCATION_ID));
+
+    // Endpoint to call the regional parameter manager server
+    String apiEndpoint = String.format("parametermanager.%s.rep.googleapis.com:443", LOCATION_ID);
+    ParameterManagerSettings parameterManagerSettings =
+        ParameterManagerSettings.newBuilder().setEndpoint(apiEndpoint).build();
+
+    try (ParameterManagerClient client = ParameterManagerClient.create(parameterManagerSettings)) {
+      ParameterVersionName parameterVersionName =
+          ParameterVersionName.of(PROJECT_ID, LOCATION_ID, PARAMETER_ID, VERSION_ID);
+      ParameterName parameterName = ParameterName.of(PROJECT_ID, LOCATION_ID, PARAMETER_ID);
+      client.deleteParameterVersion(parameterVersionName.toString());
+      client.deleteParameter(parameterName.toString());
+    } catch (com.google.api.gax.rpc.NotFoundException e) {
+      // Ignore not found error - parameter was already deleted
+    } catch (io.grpc.StatusRuntimeException e) {
+      if (e.getStatus().getCode() != io.grpc.Status.Code.NOT_FOUND) {
+        throw e;
+      }
+    }
+  }
+
+  @Test
+  public void quickstart_test() throws Exception {
+    PrintStream originalOut = System.out;
+    ByteArrayOutputStream redirected = new ByteArrayOutputStream();
+
+    System.setOut(new PrintStream(redirected));
+
+    try {
+      RegionalQuickstart.regionalQuickstart(
+          PROJECT_ID, LOCATION_ID, PARAMETER_ID, VERSION_ID);
+      assertThat(redirected.toString()).contains(
+              "{\"username\": \"test-user\", \"host\": \"localhost\"}");
+    } finally {
+      System.setOut(originalOut);
+    }
+  }
+}


### PR DESCRIPTION
## Description

Added quickstart samples for using parameter manager in global and in specified region.
Also added required tests for it.

## Checklist

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [X] `pom.xml` parent set to latest `shared-configuration`
- [X] Appropriate changes to README are included in PR
- [X] These samples need a new **API enabled** in testing projects to pass (let us know which ones) - This requires [Parameter manager API](https://cloud.google.com/secret-manager/parameter-manager/docs/prepare-environment) to be enabled
- [X] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones) - This requires `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_PROJECT_LOCATION` to be set.
- [X] **Tests** pass:   `mvn clean verify` **required**
- [X] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [X] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [x] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [X] Please **merge** this PR for me once it is approved