### PR TITLE
feat(parametermanager): Added samples for kms_key field in regional parameter

### DIFF
--- a/parametermanager/pom.xml
+++ b/parametermanager/pom.xml
@@ -43,7 +43,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>26.54.0</version>
+                <version>26.60.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -89,6 +89,11 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-iam-policy</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-kms</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/parametermanager/src/main/java/parametermanager/regionalsamples/CreateRegionalParamWithKmsKey.java
+++ b/parametermanager/src/main/java/parametermanager/regionalsamples/CreateRegionalParamWithKmsKey.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parametermanager.regionalsamples;
+
+// [START parametermanager_create_regional_param_with_kms_key]
+
+import com.google.cloud.parametermanager.v1.LocationName;
+import com.google.cloud.parametermanager.v1.Parameter;
+import com.google.cloud.parametermanager.v1.ParameterManagerClient;
+import com.google.cloud.parametermanager.v1.ParameterManagerSettings;
+import java.io.IOException;
+
+/**
+ * Example class to create a new regional parameter with provided KMS 
+ * key using the Parameter Manager SDK for GCP.
+ */
+public class CreateRegionalParamWithKmsKey {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String locationId = "your-location-id";
+    String parameterId = "your-parameter-id";
+    String kmsKeyName = "your-kms-key";
+
+    // Call the method to create a regional parameter with the specified kms key.
+    createRegionalParameterWithKmsKey(projectId, locationId, parameterId, kmsKeyName);
+  }
+
+  // This is an example snippet for creating a new parameter with a specific format.
+  public static Parameter createRegionalParameterWithKmsKey(
+      String projectId, String locationId, String parameterId, String kmsKeyName)
+      throws IOException {
+
+    // Endpoint to call the regional parameter manager server
+    String apiEndpoint = String.format("parametermanager.%s.rep.googleapis.com:443", locationId);
+    ParameterManagerSettings parameterManagerSettings =
+        ParameterManagerSettings.newBuilder().setEndpoint(apiEndpoint).build();
+
+    // Initialize the client that will be used to send requests. This client only needs to be
+    // created once, and can be reused for multiple requests.
+    try (ParameterManagerClient client = ParameterManagerClient.create(parameterManagerSettings)) {
+
+      // Build the parent name from the project.
+      LocationName location = LocationName.of(projectId, locationId);
+
+      // Build the parameter to create with the provided format.
+      Parameter parameter = Parameter.newBuilder().setKmsKey(kmsKeyName).build();
+
+      // Create the parameter.
+      Parameter createdParameter =
+          client.createParameter(location.toString(), parameter, parameterId);
+      System.out.printf(
+          "Created regional parameter %s with kms key %s\n",
+          createdParameter.getName(), createdParameter.getKmsKey());
+
+      return createdParameter;
+    }
+  }
+}
+// [END parametermanager_create_regional_param_with_kms_key]

--- a/parametermanager/src/main/java/parametermanager/regionalsamples/RemoveRegionalParamKmsKey.java
+++ b/parametermanager/src/main/java/parametermanager/regionalsamples/RemoveRegionalParamKmsKey.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parametermanager.regionalsamples;
+
+// [START parametermanager_remove_regional_param_kms_key]
+
+import com.google.cloud.parametermanager.v1.Parameter;
+import com.google.cloud.parametermanager.v1.ParameterManagerClient;
+import com.google.cloud.parametermanager.v1.ParameterManagerSettings;
+import com.google.cloud.parametermanager.v1.ParameterName;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.util.FieldMaskUtil;
+import java.io.IOException;
+
+/**
+ * This class demonstrates how to change the kms key of a parameter 
+ * using the Parameter Manager SDK for GCP.
+ */
+public class RemoveRegionalParamKmsKey {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String locationId = "your-location-id";
+    String parameterId = "your-parameter-id";
+
+    // Call the method to remove kms key of a parameter.
+    removeRegionalParamKmsKey(projectId, locationId, parameterId);
+  }
+
+  // This is an example snippet for updating the kms key of a parameter.
+  public static Parameter removeRegionalParamKmsKey(
+      String projectId, String locationId, String parameterId) throws IOException {
+
+    // Endpoint to call the regional parameter manager server
+    String apiEndpoint = String.format("parametermanager.%s.rep.googleapis.com:443", locationId);
+    ParameterManagerSettings parameterManagerSettings =
+        ParameterManagerSettings.newBuilder().setEndpoint(apiEndpoint).build();
+
+    // Initialize the client that will be used to send requests. This client only needs to be
+    // created once, and can be reused for multiple requests.
+    try (ParameterManagerClient client = ParameterManagerClient.create(parameterManagerSettings)) {
+
+      // Build the parameter name.
+      ParameterName name = ParameterName.of(projectId, locationId, parameterId);
+
+      // Remove kms key of a parameter  .
+      Parameter parameter = Parameter.newBuilder()
+          .setName(name.toString())
+          .clearKmsKey()
+          .build();
+
+      // Build the field mask for the kms_key field.
+      FieldMask fieldMask = FieldMaskUtil.fromString("kms_key");
+
+      // Update the parameter kms key.
+      Parameter updatedParameter = client.updateParameter(parameter, fieldMask);
+      System.out.printf(
+          "Removed kms key for regional parameter %s\n",
+          updatedParameter.getName());
+
+      return updatedParameter;
+    }
+  }
+}
+// [END parametermanager_remove_regional_param_kms_key]

