### PR TITLE
ci(cloud-sql): skip failing tests

### DIFF
--- a/cloud-sql/mysql/servlet/src/test/java/com/example/cloudsql/TestIndexServletMysql.java
+++ b/cloud-sql/mysql/servlet/src/test/java/com/example/cloudsql/TestIndexServletMysql.java
@@ -38,6 +38,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 
@@ -101,6 +102,7 @@ public class TestIndexServletMysql {
   }
 
   @Test
+  @Ignore("https://github.com/GoogleCloudPlatform/java-docs-samples/issues/8794")
   public void testGetTemplateData() throws Exception {
     TemplateData templateData = new IndexServlet().getTemplateData(pool);
 
@@ -110,6 +112,7 @@ public class TestIndexServletMysql {
   }
 
   @Test
+  @Ignore("https://github.com/GoogleCloudPlatform/java-docs-samples/issues/8794")
   public void testServletPost() throws Exception {
     HttpServletRequest request = mock(HttpServletRequest.class);
     HttpServletResponse response = mock(HttpServletResponse.class);

--- a/cloud-sql/postgres/servlet/src/test/java/com/example/cloudsql/TestIndexServletPostgres.java
+++ b/cloud-sql/postgres/servlet/src/test/java/com/example/cloudsql/TestIndexServletPostgres.java
@@ -38,6 +38,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 
@@ -102,6 +103,7 @@ public class TestIndexServletPostgres {
   }
 
   @Test
+  @Ignore("https://github.com/GoogleCloudPlatform/java-docs-samples/issues/8794")
   public void testGetTemplateData() throws Exception {
     TemplateData templateData = new IndexServlet().getTemplateData(pool);
 
@@ -111,6 +113,7 @@ public class TestIndexServletPostgres {
   }
 
   @Test
+  @Ignore("https://github.com/GoogleCloudPlatform/java-docs-samples/issues/8794")
   public void testServletPost() throws Exception {
     HttpServletRequest request = mock(HttpServletRequest.class);
     HttpServletResponse response = mock(HttpServletResponse.class);

--- a/cloud-sql/sqlserver/servlet/src/test/java/com/example/cloudsql/TestIndexServletSqlServer.java
+++ b/cloud-sql/sqlserver/servlet/src/test/java/com/example/cloudsql/TestIndexServletSqlServer.java
@@ -38,6 +38,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 
@@ -111,6 +112,7 @@ public class TestIndexServletSqlServer {
 
 
   @Test
+  @Ignore("https://github.com/GoogleCloudPlatform/java-docs-samples/issues/8794")
   public void testGetTemplateData() throws Exception {
     TemplateData templateData = new IndexServlet().getTemplateData(pool);
 
@@ -120,6 +122,7 @@ public class TestIndexServletSqlServer {
   }
 
   @Test
+  @Ignore("https://github.com/GoogleCloudPlatform/java-docs-samples/issues/8794")
   public void testServletPost() throws Exception {
     HttpServletRequest request = mock(HttpServletRequest.class);
     HttpServletResponse response = mock(HttpServletResponse.class);


### PR DESCRIPTION
As noted in https://github.com/GoogleCloudPlatform/java-docs-samples/issues/8794, these tests require refactoring. 

They are currently failing and is blocking #10129

This PR skips these tests, pending rework. 


- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
