### PR TITLE
ci(pubsublite): skip tests, product pending deprecation

### DIFF
--- a/pubsublite/streaming-analytics/src/test/java/examples/PubsubliteToGcsIT.java
+++ b/pubsublite/streaming-analytics/src/test/java/examples/PubsubliteToGcsIT.java
@@ -61,6 +61,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -200,6 +201,7 @@ public class PubsubliteToGcsIT {
   }
 
   @Test
+  @Ignore("https://cloud.google.com/pubsub/lite/docs Deprecated")
   public void testPubsubliteToGcs() throws InterruptedException, ExecutionException {
     // Run the pipeline on Dataflow as instructed in the README.
     PubsubliteToGcs.main(


### PR DESCRIPTION
## Description

Addresses #10129 

PubSub Lite is marked as deprecated https://cloud.google.com/pubsub/lite/docs

Pending holistic removal of documentation, disabling the tests will unblock the failing bulk dependency updates 


## Checklist

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