--- a/parametermanager/src/main/java/parametermanager/regionalsamples/UpdateRegionalParamKmsKey.java
+++ b/parametermanager/src/main/java/parametermanager/regionalsamples/UpdateRegionalParamKmsKey.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parametermanager.regionalsamples;
+
+// [START parametermanager_update_regional_param_kms_key]
+
+import com.google.cloud.parametermanager.v1.Parameter;
+import com.google.cloud.parametermanager.v1.ParameterManagerClient;
+import com.google.cloud.parametermanager.v1.ParameterManagerSettings;
+import com.google.cloud.parametermanager.v1.ParameterName;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.util.FieldMaskUtil;
+import java.io.IOException;
+
+/**
+ * This class demonstrates how to change the kms key of a regional 
+ * parameter using the Parameter Manager SDK for GCP.
+ */
+public class UpdateRegionalParamKmsKey {
+
+  public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String locationId = "your-location-id";
+    String parameterId = "your-parameter-id";
+    String kmsKeyName = "your-kms-key";
+
+    // Call the method to update kms key of a parameter.
+    updateRegionalParamKmsKey(projectId, locationId, parameterId, kmsKeyName);
+  }
+
+  // This is an example snippet for updating the kms key of a parameter.
+  public static Parameter updateRegionalParamKmsKey(
+      String projectId, String locationId, String parameterId, String kmsKeyName)
+      throws IOException {
+
+    // Endpoint to call the regional parameter manager server
+    String apiEndpoint = String.format("parametermanager.%s.rep.googleapis.com:443", locationId);
+    ParameterManagerSettings parameterManagerSettings =
+        ParameterManagerSettings.newBuilder().setEndpoint(apiEndpoint).build();
+
+    // Initialize the client that will be used to send requests. This client only needs to be
+    // created once, and can be reused for multiple requests.
+    try (ParameterManagerClient client = ParameterManagerClient.create(parameterManagerSettings)) {
+
+      // Build the parameter name.
+      ParameterName name = ParameterName.of(projectId, locationId, parameterId);
+
+      // Set the parameter kms key to update.
+      Parameter parameter = Parameter.newBuilder()
+          .setName(name.toString())
+          .setKmsKey(kmsKeyName)
+          .build();
+
+      // Build the field mask for the kms_key field.
+      FieldMask fieldMask = FieldMaskUtil.fromString("kms_key");
+
+      // Update the parameter kms key.
+      Parameter updatedParameter = client.updateParameter(parameter, fieldMask);
+      System.out.printf(
+          "Updated regional parameter %s with kms key %s\n",
+          updatedParameter.getName(), updatedParameter.getKmsKey());
+
+      return updatedParameter;
+    }
+  }
+}
+// [END parametermanager_update_regional_param_kms_key]


### PR DESCRIPTION
## Description

Added samples for kms_key field in regional parameter using Parameter manager SDK

#### Sample List (regional): 

1. create_regional_param_with_kms_key
2. update_regional_param_kms_key
3. remove_regional_param_kms_key

Added required Tests for the same.

## Checklist

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [X] `pom.xml` parent set to latest `shared-configuration`
- [X] Appropriate changes to README are included in PR
- [X] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [X] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [X] **Tests** pass:   `mvn clean verify` **required**
- [X] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [X] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [X] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [X] Please **merge** this PR for me once it is approved
