### PR TITLE
chore(secretmanager): Added samples for delayed destroy

### DIFF
--- a/secretmanager/src/main/java/secretmanager/CreateSecretWithDelayedDestroy.java
+++ b/secretmanager/src/main/java/secretmanager/CreateSecretWithDelayedDestroy.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package secretmanager;
+
+// [START secretmanager_create_secret_with_delayed_destroy]
+
+import com.google.cloud.secretmanager.v1.ProjectName;
+import com.google.cloud.secretmanager.v1.Replication;
+import com.google.cloud.secretmanager.v1.Secret;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.protobuf.Duration;
+import java.io.IOException;
+
+public class CreateSecretWithDelayedDestroy {
+
+  public static void createSecretWithDelayedDestroy() throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String secretId = "your-secret-id";
+    Integer versionDestroyTtl = 86400;
+    createSecretWithDelayedDestroy(projectId, secretId, versionDestroyTtl);
+  }
+
+  // Create secret with version destroy TTL.
+  public static void createSecretWithDelayedDestroy(
+      String projectId,
+      String secretId,
+      Integer versionDestroyTtl)
+      throws IOException {
+    // Initialize the client that will be used to send requests.
+    try (SecretManagerServiceClient client = SecretManagerServiceClient.create()) {
+      // Build the parent name from the project.
+      ProjectName projectName = ProjectName.of(projectId);
+
+      // Build the secret to create.
+      Secret secret =
+          Secret.newBuilder()
+              .setReplication(
+                  Replication.newBuilder()
+                      .setAutomatic(Replication.Automatic.newBuilder().build())
+                      .build())
+              .setVersionDestroyTtl(Duration.newBuilder().setSeconds(versionDestroyTtl))
+              .build();
+
+      // Create the secret.
+      Secret createdSecret = client.createSecret(projectName, secretId, secret);
+      System.out.printf("Created secret with version destroy ttl %s\n", createdSecret.getName());
+    }
+  }
+}
+// [END secretmanager_create_secret_with_delayed_destroy]

--- a/secretmanager/src/main/java/secretmanager/DisableSecretDelayedDestroy.java
+++ b/secretmanager/src/main/java/secretmanager/DisableSecretDelayedDestroy.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package secretmanager;
+
+// [START secretmanager_disable_secret_delayed_destroy]
+
+import com.google.cloud.secretmanager.v1.Secret;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretName;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.util.FieldMaskUtil;
+import java.io.IOException;
+
+public class DisableSecretDelayedDestroy {
+
+  public static void disableSecretDelayedDestroy() throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String secretId = "your-secret-id";
+    disableSecretDelayedDestroy(projectId, secretId);
+  }
+
+  // Disables delayed destroy for a secret.
+  public static void disableSecretDelayedDestroy(
+      String projectId,
+      String secretId)
+      throws IOException {
+    // Initialize the client that will be used to send requests.
+    try (SecretManagerServiceClient client = SecretManagerServiceClient.create()) {
+      // Build the parent name from the project and secret.
+      SecretName secretName = SecretName.of(projectId, secretId);
+
+      // Build the secret to update.
+      Secret secret =
+          Secret.newBuilder()
+              .setName(secretName.toString())
+              .build();
+
+      // Build the field mask.
+      FieldMask fieldMask = FieldMaskUtil.fromString("version_destroy_ttl");
+
+      // Update the secret.
+      Secret updatedSecret = client.updateSecret(secret, fieldMask);
+      System.out.printf("Updated secret %s\n", updatedSecret.getName());
+    }
+  }
+}
+// [END secretmanager_disable_secret_delayed_destroy]

