### PR TITLE
feat(modelarmor): Added sample for creating template with Advanced SDP settings

### DIFF
--- a/modelarmor/pom.xml
+++ b/modelarmor/pom.xml
@@ -1,0 +1,83 @@
+<!--
+ Copyright 2025 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.modelarmor</groupId>
+  <artifactId>modelarmor-samples</artifactId>
+  <packaging>jar</packaging>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.2.0</version>
+  </parent>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.59.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-modelarmor</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-dlp</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+    </dependency>
+
+    <!-- test dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.4.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/modelarmor/src/main/java/modelarmor/CreateTemplateWithAdvancedSdp.java
+++ b/modelarmor/src/main/java/modelarmor/CreateTemplateWithAdvancedSdp.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package modelarmor;
+
+// [START modelarmor_create_template_with_advanced_sdp]
+
+import com.google.cloud.modelarmor.v1.CreateTemplateRequest;
+import com.google.cloud.modelarmor.v1.FilterConfig;
+import com.google.cloud.modelarmor.v1.LocationName;
+import com.google.cloud.modelarmor.v1.ModelArmorClient;
+import com.google.cloud.modelarmor.v1.ModelArmorSettings;
+import com.google.cloud.modelarmor.v1.SdpAdvancedConfig;
+import com.google.cloud.modelarmor.v1.SdpFilterSettings;
+import com.google.cloud.modelarmor.v1.Template;
+import com.google.privacy.dlp.v2.DeidentifyTemplateName;
+import com.google.privacy.dlp.v2.InspectTemplateName;
+import java.io.IOException;
+
+public class CreateTemplateWithAdvancedSdp {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+
+    // Specify the Google Project ID.
+    String projectId = "your-project-id";
+    // Specify the location ID. For example, us-central1.
+    String locationId = "your-location-id";
+    // Specify the template ID.
+    String templateId = "your-template-id";
+    // Specify the Inspect template ID.
+    String inspectTemplateId = "your-inspect-template-id";
+    // Specify the Deidentify template ID.
+    String deidentifyTemplateId = "your-deidentify-template-id";
+
+    createTemplateWithAdvancedSdp(projectId, locationId, templateId, inspectTemplateId,
+        deidentifyTemplateId);
+  }
+
+  public static Template createTemplateWithAdvancedSdp(String projectId, String locationId,
+      String templateId, String inspectTemplateId, String deidentifyTemplateId) throws IOException {
+
+    // Construct the API endpoint URL.
+    String apiEndpoint = String.format("modelarmor.%s.rep.googleapis.com:443", locationId);
+    ModelArmorSettings modelArmorSettings = ModelArmorSettings.newBuilder().setEndpoint(apiEndpoint)
+        .build();
+
+    // Initialize the client that will be used to send requests. This client
+    // only needs to be created once, and can be reused for multiple requests.
+    try (ModelArmorClient client = ModelArmorClient.create(modelArmorSettings)) {
+      String parent = LocationName.of(projectId, locationId).toString();
+
+      String inspectTemplateName = InspectTemplateName
+          .ofProjectLocationInspectTemplateName(projectId, locationId, inspectTemplateId)
+          .toString();
+
+      String deidentifyTemplateName = DeidentifyTemplateName
+          .ofProjectLocationDeidentifyTemplateName(projectId, locationId, deidentifyTemplateId)
+          .toString();
+
+      // Build the Model Armor template with Advanced SDP Filter.
+
+      // Note: If you specify only Inspect template, Model Armor reports the filter matches if
+      // sensitive data is detected. If you specify Inspect template and De-identify template, Model
+      // Armor returns the de-identified sensitive data and sanitized version of prompts or
+      // responses in the deidentifyResult.data.text field of the finding.
+      SdpAdvancedConfig advancedSdpConfig =
+          SdpAdvancedConfig.newBuilder()
+              .setInspectTemplate(inspectTemplateName)
+              .setDeidentifyTemplate(deidentifyTemplateName)
+              .build();
+
+      SdpFilterSettings sdpSettings = SdpFilterSettings.newBuilder()
+          .setAdvancedConfig(advancedSdpConfig).build();
+
+      FilterConfig modelArmorFilter = FilterConfig.newBuilder().setSdpSettings(sdpSettings).build();
+
+      Template template = Template.newBuilder().setFilterConfig(modelArmorFilter).build();
+
+      CreateTemplateRequest request = CreateTemplateRequest.newBuilder()
+          .setParent(parent)
+          .setTemplateId(templateId)
+          .setTemplate(template)
+          .build();
+
+      Template createdTemplate = client.createTemplate(request);
+      System.out.println("Created template with Advanced SDP filter: " + createdTemplate.getName());
+
+      return createdTemplate;
+    }
+  }
+}
+// [END modelarmor_create_template_with_advanced_sdp]

