### PR TITLE
bugfix: avoid extra encoding/decoding PLD params

### DIFF
--- a/recaptcha_enterprise/snippets/src/main/java/recaptcha/passwordleak/CreatePasswordLeakAssessment.java
+++ b/recaptcha_enterprise/snippets/src/main/java/recaptcha/passwordleak/CreatePasswordLeakAssessment.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
-import org.bouncycastle.util.encoders.Base64;
 
 public class CreatePasswordLeakAssessment {
 
@@ -93,9 +92,8 @@ public class CreatePasswordLeakAssessment {
     PasswordCheckVerification verification =
         passwordLeak.createVerification(username, password).get();
 
-    byte[] lookupHashPrefix = Base64.encode(verification.getLookupHashPrefix());
-    byte[] encryptedUserCredentialsHash = Base64.encode(
-        verification.getEncryptedUserCredentialsHash());
+    byte[] lookupHashPrefix = verification.getLookupHashPrefix();
+    byte[] encryptedUserCredentialsHash = verification.getEncryptedUserCredentialsHash();
 
     // Pass the credentials to the createPasswordLeakAssessment() to get back
     // the matching database entry for the hash prefix.
@@ -108,7 +106,7 @@ public class CreatePasswordLeakAssessment {
     // Convert to appropriate input format.
     List<byte[]> leakMatchPrefixes =
         credentials.getEncryptedLeakMatchPrefixesList().stream()
-            .map(x -> Base64.decode(x.toByteArray()))
+            .map(x -> x.toByteArray())
             .collect(Collectors.toList());
 
     // Verify if the encrypted credentials are present in the obtained match list.
@@ -116,7 +114,7 @@ public class CreatePasswordLeakAssessment {
         passwordLeak
             .verify(
                 verification,
-                Base64.decode(credentials.getReencryptedUserCredentialsHash().toByteArray()),
+                credentials.getReencryptedUserCredentialsHash().toByteArray(),
                 leakMatchPrefixes)
             .get();
 

--- a/recaptcha_enterprise/snippets/src/pom.xml
+++ b/recaptcha_enterprise/snippets/src/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>com.google.cloud.samples</groupId>
     <artifactId>shared-configuration</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.2</version>
   </parent>
 
   <properties>


### PR DESCRIPTION
Change-Id: I7cd4a7baa25677689ea7e4a50f539fff8a035a4c

## Description

The params and response from the PLD library are being encoded/decoded unnecessarily. Removing this extra processing which is making the password leak check to fail.

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [x] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