--- a/secretmanager/src/main/java/secretmanager/UpdateSecretWithDelayedDestroy.java
+++ b/secretmanager/src/main/java/secretmanager/UpdateSecretWithDelayedDestroy.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package secretmanager;
+
+// [START secretmanager_update_secret_with_delayed_destroy]
+
+import com.google.cloud.secretmanager.v1.Secret;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretName;
+import com.google.protobuf.Duration;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.util.FieldMaskUtil;
+import java.io.IOException;
+
+public class UpdateSecretWithDelayedDestroy {
+
+  public static void updateSecretWithDelayedDestroy() throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String secretId = "your-secret-id";
+    Integer versionDestroyTtl = 86400;
+    updateSecretWithDelayedDestroy(projectId, secretId, versionDestroyTtl);
+  }
+
+  // Update secret with version destroy TTL.
+  public static void updateSecretWithDelayedDestroy(
+      String projectId,
+      String secretId,
+      Integer versionDestroyTtl)
+      throws IOException {
+    // Initialize the client that will be used to send requests.
+    try (SecretManagerServiceClient client = SecretManagerServiceClient.create()) {
+      // Build the parent name from the project and secret.
+      SecretName secretName = SecretName.of(projectId, secretId);
+
+      // Build the secret to update.
+      Secret secret =
+          Secret.newBuilder()
+              .setName(secretName.toString())
+              .setVersionDestroyTtl(Duration.newBuilder().setSeconds(versionDestroyTtl))
+              .build();
+
+      // Build the field mask.
+      FieldMask fieldMask = FieldMaskUtil.fromString("version_destroy_ttl");
+
+      // Update the secret.
+      Secret updatedSecret = client.updateSecret(secret, fieldMask);
+      System.out.printf("Updated secret %s\n", updatedSecret.getName());
+    }
+  }
+}
+// [END secretmanager_update_secret_with_delayed_destroy]

--- a/secretmanager/src/main/java/secretmanager/regionalsamples/CreateRegionalSecretWithDelayedDestroy.java
+++ b/secretmanager/src/main/java/secretmanager/regionalsamples/CreateRegionalSecretWithDelayedDestroy.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package secretmanager.regionalsamples;
+
+// [START secretmanager_create_regional_secret_with_delayed_destroy]
+
+import com.google.cloud.secretmanager.v1.LocationName;
+import com.google.cloud.secretmanager.v1.Secret;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceSettings;
+import com.google.protobuf.Duration;
+import java.io.IOException;
+
+public class CreateRegionalSecretWithDelayedDestroy {
+
+  public static void createRegionalSecretWithDelayedDestroy() throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String locationId = "your-location-id";
+    String secretId = "your-secret-id";
+    Integer versionDestroyTtl = 86400;
+    createRegionalSecretWithDelayedDestroy(projectId, secretId, locationId, versionDestroyTtl);
+  }
+
+  // Create secret with version destroy TTL.
+  public static void createRegionalSecretWithDelayedDestroy(
+      String projectId,
+      String locationId,
+      String secretId,
+      Integer versionDestroyTtl)
+      throws IOException {
+    // Endpoint to call the regional secret manager sever
+    String apiEndpoint = String.format("secretmanager.%s.rep.googleapis.com:443", locationId);
+    SecretManagerServiceSettings secretManagerServiceSettings =
+        SecretManagerServiceSettings.newBuilder().setEndpoint(apiEndpoint).build();
+
+    // Initialize the client that will be used to send requests.
+    try (SecretManagerServiceClient client =
+             SecretManagerServiceClient.create(secretManagerServiceSettings)) {
+      // Build the parent name from the project.
+      LocationName locationName = LocationName.of(projectId, locationId);
+
+      // Build the secret to create.
+      Secret secret =
+          Secret.newBuilder()
+              .setVersionDestroyTtl(Duration.newBuilder().setSeconds(versionDestroyTtl))
+              .build();
+
+      // Create the secret.
+      Secret createdSecret = client.createSecret(locationName, secretId, secret);
+      System.out.printf("Created secret with version destroy ttl %s\n", createdSecret.getName());
+    }
+  }
+}
+// [END secretmanager_create_regional_secret_with_delayed_destroy]

