### PR TITLE
fix: sync setting for Java header check

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -39,3 +39,4 @@ sourceFileExtensions:
 ignoreFiles:
   - '.github/auto-label.yaml'
   - '.github/sync-repo-settings.yaml'
+ignoreLicenseYear: true


### PR DESCRIPTION
## Description

existing copyright headers should be maintained; we often shift code from one place to another and it can appear as if the file is a new file which requires current year which is incorrect. this fixes this problem. 

- [X] Please **merge** this PR for me once it is approved
