### PR TITLE
fix: remove header checks for config files that don't have headers

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -38,5 +38,9 @@ sourceFileExtensions:
   - 'yml'
 ignoreFiles:
   - '.github/auto-label.yaml'
+  - '.github/auto-approve.yml'
+  - '.github/renovate.json5'
+  - '.github/snippet-bot.yml'
+  - '.github/stale.yml'
   - '.github/sync-repo-settings.yaml'
 ignoreLicenseYear: true


### PR DESCRIPTION
resolves PR to remove flakybot configuration. this check is getting deprecated but there isn't a straightforward replacement



Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