--- a/secretmanager/src/main/java/secretmanager/regionalsamples/DisableRegionalSecretDelayedDestroy.java
+++ b/secretmanager/src/main/java/secretmanager/regionalsamples/DisableRegionalSecretDelayedDestroy.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package secretmanager.regionalsamples;
+
+// [START secretmanager_disable_regional_secret_delayed_destroy]
+
+import com.google.cloud.secretmanager.v1.Secret;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceSettings;
+import com.google.cloud.secretmanager.v1.SecretName;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.util.FieldMaskUtil;
+import java.io.IOException;
+
+public class DisableRegionalSecretDelayedDestroy {
+
+  public static void disableRegionalSecretDelayedDestroy() throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String locationId = "your-location-id";
+    String secretId = "your-secret-id";
+    disableRegionalSecretDelayedDestroy(projectId, locationId, secretId);
+  }
+
+  // Disables the secret's delayed destroy.
+  public static void disableRegionalSecretDelayedDestroy(
+      String projectId,
+      String locationId,
+      String secretId)
+      throws IOException {
+    // Endpoint to call the regional secret manager sever
+    String apiEndpoint = String.format("secretmanager.%s.rep.googleapis.com:443", locationId);
+    SecretManagerServiceSettings secretManagerServiceSettings =
+        SecretManagerServiceSettings.newBuilder().setEndpoint(apiEndpoint).build();
+
+    // Initialize the client that will be used to send requests.
+    try (SecretManagerServiceClient client =
+             SecretManagerServiceClient.create(secretManagerServiceSettings)) {
+      // Build the parent name from the project and secret.
+      SecretName secretName =
+          SecretName.ofProjectLocationSecretName(projectId, locationId, secretId);
+
+      // Build the secret to update.
+      Secret secret =
+          Secret.newBuilder()
+              .setName(secretName.toString())
+              .build();
+
+      // Build the field mask.
+      FieldMask fieldMask = FieldMaskUtil.fromString("version_destroy_ttl");
+
+      // Update the secret.
+      Secret updatedSecret = client.updateSecret(secret, fieldMask);
+      System.out.printf("Updated secret %s\n", updatedSecret.getName());
+    }
+  }
+}
+// [END secretmanager_disable_regional_secret_delayed_destroy]

--- a/secretmanager/src/main/java/secretmanager/regionalsamples/UpdateRegionalSecretWithDelayedDestroy.java
+++ b/secretmanager/src/main/java/secretmanager/regionalsamples/UpdateRegionalSecretWithDelayedDestroy.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package secretmanager.regionalsamples;
+
+// [START secretmanager_update_regional_secret_with_delayed_destroy]
+
+import com.google.cloud.secretmanager.v1.Secret;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceSettings;
+import com.google.cloud.secretmanager.v1.SecretName;
+import com.google.protobuf.Duration;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.util.FieldMaskUtil;
+import java.io.IOException;
+
+public class UpdateRegionalSecretWithDelayedDestroy {
+
+  public static void updateRegionalSecretWithDelayedDestroy() throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String locationId = "your-location-id";
+    String secretId = "your-secret-id";
+    Integer versionDestroyTtl = 86400;
+    updateRegionalSecretWithDelayedDestroy(projectId, locationId, secretId, versionDestroyTtl);
+  }
+
+  // Update secret with version destroy TTL.
+  public static void updateRegionalSecretWithDelayedDestroy(
+      String projectId,
+      String locationId,
+      String secretId,
+      Integer versionDestroyTtl)
+      throws IOException {
+    // Endpoint to call the regional secret manager sever
+    String apiEndpoint = String.format("secretmanager.%s.rep.googleapis.com:443", locationId);
+    SecretManagerServiceSettings secretManagerServiceSettings =
+        SecretManagerServiceSettings.newBuilder().setEndpoint(apiEndpoint).build();
+
+    // Initialize the client that will be used to send requests.
+    try (SecretManagerServiceClient client =
+             SecretManagerServiceClient.create(secretManagerServiceSettings)) {
+      // Build the parent name from the project and secret.
+      SecretName secretName =
+          SecretName.ofProjectLocationSecretName(projectId, locationId, secretId);
+
+      // Build the secret to update.
+      Secret secret =
+          Secret.newBuilder()
+              .setName(secretName.toString())
+              .setVersionDestroyTtl(Duration.newBuilder().setSeconds(versionDestroyTtl))
+              .build();
+
+      // Build the field mask.
+      FieldMask fieldMask = FieldMaskUtil.fromString("version_destroy_ttl");
+
+      // Update the secret.
+      Secret updatedSecret = client.updateSecret(secret, fieldMask);
+      System.out.printf("Updated secret %s\n", updatedSecret.getName());
+    }
+  }
+}
+// [END secretmanager_update_regional_secret_with_delayed_destroy]