--- a/modelarmor/src/test/java/modelarmor/SnippetsIT.java
+++ b/modelarmor/src/test/java/modelarmor/SnippetsIT.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package modelarmor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.google.api.gax.rpc.NotFoundException;
+import com.google.cloud.dlp.v2.DlpServiceClient;
+import com.google.cloud.modelarmor.v1.ModelArmorClient;
+import com.google.cloud.modelarmor.v1.ModelArmorSettings;
+import com.google.cloud.modelarmor.v1.SdpAdvancedConfig;
+import com.google.cloud.modelarmor.v1.Template;
+import com.google.cloud.modelarmor.v1.TemplateName;
+import com.google.privacy.dlp.v2.CreateDeidentifyTemplateRequest;
+import com.google.privacy.dlp.v2.CreateInspectTemplateRequest;
+import com.google.privacy.dlp.v2.DeidentifyConfig;
+import com.google.privacy.dlp.v2.DeidentifyTemplate;
+import com.google.privacy.dlp.v2.DeidentifyTemplateName;
+import com.google.privacy.dlp.v2.InfoType;
+import com.google.privacy.dlp.v2.InfoTypeTransformations;
+import com.google.privacy.dlp.v2.InfoTypeTransformations.InfoTypeTransformation;
+import com.google.privacy.dlp.v2.InspectConfig;
+import com.google.privacy.dlp.v2.InspectTemplate;
+import com.google.privacy.dlp.v2.InspectTemplateName;
+import com.google.privacy.dlp.v2.LocationName;
+import com.google.privacy.dlp.v2.PrimitiveTransformation;
+import com.google.privacy.dlp.v2.ReplaceValueConfig;
+import com.google.privacy.dlp.v2.Value;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Integration (system) tests for {@link Snippets}. */
+@RunWith(JUnit4.class)
+public class SnippetsIT {
+  private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static final String LOCATION_ID = System.getenv()
+      .getOrDefault("GOOGLE_CLOUD_PROJECT_LOCATION", "us-central1");
+  private static final String MA_ENDPOINT =
+      String.format("modelarmor.%s.rep.googleapis.com:443", LOCATION_ID);
+  private static String TEST_TEMPLATE_ID;
+  private static String TEST_INSPECT_TEMPLATE_ID;
+  private static String TEST_DEIDENTIFY_TEMPLATE_ID;
+  private static String TEST_TEMPLATE_NAME;
+  private static String TEST_INSPECT_TEMPLATE_NAME;
+  private static String TEST_DEIDENTIFY_TEMPLATE_NAME;
+  private ByteArrayOutputStream stdOut;
+
+  // Check if the required environment variables are set.
+  private static String requireEnvVar(String varName) {
+    String value = System.getenv(varName);
+    assertNotNull("Environment variable " + varName + " is required to run these tests.",
+        System.getenv(varName));
+    return value;
+  }
+
+  @BeforeClass
+  public static void beforeAll() throws IOException {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  
+    TEST_TEMPLATE_ID = randomId();
+    TEST_INSPECT_TEMPLATE_ID = randomId();
+    TEST_DEIDENTIFY_TEMPLATE_ID = randomId();
+    TEST_TEMPLATE_NAME = TemplateName.of(PROJECT_ID, LOCATION_ID, TEST_TEMPLATE_ID).toString();
+    TEST_INSPECT_TEMPLATE_NAME = InspectTemplateName
+        .ofProjectLocationInspectTemplateName(PROJECT_ID, LOCATION_ID, TEST_INSPECT_TEMPLATE_ID)
+        .toString();
+    TEST_DEIDENTIFY_TEMPLATE_NAME = DeidentifyTemplateName.ofProjectLocationDeidentifyTemplateName(
+        PROJECT_ID, LOCATION_ID, TEST_DEIDENTIFY_TEMPLATE_ID).toString();
+
+    createInspectTemplate(TEST_INSPECT_TEMPLATE_ID);
+    createDeidentifyTemplate(TEST_DEIDENTIFY_TEMPLATE_ID);
+  }
+
+  @AfterClass
+  public static void afterAll() throws IOException {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+
+    try {
+      deleteModelArmorTemplate(TEST_TEMPLATE_ID);
+    } catch (NotFoundException e) {
+      // Ignore not found error - template already deleted.
+    }
+    deleteSdpTemplates();
+  }
+
+  @Before
+  public void beforeEach() {
+    stdOut = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(stdOut));
+  }
+
+  @After
+  public void afterEach() throws IOException {
+    stdOut = null;
+    System.setOut(null);
+  }
+
+  private static String randomId() {
+    Random random = new Random();
+    return "java-ma-" + random.nextLong();
+  }
+
+  private static void deleteModelArmorTemplate(String templateId) throws IOException {
+    ModelArmorSettings modelArmorSettings = ModelArmorSettings.newBuilder().setEndpoint(MA_ENDPOINT)
+        .build();
+
+    try (ModelArmorClient client = ModelArmorClient.create(modelArmorSettings)) {
+      String name = TemplateName.of(PROJECT_ID, LOCATION_ID, templateId).toString();
+      client.deleteTemplate(name);
+    }
+  }
+
+  private static void deleteSdpTemplates() throws IOException {
+    try (DlpServiceClient dlpServiceClient = DlpServiceClient.create()) {
+      dlpServiceClient.deleteInspectTemplate(TEST_INSPECT_TEMPLATE_NAME);
+      dlpServiceClient.deleteDeidentifyTemplate(TEST_DEIDENTIFY_TEMPLATE_NAME);
+    }
+  }
+
+  private static InspectTemplate createInspectTemplate(String templateId) throws IOException {
+    try (DlpServiceClient dlpServiceClient = DlpServiceClient.create()) {
+      // Info Types: https://cloud.google.com/sensitive-data-protection/docs/infotypes-reference
+      List<InfoType> infoTypes = Stream
+          .of("PHONE_NUMBER", "EMAIL_ADDRESS", "US_INDIVIDUAL_TAXPAYER_IDENTIFICATION_NUMBER")
+          .map(it -> InfoType.newBuilder().setName(it).build())
+          .collect(Collectors.toList());
+
+      InspectConfig inspectConfig = InspectConfig.newBuilder()
+          .addAllInfoTypes(infoTypes)
+          .build();
+
+      InspectTemplate inspectTemplate = InspectTemplate.newBuilder()
+          .setInspectConfig(inspectConfig)
+          .build();
+
+      CreateInspectTemplateRequest createInspectTemplateRequest = 
+          CreateInspectTemplateRequest.newBuilder()
+            .setParent(LocationName.of(PROJECT_ID, LOCATION_ID).toString())
+            .setTemplateId(templateId)
+            .setInspectTemplate(inspectTemplate)
+            .build();
+
+      return dlpServiceClient.createInspectTemplate(createInspectTemplateRequest);
+    }
+  }
+
+  private static DeidentifyTemplate createDeidentifyTemplate(String templateId) throws IOException {
+    try (DlpServiceClient dlpServiceClient = DlpServiceClient.create()) {
+      // Specify replacement string to be used for the finding.
+      ReplaceValueConfig replaceValueConfig = ReplaceValueConfig.newBuilder()
+          .setNewValue(Value.newBuilder().setStringValue("[REDACTED]").build())
+          .build();
+
+      // Define type of deidentification.
+      PrimitiveTransformation primitiveTransformation = PrimitiveTransformation.newBuilder()
+          .setReplaceConfig(replaceValueConfig)
+          .build();
+
+      // Associate deidentification type with info type.
+      InfoTypeTransformation transformation = InfoTypeTransformation.newBuilder()
+          .setPrimitiveTransformation(primitiveTransformation)
+          .build();
+
+      // Construct the configuration for the Redact request and list all desired transformations.
+      DeidentifyConfig redactConfig = DeidentifyConfig.newBuilder()
+          .setInfoTypeTransformations(
+            InfoTypeTransformations.newBuilder()
+            .addTransformations(transformation))
+          .build();
+
+      DeidentifyTemplate deidentifyTemplate = DeidentifyTemplate.newBuilder()
+          .setDeidentifyConfig(redactConfig)
+          .build();
+
+      CreateDeidentifyTemplateRequest createDeidentifyTemplateRequest = 
+          CreateDeidentifyTemplateRequest.newBuilder()
+            .setParent(LocationName.of(PROJECT_ID, LOCATION_ID).toString())
+            .setTemplateId(templateId)
+            .setDeidentifyTemplate(deidentifyTemplate)
+            .build();
+
+      return dlpServiceClient.createDeidentifyTemplate(createDeidentifyTemplateRequest);
+    }
+  }
+
+  @Test
+  public void testCreateModelArmorTemplateWithAdvancedSDP() throws IOException {
+
+    Template createdTemplate = CreateTemplateWithAdvancedSdp.createTemplateWithAdvancedSdp(
+        PROJECT_ID, LOCATION_ID, TEST_TEMPLATE_ID,
+        TEST_INSPECT_TEMPLATE_ID, TEST_DEIDENTIFY_TEMPLATE_ID);
+
+    assertEquals(TEST_TEMPLATE_NAME, createdTemplate.getName());
+
+    SdpAdvancedConfig advancedSdpConfig = createdTemplate.getFilterConfig().getSdpSettings()
+        .getAdvancedConfig();
+
+    assertEquals(TEST_INSPECT_TEMPLATE_NAME, advancedSdpConfig.getInspectTemplate());
+    assertEquals(TEST_DEIDENTIFY_TEMPLATE_NAME, advancedSdpConfig.getDeidentifyTemplate());
+  }
+}


### PR DESCRIPTION
Added sample for creating template with Advanced SDP settings

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [x] These samples need a new **API enabled** in testing projects to pass (Model Armor API)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
