### PR TITLE
feat(genai): add text generation samples - part 3

### DIFF
--- a/genai/snippets/src/main/java/genai/textgeneration/TextGenerationChatStreamWithText.java
+++ b/genai/snippets/src/main/java/genai/textgeneration/TextGenerationChatStreamWithText.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package genai.textgeneration;
+
+// [START googlegenaisdk_textgen_chat_stream_with_txt]
+
+import com.google.genai.Chat;
+import com.google.genai.Client;
+import com.google.genai.ResponseStream;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.HttpOptions;
+
+public class TextGenerationChatStreamWithText {
+
+  public static void main(String[] args) {
+    // TODO(developer): Replace these variables before running the sample.
+    String modelId = "gemini-2.5-flash";
+    generateContent(modelId);
+  }
+
+  // Shows how to create a new chat session stream
+  public static String generateContent(String modelId) {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    try (Client client =
+        Client.builder()
+            .location("global")
+            .vertexAI(true)
+            .httpOptions(HttpOptions.builder().apiVersion("v1").build())
+            .build()) {
+
+      Chat chatSession = client.chats.create(modelId);
+      StringBuilder responseTextBuilder = new StringBuilder();
+
+      try (ResponseStream<GenerateContentResponse> response =
+          chatSession.sendMessageStream("Why is the sky blue?")) {
+
+        for (GenerateContentResponse chunk : response) {
+          System.out.println(chunk.text());
+          responseTextBuilder.append(chunk.text());
+        }
+
+      }
+      // Example response:
+      //
+      // The sky is blue primarily due to a phenomenon called **Rayleigh scattering**,
+      // named after the British physicist Lord Rayleigh. Here's a breakdown of how...
+      return responseTextBuilder.toString();
+    }
+  }
+}
+// [END googlegenaisdk_textgen_chat_stream_with_txt]

--- a/genai/snippets/src/main/java/genai/textgeneration/TextGenerationChatWithText.java
+++ b/genai/snippets/src/main/java/genai/textgeneration/TextGenerationChatWithText.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package genai.textgeneration;
+
+// [START googlegenaisdk_textgen_chat_with_txt]
+
+import com.google.genai.Chat;
+import com.google.genai.Client;
+import com.google.genai.types.Content;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.HttpOptions;
+import com.google.genai.types.Part;
+
+public class TextGenerationChatWithText {
+
+  public static void main(String[] args) {
+    // TODO(developer): Replace these variables before running the sample.
+    String modelId = "gemini-2.5-flash";
+    generateContent(modelId);
+  }
+
+  // Shows how to create a chat session
+  public static String generateContent(String modelId) {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    try (Client client =
+        Client.builder()
+            .location("global")
+            .vertexAI(true)
+            .httpOptions(HttpOptions.builder().apiVersion("v1").build())
+            .build()) {
+
+      // Create a new chat session
+      Chat chatSession =
+          client.chats.create(
+              modelId,
+              GenerateContentConfig.builder()
+                  .systemInstruction(Content.fromParts(Part.fromText("Hello")))
+                  .systemInstruction(
+                      Content.builder()
+                          .role("model")
+                          .parts(Part.fromText("Great to meet you. What would you like to know?"))
+                          .build())
+                  .build());
+
+      GenerateContentResponse response = chatSession.sendMessage("Tell me a story");
+      System.out.print(response.text());
+      // Example response:
+      //
+      // In the heart of the Whispering Peaks lay the Valley of Silent Echoes, a place perpetually
+      // shrouded in a twilight mist. No birds sang there, no rivers flowed, and the few trees that
+      // clung to its edges were gnarled and bare...
+      return response.text();
+    }
+  }
+}
+// [END googlegenaisdk_textgen_chat_with_txt]

--- a/genai/snippets/src/main/java/genai/textgeneration/TextGenerationTranscriptWithGcsAudio.java
+++ b/genai/snippets/src/main/java/genai/textgeneration/TextGenerationTranscriptWithGcsAudio.java
@@ -33,7 +33,7 @@ public class TextGenerationTranscriptWithGcsAudio {
     generateContent(modelId);
   }
 
-  // Generates audio transcription
+  // Generates transcript with audio input
   public static String generateContent(String modelId) {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests.

--- a/genai/snippets/src/main/java/genai/textgeneration/TextGenerationTranscriptWithGcsAudio.java
+++ b/genai/snippets/src/main/java/genai/textgeneration/TextGenerationTranscriptWithGcsAudio.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package genai.textgeneration;
+
+// [START googlegenaisdk_textgen_transcript_with_gcs_audio]
+
+import com.google.genai.Client;
+import com.google.genai.types.Content;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.HttpOptions;
+import com.google.genai.types.Part;
+
+public class TextGenerationTranscriptWithGcsAudio {
+
+  public static void main(String[] args) {
+    // TODO(developer): Replace these variables before running the sample.
+    String modelId = "gemini-2.5-flash";
+    generateContent(modelId);
+  }
+
+  // Generates audio transcription
+  public static String generateContent(String modelId) {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests.
+    try (Client client =
+        Client.builder()
+            .location("global")
+            .vertexAI(true)
+            .httpOptions(HttpOptions.builder().apiVersion("v1").build())
+            .build()) {
+
+      String prompt =
+          "Transcribe the interview, in the format of timecode, speaker, caption.\n"
+              + "Use speaker A, speaker B, etc. to identify speakers.";
+
+      // Enable audioTimestamp to generate accurately timestamps for audio-only files
+      GenerateContentConfig contentConfig =
+          GenerateContentConfig.builder().audioTimestamp(true).build();
+
+      GenerateContentResponse response =
+          client.models.generateContent(
+              modelId,
+              Content.fromParts(
+                  Part.fromUri(
+                      "gs://cloud-samples-data/generative-ai/audio/pixel.mp3", "audio/mpeg"),
+                  Part.fromText(prompt)),
+              contentConfig);
+
+      System.out.print(response.text());
+      // Example response:
+      // 00:00 - Speaker A: your devices are getting better over time. And so we think about it...
+      // 00:14 - Speaker B: Welcome to the Made by Google Podcast, where we meet the people who...
+      // 00:41 - Speaker A: So many features. I am a singer, so I actually think recorder...
+      return response.text();
+    }
+  }
+}
+// [END googlegenaisdk_textgen_transcript_with_gcs_audio]

--- a/genai/snippets/src/test/java/genai/textgeneration/TextGenerationIT.java
+++ b/genai/snippets/src/test/java/genai/textgeneration/TextGenerationIT.java
@@ -111,4 +111,23 @@ public class TextGenerationIT {
 
     assertThat(response).isNotEmpty();
   }
+
+  @Test
+  public void testTextGenerationChatStreamWithText() {
+    String response = TextGenerationChatStreamWithText.generateContent(GEMINI_FLASH);
+    assertThat(response).isNotEmpty();
+  }
+
+  @Test
+  public void testTextGenerationChatWithText() {
+    String response = TextGenerationChatWithText.generateContent(GEMINI_FLASH);
+    assertThat(response).isNotEmpty();
+  }
+
+  @Test
+  public void testTextGenerationTranscriptWithGcsAudio() {
+    String response = TextGenerationTranscriptWithGcsAudio.generateContent(GEMINI_FLASH);
+    assertThat(response).isNotEmpty();
+  }
+
 }


### PR DESCRIPTION
## Description

Add new text generation samples (3):

- Text generation with a new chat session
- Text generation with a new chat stream session
- Text generation transcript with audio input

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [x] Please **merge** this PR for me once it is approved