--- a/secretmanager/src/test/java/secretmanager/SnippetsIT.java
+++ b/secretmanager/src/test/java/secretmanager/SnippetsIT.java
@@ -89,7 +89,9 @@ public class SnippetsIT {
   private static Secret TEST_SECRET;
   private static Secret TEST_SECRET_TO_DELETE;
   private static Secret TEST_SECRET_TO_DELETE_WITH_ETAG;
+  private static Secret TEST_SECRET_TO_DELAYED_DESTROY;
   private static Secret TEST_SECRET_WITH_VERSIONS;
+  private static SecretName TEST_SECRET_WITH_DELAYED_DESTROY;
   private static SecretName TEST_SECRET_TO_CREATE_NAME;
   private static SecretName TEST_SECRET_WITH_LABEL_TO_CREATE_NAME;
   private static SecretName TEST_SECRET_WITH_TAGS_TO_CREATE_NAME;
@@ -116,6 +118,8 @@ public class SnippetsIT {
     TEST_SECRET_TO_DELETE = createSecret(false);
     TEST_SECRET_TO_DELETE_WITH_ETAG = createSecret(false);
     TEST_SECRET_WITH_VERSIONS = createSecret(false);
+    TEST_SECRET_TO_DELAYED_DESTROY = createSecret(false);
+    TEST_SECRET_WITH_DELAYED_DESTROY = SecretName.of(PROJECT_ID, randomSecretId());
     TEST_SECRET_TO_CREATE_NAME = SecretName.of(PROJECT_ID, randomSecretId());
     TEST_UMMR_SECRET_TO_CREATE_NAME = SecretName.of(PROJECT_ID, randomSecretId());
     TEST_SECRET_WITH_TAGS_TO_CREATE_NAME = SecretName.of(PROJECT_ID, randomSecretId());
@@ -160,6 +164,8 @@ public class SnippetsIT {
     deleteSecret(TEST_SECRET_TO_DELETE.getName());
     deleteSecret(TEST_SECRET_TO_DELETE_WITH_ETAG.getName());
     deleteSecret(TEST_SECRET_WITH_VERSIONS.getName());
+    deleteSecret(TEST_SECRET_WITH_DELAYED_DESTROY.toString());
+    deleteSecret(TEST_SECRET_TO_DELAYED_DESTROY.getName());
     deleteTags();
   }
 
@@ -584,6 +590,32 @@ public class SnippetsIT {
   }
 
   @Test
+  public void testCreateSecretWithDelayedDestroy() throws IOException {
+    SecretName name = TEST_SECRET_WITH_DELAYED_DESTROY;
+    CreateSecretWithDelayedDestroy.createSecretWithDelayedDestroy(
+        name.getProject(), name.getSecret(), 86400);
+
+    assertThat(stdOut.toString()).contains("Created secret with version destroy ttl");
+  }
+
+  @Test
+  public void testUpdateSecretWithDelayedDestroy() throws IOException {
+    SecretName name = SecretName.parse(TEST_SECRET_TO_DELAYED_DESTROY.getName());
+    UpdateSecretWithDelayedDestroy.updateSecretWithDelayedDestroy(
+        name.getProject(), name.getSecret(), 86400);
+
+    assertThat(stdOut.toString()).contains("Updated secret");
+  }
+
+  @Test
+  public void testDisableSecretDelayedDestroy() throws IOException {
+    SecretName name = SecretName.parse(TEST_SECRET_TO_DELAYED_DESTROY.getName());
+    DisableSecretDelayedDestroy.disableSecretDelayedDestroy(name.getProject(), name.getSecret());
+
+    assertThat(stdOut.toString()).contains("Updated secret");
+  }
+
+  @Test
   public void testConsumeEventNotification() {
     String message = "hello!";
     byte[] base64Bytes = Base64.getEncoder().encode(message.getBytes(StandardCharsets.UTF_8));
@@ -599,5 +631,4 @@ public class SnippetsIT {
     assertThat(log).isEqualTo(
         "Received SECRET_UPDATE for projects/p/secrets/s. New metadata: hello!");
   }
-        
 }

--- a/secretmanager/src/test/java/secretmanager/regionalsamples/SnippetsIT.java
+++ b/secretmanager/src/test/java/secretmanager/regionalsamples/SnippetsIT.java
@@ -99,6 +99,8 @@ public class SnippetsIT {
   private static Secret TEST_REGIONAL_SECRET_TO_DELETE;
   private static Secret TEST_REGIONAL_SECRET_TO_DELETE_WITH_ETAG;
   private static Secret TEST_REGIONAL_SECRET_WITH_VERSIONS;
+  private static Secret TEST_REGIONAL_SECRET_TO_DELAYED_DESTROY;
+  private static SecretName TEST_REGIONAL_SECRET_WITH_DELAYED_DESTROY;
   private static SecretName TEST_REGIONAL_SECRET_TO_CREATE_NAME;
   private static SecretName TEST_REGIONAL_SECRET_WITH_LABEL_TO_CREATE_NAME;
   private static SecretName TEST_REGIONAL_SECRET_WITH_TAGS_TO_CREATE_NAME;
@@ -126,6 +128,9 @@ public class SnippetsIT {
     TEST_REGIONAL_SECRET_TO_DELETE = createRegionalSecret();
     TEST_REGIONAL_SECRET_TO_DELETE_WITH_ETAG = createRegionalSecret();
     TEST_REGIONAL_SECRET_WITH_VERSIONS = createRegionalSecret();
+    TEST_REGIONAL_SECRET_TO_DELAYED_DESTROY = createRegionalSecret();
+    TEST_REGIONAL_SECRET_WITH_DELAYED_DESTROY =
+        SecretName.ofProjectLocationSecretName(PROJECT_ID, LOCATION_ID, randomSecretId());
     TEST_REGIONAL_SECRET_TO_CREATE_NAME = 
         SecretName.ofProjectLocationSecretName(PROJECT_ID, LOCATION_ID, randomSecretId());
     TEST_REGIONAL_SECRET_WITH_ANNOTATION_TO_CREATE_NAME =
@@ -178,6 +183,8 @@ public class SnippetsIT {
     deleteRegionalSecret(TEST_REGIONAL_SECRET_TO_DELETE.getName());
     deleteRegionalSecret(TEST_REGIONAL_SECRET_TO_DELETE_WITH_ETAG.getName());
     deleteRegionalSecret(TEST_REGIONAL_SECRET_WITH_VERSIONS.getName());
+    deleteRegionalSecret(TEST_REGIONAL_SECRET_WITH_DELAYED_DESTROY.toString());
+    deleteRegionalSecret(TEST_REGIONAL_SECRET_TO_DELAYED_DESTROY.getName());
     deleteTags();
   }
 
@@ -673,6 +680,33 @@ public class SnippetsIT {
 
     assertThat(updatedSecret.getAnnotationsMap()).containsEntry(
         UPDATED_ANNOTATION_KEY, UPDATED_ANNOTATION_VALUE);
+  }
+
+  @Test
+  public void testCreateRegionalSecretWithDelayedDestroy() throws IOException {
+    SecretName name = TEST_REGIONAL_SECRET_WITH_DELAYED_DESTROY;
+    CreateRegionalSecretWithDelayedDestroy.createRegionalSecretWithDelayedDestroy(
+        name.getProject(), name.getLocation(), name.getSecret(), 86400);
+
+    assertThat(stdOut.toString()).contains("Created secret with version destroy ttl");
+  }
+
+  @Test
+  public void testUpdateRegionalSecretWithDelayedDestroy() throws IOException {
+    SecretName name = SecretName.parse(TEST_REGIONAL_SECRET_TO_DELAYED_DESTROY.getName());
+    UpdateRegionalSecretWithDelayedDestroy.updateRegionalSecretWithDelayedDestroy(
+        name.getProject(), name.getLocation(), name.getSecret(), 86400);
+
+    assertThat(stdOut.toString()).contains("Updated secret");
+  }
+
+  @Test
+  public void testDisableRegionalSecretDelayedDestroy() throws IOException {
+    SecretName name = SecretName.parse(TEST_REGIONAL_SECRET_TO_DELAYED_DESTROY.getName());
+    DisableRegionalSecretDelayedDestroy.disableRegionalSecretDelayedDestroy(
+        name.getProject(), name.getLocation(), name.getSecret());
+
+    assertThat(stdOut.toString()).contains("Updated secret");
   }
 }
  


### PR DESCRIPTION
## Description

Added samples for kms_key field in regional parameter using Parameter manager SDK

#### Sample List (global & regional): 

1. Create Secret With Delayed Destroy
2. Disable Secret Delayed Destroy
3. Update Secret With Delayed Destroy

Added required Tests for the same.

## Checklist

- [X] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [X] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [X] **Tests** pass:   `mvn clean verify` **required**
- [X] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [X] Please **merge** this PR for me once it is approved
