### PR TITLE
fix(appengine): removing obsolete symlink from java 8 on java 17 bundle services

### DIFF
--- a/appengine-java17-bundled-services/datastore/pom.xml
+++ b/appengine-java17-bundled-services/datastore/pom.xml
@@ -126,6 +126,11 @@
       <version>1.4.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>jstl</groupId>
+      <artifactId>jstl</artifactId>
+      <version>1.2</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/AbstractGuestbook.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/AbstractGuestbook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/AbstractGuestbook.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/AbstractGuestbook.java
@@ -1,1 +1,76 @@
-../../../../../../../../appengine-java8/datastore/src/main/java/com/example/appengine/AbstractGuestbook.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import com.example.time.Clock;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.users.User;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.common.collect.ImmutableList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * A log of notes left by users.
+ *
+ * <p>This is meant to be subclassed to demonstrate different storage structures in Datastore.
+ */
+abstract class AbstractGuestbook {
+
+  private final DatastoreService datastore;
+  private final UserService userService;
+  private final Clock clock;
+
+  AbstractGuestbook(Clock clock) {
+    this.datastore = DatastoreServiceFactory.getDatastoreService();
+    this.userService = UserServiceFactory.getUserService();
+    this.clock = clock;
+  }
+
+  /**
+   * Appends a new greeting to the guestbook and returns the {@link Entity} that was created.
+   **/
+  public Greeting appendGreeting(String content) {
+    return Greeting.create(
+        createGreeting(datastore, userService.getCurrentUser(), Date.from(clock.now()), content));
+  }
+
+  /**
+   * Write a greeting to Datastore.
+   */
+  protected abstract Entity createGreeting(
+      DatastoreService datastore, User user, Date date, String content);
+
+  /**
+   * Return a list of the most recent greetings.
+   */
+  public List<Greeting> listGreetings() {
+    ImmutableList.Builder<Greeting> greetings = ImmutableList.builder();
+    for (Entity entity : listGreetingEntities(datastore)) {
+      greetings.add(Greeting.create(entity));
+    }
+    return greetings.build();
+  }
+
+  /**
+   * Return a list of the most recent greetings.
+   */
+  protected abstract List<Entity> listGreetingEntities(DatastoreService datastore);
+}

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/AbstractGuestbookServlet.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/AbstractGuestbookServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/AbstractGuestbookServlet.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/AbstractGuestbookServlet.java
@@ -1,1 +1,58 @@
-../../../../../../../../appengine-java8/datastore/src/main/java/com/example/appengine/AbstractGuestbookServlet.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+abstract class AbstractGuestbookServlet extends HttpServlet {
+
+  private final AbstractGuestbook guestbook;
+
+  public AbstractGuestbookServlet(AbstractGuestbook guestbook) {
+    this.guestbook = guestbook;
+  }
+
+  private void renderGuestbook(HttpServletRequest req, HttpServletResponse resp)
+      throws IOException, ServletException {
+    resp.setContentType("text/html");
+    resp.setCharacterEncoding("UTF-8");
+    req.setAttribute("greetings", guestbook.listGreetings());
+    req.getRequestDispatcher("/guestbook.jsp").forward(req, resp);
+  }
+
+  @Override
+  public void doGet(HttpServletRequest req, HttpServletResponse resp)
+      throws IOException, ServletException {
+    renderGuestbook(req, resp);
+  }
+
+  @Override
+  public void doPost(HttpServletRequest req, HttpServletResponse resp)
+      throws IOException, ServletException {
+    String content = req.getParameter("content");
+    if (content == null || content.isEmpty()) {
+      resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "missing content");
+      return;
+    }
+    guestbook.appendGreeting(content);
+    renderGuestbook(req, resp);
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/AbstractGuestbookServlet.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/AbstractGuestbookServlet.java
@@ -53,6 +53,6 @@ abstract class AbstractGuestbookServlet extends HttpServlet {
       return;
     }
     guestbook.appendGreeting(content);
-    renderGuestbook(req, resp);
+    resp.sendRedirect(req.getRequestURI());
   }
 }

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/Greeting.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/Greeting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/Greeting.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/Greeting.java
@@ -1,1 +1,42 @@
-../../../../../../../../appengine-java8/datastore/src/main/java/com/example/appengine/Greeting.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.users.User;
+import com.google.auto.value.AutoValue;
+import java.time.Instant;
+import java.util.Date;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class Greeting {
+
+  static Greeting create(Entity entity) {
+    User user = (User) entity.getProperty("user");
+    Instant date = ((Date) entity.getProperty("date")).toInstant();
+    String content = (String) entity.getProperty("content");
+    return new AutoValue_Greeting(user, date, content);
+  }
+
+  @Nullable
+  public abstract User getUser();
+
+  public abstract Instant getDate();
+
+  public abstract String getContent();
+}

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/Guestbook.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/Guestbook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/Guestbook.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/Guestbook.java
@@ -1,1 +1,59 @@
-../../../../../../../../appengine-java8/datastore/src/main/java/com/example/appengine/Guestbook.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import com.example.time.Clock;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.users.User;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * A log of notes left by users.
+ *
+ * <p>This demonstrates the use of Google Cloud Datastore using the App Engine APIs. See the <a
+ * href="https://cloud.google.com/appengine/docs/java/datastore/">documentation</a> for more
+ * information.
+ */
+class Guestbook extends AbstractGuestbook {
+
+  Guestbook(Clock clock) {
+    super(clock);
+  }
+
+  @Override
+  protected Entity createGreeting(
+      DatastoreService datastore, User user, Date date, String content) {
+    // No parent key specified, so Greeting is a root entity.
+    Entity greeting = new Entity("Greeting");
+    greeting.setProperty("user", user);
+    greeting.setProperty("date", date);
+    greeting.setProperty("content", content);
+
+    datastore.put(greeting);
+    return greeting;
+  }
+
+  @Override
+  protected List<Entity> listGreetingEntities(DatastoreService datastore) {
+    Query query = new Query("Greeting").addSort("date", Query.SortDirection.DESCENDING);
+    return datastore.prepare(query).asList(FetchOptions.Builder.withLimit(10));
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/GuestbookServlet.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/GuestbookServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/GuestbookServlet.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/GuestbookServlet.java
@@ -1,1 +1,26 @@
-../../../../../../../../appengine-java8/datastore/src/main/java/com/example/appengine/GuestbookServlet.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import com.example.time.SystemClock;
+
+public class GuestbookServlet extends AbstractGuestbookServlet {
+
+  public GuestbookServlet() {
+    super(new Guestbook(new SystemClock()));
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/GuestbookStrong.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/GuestbookStrong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/GuestbookStrong.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/GuestbookStrong.java
@@ -1,1 +1,71 @@
-../../../../../../../../appengine-java8/datastore/src/main/java/com/example/appengine/GuestbookStrong.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import com.example.time.Clock;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.users.User;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * A log of notes left by users.
+ *
+ * <p>This demonstrates the use of Google Cloud Datastore using the App Engine APIs. See the <a
+ * href="https://cloud.google.com/appengine/docs/java/datastore/">documentation</a> for more
+ * information.
+ */
+class GuestbookStrong extends AbstractGuestbook {
+
+  private final String guestbookName;
+
+  GuestbookStrong(String guestbookName, Clock clock) {
+    super(clock);
+    this.guestbookName = guestbookName;
+  }
+
+  @Override
+  protected Entity createGreeting(
+      DatastoreService datastore, User user, Date date, String content) {
+    // String guestbookName = "my guestbook"; -- Set elsewhere (injected to the constructor).
+    Key guestbookKey = KeyFactory.createKey("Guestbook", guestbookName);
+
+    // Place greeting in the same entity group as guestbook.
+    Entity greeting = new Entity("Greeting", guestbookKey);
+    greeting.setProperty("user", user);
+    greeting.setProperty("date", date);
+    greeting.setProperty("content", content);
+
+    datastore.put(greeting);
+    return greeting;
+  }
+
+  @Override
+  protected List<Entity> listGreetingEntities(DatastoreService datastore) {
+    Key guestbookKey = KeyFactory.createKey("Guestbook", guestbookName);
+    Query query =
+        new Query("Greeting", guestbookKey)
+            .setAncestor(guestbookKey)
+            .addSort("date", Query.SortDirection.DESCENDING);
+    return datastore.prepare(query).asList(FetchOptions.Builder.withLimit(10));
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/GuestbookStrongServlet.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/GuestbookStrongServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/GuestbookStrongServlet.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/GuestbookStrongServlet.java
@@ -1,1 +1,28 @@
-../../../../../../../../appengine-java8/datastore/src/main/java/com/example/appengine/GuestbookStrongServlet.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import com.example.time.SystemClock;
+
+public class GuestbookStrongServlet extends AbstractGuestbookServlet {
+
+  public static final String GUESTBOOK_ID = "my guestbook";
+
+  public GuestbookStrongServlet() {
+    super(new GuestbookStrong(GUESTBOOK_ID, new SystemClock()));
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/ListPeopleServlet.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/ListPeopleServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/ListPeopleServlet.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/ListPeopleServlet.java
@@ -85,7 +85,9 @@ public class ListPeopleServlet extends HttpServlet {
     String cursorString = results.getCursor().toWebSafeString();
 
     // This servlet lives at '/people'.
-    w.println("<a href='/people?cursor=" + cursorString + "'>Next page</a>");
+    if (results.size() == PAGE_SIZE) {
+      w.println("<a href='/people?cursor=" + cursorString + "'>Next page</a>");
+    }
   }
 }
 // [END cursors]

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/ListPeopleServlet.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/ListPeopleServlet.java
@@ -1,1 +1,91 @@
-../../../../../../../../appengine-java8/datastore/src/main/java/com/example/appengine/ListPeopleServlet.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+// [START cursors]
+
+import com.google.appengine.api.datastore.Cursor;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.appengine.api.datastore.QueryResultList;
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class ListPeopleServlet extends HttpServlet {
+
+  static final int PAGE_SIZE = 15;
+  private final DatastoreService datastore;
+
+  public ListPeopleServlet() {
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
+    FetchOptions fetchOptions = FetchOptions.Builder.withLimit(PAGE_SIZE);
+
+    // If this servlet is passed a cursor parameter, let's use it.
+    String startCursor = req.getParameter("cursor");
+    if (startCursor != null) {
+      fetchOptions.startCursor(Cursor.fromWebSafeString(startCursor));
+    }
+
+    Query q = new Query("Person").addSort("name", SortDirection.ASCENDING);
+    PreparedQuery pq = datastore.prepare(q);
+
+    QueryResultList<Entity> results;
+    try {
+      results = pq.asQueryResultList(fetchOptions);
+    } catch (IllegalArgumentException e) {
+      // IllegalArgumentException happens when an invalid cursor is used.
+      // A user could have manually entered a bad cursor in the URL or there
+      // may have been an internal implementation detail change in App Engine.
+      // Redirect to the page without the cursor parameter to show something
+      // rather than an error.
+      resp.sendRedirect("/people");
+      return;
+    }
+
+    resp.setContentType("text/html");
+    resp.setCharacterEncoding("UTF-8");
+    PrintWriter w = resp.getWriter();
+    w.println("<!DOCTYPE html>");
+    w.println("<meta charset=\"utf-8\">");
+    w.println("<title>Cloud Datastore Cursor Sample</title>");
+    w.println("<ul>");
+    for (Entity entity : results) {
+      w.println("<li>" + entity.getProperty("name") + "</li>");
+    }
+    w.println("</ul>");
+
+    String cursorString = results.getCursor().toWebSafeString();
+
+    // This servlet lives at '/people'.
+    w.println("<a href='/people?cursor=" + cursorString + "'>Next page</a>");
+  }
+}
+// [END cursors]

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/ListPeopleServlet.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/ListPeopleServlet.java
@@ -16,7 +16,6 @@
 
 package com.example.appengine;
 
-// [START cursors]
 
 import com.google.appengine.api.datastore.Cursor;
 import com.google.appengine.api.datastore.DatastoreService;
@@ -90,4 +89,3 @@ public class ListPeopleServlet extends HttpServlet {
     }
   }
 }
-// [END cursors]

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/ProjectionServlet.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/ProjectionServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/ProjectionServlet.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/ProjectionServlet.java
@@ -1,1 +1,78 @@
-../../../../../../../../appengine-java8/datastore/src/main/java/com/example/appengine/ProjectionServlet.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.PropertyProjection;
+import com.google.appengine.api.datastore.Query;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Date;
+import java.util.List;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Servlet to demonstrate use of Datastore projection queries.
+ *
+ * <p>See the
+ * <a href="https://cloud.google.com/appengine/docs/java/datastore/projectionqueries">documentation</a>
+ * for using Datastore projection queries from the Google App Engine standard environment.
+ */
+@SuppressWarnings("serial")
+public class ProjectionServlet extends HttpServlet {
+
+  private static final String GUESTBOOK_ID = GuestbookStrongServlet.GUESTBOOK_ID;
+  private final DatastoreService datastore;
+
+  public ProjectionServlet() {
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+
+  @Override
+  public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    resp.setContentType("text/plain");
+    resp.setCharacterEncoding("UTF-8");
+    PrintWriter out = resp.getWriter();
+    out.printf("Latest entries from guestbook: \n");
+
+    Key guestbookKey = KeyFactory.createKey("Guestbook", GUESTBOOK_ID);
+    Query query = new Query("Greeting", guestbookKey);
+    addGuestbookProjections(query);
+    printGuestbookEntries(datastore, query, out);
+  }
+
+  private void addGuestbookProjections(Query query) {
+    query.addProjection(new PropertyProjection("content", String.class));
+    query.addProjection(new PropertyProjection("date", Date.class));
+  }
+
+  private void printGuestbookEntries(DatastoreService datastore, Query query, PrintWriter out) {
+    List<Entity> guests = datastore.prepare(query).asList(FetchOptions.Builder.withLimit(5));
+    for (Entity guest : guests) {
+      String content = (String) guest.getProperty("content");
+      Date stamp = (Date) guest.getProperty("date");
+      out.printf("Message %s posted on %s.\n", content, stamp.toString());
+    }
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/StartupServlet.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/StartupServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/StartupServlet.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/StartupServlet.java
@@ -1,1 +1,119 @@
-../../../../../../../../appengine-java8/datastore/src/main/java/com/example/appengine/StartupServlet.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EntityNotFoundException;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A startup handler to populate the datastore with example entities.
+ */
+public class StartupServlet extends HttpServlet {
+
+  static final String IS_POPULATED_ENTITY = "IsPopulated";
+  static final String IS_POPULATED_KEY_NAME = "is-populated";
+
+  private static final String PERSON_ENTITY = "Person";
+  private static final String NAME_PROPERTY = "name";
+  private static final ImmutableList<String> US_PRESIDENTS =
+      ImmutableList.<String>builder()
+          .add("George Washington")
+          .add("John Adams")
+          .add("Thomas Jefferson")
+          .add("James Madison")
+          .add("James Monroe")
+          .add("John Quincy Adams")
+          .add("Andrew Jackson")
+          .add("Martin Van Buren")
+          .add("William Henry Harrison")
+          .add("John Tyler")
+          .add("James K. Polk")
+          .add("Zachary Taylor")
+          .add("Millard Fillmore")
+          .add("Franklin Pierce")
+          .add("James Buchanan")
+          .add("Abraham Lincoln")
+          .add("Andrew Johnson")
+          .add("Ulysses S. Grant")
+          .add("Rutherford B. Hayes")
+          .add("James A. Garfield")
+          .add("Chester A. Arthur")
+          .add("Grover Cleveland")
+          .add("Benjamin Harrison")
+          .add("Grover Cleveland")
+          .add("William McKinley")
+          .add("Theodore Roosevelt")
+          .add("William Howard Taft")
+          .add("Woodrow Wilson")
+          .add("Warren G. Harding")
+          .add("Calvin Coolidge")
+          .add("Herbert Hoover")
+          .add("Franklin D. Roosevelt")
+          .add("Harry S. Truman")
+          .add("Dwight D. Eisenhower")
+          .add("John F. Kennedy")
+          .add("Lyndon B. Johnson")
+          .add("Richard Nixon")
+          .add("Gerald Ford")
+          .add("Jimmy Carter")
+          .add("Ronald Reagan")
+          .add("George H. W. Bush")
+          .add("Bill Clinton")
+          .add("George W. Bush")
+          .add("Barack Obama")
+          .build();
+
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
+    resp.setContentType("text/plain");
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+    Key isPopulatedKey = KeyFactory.createKey(IS_POPULATED_ENTITY, IS_POPULATED_KEY_NAME);
+    boolean isAlreadyPopulated;
+    try {
+      datastore.get(isPopulatedKey);
+      isAlreadyPopulated = true;
+    } catch (EntityNotFoundException expected) {
+      isAlreadyPopulated = false;
+    }
+    if (isAlreadyPopulated) {
+      resp.getWriter().println("ok");
+      return;
+    }
+
+    ImmutableList.Builder<Entity> people = ImmutableList.builder();
+    for (String name : US_PRESIDENTS) {
+      Entity person = new Entity(PERSON_ENTITY);
+      person.setProperty(NAME_PROPERTY, name);
+      people.add(person);
+    }
+    datastore.put(people.build());
+    datastore.put(new Entity(isPopulatedKey));
+    resp.getWriter().println("ok");
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/StatsServlet.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/StatsServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/StatsServlet.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/StatsServlet.java
@@ -1,1 +1,47 @@
-../../../../../../../../appengine-java8/datastore/src/main/java/com/example/appengine/StatsServlet.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Query;
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class StatsServlet extends HttpServlet {
+
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
+    // [START stat_example]
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    Entity globalStat = datastore.prepare(new Query("__Stat_Total__")).asSingleEntity();
+    Long totalBytes = (Long) globalStat.getProperty("bytes");
+    Long totalEntities = (Long) globalStat.getProperty("count");
+    // [END stat_example]
+
+    resp.setContentType("text/plain");
+    resp.setCharacterEncoding("UTF-8");
+    PrintWriter w = resp.getWriter();
+    w.printf("%d bytes\n%d entities\n", totalBytes, totalEntities);
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/StatsServlet.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/appengine/StatsServlet.java
@@ -32,12 +32,10 @@ public class StatsServlet extends HttpServlet {
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp)
       throws ServletException, IOException {
-    // [START stat_example]
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Entity globalStat = datastore.prepare(new Query("__Stat_Total__")).asSingleEntity();
     Long totalBytes = (Long) globalStat.getProperty("bytes");
     Long totalEntities = (Long) globalStat.getProperty("count");
-    // [END stat_example]
 
     resp.setContentType("text/plain");
     resp.setCharacterEncoding("UTF-8");

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/time/Clock.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/time/Clock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/time/Clock.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/time/Clock.java
@@ -1,1 +1,36 @@
-../../../../../../../../appengine-java8/datastore/src/main/java/com/example/time/Clock.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.time;
+
+import java.time.Instant;
+
+/**
+ * Provides the current value of "now." To preserve testability, avoid all other libraries that
+ * access the system clock (whether {@linkplain System#currentTimeMillis directly} or {@linkplain
+ * java.time.Instant#now() indirectly}).
+ *
+ * <p>In production, use the {@link SystemClock} implementation to return the "real" system time. In
+ * tests, either use {@link com.example.time.testing.FakeClock}, or get an instance from a mocking
+ * framework such as Mockito.
+ */
+public interface Clock {
+
+  /**
+   * Returns the current, absolute time according to this clock.
+   */
+  Instant now();
+}

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/time/SystemClock.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/time/SystemClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/time/SystemClock.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/time/SystemClock.java
@@ -1,1 +1,39 @@
-../../../../../../../../appengine-java8/datastore/src/main/java/com/example/time/SystemClock.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.time;
+
+import java.time.Instant;
+
+/**
+ * Clock implementation that returns the "real" system time.
+ *
+ * <p>This class exists so that we can use a fake implementation for unit testing classes that need
+ * the current time value. See {@link Clock} for general information about clocks.
+ */
+public class SystemClock implements Clock {
+
+  /**
+   * Creates a new instance. All {@code SystemClock} instances function identically.
+   */
+  public SystemClock() {
+  }
+
+  @Override
+  public Instant now() {
+    return Instant.now();
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/time/testing/FakeClock.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/time/testing/FakeClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/main/java/com/example/time/testing/FakeClock.java
+++ b/appengine-java17-bundled-services/datastore/src/main/java/com/example/time/testing/FakeClock.java
@@ -1,1 +1,180 @@
-../../../../../../../../../appengine-java8/datastore/src/main/java/com/example/time/testing/FakeClock.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.time.testing;
+
+import com.example.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A Clock that returns a fixed Instant value as the current clock time. The fixed Instant is
+ * settable for testing. Test code should hold a reference to the FakeClock, while code under test
+ * should hold a Clock reference.
+ *
+ * <p>The clock time can be incremented/decremented manually, with {@link #incrementTime} and {@link
+ * #decrementTime} respectively.
+ *
+ * <p>The clock can also be configured so that the time is incremented whenever {@link #now()} is
+ * called: see {@link #setAutoIncrementStep}.
+ */
+public class FakeClock implements Clock {
+
+  private static final Instant DEFAULT_TIME = Instant.ofEpochMilli(1000000000L);
+  private final long baseTimeMs;
+  private final AtomicLong fakeNowMs;
+  private volatile long autoIncrementStepMs;
+
+  /**
+   * Creates a FakeClock instance initialized to an arbitrary constant.
+   */
+  public FakeClock() {
+    this(DEFAULT_TIME);
+  }
+
+  /**
+   * Creates a FakeClock instance initialized to the given time.
+   */
+  public FakeClock(Instant now) {
+    baseTimeMs = now.toEpochMilli();
+    fakeNowMs = new AtomicLong(baseTimeMs);
+  }
+
+  /**
+   * Sets the value of the underlying instance for testing purposes.
+   *
+   * @return this
+   */
+  public FakeClock setNow(Instant now) {
+    fakeNowMs.set(now.toEpochMilli());
+    return this;
+  }
+
+  @Override
+  public Instant now() {
+    return getAndAdd(autoIncrementStepMs);
+  }
+
+  /**
+   * Returns the current time without applying an auto increment, if configured. The default
+   * behavior of {@link #now()} is the same as this method.
+   */
+  public Instant peek() {
+    return Instant.ofEpochMilli(fakeNowMs.get());
+  }
+
+  /**
+   * Reset the given clock back to the base time with which the FakeClock was initially
+   * constructed.
+   *
+   * @return this
+   */
+  public FakeClock resetTime() {
+    fakeNowMs.set(baseTimeMs);
+    return this;
+  }
+
+  /**
+   * Increments the clock time by the given duration.
+   *
+   * @param duration the duration to increment the clock time by
+   * @return this
+   */
+  public FakeClock incrementTime(Duration duration) {
+    incrementTime(duration.toMillis());
+    return this;
+  }
+
+  /**
+   * Increments the clock time by the given duration.
+   *
+   * @param durationMs the duration to increment the clock time by, in milliseconds
+   * @return this
+   */
+  public FakeClock incrementTime(long durationMs) {
+    fakeNowMs.addAndGet(durationMs);
+    return this;
+  }
+
+  /**
+   * Decrements the clock time by the given duration.
+   *
+   * @param duration the duration to decrement the clock time by
+   * @return this
+   */
+  public FakeClock decrementTime(Duration duration) {
+    incrementTime(-duration.toMillis());
+    return this;
+  }
+
+  /**
+   * Decrements the clock time by the given duration.
+   *
+   * @param durationMs the duration to decrement the clock time by, in milliseconds
+   * @return this
+   */
+  public FakeClock decrementTime(long durationMs) {
+    incrementTime(-durationMs);
+    return this;
+  }
+
+  /**
+   * Sets the increment applied to the clock whenever it is queried. The increment is zero by
+   * default: the clock is left unchanged when queried.
+   *
+   * @param autoIncrementStep the new auto increment duration
+   * @return this
+   */
+  public FakeClock setAutoIncrementStep(Duration autoIncrementStep) {
+    setAutoIncrementStep(autoIncrementStep.toMillis());
+    return this;
+  }
+
+  /**
+   * Sets the increment applied to the clock whenever it is queried. The increment is zero by
+   * default: the clock is left unchanged when queried.
+   *
+   * @param autoIncrementStepMs the new auto increment duration, in milliseconds
+   * @return this
+   */
+  public FakeClock setAutoIncrementStep(long autoIncrementStepMs) {
+    this.autoIncrementStepMs = autoIncrementStepMs;
+    return this;
+  }
+
+  /**
+   * Atomically adds the given value to the current time.
+   *
+   * @param durationMs the duration to add, in milliseconds
+   * @return the updated current time
+   * @see AtomicLong#addAndGet
+   */
+  protected final Instant addAndGet(long durationMs) {
+    return Instant.ofEpochMilli(fakeNowMs.addAndGet(durationMs));
+  }
+
+  /**
+   * Atomically adds the given value to the current time.
+   *
+   * @param durationMs the duration to add, in milliseconds
+   * @return the previous time
+   * @see AtomicLong#getAndAdd
+   */
+  protected final Instant getAndAdd(long durationMs) {
+    return Instant.ofEpochMilli(fakeNowMs.getAndAdd(durationMs));
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/main/webapp/WEB-INF/datastore-indexes.xml
+++ b/appengine-java17-bundled-services/datastore/src/main/webapp/WEB-INF/datastore-indexes.xml
@@ -1,1 +1,22 @@
-../../../../../../appengine-java8/datastore/src/main/webapp/WEB-INF/datastore-indexes.xml
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2016 Google Inc.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<datastore-indexes autoGenerate="true">
+  <datastore-index kind="Greeting" ancestor="true" source="manual">
+    <property name="date" direction="asc"/>
+    <property name="content" direction="asc"/>
+  </datastore-index>
+  <datastore-index kind="Greeting" ancestor="true" source="manual">
+    <property name="date" direction="desc"/>
+  </datastore-index>
+</datastore-indexes>

--- a/appengine-java17-bundled-services/datastore/src/main/webapp/WEB-INF/datastore-indexes.xml
+++ b/appengine-java17-bundled-services/datastore/src/main/webapp/WEB-INF/datastore-indexes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Copyright 2016 Google Inc.
+  Copyright 2016 Google LLC
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

--- a/appengine-java17-bundled-services/datastore/src/main/webapp/WEB-INF/web.xml
+++ b/appengine-java17-bundled-services/datastore/src/main/webapp/WEB-INF/web.xml
@@ -1,1 +1,98 @@
-../../../../../../appengine-java8/datastore/src/main/webapp/WEB-INF/web.xml
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2016 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+         http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+  <servlet>
+    <servlet-name>guestbook-strong</servlet-name>
+    <servlet-class>com.example.appengine.GuestbookStrongServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>guestbook-strong</servlet-name>
+    <url-pattern>/</url-pattern>
+  </servlet-mapping>
+  <servlet>
+    <servlet-name>guestbook</servlet-name>
+    <servlet-class>com.example.appengine.GuestbookServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>guestbook</servlet-name>
+    <url-pattern>/guestbook</url-pattern>
+  </servlet-mapping>
+  <servlet>
+    <servlet-name>people</servlet-name>
+    <servlet-class>com.example.appengine.ListPeopleServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>people</servlet-name>
+    <url-pattern>/people</url-pattern>
+  </servlet-mapping>
+  <servlet>
+    <servlet-name>projection</servlet-name>
+    <servlet-class>com.example.appengine.ProjectionServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>projection</servlet-name>
+    <url-pattern>/projection</url-pattern>
+  </servlet-mapping>
+  <servlet>
+    <servlet-name>stats</servlet-name>
+    <servlet-class>com.example.appengine.StatsServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>stats</servlet-name>
+    <url-pattern>/stats</url-pattern>
+  </servlet-mapping>
+
+  <!-- Special handler to populate Datastore with default values. -->
+  <servlet>
+    <servlet-name>startup</servlet-name>
+    <servlet-class>com.example.appengine.StartupServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>startup</servlet-name>
+    <url-pattern>/_ah/start</url-pattern>
+  </servlet-mapping>
+
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>profile</web-resource-name>
+      <url-pattern>/*</url-pattern>
+    </web-resource-collection>
+    <user-data-constraint>
+      <transport-guarantee>CONFIDENTIAL</transport-guarantee> <!-- Require HTTPS. -->
+    </user-data-constraint>
+    <auth-constraint>
+      <role-name>*</role-name> <!-- Require users to login. -->
+    </auth-constraint>
+  </security-constraint>
+
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>profile</web-resource-name>
+      <url-pattern>/stats</url-pattern>
+    </web-resource-collection>
+    <user-data-constraint>
+      <transport-guarantee>CONFIDENTIAL</transport-guarantee>
+    </user-data-constraint>
+    <auth-constraint>
+      <role-name>admin</role-name>
+    </auth-constraint>
+  </security-constraint>
+</web-app>

--- a/appengine-java17-bundled-services/datastore/src/main/webapp/WEB-INF/web.xml
+++ b/appengine-java17-bundled-services/datastore/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Copyright 2016 Google Inc.
+  Copyright 2016 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/main/webapp/guestbook.jsp
+++ b/appengine-java17-bundled-services/datastore/src/main/webapp/guestbook.jsp
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  Copyright 2016 Google Inc.
+  Copyright 2016 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/main/webapp/guestbook.jsp
+++ b/appengine-java17-bundled-services/datastore/src/main/webapp/guestbook.jsp
@@ -25,7 +25,7 @@
     <h2>Latest Greetings</h2>
     <c:forEach items="${greetings}" var="greeting">
       <p>
-        ${greeting.content}<br>
+        <c:out value="${greeting.content}"/><br>
         Posted: ${greeting.date}
       </p>
     </c:forEach>

--- a/appengine-java17-bundled-services/datastore/src/main/webapp/guestbook.jsp
+++ b/appengine-java17-bundled-services/datastore/src/main/webapp/guestbook.jsp
@@ -1,1 +1,45 @@
-../../../../../appengine-java8/datastore/src/main/webapp/guestbook.jsp
+<!DOCTYPE html>
+<!--
+  Copyright 2016 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Guestbook</title>
+  </head>
+  <body>
+    <h2>Latest Greetings</h2>
+    <c:forEach items="${greetings}" var="greeting">
+      <p>
+        ${greeting.content}<br>
+        Posted: ${greeting.date}
+      </p>
+    </c:forEach>
+
+    <h2>Add Greeting</h2>
+    <form method="post">
+      <p>
+        <label for="greeting-content">Greeting</label>
+        <input type="text" name="content" id="greeting-content">
+      </p>
+      <p>
+        <input type="submit" value="Sign Guestbook">
+      </p>
+    </form>
+  </body>
+</html>
+

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/EntitiesTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/EntitiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/EntitiesTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/EntitiesTest.java
@@ -1,1 +1,373 @@
-../../../../../../../../appengine-java8/datastore/src/test/java/com/example/appengine/EntitiesTest.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.Assert.fail;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.EmbeddedEntity;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EntityNotFoundException;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.KeyRange;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests to demonstrate App Engine Datastore entities. */
+@RunWith(JUnit4.class)
+public class EntitiesTest {
+
+  // Set no eventual consistency, that way queries return all results.
+  // https://cloud.google.com/appengine/docs/java/tools/localunittesting
+  // #Java_Writing_High_Replication_Datastore_tests
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+          new LocalDatastoreServiceTestConfig()
+              .setDefaultHighRepJobPolicyUnappliedJobPercentage(0));
+
+  private DatastoreService datastore;
+
+  @Before
+  public void setUp() {
+    helper.setUp();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void kindExample_writesEntity() throws Exception {
+    // [START kind_example]
+    Entity employee = new Entity("Employee", "asalieri");
+    employee.setProperty("firstName", "Antonio");
+    employee.setProperty("lastName", "Salieri");
+    employee.setProperty("hireDate", new Date());
+    employee.setProperty("attendedHrTraining", true);
+
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    datastore.put(employee);
+    // [END kind_example]
+
+    Entity got = datastore.get(employee.getKey());
+    assertWithMessage("got.firstName")
+        .that((String) got.getProperty("firstName"))
+        .isEqualTo("Antonio");
+    assertWithMessage("got.lastName")
+        .that((String) got.getProperty("lastName"))
+        .isEqualTo("Salieri");
+    assertWithMessage("got.hireDate").that((Date) got.getProperty("hireDate")).isNotNull();
+    assertWithMessage("got.attendedHrTraining")
+        .that((boolean) got.getProperty("attendedHrTraining"))
+        .isTrue();
+  }
+
+  @Test
+  public void identifiers_keyName_setsKeyName() throws Exception {
+    // [START identifiers_1]
+    Entity employee = new Entity("Employee", "asalieri");
+    // [END identifiers_1]
+    datastore.put(employee);
+
+    assertWithMessage("key name").that(employee.getKey().getName()).isEqualTo("asalieri");
+  }
+
+  @Test
+  public void identifiers_autoId_setsUnallocatedId() throws Exception {
+    KeyRange keys = datastore.allocateIds("Employee", 1);
+    long usedId = keys.getStart().getId();
+
+    // [START identifiers_2]
+    Entity employee = new Entity("Employee");
+    // [END identifiers_2]
+    datastore.put(employee);
+
+    assertWithMessage("key id").that(employee.getKey().getId()).isNotEqualTo(usedId);
+  }
+
+  @Test
+  public void parent_withinEntityConstructor_setsParent() throws Exception {
+    // [START parent_1]
+    Entity employee = new Entity("Employee");
+    datastore.put(employee);
+
+    Entity address = new Entity("Address", employee.getKey());
+    datastore.put(address);
+    // [END parent_1]
+
+    assertWithMessage("address parent").that(address.getParent()).isEqualTo(employee.getKey());
+  }
+
+  @Test
+  public void parent_withKeyName_setsKeyName() throws Exception {
+    Entity employee = new Entity("Employee");
+    datastore.put(employee);
+
+    // [START parent_2]
+    Entity address = new Entity("Address", "addr1", employee.getKey());
+    // [END parent_2]
+    datastore.put(address);
+
+    assertWithMessage("address key name").that(address.getKey().getName()).isEqualTo("addr1");
+  }
+
+  @Test
+  public void datastoreServiceFactory_returnsDatastoreService() throws Exception {
+    // [START working_with_entities]
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    // [END working_with_entities]
+    assertWithMessage("datastore").that(datastore).isNotNull();
+  }
+
+  @Test
+  public void creatingAnEntity_withKeyName_writesEntity() throws Exception {
+    // [START creating_an_entity_1]
+    Entity employee = new Entity("Employee", "asalieri");
+    // Set the entity properties.
+    // ...
+    datastore.put(employee);
+    // [END creating_an_entity_1]
+
+    assertWithMessage("employee key name").that(employee.getKey().getName()).isEqualTo("asalieri");
+  }
+
+  private Key writeEmptyEmployee() {
+    // [START creating_an_entity_2]
+    Entity employee = new Entity("Employee");
+    // Set the entity properties.
+    // ...
+    datastore.put(employee);
+    // [END creating_an_entity_2]
+    return employee.getKey();
+  }
+
+  @Test
+  public void creatingAnEntity_withoutKeyName_writesEntity() throws Exception {
+    Key employeeKey = writeEmptyEmployee();
+    // [START retrieving_an_entity]
+    // Key employeeKey = ...;
+    Entity employee = datastore.get(employeeKey);
+    // [END retrieving_an_entity]
+
+    assertWithMessage("retrieved key ID")
+        .that(employee.getKey().getId())
+        .isEqualTo(employeeKey.getId());
+  }
+
+  @Test
+  public void deletingAnEntity_deletesAnEntity() throws Exception {
+    Entity employee = new Entity("Employee", "asalieri");
+    datastore.put(employee);
+
+    Key employeeKey = KeyFactory.createKey("Employee", "asalieri");
+    // [START deleting_an_entity]
+    // Key employeeKey = ...;
+    datastore.delete(employeeKey);
+    // [END deleting_an_entity]
+
+    try {
+      Entity got = datastore.get(employeeKey);
+      fail("Expected EntityNotFoundException");
+    } catch (EntityNotFoundException expected) {
+      assertWithMessage("exception key name")
+          .that(expected.getKey().getName())
+          .isEqualTo("asalieri");
+    }
+  }
+
+  @Test
+  public void repeatedProperties_storesList() throws Exception {
+    // [START repeated_properties]
+    Entity employee = new Entity("Employee");
+    ArrayList<String> favoriteFruit = new ArrayList<>();
+    favoriteFruit.add("Pear");
+    favoriteFruit.add("Apple");
+    employee.setProperty("favoriteFruit", favoriteFruit);
+    datastore.put(employee);
+
+    // Sometime later
+    employee = datastore.get(employee.getKey());
+    @SuppressWarnings("unchecked") // Cast can't verify generic type.
+    ArrayList<String> retrievedFruits = (ArrayList<String>) employee.getProperty("favoriteFruit");
+    // [END repeated_properties]
+
+    assertThat(retrievedFruits).containsExactlyElementsIn(favoriteFruit).inOrder();
+  }
+
+  // CHECKSTYLE.OFF: VariableDeclarationUsageDistance
+  @SuppressWarnings("VariableDeclarationUsageDistance")
+  @Test
+  public void embeddedEntity_fromEmbedded_embedsProperties() throws Exception {
+    Entity employee = new Entity("Employee");
+    // [START embedded_entities_1]
+    // Entity employee = ...;
+    EmbeddedEntity embeddedContactInfo = new EmbeddedEntity();
+
+    embeddedContactInfo.setProperty("homeAddress", "123 Fake St, Made, UP 45678");
+    embeddedContactInfo.setProperty("phoneNumber", "555-555-5555");
+    embeddedContactInfo.setProperty("emailAddress", "test@example.com");
+
+    employee.setProperty("contactInfo", embeddedContactInfo);
+    // [END embedded_entities_1]
+    datastore.put(employee);
+
+    Entity gotEmployee = datastore.get(employee.getKey());
+    EmbeddedEntity got = (EmbeddedEntity) gotEmployee.getProperty("contactInfo");
+    assertWithMessage("got.homeAddress")
+        .that((String) got.getProperty("homeAddress"))
+        .isEqualTo("123 Fake St, Made, UP 45678");
+  }
+  // CHECKSTYLE.ON: VariableDeclarationUsageDistance
+
+  private Key putEmployeeWithContactInfo(Entity contactInfo) {
+    Entity employee = new Entity("Employee");
+    // [START embedded_entities_2]
+    // Entity employee = ...;
+    // Entity contactInfo = ...;
+    EmbeddedEntity embeddedContactInfo = new EmbeddedEntity();
+
+    embeddedContactInfo.setKey(contactInfo.getKey()); // Optional, used so we can recover original.
+    embeddedContactInfo.setPropertiesFrom(contactInfo);
+
+    employee.setProperty("contactInfo", embeddedContactInfo);
+    // [END embedded_entities_2]
+    datastore.put(employee);
+    return employee.getKey();
+  }
+
+  @Test
+  public void embeddedEntity_fromExisting_canRecover() throws Exception {
+    Entity initialContactInfo = new Entity("Contact");
+    initialContactInfo.setProperty("homeAddress", "123 Fake St, Made, UP 45678");
+    initialContactInfo.setProperty("phoneNumber", "555-555-5555");
+    initialContactInfo.setProperty("emailAddress", "test@example.com");
+    datastore.put(initialContactInfo);
+    Key employeeKey = putEmployeeWithContactInfo(initialContactInfo);
+
+    // [START embedded_entities_3]
+    Entity employee = datastore.get(employeeKey);
+    EmbeddedEntity embeddedContactInfo = (EmbeddedEntity) employee.getProperty("contactInfo");
+
+    Key infoKey = embeddedContactInfo.getKey();
+    Entity contactInfo = new Entity(infoKey);
+    contactInfo.setPropertiesFrom(embeddedContactInfo);
+    // [END embedded_entities_3]
+    datastore.put(contactInfo);
+
+    Entity got = datastore.get(infoKey);
+    assertThat(got.getKey()).isEqualTo(initialContactInfo.getKey());
+    assertWithMessage("got.homeAddress")
+        .that((String) got.getProperty("homeAddress"))
+        .isEqualTo("123 Fake St, Made, UP 45678");
+  }
+
+  @Test
+  public void batchOperations_putsEntities() {
+    // [START gae_batch_operations]
+    Entity employee1 = new Entity("Employee");
+    Entity employee2 = new Entity("Employee");
+    Entity employee3 = new Entity("Employee");
+    // [START_EXCLUDE]
+    employee1.setProperty("firstName", "Bill");
+    employee2.setProperty("firstName", "Jane");
+    employee3.setProperty("firstName", "Alex");
+    // [END_EXCLUDE]
+
+    List<Entity> employees = Arrays.asList(employee1, employee2, employee3);
+    datastore.put(employees);
+    // [END gae_batch_operations]
+
+    Map<Key, Entity> got =
+        datastore.get(Arrays.asList(employee1.getKey(), employee2.getKey(), employee3.getKey()));
+    assertWithMessage("employee1.firstName")
+        .that((String) got.get(employee1.getKey()).getProperty("firstName"))
+        .isEqualTo("Bill");
+    assertWithMessage("employee2.firstName")
+        .that((String) got.get(employee2.getKey()).getProperty("firstName"))
+        .isEqualTo("Jane");
+    assertWithMessage("employee3.firstName")
+        .that((String) got.get(employee3.getKey()).getProperty("firstName"))
+        .isEqualTo("Alex");
+  }
+
+  @Test
+  public void createKey_makesKey() {
+    // [START generating_keys_1]
+    Key k1 = KeyFactory.createKey("Person", "GreatGrandpa");
+    Key k2 = KeyFactory.createKey("Person", 74219);
+    // [END generating_keys_1]
+
+    assertThat(k1).isNotNull();
+    assertThat(k2).isNotNull();
+  }
+
+  @Test
+  public void keyFactoryBuilder_makeKeyWithParents() {
+    Key greatKey = KeyFactory.createKey("Person", "GreatGrandpa");
+    Key grandKey = KeyFactory.createKey(greatKey, "Person", "Grandpa");
+    Key dadKey = KeyFactory.createKey(grandKey, "Person", "Dad");
+    Key meKey = KeyFactory.createKey(dadKey, "Person", "Me");
+
+    // [START generating_keys_2]
+    Key k =
+        new KeyFactory.Builder("Person", "GreatGrandpa")
+            .addChild("Person", "Grandpa")
+            .addChild("Person", "Dad")
+            .addChild("Person", "Me")
+            .getKey();
+    // [END generating_keys_2]
+
+    assertThat(k).isEqualTo(meKey);
+  }
+
+  @Test
+  public void keyToString_getsPerson() throws Exception {
+    Entity p = new Entity("Person");
+    p.setProperty("relationship", "Me");
+    datastore.put(p);
+    Key k = p.getKey();
+
+    // [START generating_keys_3]
+    String personKeyStr = KeyFactory.keyToString(k);
+
+    // Some time later (for example, after using personKeyStr in a link).
+    Key personKey = KeyFactory.stringToKey(personKeyStr);
+    Entity person = datastore.get(personKey);
+    // [END generating_keys_3]
+
+    assertThat(personKey).isEqualTo(k);
+    assertWithMessage("person.relationship")
+        .that((String) person.getProperty("relationship"))
+        .isEqualTo("Me");
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/EntitiesTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/EntitiesTest.java
@@ -68,7 +68,6 @@ public class EntitiesTest {
 
   @Test
   public void kindExample_writesEntity() throws Exception {
-    // [START kind_example]
     Entity employee = new Entity("Employee", "asalieri");
     employee.setProperty("firstName", "Antonio");
     employee.setProperty("lastName", "Salieri");
@@ -77,7 +76,6 @@ public class EntitiesTest {
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     datastore.put(employee);
-    // [END kind_example]
 
     Entity got = datastore.get(employee.getKey());
     assertWithMessage("got.firstName")
@@ -94,9 +92,7 @@ public class EntitiesTest {
 
   @Test
   public void identifiers_keyName_setsKeyName() throws Exception {
-    // [START identifiers_1]
     Entity employee = new Entity("Employee", "asalieri");
-    // [END identifiers_1]
     datastore.put(employee);
 
     assertWithMessage("key name").that(employee.getKey().getName()).isEqualTo("asalieri");
@@ -107,9 +103,7 @@ public class EntitiesTest {
     KeyRange keys = datastore.allocateIds("Employee", 1);
     long usedId = keys.getStart().getId();
 
-    // [START identifiers_2]
     Entity employee = new Entity("Employee");
-    // [END identifiers_2]
     datastore.put(employee);
 
     assertWithMessage("key id").that(employee.getKey().getId()).isNotEqualTo(usedId);
@@ -117,13 +111,11 @@ public class EntitiesTest {
 
   @Test
   public void parent_withinEntityConstructor_setsParent() throws Exception {
-    // [START parent_1]
     Entity employee = new Entity("Employee");
     datastore.put(employee);
 
     Entity address = new Entity("Address", employee.getKey());
     datastore.put(address);
-    // [END parent_1]
 
     assertWithMessage("address parent").that(address.getParent()).isEqualTo(employee.getKey());
   }
@@ -133,9 +125,7 @@ public class EntitiesTest {
     Entity employee = new Entity("Employee");
     datastore.put(employee);
 
-    // [START parent_2]
     Entity address = new Entity("Address", "addr1", employee.getKey());
-    // [END parent_2]
     datastore.put(address);
 
     assertWithMessage("address key name").that(address.getKey().getName()).isEqualTo("addr1");
@@ -143,41 +133,33 @@ public class EntitiesTest {
 
   @Test
   public void datastoreServiceFactory_returnsDatastoreService() throws Exception {
-    // [START working_with_entities]
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    // [END working_with_entities]
     assertWithMessage("datastore").that(datastore).isNotNull();
   }
 
   @Test
   public void creatingAnEntity_withKeyName_writesEntity() throws Exception {
-    // [START creating_an_entity_1]
     Entity employee = new Entity("Employee", "asalieri");
     // Set the entity properties.
     // ...
     datastore.put(employee);
-    // [END creating_an_entity_1]
 
     assertWithMessage("employee key name").that(employee.getKey().getName()).isEqualTo("asalieri");
   }
 
   private Key writeEmptyEmployee() {
-    // [START creating_an_entity_2]
     Entity employee = new Entity("Employee");
     // Set the entity properties.
     // ...
     datastore.put(employee);
-    // [END creating_an_entity_2]
     return employee.getKey();
   }
 
   @Test
   public void creatingAnEntity_withoutKeyName_writesEntity() throws Exception {
     Key employeeKey = writeEmptyEmployee();
-    // [START retrieving_an_entity]
     // Key employeeKey = ...;
     Entity employee = datastore.get(employeeKey);
-    // [END retrieving_an_entity]
 
     assertWithMessage("retrieved key ID")
         .that(employee.getKey().getId())
@@ -190,10 +172,8 @@ public class EntitiesTest {
     datastore.put(employee);
 
     Key employeeKey = KeyFactory.createKey("Employee", "asalieri");
-    // [START deleting_an_entity]
     // Key employeeKey = ...;
     datastore.delete(employeeKey);
-    // [END deleting_an_entity]
 
     try {
       Entity got = datastore.get(employeeKey);
@@ -207,7 +187,6 @@ public class EntitiesTest {
 
   @Test
   public void repeatedProperties_storesList() throws Exception {
-    // [START repeated_properties]
     Entity employee = new Entity("Employee");
     ArrayList<String> favoriteFruit = new ArrayList<>();
     favoriteFruit.add("Pear");
@@ -219,7 +198,6 @@ public class EntitiesTest {
     employee = datastore.get(employee.getKey());
     @SuppressWarnings("unchecked") // Cast can't verify generic type.
     ArrayList<String> retrievedFruits = (ArrayList<String>) employee.getProperty("favoriteFruit");
-    // [END repeated_properties]
 
     assertThat(retrievedFruits).containsExactlyElementsIn(favoriteFruit).inOrder();
   }
@@ -229,7 +207,6 @@ public class EntitiesTest {
   @Test
   public void embeddedEntity_fromEmbedded_embedsProperties() throws Exception {
     Entity employee = new Entity("Employee");
-    // [START embedded_entities_1]
     // Entity employee = ...;
     EmbeddedEntity embeddedContactInfo = new EmbeddedEntity();
 
@@ -238,7 +215,6 @@ public class EntitiesTest {
     embeddedContactInfo.setProperty("emailAddress", "test@example.com");
 
     employee.setProperty("contactInfo", embeddedContactInfo);
-    // [END embedded_entities_1]
     datastore.put(employee);
 
     Entity gotEmployee = datastore.get(employee.getKey());
@@ -251,7 +227,6 @@ public class EntitiesTest {
 
   private Key putEmployeeWithContactInfo(Entity contactInfo) {
     Entity employee = new Entity("Employee");
-    // [START embedded_entities_2]
     // Entity employee = ...;
     // Entity contactInfo = ...;
     EmbeddedEntity embeddedContactInfo = new EmbeddedEntity();
@@ -260,7 +235,6 @@ public class EntitiesTest {
     embeddedContactInfo.setPropertiesFrom(contactInfo);
 
     employee.setProperty("contactInfo", embeddedContactInfo);
-    // [END embedded_entities_2]
     datastore.put(employee);
     return employee.getKey();
   }
@@ -274,14 +248,12 @@ public class EntitiesTest {
     datastore.put(initialContactInfo);
     Key employeeKey = putEmployeeWithContactInfo(initialContactInfo);
 
-    // [START embedded_entities_3]
     Entity employee = datastore.get(employeeKey);
     EmbeddedEntity embeddedContactInfo = (EmbeddedEntity) employee.getProperty("contactInfo");
 
     Key infoKey = embeddedContactInfo.getKey();
     Entity contactInfo = new Entity(infoKey);
     contactInfo.setPropertiesFrom(embeddedContactInfo);
-    // [END embedded_entities_3]
     datastore.put(contactInfo);
 
     Entity got = datastore.get(infoKey);
@@ -293,7 +265,6 @@ public class EntitiesTest {
 
   @Test
   public void batchOperations_putsEntities() {
-    // [START gae_batch_operations]
     Entity employee1 = new Entity("Employee");
     Entity employee2 = new Entity("Employee");
     Entity employee3 = new Entity("Employee");
@@ -305,7 +276,6 @@ public class EntitiesTest {
 
     List<Entity> employees = Arrays.asList(employee1, employee2, employee3);
     datastore.put(employees);
-    // [END gae_batch_operations]
 
     Map<Key, Entity> got =
         datastore.get(Arrays.asList(employee1.getKey(), employee2.getKey(), employee3.getKey()));
@@ -322,10 +292,8 @@ public class EntitiesTest {
 
   @Test
   public void createKey_makesKey() {
-    // [START generating_keys_1]
     Key k1 = KeyFactory.createKey("Person", "GreatGrandpa");
     Key k2 = KeyFactory.createKey("Person", 74219);
-    // [END generating_keys_1]
 
     assertThat(k1).isNotNull();
     assertThat(k2).isNotNull();
@@ -338,14 +306,12 @@ public class EntitiesTest {
     Key dadKey = KeyFactory.createKey(grandKey, "Person", "Dad");
     Key meKey = KeyFactory.createKey(dadKey, "Person", "Me");
 
-    // [START generating_keys_2]
     Key k =
         new KeyFactory.Builder("Person", "GreatGrandpa")
             .addChild("Person", "Grandpa")
             .addChild("Person", "Dad")
             .addChild("Person", "Me")
             .getKey();
-    // [END generating_keys_2]
 
     assertThat(k).isEqualTo(meKey);
   }
@@ -357,13 +323,11 @@ public class EntitiesTest {
     datastore.put(p);
     Key k = p.getKey();
 
-    // [START generating_keys_3]
     String personKeyStr = KeyFactory.keyToString(k);
 
     // Some time later (for example, after using personKeyStr in a link).
     Key personKey = KeyFactory.stringToKey(personKeyStr);
     Entity person = datastore.get(personKey);
-    // [END generating_keys_3]
 
     assertThat(personKey).isEqualTo(k);
     assertWithMessage("person.relationship")

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/GuestbookStrongTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/GuestbookStrongTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/GuestbookStrongTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/GuestbookStrongTest.java
@@ -1,1 +1,99 @@
-../../../../../../../../appengine-java8/datastore/src/test/java/com/example/appengine/GuestbookStrongTest.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.example.time.testing.FakeClock;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.appengine.tools.development.testing.LocalUserServiceTestConfig;
+import java.time.Instant;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link GuestbookStrong}.
+ */
+@RunWith(JUnit4.class)
+public class GuestbookStrongTest {
+
+  private static final Instant FAKE_NOW = Instant.ofEpochMilli(1234567890L);
+  private static final String GUESTBOOK_ID = "my guestbook";
+
+  // Set maximum eventual consistency.
+  // https://cloud.google.com/appengine/docs/java/tools/localunittesting
+  // #Java_Writing_High_Replication_Datastore_tests
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+          new LocalDatastoreServiceTestConfig()
+              .setDefaultHighRepJobPolicyUnappliedJobPercentage(100),
+          // Make sure there is a user logged in. We enforce this in web.xml.
+          new LocalUserServiceTestConfig())
+          .setEnvIsLoggedIn(true)
+          .setEnvEmail("test@example.com")
+          .setEnvAuthDomain("gmail.com");
+
+  private FakeClock clock;
+  private GuestbookStrong guestbookUnderTest;
+
+  @Before
+  public void setUp() throws Exception {
+    helper.setUp();
+    clock = new FakeClock(FAKE_NOW);
+    guestbookUnderTest = new GuestbookStrong(GUESTBOOK_ID, clock);
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void appendGreeting_normalData_setsContentProperty() {
+    Greeting got = guestbookUnderTest.appendGreeting("Hello, Datastore!");
+
+    assertWithMessage("content property").that(got.getContent()).isEqualTo("Hello, Datastore!");
+  }
+
+  @Test
+  public void appendGreeting_normalData_setsDateProperty() {
+    Greeting got = guestbookUnderTest.appendGreeting("Hello, Datastore!");
+
+    assertWithMessage("date property").that(got.getDate()).isEqualTo(FAKE_NOW);
+  }
+
+  @Test
+  public void listGreetings_maximumEventualConsistency_returnsAllGreetings() {
+    // Arrange
+    guestbookUnderTest.appendGreeting("Hello, Datastore!");
+    guestbookUnderTest.appendGreeting("Hello, Eventual Consistency!");
+    guestbookUnderTest.appendGreeting("Hello, World!");
+
+    // Act
+    List<Greeting> got = guestbookUnderTest.listGreetings();
+
+    // Assert
+    // Since we use an ancestor query, all greetings should be available.
+    assertThat(got).hasSize(3);
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/GuestbookTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/GuestbookTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/GuestbookTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/GuestbookTest.java
@@ -1,1 +1,125 @@
-../../../../../../../../appengine-java8/datastore/src/test/java/com/example/appengine/GuestbookTest.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.example.time.testing.FakeClock;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.dev.HighRepJobPolicy;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.appengine.tools.development.testing.LocalUserServiceTestConfig;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link Guestbook}.
+ */
+@RunWith(JUnit4.class)
+public class GuestbookTest {
+
+  private static final class CustomHighRepJobPolicy implements HighRepJobPolicy {
+
+    static int newJobCounter = 0;
+    static int existingJobCounter = 0;
+
+    @Override
+    public boolean shouldApplyNewJob(Key entityGroup) {
+      // Every other new job fails to apply.
+      return newJobCounter++ % 2 == 0;
+    }
+
+    @Override
+    public boolean shouldRollForwardExistingJob(Key entityGroup) {
+      // Existing jobs always apply after every Get and every Query.
+      return true;
+    }
+  }
+
+  // Set custom, deterministic, eventual consistency.
+  // https://cloud.google.com/appengine/docs/java/tools/localunittesting
+  // #Java_Writing_High_Replication_Datastore_tests
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+          new LocalDatastoreServiceTestConfig()
+              .setAlternateHighRepJobPolicyClass(CustomHighRepJobPolicy.class),
+          // Make sure there is a user logged in. We enforce this in web.xml.
+          new LocalUserServiceTestConfig())
+          .setEnvIsLoggedIn(true)
+          .setEnvEmail("test@example.com")
+          .setEnvAuthDomain("gmail.com");
+
+  private FakeClock clock;
+  private Guestbook guestbookUnderTest;
+
+  @Before
+  public void setUp() throws Exception {
+    helper.setUp();
+    clock = new FakeClock();
+    guestbookUnderTest = new Guestbook(clock);
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void appendGreeting_normalData_setsContentProperty() {
+    Greeting got = guestbookUnderTest.appendGreeting("Hello, Datastore!");
+
+    assertWithMessage("content property").that(got.getContent()).isEqualTo("Hello, Datastore!");
+  }
+
+  @Test
+  public void listGreetings_eventualConsistency_returnsPartialGreetings() {
+    // Arrange
+    guestbookUnderTest.appendGreeting("Hello, Datastore!");
+    guestbookUnderTest.appendGreeting("Hello, Eventual Consistency!");
+    guestbookUnderTest.appendGreeting("Hello, World!");
+    guestbookUnderTest.appendGreeting("Güten Tag!");
+
+    // Act
+    List<Greeting> got = guestbookUnderTest.listGreetings();
+
+    // The first time we query we should half of the results due to the fact that we simulate
+    // eventual consistency by applying every other write.
+    assertThat(got).hasSize(2);
+  }
+
+  @Test
+  public void listGreetings_groomedDatastore_returnsAllGreetings() {
+    // Arrange
+    guestbookUnderTest.appendGreeting("Hello, Datastore!");
+    guestbookUnderTest.appendGreeting("Hello, Eventual Consistency!");
+    guestbookUnderTest.appendGreeting("Hello, World!");
+
+    // Act
+    guestbookUnderTest.listGreetings();
+    // Second global query sees both Entities because we "groom" (attempt to
+    // apply unapplied jobs) after every query.
+    List<Greeting> got = guestbookUnderTest.listGreetings();
+
+    assertThat(got).hasSize(3);
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/IndexesTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/IndexesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/IndexesTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/IndexesTest.java
@@ -66,7 +66,6 @@ public class IndexesTest {
 
   @Test
   public void propertyFilterExample_returnsMatchingEntities() throws Exception {
-    // [START unindexed_properties_1]
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
     Key acmeKey = KeyFactory.createKey("Company", "Acme");
@@ -87,7 +86,6 @@ public class IndexesTest {
 
     // Returns tom but not lucy, because her age is unindexed
     List<Entity> results = datastore.prepare(q).asList(FetchOptions.Builder.withDefaults());
-    // [END unindexed_properties_1]
 
     assertWithMessage("query results").that(results).containsExactly(tom);
   }

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/IndexesTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/IndexesTest.java
@@ -1,1 +1,94 @@
-../../../../../../../../appengine-java8/datastore/src/test/java/com/example/appengine/IndexesTest.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.Filter;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests to demonstrate App Engine Datastore queries.
+ */
+@RunWith(JUnit4.class)
+public class IndexesTest {
+
+  // Set no eventual consistency, that way queries return all results.
+  // https://cloud.google.com/appengine/docs/java/tools/localunittesting
+  // #Java_Writing_High_Replication_Datastore_tests
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+          new LocalDatastoreServiceTestConfig()
+              .setDefaultHighRepJobPolicyUnappliedJobPercentage(0));
+
+  private DatastoreService datastore;
+
+  @Before
+  public void setUp() {
+    helper.setUp();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void propertyFilterExample_returnsMatchingEntities() throws Exception {
+    // [START unindexed_properties_1]
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+    Key acmeKey = KeyFactory.createKey("Company", "Acme");
+
+    Entity tom = new Entity("Person", "Tom", acmeKey);
+    tom.setProperty("name", "Tom");
+    tom.setProperty("age", 32);
+    datastore.put(tom);
+
+    Entity lucy = new Entity("Person", "Lucy", acmeKey);
+    lucy.setProperty("name", "Lucy");
+    lucy.setUnindexedProperty("age", 29);
+    datastore.put(lucy);
+
+    Filter ageFilter = new FilterPredicate("age", FilterOperator.GREATER_THAN, 25);
+
+    Query q = new Query("Person").setAncestor(acmeKey).setFilter(ageFilter);
+
+    // Returns tom but not lucy, because her age is unindexed
+    List<Entity> results = datastore.prepare(q).asList(FetchOptions.Builder.withDefaults());
+    // [END unindexed_properties_1]
+
+    assertWithMessage("query results").that(results).containsExactly(tom);
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/ListPeopleServletTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/ListPeopleServletTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/ListPeopleServletTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/ListPeopleServletTest.java
@@ -1,1 +1,165 @@
-../../../../../../../../appengine-java8/datastore/src/test/java/com/example/appengine/ListPeopleServletTest.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.appengine.api.datastore.QueryResultList;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.common.collect.ImmutableList;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Unit tests for {@link ListPeopleServlet}.
+ */
+@RunWith(JUnit4.class)
+public class ListPeopleServletTest {
+
+  private static final ImmutableList<String> TEST_NAMES =
+      // Keep in alphabetical order, so this is the same as the query order.
+      ImmutableList.<String>builder()
+          .add("Alpha")
+          .add("Bravo")
+          .add("Charlie")
+          .add("Delta")
+          .add("Echo")
+          .add("Foxtrot")
+          .add("Golf")
+          .add("Hotel")
+          .add("India")
+          .add("Juliett")
+          .add("Kilo")
+          .add("Lima")
+          .add("Mike")
+          .add("November")
+          .add("Oscar")
+          .add("Papa")
+          .add("Quebec")
+          .add("Romeo")
+          .add("Sierra")
+          .add("Tango")
+          .build();
+
+  // Set no eventual consistency, that way queries return all results.
+  // https://cloud.google.com/appengine/docs/java/tools/localunittesting
+  // #Java_Writing_High_Replication_Datastore_tests
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+          new LocalDatastoreServiceTestConfig()
+              .setDefaultHighRepJobPolicyUnappliedJobPercentage(0));
+
+  @Mock
+  private HttpServletRequest mockRequest;
+  @Mock
+  private HttpServletResponse mockResponse;
+  private StringWriter responseWriter;
+  private DatastoreService datastore;
+
+  private ListPeopleServlet servletUnderTest;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
+    helper.setUp();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+
+    // Add test data.
+    ImmutableList.Builder<Entity> people = ImmutableList.builder();
+    for (String name : TEST_NAMES) {
+      people.add(createPerson(name));
+    }
+    datastore.put(people.build());
+
+    // Set up a fake HTTP response.
+    responseWriter = new StringWriter();
+    when(mockResponse.getWriter()).thenReturn(new PrintWriter(responseWriter));
+
+    servletUnderTest = new ListPeopleServlet();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  private Entity createPerson(String name) {
+    Entity person = new Entity("Person");
+    person.setProperty("name", name);
+    return person;
+  }
+
+  @Test
+  public void doGet_noCursor_writesNames() throws Exception {
+    servletUnderTest.doGet(mockRequest, mockResponse);
+
+    String response = responseWriter.toString();
+    for (int i = 0; i < ListPeopleServlet.PAGE_SIZE; i++) {
+      assertWithMessage("ListPeopleServlet response").that(response).contains(TEST_NAMES.get(i));
+    }
+  }
+
+  private String getFirstCursor() {
+    Query q = new Query("Person").addSort("name", SortDirection.ASCENDING);
+    PreparedQuery pq = datastore.prepare(q);
+    FetchOptions fetchOptions = FetchOptions.Builder.withLimit(ListPeopleServlet.PAGE_SIZE);
+    QueryResultList<Entity> results = pq.asQueryResultList(fetchOptions);
+    return results.getCursor().toWebSafeString();
+  }
+
+  @Test
+  public void doGet_withValidCursor_writesNames() throws Exception {
+    when(mockRequest.getParameter("cursor")).thenReturn(getFirstCursor());
+
+    servletUnderTest.doGet(mockRequest, mockResponse);
+
+    String response = responseWriter.toString();
+    int i = 0;
+    while (i + ListPeopleServlet.PAGE_SIZE < TEST_NAMES.size() && i < ListPeopleServlet.PAGE_SIZE) {
+      assertWithMessage("ListPeopleServlet response")
+          .that(response)
+          .contains(TEST_NAMES.get(i + ListPeopleServlet.PAGE_SIZE));
+      i++;
+    }
+  }
+
+  @Test
+  public void doGet_withInvalidCursor_writesRedirect() throws Exception {
+    when(mockRequest.getParameter("cursor")).thenReturn("ThisCursorIsTotallyInvalid");
+    servletUnderTest.doGet(mockRequest, mockResponse);
+    verify(mockResponse).sendRedirect("/people");
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataEntityGroupTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataEntityGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataEntityGroupTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataEntityGroupTest.java
@@ -1,1 +1,164 @@
-../../../../../../../../appengine-java8/datastore/src/test/java/com/example/appengine/MetadataEntityGroupTest.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entities;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EntityNotFoundException;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Transaction;
+import com.google.appengine.api.memcache.MemcacheService;
+import com.google.appengine.api.memcache.MemcacheServiceFactory;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalMemcacheServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.io.StringWriter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests to demonstrate App Engine Datastore entity group metadata.
+ */
+@RunWith(JUnit4.class)
+public class MetadataEntityGroupTest {
+
+  // Set no eventual consistency, that way queries return all results.
+  // https://cloud.google.com/appengine/docs/java/tools/localunittesting
+  // #Java_Writing_High_Replication_Datastore_tests
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+          new LocalDatastoreServiceTestConfig().setDefaultHighRepJobPolicyUnappliedJobPercentage(0),
+          new LocalMemcacheServiceTestConfig());
+
+  private DatastoreService datastore;
+
+  @Before
+  public void setUp() {
+    helper.setUp();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  // [START entity_group_1]
+  private static long getEntityGroupVersion(DatastoreService ds, Transaction tx, Key entityKey) {
+    try {
+      return Entities.getVersionProperty(ds.get(tx, Entities.createEntityGroupKey(entityKey)));
+    } catch (EntityNotFoundException e) {
+      // No entity group information, return a value strictly smaller than any
+      // possible version
+      return 0;
+    }
+  }
+
+  private static void printEntityGroupVersions(DatastoreService ds, PrintWriter writer) {
+    Entity entity1 = new Entity("Simple");
+    Key key1 = ds.put(entity1);
+    Key entityGroupKey = Entities.createEntityGroupKey(key1);
+
+    // Print entity1's entity group version
+    writer.println("version " + getEntityGroupVersion(ds, null, key1));
+
+    // Write to a different entity group
+    Entity entity2 = new Entity("Simple");
+    ds.put(entity2);
+
+    // Will print the same version, as entity1's entity group has not changed
+    writer.println("version " + getEntityGroupVersion(ds, null, key1));
+
+    // Change entity1's entity group by adding a new child entity
+    Entity entity3 = new Entity("Simple", entity1.getKey());
+    ds.put(entity3);
+
+    // Will print a higher version, as entity1's entity group has changed
+    writer.println("version " + getEntityGroupVersion(ds, null, key1));
+  }
+  // [END entity_group_1]
+
+  @Test
+  public void printEntityGroupVersions_printsVersions() throws Exception {
+    StringWriter responseWriter = new StringWriter();
+    printEntityGroupVersions(datastore, new PrintWriter(responseWriter));
+    assertThat(responseWriter.toString()).contains("version");
+  }
+
+  // [START entity_group_2]
+  // A simple class for tracking consistent entity group counts.
+  private static class EntityGroupCount implements Serializable {
+
+    long version; // Version of the entity group whose count we are tracking
+    int count;
+
+    EntityGroupCount(long version, int count) {
+      this.version = version;
+      this.count = count;
+    }
+
+    // Display count of entities in an entity group, with consistent caching
+    void showEntityGroupCount(
+        DatastoreService ds, MemcacheService cache, PrintWriter writer, Key entityGroupKey) {
+      EntityGroupCount egCount = (EntityGroupCount) cache.get(entityGroupKey);
+      // Reuses getEntityGroupVersion method from the previous example.
+      if (egCount != null && egCount.version == getEntityGroupVersion(ds, null, entityGroupKey)) {
+        // Cached value matched current entity group version, use that
+        writer.println(egCount.count + " entities (cached)");
+      } else {
+        // Need to actually count entities. Using a transaction to get a consistent count
+        // and entity group version.
+        Transaction tx = ds.beginTransaction();
+        PreparedQuery pq = ds.prepare(tx, new Query(entityGroupKey));
+        int count = pq.countEntities(FetchOptions.Builder.withLimit(5000));
+        cache.put(
+            entityGroupKey,
+            new EntityGroupCount(getEntityGroupVersion(ds, tx, entityGroupKey), count));
+        tx.rollback();
+        writer.println(count + " entities");
+      }
+    }
+  }
+  // [END entity_group_2]
+
+  @Test
+  public void entityGroupCount_printsCount() throws Exception {
+    StringWriter responseWriter = new StringWriter();
+    MemcacheService cache = MemcacheServiceFactory.getMemcacheService();
+    Entity entity1 = new Entity("Simple");
+    Key key1 = datastore.put(entity1);
+    Key entityGroupKey = Entities.createEntityGroupKey(key1);
+
+    EntityGroupCount groupCount = new EntityGroupCount(0, 0);
+    groupCount.showEntityGroupCount(
+        datastore, cache, new PrintWriter(responseWriter), entityGroupKey);
+
+    assertThat(responseWriter.toString()).contains(" entities");
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataEntityGroupTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataEntityGroupTest.java
@@ -69,7 +69,6 @@ public class MetadataEntityGroupTest {
     helper.tearDown();
   }
 
-  // [START entity_group_1]
   private static long getEntityGroupVersion(DatastoreService ds, Transaction tx, Key entityKey) {
     try {
       return Entities.getVersionProperty(ds.get(tx, Entities.createEntityGroupKey(entityKey)));
@@ -102,7 +101,6 @@ public class MetadataEntityGroupTest {
     // Will print a higher version, as entity1's entity group has changed
     writer.println("version " + getEntityGroupVersion(ds, null, key1));
   }
-  // [END entity_group_1]
 
   @Test
   public void printEntityGroupVersions_printsVersions() throws Exception {
@@ -111,7 +109,6 @@ public class MetadataEntityGroupTest {
     assertThat(responseWriter.toString()).contains("version");
   }
 
-  // [START entity_group_2]
   // A simple class for tracking consistent entity group counts.
   private static class EntityGroupCount implements Serializable {
 
@@ -145,7 +142,6 @@ public class MetadataEntityGroupTest {
       }
     }
   }
-  // [END entity_group_2]
 
   @Test
   public void entityGroupCount_printsCount() throws Exception {

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataKindsTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataKindsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataKindsTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataKindsTest.java
@@ -1,1 +1,122 @@
-../../../../../../../../appengine-java8/datastore/src/test/java/com/example/appengine/MetadataKindsTest.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entities;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.CompositeFilterOperator;
+import com.google.appengine.api.datastore.Query.Filter;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests to demonstrate App Engine Datastore kinds metadata.
+ */
+@RunWith(JUnit4.class)
+public class MetadataKindsTest {
+
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+          // Set no eventual consistency, that way queries return all results.
+          // https://cloud.google
+          // .com/appengine/docs/java/tools/localunittesting
+          // #Java_Writing_High_Replication_Datastore_tests
+          new LocalDatastoreServiceTestConfig()
+              .setDefaultHighRepJobPolicyUnappliedJobPercentage(0));
+
+  private StringWriter responseWriter;
+  private DatastoreService datastore;
+
+  @Before
+  public void setUp() {
+    helper.setUp();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+    responseWriter = new StringWriter();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  // [START kind_query_example]
+  void printLowercaseKinds(DatastoreService ds, PrintWriter writer) {
+
+    // Start with unrestricted kind query
+    Query q = new Query(Entities.KIND_METADATA_KIND);
+
+    List<Filter> subFils = new ArrayList<>();
+
+    // Limit to lowercase initial letters
+    subFils.add(
+        new FilterPredicate(
+            Entity.KEY_RESERVED_PROPERTY,
+            FilterOperator.GREATER_THAN_OR_EQUAL,
+            Entities.createKindKey("a")));
+
+    String endChar = Character.toString((char) ('z' + 1)); // Character after 'z'
+
+    subFils.add(
+        new FilterPredicate(
+            Entity.KEY_RESERVED_PROPERTY,
+            FilterOperator.LESS_THAN,
+            Entities.createKindKey(endChar)));
+
+    q.setFilter(CompositeFilterOperator.and(subFils));
+
+    // Print heading
+    writer.println("Lowercase kinds:");
+
+    // Print query results
+    for (Entity e : ds.prepare(q).asIterable()) {
+      writer.println("  " + e.getKey().getName());
+    }
+  }
+  // [END kind_query_example]
+
+  @Test
+  public void printLowercaseKinds_printsKinds() throws Exception {
+    datastore.put(new Entity("alpha"));
+    datastore.put(new Entity("beta"));
+    datastore.put(new Entity("NotIncluded"));
+    datastore.put(new Entity("zed"));
+
+    printLowercaseKinds(datastore, new PrintWriter(responseWriter));
+
+    String response = responseWriter.toString();
+    assertThat(response).contains("alpha");
+    assertThat(response).contains("beta");
+    assertThat(response).contains("zed");
+    assertThat(response).doesNotContain("NotIncluded");
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataKindsTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataKindsTest.java
@@ -69,7 +69,6 @@ public class MetadataKindsTest {
     helper.tearDown();
   }
 
-  // [START kind_query_example]
   void printLowercaseKinds(DatastoreService ds, PrintWriter writer) {
 
     // Start with unrestricted kind query
@@ -102,7 +101,6 @@ public class MetadataKindsTest {
       writer.println("  " + e.getKey().getName());
     }
   }
-  // [END kind_query_example]
 
   @Test
   public void printLowercaseKinds_printsKinds() throws Exception {

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataNamespacesTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataNamespacesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataNamespacesTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataNamespacesTest.java
@@ -70,7 +70,6 @@ public class MetadataNamespacesTest {
     helper.tearDown();
   }
 
-  // [START queries_intro_example]
   void printAllNamespaces(DatastoreService ds, PrintWriter writer) {
     Query q = new Query(Entities.NAMESPACE_METADATA_KIND);
 
@@ -84,7 +83,6 @@ public class MetadataNamespacesTest {
       }
     }
   }
-  // [END queries_intro_example]
 
   @Test
   public void printAllNamespaces_printsNamespaces() throws Exception {
@@ -99,7 +97,6 @@ public class MetadataNamespacesTest {
     assertThat(response).contains("another-namespace");
   }
 
-  // [START namespace_query_example]
   List<String> getNamespaces(DatastoreService ds, String start, String end) {
 
     // Start with unrestricted namespace query
@@ -134,7 +131,6 @@ public class MetadataNamespacesTest {
     // Return result list
     return results;
   }
-  // [END namespace_query_example]
 
   @Test
   public void getNamespaces_returnsNamespaces() throws Exception {

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataNamespacesTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataNamespacesTest.java
@@ -1,1 +1,154 @@
-../../../../../../../../appengine-java8/datastore/src/test/java/com/example/appengine/MetadataNamespacesTest.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.appengine.api.NamespaceManager;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entities;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.CompositeFilterOperator;
+import com.google.appengine.api.datastore.Query.Filter;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests to demonstrate App Engine Datastore namespaces metadata.
+ */
+@RunWith(JUnit4.class)
+public class MetadataNamespacesTest {
+
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+          // Set no eventual consistency, that way queries return all results.
+          // https://cloud.google
+          // .com/appengine/docs/java/tools/localunittesting
+          // #Java_Writing_High_Replication_Datastore_tests
+          new LocalDatastoreServiceTestConfig()
+              .setDefaultHighRepJobPolicyUnappliedJobPercentage(0));
+
+  private StringWriter responseWriter;
+  private DatastoreService datastore;
+
+  @Before
+  public void setUp() {
+    helper.setUp();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+    responseWriter = new StringWriter();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  // [START queries_intro_example]
+  void printAllNamespaces(DatastoreService ds, PrintWriter writer) {
+    Query q = new Query(Entities.NAMESPACE_METADATA_KIND);
+
+    for (Entity e : ds.prepare(q).asIterable()) {
+      // A nonzero numeric id denotes the default namespace;
+      // see <a href="#Namespace_Queries">Namespace Queries</a>, below
+      if (e.getKey().getId() != 0) {
+        writer.println("<default>");
+      } else {
+        writer.println(e.getKey().getName());
+      }
+    }
+  }
+  // [END queries_intro_example]
+
+  @Test
+  public void printAllNamespaces_printsNamespaces() throws Exception {
+    datastore.put(new Entity("Simple"));
+    NamespaceManager.set("another-namespace");
+    datastore.put(new Entity("Simple"));
+
+    printAllNamespaces(datastore, new PrintWriter(responseWriter));
+
+    String response = responseWriter.toString();
+    assertThat(response).contains("<default>");
+    assertThat(response).contains("another-namespace");
+  }
+
+  // [START namespace_query_example]
+  List<String> getNamespaces(DatastoreService ds, String start, String end) {
+
+    // Start with unrestricted namespace query
+    Query q = new Query(Entities.NAMESPACE_METADATA_KIND);
+    List<Filter> subFilters = new ArrayList<>();
+    // Limit to specified range, if any
+    if (start != null) {
+      subFilters.add(
+          new FilterPredicate(
+              Entity.KEY_RESERVED_PROPERTY,
+              FilterOperator.GREATER_THAN_OR_EQUAL,
+              Entities.createNamespaceKey(start)));
+    }
+    if (end != null) {
+      subFilters.add(
+          new FilterPredicate(
+              Entity.KEY_RESERVED_PROPERTY,
+              FilterOperator.LESS_THAN_OR_EQUAL,
+              Entities.createNamespaceKey(end)));
+    }
+
+    q.setFilter(CompositeFilterOperator.and(subFilters));
+
+    // Initialize result list
+    List<String> results = new ArrayList<>();
+
+    // Build list of query results
+    for (Entity e : ds.prepare(q).asIterable()) {
+      results.add(Entities.getNamespaceFromNamespaceKey(e.getKey()));
+    }
+
+    // Return result list
+    return results;
+  }
+  // [END namespace_query_example]
+
+  @Test
+  public void getNamespaces_returnsNamespaces() throws Exception {
+    NamespaceManager.set("alpha");
+    datastore.put(new Entity("Simple"));
+    NamespaceManager.set("bravo");
+    datastore.put(new Entity("Simple"));
+    NamespaceManager.set("charlie");
+    datastore.put(new Entity("Simple"));
+    NamespaceManager.set("zed");
+    datastore.put(new Entity("Simple"));
+
+    List<String> results = getNamespaces(datastore, "bravo", "echo");
+
+    assertThat(results).containsExactly("bravo", "charlie");
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataPropertiesTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataPropertiesTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataPropertiesTest.java
@@ -1,1 +1,235 @@
-../../../../../../../../appengine-java8/datastore/src/test/java/com/example/appengine/MetadataPropertiesTest.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entities;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.CompositeFilterOperator;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests to demonstrate App Engine Datastore properties metadata.
+ */
+@RunWith(JUnit4.class)
+public class MetadataPropertiesTest {
+
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+          // Set no eventual consistency, that way queries return all results.
+          // https://cloud.google
+          // .com/appengine/docs/java/tools/localunittesting
+          // #Java_Writing_High_Replication_Datastore_tests
+          new LocalDatastoreServiceTestConfig()
+              .setDefaultHighRepJobPolicyUnappliedJobPercentage(0));
+
+  private StringWriter responseWriter;
+  private DatastoreService datastore;
+
+  @Before
+  public void setUp() {
+    helper.setUp();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+    responseWriter = new StringWriter();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  // [START property_query_example]
+  void printProperties(DatastoreService ds, PrintWriter writer) {
+
+    // Create unrestricted keys-only property query
+    Query q = new Query(Entities.PROPERTY_METADATA_KIND).setKeysOnly();
+
+    // Print query results
+    for (Entity e : ds.prepare(q).asIterable()) {
+      writer.println(e.getKey().getParent().getName() + ": " + e.getKey().getName());
+    }
+  }
+  // [END property_query_example]
+
+  @Test
+  public void printProperties_printsProperties() throws Exception {
+    Entity a = new Entity("Widget");
+    a.setProperty("combobulators", 2);
+    a.setProperty("oscillatorState", "harmonzing");
+    Entity b = new Entity("Ship");
+    b.setProperty("sails", 2);
+    b.setProperty("captain", "Blackbeard");
+    Entity c = new Entity("Ship");
+    c.setProperty("captain", "Redbeard");
+    c.setProperty("motor", "outboard");
+    datastore.put(Arrays.asList(a, b, c));
+
+    printProperties(datastore, new PrintWriter(responseWriter));
+
+    String response = responseWriter.toString();
+    assertThat(response).contains("Widget: combobulators");
+    assertThat(response).contains("Widget: oscillatorState");
+    assertThat(response).contains("Ship: sails");
+    assertThat(response).contains("Ship: captain");
+    assertThat(response).contains("Ship: motor");
+  }
+
+  // [START property_filtering_example]
+  void printPropertyRange(DatastoreService ds, PrintWriter writer) {
+
+    // Start with unrestricted keys-only property query
+    Query q = new Query(Entities.PROPERTY_METADATA_KIND).setKeysOnly();
+
+    // Limit range
+    q.setFilter(
+        CompositeFilterOperator.and(
+            new FilterPredicate(
+                Entity.KEY_RESERVED_PROPERTY,
+                Query.FilterOperator.GREATER_THAN_OR_EQUAL,
+                Entities.createPropertyKey("Employee", "salary")),
+            new FilterPredicate(
+                Entity.KEY_RESERVED_PROPERTY,
+                Query.FilterOperator.LESS_THAN_OR_EQUAL,
+                Entities.createPropertyKey("Manager", "salary"))));
+    q.addSort(Entity.KEY_RESERVED_PROPERTY, SortDirection.ASCENDING);
+
+    // Print query results
+    for (Entity e : ds.prepare(q).asIterable()) {
+      writer.println(e.getKey().getParent().getName() + ": " + e.getKey().getName());
+    }
+  }
+  // [END property_filtering_example]
+
+  @Test
+  public void printPropertyRange_printsProperties() throws Exception {
+    Entity account = new Entity("Account");
+    account.setProperty("balance", "10.30");
+    account.setProperty("company", "General Company");
+    Entity employee = new Entity("Employee");
+    employee.setProperty("name", "John Doe");
+    employee.setProperty("ssn", "987-65-4321");
+    Entity invoice = new Entity("Invoice");
+    invoice.setProperty("date", new Date());
+    invoice.setProperty("amount", "99.98");
+    Entity manager = new Entity("Manager");
+    manager.setProperty("name", "Jane Doe");
+    manager.setProperty("title", "Technical Director");
+    Entity product = new Entity("Product");
+    product.setProperty("description", "Widget to re-ionize an oscillator");
+    product.setProperty("price", "19.97");
+    datastore.put(Arrays.asList(account, employee, invoice, manager, product));
+
+    printPropertyRange(datastore, new PrintWriter(responseWriter));
+
+    String response = responseWriter.toString();
+    assertThat(response)
+        .isEqualTo("Employee: ssn\nInvoice: amount\nInvoice: date\nManager: name\n");
+  }
+
+  // [START property_ancestor_query_example]
+  List<String> propertiesOfKind(DatastoreService ds, String kind) {
+
+    // Start with unrestricted keys-only property query
+    Query q = new Query(Entities.PROPERTY_METADATA_KIND).setKeysOnly();
+
+    // Limit to specified kind
+    q.setAncestor(Entities.createKindKey(kind));
+
+    // Initialize result list
+    ArrayList<String> results = new ArrayList<>();
+
+    //Build list of query results
+    for (Entity e : ds.prepare(q).asIterable()) {
+      results.add(e.getKey().getName());
+    }
+
+    // Return result list
+    return results;
+  }
+  // [END property_ancestor_query_example]
+
+  @Test
+  public void propertiesOfKind_returnsProperties() throws Exception {
+    Entity a = new Entity("Alpha");
+    a.setProperty("beta", 12);
+    a.setProperty("charlie", "misc.");
+    Entity b = new Entity("Alpha");
+    b.setProperty("charlie", "assorted");
+    b.setProperty("delta", new Date());
+    Entity c = new Entity("Charlie");
+    c.setProperty("charlie", "some");
+    c.setProperty("echo", new Date());
+    datastore.put(Arrays.asList(a, b, c));
+
+    List<String> properties = propertiesOfKind(datastore, "Alpha");
+
+    assertThat(properties).containsExactly("beta", "charlie", "delta");
+  }
+
+  // [START property_representation_query_example]
+  Collection<String> representationsOfProperty(DatastoreService ds, String kind, String property) {
+
+    // Start with unrestricted non-keys-only property query
+    Query q = new Query(Entities.PROPERTY_METADATA_KIND);
+
+    // Limit to specified kind and property
+    q.setFilter(
+        new FilterPredicate(
+            "__key__", Query.FilterOperator.EQUAL, Entities.createPropertyKey(kind, property)));
+
+    // Get query result
+    Entity propInfo = ds.prepare(q).asSingleEntity();
+
+    // Return collection of property representations
+    return (Collection<String>) propInfo.getProperty("property_representation");
+  }
+  // [END property_representation_query_example]
+
+  @Test
+  public void representationsOfProperty_returnsRepresentations() throws Exception {
+    Entity a = new Entity("Alpha");
+    a.setProperty("beta", 12);
+    Entity b = new Entity("Alpha");
+    b.setProperty("beta", true);
+    Entity c = new Entity("Alpha");
+    c.setProperty("beta", new Date());
+    datastore.put(Arrays.asList(a, b, c));
+
+    Collection<String> results = representationsOfProperty(datastore, "Alpha", "beta");
+
+    assertThat(results).containsExactly("INT64", "BOOLEAN");
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataPropertiesTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/MetadataPropertiesTest.java
@@ -71,7 +71,6 @@ public class MetadataPropertiesTest {
     helper.tearDown();
   }
 
-  // [START property_query_example]
   void printProperties(DatastoreService ds, PrintWriter writer) {
 
     // Create unrestricted keys-only property query
@@ -82,7 +81,6 @@ public class MetadataPropertiesTest {
       writer.println(e.getKey().getParent().getName() + ": " + e.getKey().getName());
     }
   }
-  // [END property_query_example]
 
   @Test
   public void printProperties_printsProperties() throws Exception {
@@ -107,7 +105,6 @@ public class MetadataPropertiesTest {
     assertThat(response).contains("Ship: motor");
   }
 
-  // [START property_filtering_example]
   void printPropertyRange(DatastoreService ds, PrintWriter writer) {
 
     // Start with unrestricted keys-only property query
@@ -131,7 +128,6 @@ public class MetadataPropertiesTest {
       writer.println(e.getKey().getParent().getName() + ": " + e.getKey().getName());
     }
   }
-  // [END property_filtering_example]
 
   @Test
   public void printPropertyRange_printsProperties() throws Exception {
@@ -159,7 +155,6 @@ public class MetadataPropertiesTest {
         .isEqualTo("Employee: ssn\nInvoice: amount\nInvoice: date\nManager: name\n");
   }
 
-  // [START property_ancestor_query_example]
   List<String> propertiesOfKind(DatastoreService ds, String kind) {
 
     // Start with unrestricted keys-only property query
@@ -179,7 +174,6 @@ public class MetadataPropertiesTest {
     // Return result list
     return results;
   }
-  // [END property_ancestor_query_example]
 
   @Test
   public void propertiesOfKind_returnsProperties() throws Exception {
@@ -199,7 +193,6 @@ public class MetadataPropertiesTest {
     assertThat(properties).containsExactly("beta", "charlie", "delta");
   }
 
-  // [START property_representation_query_example]
   Collection<String> representationsOfProperty(DatastoreService ds, String kind, String property) {
 
     // Start with unrestricted non-keys-only property query
@@ -216,7 +209,6 @@ public class MetadataPropertiesTest {
     // Return collection of property representations
     return (Collection<String>) propInfo.getProperty("property_representation");
   }
-  // [END property_representation_query_example]
 
   @Test
   public void representationsOfProperty_returnsRepresentations() throws Exception {

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/ProjectionServletTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/ProjectionServletTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/ProjectionServletTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/ProjectionServletTest.java
@@ -1,1 +1,97 @@
-../../../../../../../../appengine-java8/datastore/src/test/java/com/example/appengine/ProjectionServletTest.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.mockito.Mockito.when;
+
+import com.example.time.testing.FakeClock;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Unit tests for {@link ProjectionServlet}.
+ */
+@RunWith(JUnit4.class)
+public class ProjectionServletTest {
+
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+
+  @Mock
+  private HttpServletRequest mockRequest;
+  @Mock
+  private HttpServletResponse mockResponse;
+  private StringWriter responseWriter;
+  private ProjectionServlet servletUnderTest;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
+    helper.setUp();
+
+    // Set up a fake HTTP response.
+    responseWriter = new StringWriter();
+    when(mockResponse.getWriter()).thenReturn(new PrintWriter(responseWriter));
+
+    servletUnderTest = new ProjectionServlet();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void doGet_emptyDatastore_writesNoGreetings() throws Exception {
+    servletUnderTest.doGet(mockRequest, mockResponse);
+
+    assertWithMessage("ProjectionServlet response")
+        .that(responseWriter.toString())
+        .doesNotContain("Message");
+  }
+
+  @Test
+  public void doGet_manyGreetings_writesLatestGreetings() throws Exception {
+    // Arrange
+    GuestbookStrong guestbook =
+        new GuestbookStrong(GuestbookStrongServlet.GUESTBOOK_ID, new FakeClock());
+    guestbook.appendGreeting("Hello.");
+    guestbook.appendGreeting("Güten Tag!");
+    guestbook.appendGreeting("Hi.");
+    guestbook.appendGreeting("Hola.");
+
+    // Act
+    servletUnderTest.doGet(mockRequest, mockResponse);
+    String output = responseWriter.toString();
+
+    assertWithMessage("ProjectionServlet response").that(output).contains("Message Hello.");
+    assertWithMessage("ProjectionServlet response").that(output).contains("Message Güten Tag!");
+    assertWithMessage("ProjectionServlet response").that(output).contains("Message Hola.");
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/ProjectionTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/ProjectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/ProjectionTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/ProjectionTest.java
@@ -1,1 +1,94 @@
-../../../../../../../../appengine-java8/datastore/src/test/java/com/example/appengine/ProjectionTest.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.PropertyProjection;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests to demonstrate App Engine Datastore projection queries. */
+@RunWith(JUnit4.class)
+public class ProjectionTest {
+
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+          // Set no eventual consistency, that way queries return all results.
+          // https://cloud.google
+          // .com/appengine/docs/java/tools/localunittesting
+          // #Java_Writing_High_Replication_Datastore_tests
+          new LocalDatastoreServiceTestConfig()
+              .setDefaultHighRepJobPolicyUnappliedJobPercentage(0));
+
+  private DatastoreService datastore;
+
+  @Before
+  public void setUp() throws Exception {
+    helper.setUp();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void projectionQuery_grouping_filtersDuplicates() {
+    putTestData("some duplicate", 0L);
+    putTestData("some duplicate", 0L);
+    putTestData("too big", 1L);
+
+    // [START grouping]
+    Query q = new Query("TestKind");
+    q.addProjection(new PropertyProjection("A", String.class));
+    q.addProjection(new PropertyProjection("B", Long.class));
+    q.setDistinct(true);
+    q.setFilter(Query.FilterOperator.LESS_THAN.of("B", 1L));
+    q.addSort("B", Query.SortDirection.DESCENDING);
+    q.addSort("A");
+    // [END grouping]
+
+    List<Entity> entities = datastore.prepare(q).asList(FetchOptions.Builder.withLimit(5));
+    assertThat(entities).hasSize(1);
+    Entity entity = entities.get(0);
+    assertWithMessage("entity.A")
+        .that((String) entity.getProperty("A"))
+        .isEqualTo("some duplicate");
+    assertWithMessage("entity.B").that((long) entity.getProperty("B")).isEqualTo(0L);
+  }
+
+  private void putTestData(String a, long b) {
+    Entity entity = new Entity("TestKind");
+    entity.setProperty("A", a);
+    entity.setProperty("B", b);
+    datastore.put(entity);
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/ProjectionTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/ProjectionTest.java
@@ -66,7 +66,6 @@ public class ProjectionTest {
     putTestData("some duplicate", 0L);
     putTestData("too big", 1L);
 
-    // [START grouping]
     Query q = new Query("TestKind");
     q.addProjection(new PropertyProjection("A", String.class));
     q.addProjection(new PropertyProjection("B", Long.class));
@@ -74,7 +73,6 @@ public class ProjectionTest {
     q.setFilter(Query.FilterOperator.LESS_THAN.of("B", 1L));
     q.addSort("B", Query.SortDirection.DESCENDING);
     q.addSort("A");
-    // [END grouping]
 
     List<Entity> entities = datastore.prepare(q).asList(FetchOptions.Builder.withLimit(5));
     assertThat(entities).hasSize(1);

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/QueriesTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/QueriesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/QueriesTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/QueriesTest.java
@@ -86,11 +86,9 @@ public class QueriesTest {
 
     // Act
     long minHeight = 160;
-    // [START gae_java8_datastore_property_filter]
     Filter propertyFilter =
         new FilterPredicate("height", FilterOperator.GREATER_THAN_OR_EQUAL, minHeight);
     Query q = new Query("Person").setFilter(propertyFilter);
-    // [END gae_java8_datastore_property_filter]
 
     // Assert
     List<Entity> results =
@@ -112,11 +110,9 @@ public class QueriesTest {
 
     // Act
     Key lastSeenKey = bb.getKey();
-    // [START gae_java8_datastore_key_filter]
     Filter keyFilter =
         new FilterPredicate(Entity.KEY_RESERVED_PROPERTY, FilterOperator.GREATER_THAN, lastSeenKey);
     Query q = new Query("Person").setFilter(keyFilter);
-    // [END gae_java8_datastore_key_filter]
 
     // Assert
     List<Entity> results =
@@ -145,11 +141,9 @@ public class QueriesTest {
 
     // Act
     Key lastSeenKey = bb.getKey();
-    // [START gae_java8_datastore_kindless_query]
     Filter keyFilter =
         new FilterPredicate(Entity.KEY_RESERVED_PROPERTY, FilterOperator.GREATER_THAN, lastSeenKey);
     Query q = new Query().setFilter(keyFilter);
-    // [END gae_java8_datastore_kindless_query]
 
     // Assert
     List<Entity> results =
@@ -173,9 +167,7 @@ public class QueriesTest {
     datastore.put(ImmutableList.<Entity>of(a, b, aa, ab, bb));
 
     Key ancestorKey = a.getKey();
-    // [START gae_java8_datastore_ancestor_filter]
     Query q = new Query("Person").setAncestor(ancestorKey);
-    // [END gae_java8_datastore_ancestor_filter]
 
     // Assert
     List<Entity> results =
@@ -185,7 +177,6 @@ public class QueriesTest {
 
   @Test
   public void ancestorQueryExample_returnsMatchingEntities() throws Exception {
-    // [START gae_java8_datastore_ancestor_query]
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
     Entity tom = new Entity("Person", "Tom");
@@ -213,7 +204,6 @@ public class QueriesTest {
     // but not campingPhoto, because tom is not an ancestor
     List<Entity> results =
         datastore.prepare(photoQuery).asList(FetchOptions.Builder.withDefaults());
-    // [END gae_java8_datastore_ancestor_query]
 
     assertWithMessage("query results")
         .that(results)
@@ -238,11 +228,9 @@ public class QueriesTest {
     // Act
     Key ancestorKey = b.getKey();
     Key lastSeenKey = bb.getKey();
-    // [START gae_java8_datastore_kindless_ancestor_key_query]
     Filter keyFilter =
         new FilterPredicate(Entity.KEY_RESERVED_PROPERTY, FilterOperator.GREATER_THAN, lastSeenKey);
     Query q = new Query().setAncestor(ancestorKey).setFilter(keyFilter);
-    // [END gae_java8_datastore_kindless_ancestor_key_query]
 
     // Assert
     List<Entity> results =
@@ -253,7 +241,6 @@ public class QueriesTest {
   @Test
   public void ancestorQueryExample_kindlessKeyFilterFull_returnsMatchingEntities()
       throws Exception {
-    // [START gae_java8_datastore_kindless_ancestor_query]
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
     Entity tom = new Entity("Person", "Tom");
@@ -280,7 +267,6 @@ public class QueriesTest {
     // even though they are of different entity kinds
     List<Entity> results =
         datastore.prepare(mediaQuery).asList(FetchOptions.Builder.withDefaults());
-    // [END gae_java8_datastore_kindless_ancestor_query]
 
     assertWithMessage("query result keys")
         .that(results)
@@ -295,9 +281,7 @@ public class QueriesTest {
     Entity c = new Entity("Person", "c");
     datastore.put(ImmutableList.<Entity>of(a, b, c));
 
-    // [START gae_java8_datastore_keys_only]
     Query q = new Query("Person").setKeysOnly();
-    // [END gae_java8_datastore_keys_only]
 
     // Assert
     List<Entity> results = datastore.prepare(q).asList(FetchOptions.Builder.withDefaults());
@@ -319,13 +303,11 @@ public class QueriesTest {
     datastore.put(ImmutableList.<Entity>of(a, b, c));
 
     // Act
-    // [START gae_java8_datastore_sort_order]
     // Order alphabetically by last name:
     Query q1 = new Query("Person").addSort("lastName", SortDirection.ASCENDING);
 
     // Order by height, tallest to shortest:
     Query q2 = new Query("Person").addSort("height", SortDirection.DESCENDING);
-    // [END gae_java8_datastore_sort_order]
 
     // Assert
     List<Entity> lastNameResults =
@@ -360,12 +342,10 @@ public class QueriesTest {
     datastore.put(ImmutableList.<Entity>of(a, b1, b2, c));
 
     // Act
-    // [START gae_java8_datastore_multiple_sort_orders]
     Query q =
         new Query("Person")
             .addSort("lastName", SortDirection.ASCENDING)
             .addSort("height", SortDirection.DESCENDING);
-    // [END gae_java8_datastore_multiple_sort_orders]
 
     // Assert
     List<Entity> results =
@@ -396,7 +376,6 @@ public class QueriesTest {
     long maxHeight = 72;
 
     // Act
-    // [START gae_java8_datastore_interface_1]
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
     Filter heightMinFilter =
@@ -422,7 +401,6 @@ public class QueriesTest {
 
       out.println(firstName + " " + lastName + ", " + height + " inches tall");
     }
-    // [END gae_java8_datastore_interface_1]
 
     // Assert
     assertThat(buf.toString()).contains("Alph Alpha, 60 inches tall");
@@ -447,7 +425,6 @@ public class QueriesTest {
     long maxHeight = 175;
 
     // Act
-    // [START gae_java8_datastore_interface_3]
     Filter tooShortFilter = new FilterPredicate("height", FilterOperator.LESS_THAN, minHeight);
 
     Filter tooTallFilter = new FilterPredicate("height", FilterOperator.GREATER_THAN, maxHeight);
@@ -455,7 +432,6 @@ public class QueriesTest {
     Filter heightOutOfRangeFilter = CompositeFilterOperator.or(tooShortFilter, tooTallFilter);
 
     Query q = new Query("Person").setFilter(heightOutOfRangeFilter);
-    // [END gae_java8_datastore_interface_3]
 
     // Assert
     List<Entity> results =
@@ -477,7 +453,6 @@ public class QueriesTest {
     // Act
     long minBirthYear = 1940;
     long maxBirthYear = 1980;
-    // [START gae_java8_datastore_inequality_filters_one_property_valid_1]
     Filter birthYearMinFilter =
         new FilterPredicate("birthYear", FilterOperator.GREATER_THAN_OR_EQUAL, minBirthYear);
 
@@ -488,7 +463,6 @@ public class QueriesTest {
         CompositeFilterOperator.and(birthYearMinFilter, birthYearMaxFilter);
 
     Query q = new Query("Person").setFilter(birthYearRangeFilter);
-    // [END gae_java8_datastore_inequality_filters_one_property_valid_1]
 
     // Assert
     List<Entity> results =
@@ -500,7 +474,6 @@ public class QueriesTest {
   public void queryRestrictions_compositeFilter_isInvalid() throws Exception {
     long minBirthYear = 1940;
     long maxHeight = 200;
-    // [START gae_java8_datastore_inequality_filters_one_property_invalid]
     Filter birthYearMinFilter =
         new FilterPredicate("birthYear", FilterOperator.GREATER_THAN_OR_EQUAL, minBirthYear);
 
@@ -510,7 +483,6 @@ public class QueriesTest {
     Filter invalidFilter = CompositeFilterOperator.and(birthYearMinFilter, heightMaxFilter);
 
     Query q = new Query("Person").setFilter(invalidFilter);
-    // [END gae_java8_datastore_inequality_filters_one_property_invalid]
 
     // Note: The local devserver behavior is different than the production
     // version of Cloud Datastore, so there aren't any assertions we can make
@@ -547,7 +519,6 @@ public class QueriesTest {
     String targetCity = "Somewhere";
     String targetLastName = "Someone";
 
-    // [START gae_java8_datastore_inequality_filters_one_property_valid_2]
     Filter lastNameFilter = new FilterPredicate("lastName", FilterOperator.EQUAL, targetLastName);
 
     Filter cityFilter = new FilterPredicate("city", FilterOperator.EQUAL, targetCity);
@@ -563,7 +534,6 @@ public class QueriesTest {
             lastNameFilter, cityFilter, birthYearMinFilter, birthYearMaxFilter);
 
     Query q = new Query("Person").setFilter(validFilter);
-    // [END gae_java8_datastore_inequality_filters_one_property_valid_2]
 
     // Assert
     List<Entity> results =
@@ -607,7 +577,6 @@ public class QueriesTest {
   @Test
   public void queryRestrictions_missingSortOnInequality_isInvalid() throws Exception {
     long minBirthYear = 1940;
-    // [START gae_java8_datastore_inequality_filters_sort_orders_invalid_1]
     Filter birthYearMinFilter =
         new FilterPredicate("birthYear", FilterOperator.GREATER_THAN_OR_EQUAL, minBirthYear);
 
@@ -616,7 +585,6 @@ public class QueriesTest {
         new Query("Person")
             .setFilter(birthYearMinFilter)
             .addSort("lastName", SortDirection.ASCENDING);
-    // [END gae_java8_datastore_inequality_filters_sort_orders_invalid_1]
 
     // Note: The local devserver behavior is different than the production
     // version of Cloud Datastore, so there aren't any assertions we can make
@@ -627,7 +595,6 @@ public class QueriesTest {
   @Test
   public void queryRestrictions_sortWrongOrderOnInequality_isInvalid() throws Exception {
     long minBirthYear = 1940;
-    // [START gae_java8_datastore_inequality_filters_sort_orders_invalid_2]
     Filter birthYearMinFilter =
         new FilterPredicate("birthYear", FilterOperator.GREATER_THAN_OR_EQUAL, minBirthYear);
 
@@ -637,7 +604,6 @@ public class QueriesTest {
             .setFilter(birthYearMinFilter)
             .addSort("lastName", SortDirection.ASCENDING)
             .addSort("birthYear", SortDirection.ASCENDING);
-    // [END gae_java8_datastore_inequality_filters_sort_orders_invalid_2]
 
     // Note: The local devserver behavior is different than the production
     // version of Cloud Datastore, so there aren't any assertions we can make
@@ -653,14 +619,12 @@ public class QueriesTest {
     a.setProperty("x", xs);
     datastore.put(a);
 
-    // [START gae_java8_datastore_surprising_behavior_1]
     Query q =
         new Query("Widget")
             .setFilter(
                 CompositeFilterOperator.and(
                     new FilterPredicate("x", FilterOperator.GREATER_THAN, 1),
                     new FilterPredicate("x", FilterOperator.LESS_THAN, 2)));
-    // [END gae_java8_datastore_surprising_behavior_1]
 
     // Entity "a" will not match because no individual value matches all filters.
     // See the documentation for more details:
@@ -686,14 +650,12 @@ public class QueriesTest {
     e.setProperty("x", ImmutableList.<Long>of(1L, 2L, 3L));
     datastore.put(ImmutableList.<Entity>of(a, b, c, d, e));
 
-    // [START gae_java8_datastore_surprising_behavior_2]
     Query q =
         new Query("Widget")
             .setFilter(
                 CompositeFilterOperator.and(
                     new FilterPredicate("x", FilterOperator.EQUAL, 1),
                     new FilterPredicate("x", FilterOperator.EQUAL, 2)));
-    // [END gae_java8_datastore_surprising_behavior_2]
 
     // Only "a" and "e" have both 1 and 2 in the "x" array-valued property.
     // See the documentation for more details:
@@ -719,9 +681,7 @@ public class QueriesTest {
     e.setProperty("x", ImmutableList.<Long>of(1L));
     datastore.put(ImmutableList.<Entity>of(a, b, c, d, e));
 
-    // [START gae_java8_datastore_surprising_behavior_3]
     Query q = new Query("Widget").setFilter(new FilterPredicate("x", FilterOperator.NOT_EQUAL, 1));
-    // [END gae_java8_datastore_surprising_behavior_3]
 
     // The query matches any entity that has a some value other than 1. Only
     // entity "e" is not matched.  See the documentation for more details:
@@ -741,14 +701,12 @@ public class QueriesTest {
     b.setProperty("x", ImmutableList.<Long>of(1L, 2L, 3L));
     datastore.put(ImmutableList.<Entity>of(a, b));
 
-    // [START gae_java8_datastore_surprising_behavior_4]
     Query q =
         new Query("Widget")
             .setFilter(
                 CompositeFilterOperator.and(
                     new FilterPredicate("x", FilterOperator.NOT_EQUAL, 1),
                     new FilterPredicate("x", FilterOperator.NOT_EQUAL, 2)));
-    // [END gae_java8_datastore_surprising_behavior_4]
 
     // The two NOT_EQUAL filters in the query become like the combination of queries:
     // x < 1 OR (x > 1 AND x < 2) OR x > 2
@@ -764,14 +722,12 @@ public class QueriesTest {
   }
 
   private Entity retrievePersonWithLastName(String targetLastName) {
-    // [START gae_java8_datastore_single_retrieval]
     Query q =
         new Query("Person")
             .setFilter(new FilterPredicate("lastName", FilterOperator.EQUAL, targetLastName));
 
     PreparedQuery pq = datastore.prepare(q);
     Entity result = pq.asSingleEntity();
-    // [END gae_java8_datastore_single_retrieval]
     return result;
   }
 
@@ -806,7 +762,6 @@ public class QueriesTest {
     }
   }
 
-  // [START gae_java8_datastore_query_limit]
   private List<Entity> getTallestPeople() {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
@@ -815,7 +770,6 @@ public class QueriesTest {
     PreparedQuery pq = datastore.prepare(q);
     return pq.asList(FetchOptions.Builder.withLimit(5));
   }
-  // [END gae_java8_datastore_query_limit]
 
   @Test
   public void queryLimitExample_returnsLimitedEntities() throws Exception {

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/QueriesTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/QueriesTest.java
@@ -1,1 +1,844 @@
-../../../../../../../../appengine-java8/datastore/src/test/java/com/example/appengine/QueriesTest.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.Assert.fail;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.PreparedQuery.TooManyResultsException;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.CompositeFilter;
+import com.google.appengine.api.datastore.Query.CompositeFilterOperator;
+import com.google.appengine.api.datastore.Query.Filter;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.common.collect.ImmutableList;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests to demonstrate App Engine Datastore queries. */
+@RunWith(JUnit4.class)
+public class QueriesTest {
+
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+          // Set no eventual consistency, that way queries return all results.
+          // https://cloud.google
+          // .com/appengine/docs/java/tools/localunittesting
+          // #Java_Writing_High_Replication_Datastore_tests
+          new LocalDatastoreServiceTestConfig()
+              .setDefaultHighRepJobPolicyUnappliedJobPercentage(0));
+
+  private DatastoreService datastore;
+
+  @Before
+  public void setUp() {
+    helper.setUp();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void propertyFilterExample_returnsMatchingEntities() throws Exception {
+    // Arrange
+    Entity p1 = new Entity("Person");
+    p1.setProperty("height", 120);
+    Entity p2 = new Entity("Person");
+    p2.setProperty("height", 180);
+    Entity p3 = new Entity("Person");
+    p3.setProperty("height", 160);
+    datastore.put(ImmutableList.<Entity>of(p1, p2, p3));
+
+    // Act
+    long minHeight = 160;
+    // [START gae_java8_datastore_property_filter]
+    Filter propertyFilter =
+        new FilterPredicate("height", FilterOperator.GREATER_THAN_OR_EQUAL, minHeight);
+    Query q = new Query("Person").setFilter(propertyFilter);
+    // [END gae_java8_datastore_property_filter]
+
+    // Assert
+    List<Entity> results =
+        datastore.prepare(q.setKeysOnly()).asList(FetchOptions.Builder.withDefaults());
+    assertWithMessage("query results").that(results).containsExactly(p2, p3);
+  }
+
+  @Test
+  public void keyFilterExample_returnsMatchingEntities() throws Exception {
+    // Arrange
+    Entity a = new Entity("Person", "a");
+    Entity b = new Entity("Person", "b");
+    Entity c = new Entity("Person", "c");
+    Entity aa = new Entity("Person", "aa", b.getKey());
+    Entity bb = new Entity("Person", "bb", b.getKey());
+    Entity aaa = new Entity("Person", "aaa", bb.getKey());
+    Entity bbb = new Entity("Person", "bbb", bb.getKey());
+    datastore.put(ImmutableList.<Entity>of(a, b, c, aa, bb, aaa, bbb));
+
+    // Act
+    Key lastSeenKey = bb.getKey();
+    // [START gae_java8_datastore_key_filter]
+    Filter keyFilter =
+        new FilterPredicate(Entity.KEY_RESERVED_PROPERTY, FilterOperator.GREATER_THAN, lastSeenKey);
+    Query q = new Query("Person").setFilter(keyFilter);
+    // [END gae_java8_datastore_key_filter]
+
+    // Assert
+    List<Entity> results =
+        datastore.prepare(q.setKeysOnly()).asList(FetchOptions.Builder.withDefaults());
+    assertWithMessage("query results")
+        .that(results)
+        .containsExactly(
+            aaa, // Ancestor path "b/bb/aaa" is greater than "b/bb".
+            bbb, // Ancestor path "b/bb/bbb" is greater than "b/bb".
+            c); // Key name identifier "c" is greater than b.
+  }
+
+  @Test
+  public void keyFilterExample_kindless_returnsMatchingEntities() throws Exception {
+    // Arrange
+    Entity a = new Entity("Child", "a");
+    Entity b = new Entity("Child", "b");
+    Entity c = new Entity("Child", "c");
+    Entity aa = new Entity("Child", "aa", b.getKey());
+    Entity bb = new Entity("Child", "bb", b.getKey());
+    Entity aaa = new Entity("Child", "aaa", bb.getKey());
+    Entity bbb = new Entity("Child", "bbb", bb.getKey());
+    Entity adult = new Entity("Adult", "a");
+    Entity zooAnimal = new Entity("ZooAnimal", "a");
+    datastore.put(ImmutableList.<Entity>of(a, b, c, aa, bb, aaa, bbb, adult, zooAnimal));
+
+    // Act
+    Key lastSeenKey = bb.getKey();
+    // [START gae_java8_datastore_kindless_query]
+    Filter keyFilter =
+        new FilterPredicate(Entity.KEY_RESERVED_PROPERTY, FilterOperator.GREATER_THAN, lastSeenKey);
+    Query q = new Query().setFilter(keyFilter);
+    // [END gae_java8_datastore_kindless_query]
+
+    // Assert
+    List<Entity> results =
+        datastore.prepare(q.setKeysOnly()).asList(FetchOptions.Builder.withDefaults());
+    assertWithMessage("query results")
+        .that(results)
+        .containsExactly(
+            aaa, // Ancestor path "b/bb/aaa" is greater than "b/bb".
+            bbb, // Ancestor path "b/bb/bbb" is greater than "b/bb".
+            zooAnimal, // Kind "ZooAnimal" is greater than "Child"
+            c); // Key name identifier "c" is greater than b.
+  }
+
+  @Test
+  public void ancestorFilterExample_returnsMatchingEntities() throws Exception {
+    Entity a = new Entity("Person", "a");
+    Entity b = new Entity("Person", "b");
+    Entity aa = new Entity("Person", "aa", a.getKey());
+    Entity ab = new Entity("Person", "ab", a.getKey());
+    Entity bb = new Entity("Person", "bb", b.getKey());
+    datastore.put(ImmutableList.<Entity>of(a, b, aa, ab, bb));
+
+    Key ancestorKey = a.getKey();
+    // [START gae_java8_datastore_ancestor_filter]
+    Query q = new Query("Person").setAncestor(ancestorKey);
+    // [END gae_java8_datastore_ancestor_filter]
+
+    // Assert
+    List<Entity> results =
+        datastore.prepare(q.setKeysOnly()).asList(FetchOptions.Builder.withDefaults());
+    assertWithMessage("query results").that(results).containsExactly(a, aa, ab);
+  }
+
+  @Test
+  public void ancestorQueryExample_returnsMatchingEntities() throws Exception {
+    // [START gae_java8_datastore_ancestor_query]
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+    Entity tom = new Entity("Person", "Tom");
+    Key tomKey = tom.getKey();
+    datastore.put(tom);
+
+    Entity weddingPhoto = new Entity("Photo", tomKey);
+    weddingPhoto.setProperty("imageURL", "http://domain.com/some/path/to/wedding_photo.jpg");
+
+    Entity babyPhoto = new Entity("Photo", tomKey);
+    babyPhoto.setProperty("imageURL", "http://domain.com/some/path/to/baby_photo.jpg");
+
+    Entity dancePhoto = new Entity("Photo", tomKey);
+    dancePhoto.setProperty("imageURL", "http://domain.com/some/path/to/dance_photo.jpg");
+
+    Entity campingPhoto = new Entity("Photo");
+    campingPhoto.setProperty("imageURL", "http://domain.com/some/path/to/camping_photo.jpg");
+
+    List<Entity> photoList = Arrays.asList(weddingPhoto, babyPhoto, dancePhoto, campingPhoto);
+    datastore.put(photoList);
+
+    Query photoQuery = new Query("Photo").setAncestor(tomKey);
+
+    // This returns weddingPhoto, babyPhoto, and dancePhoto,
+    // but not campingPhoto, because tom is not an ancestor
+    List<Entity> results =
+        datastore.prepare(photoQuery).asList(FetchOptions.Builder.withDefaults());
+    // [END gae_java8_datastore_ancestor_query]
+
+    assertWithMessage("query results")
+        .that(results)
+        .containsExactly(weddingPhoto, babyPhoto, dancePhoto);
+  }
+
+  @Test
+  public void ancestorQueryExample_kindlessKeyFilter_returnsMatchingEntities() throws Exception {
+    // Arrange
+    Entity a = new Entity("Grandparent", "a");
+    Entity b = new Entity("Grandparent", "b");
+    Entity c = new Entity("Grandparent", "c");
+    Entity aa = new Entity("Parent", "aa", a.getKey());
+    Entity ba = new Entity("Parent", "ba", b.getKey());
+    Entity bb = new Entity("Parent", "bb", b.getKey());
+    Entity bc = new Entity("Parent", "bc", b.getKey());
+    Entity cc = new Entity("Parent", "cc", c.getKey());
+    Entity aaa = new Entity("Child", "aaa", aa.getKey());
+    Entity bbb = new Entity("Child", "bbb", bb.getKey());
+    datastore.put(ImmutableList.<Entity>of(a, b, c, aa, ba, bb, bc, cc, aaa, bbb));
+
+    // Act
+    Key ancestorKey = b.getKey();
+    Key lastSeenKey = bb.getKey();
+    // [START gae_java8_datastore_kindless_ancestor_key_query]
+    Filter keyFilter =
+        new FilterPredicate(Entity.KEY_RESERVED_PROPERTY, FilterOperator.GREATER_THAN, lastSeenKey);
+    Query q = new Query().setAncestor(ancestorKey).setFilter(keyFilter);
+    // [END gae_java8_datastore_kindless_ancestor_key_query]
+
+    // Assert
+    List<Entity> results =
+        datastore.prepare(q.setKeysOnly()).asList(FetchOptions.Builder.withDefaults());
+    assertWithMessage("query results").that(results).containsExactly(bc, bbb);
+  }
+
+  @Test
+  public void ancestorQueryExample_kindlessKeyFilterFull_returnsMatchingEntities()
+      throws Exception {
+    // [START gae_java8_datastore_kindless_ancestor_query]
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+    Entity tom = new Entity("Person", "Tom");
+    Key tomKey = tom.getKey();
+    datastore.put(tom);
+
+    Entity weddingPhoto = new Entity("Photo", tomKey);
+    weddingPhoto.setProperty("imageURL", "http://domain.com/some/path/to/wedding_photo.jpg");
+
+    Entity weddingVideo = new Entity("Video", tomKey);
+    weddingVideo.setProperty("videoURL", "http://domain.com/some/path/to/wedding_video.avi");
+
+    List<Entity> mediaList = Arrays.asList(weddingPhoto, weddingVideo);
+    datastore.put(mediaList);
+
+    // By default, ancestor queries include the specified ancestor itself.
+    // The following filter excludes the ancestor from the query results.
+    Filter keyFilter =
+        new FilterPredicate(Entity.KEY_RESERVED_PROPERTY, FilterOperator.GREATER_THAN, tomKey);
+
+    Query mediaQuery = new Query().setAncestor(tomKey).setFilter(keyFilter);
+
+    // Returns both weddingPhoto and weddingVideo,
+    // even though they are of different entity kinds
+    List<Entity> results =
+        datastore.prepare(mediaQuery).asList(FetchOptions.Builder.withDefaults());
+    // [END gae_java8_datastore_kindless_ancestor_query]
+
+    assertWithMessage("query result keys")
+        .that(results)
+        .containsExactly(weddingPhoto, weddingVideo);
+  }
+
+  @Test
+  public void keysOnlyExample_returnsMatchingEntities() throws Exception {
+    // Arrange
+    Entity a = new Entity("Person", "a");
+    Entity b = new Entity("Building", "b");
+    Entity c = new Entity("Person", "c");
+    datastore.put(ImmutableList.<Entity>of(a, b, c));
+
+    // [START gae_java8_datastore_keys_only]
+    Query q = new Query("Person").setKeysOnly();
+    // [END gae_java8_datastore_keys_only]
+
+    // Assert
+    List<Entity> results = datastore.prepare(q).asList(FetchOptions.Builder.withDefaults());
+    assertWithMessage("query results").that(results).containsExactly(a, c);
+  }
+
+  @Test
+  public void sortOrderExample_returnsSortedEntities() throws Exception {
+    // Arrange
+    Entity a = new Entity("Person", "a");
+    a.setProperty("lastName", "Alpha");
+    a.setProperty("height", 100);
+    Entity b = new Entity("Person", "b");
+    b.setProperty("lastName", "Bravo");
+    b.setProperty("height", 200);
+    Entity c = new Entity("Person", "c");
+    c.setProperty("lastName", "Charlie");
+    c.setProperty("height", 300);
+    datastore.put(ImmutableList.<Entity>of(a, b, c));
+
+    // Act
+    // [START gae_java8_datastore_sort_order]
+    // Order alphabetically by last name:
+    Query q1 = new Query("Person").addSort("lastName", SortDirection.ASCENDING);
+
+    // Order by height, tallest to shortest:
+    Query q2 = new Query("Person").addSort("height", SortDirection.DESCENDING);
+    // [END gae_java8_datastore_sort_order]
+
+    // Assert
+    List<Entity> lastNameResults =
+        datastore.prepare(q1.setKeysOnly()).asList(FetchOptions.Builder.withDefaults());
+    assertWithMessage("last name query results")
+        .that(lastNameResults)
+        .containsExactly(a, b, c)
+        .inOrder();
+    List<Entity> heightResults =
+        datastore.prepare(q2.setKeysOnly()).asList(FetchOptions.Builder.withDefaults());
+    assertWithMessage("height query results")
+        .that(heightResults)
+        .containsExactly(c, b, a)
+        .inOrder();
+  }
+
+  @Test
+  public void sortOrderExample_multipleSortOrders_returnsSortedEntities() throws Exception {
+    // Arrange
+    Entity a = new Entity("Person", "a");
+    a.setProperty("lastName", "Alpha");
+    a.setProperty("height", 100);
+    Entity b1 = new Entity("Person", "b1");
+    b1.setProperty("lastName", "Bravo");
+    b1.setProperty("height", 150);
+    Entity b2 = new Entity("Person", "b2");
+    b2.setProperty("lastName", "Bravo");
+    b2.setProperty("height", 200);
+    Entity c = new Entity("Person", "c");
+    c.setProperty("lastName", "Charlie");
+    c.setProperty("height", 300);
+    datastore.put(ImmutableList.<Entity>of(a, b1, b2, c));
+
+    // Act
+    // [START gae_java8_datastore_multiple_sort_orders]
+    Query q =
+        new Query("Person")
+            .addSort("lastName", SortDirection.ASCENDING)
+            .addSort("height", SortDirection.DESCENDING);
+    // [END gae_java8_datastore_multiple_sort_orders]
+
+    // Assert
+    List<Entity> results =
+        datastore.prepare(q.setKeysOnly()).asList(FetchOptions.Builder.withDefaults());
+    assertWithMessage("query results").that(results).containsExactly(a, b2, b1, c).inOrder();
+  }
+
+  @Test
+  public void queryInterface_multipleFilters_printsMatchedEntities() throws Exception {
+    // Arrange
+    Entity a = new Entity("Person", "a");
+    a.setProperty("firstName", "Alph");
+    a.setProperty("lastName", "Alpha");
+    a.setProperty("height", 60);
+    Entity b = new Entity("Person", "b");
+    b.setProperty("firstName", "Bee");
+    b.setProperty("lastName", "Bravo");
+    b.setProperty("height", 70);
+    Entity c = new Entity("Person", "c");
+    c.setProperty("firstName", "Charles");
+    c.setProperty("lastName", "Charlie");
+    c.setProperty("height", 100);
+    datastore.put(ImmutableList.<Entity>of(a, b, c));
+
+    StringWriter buf = new StringWriter();
+    PrintWriter out = new PrintWriter(buf);
+    long minHeight = 60;
+    long maxHeight = 72;
+
+    // Act
+    // [START gae_java8_datastore_interface_1]
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+    Filter heightMinFilter =
+        new FilterPredicate("height", FilterOperator.GREATER_THAN_OR_EQUAL, minHeight);
+
+    Filter heightMaxFilter =
+        new FilterPredicate("height", FilterOperator.LESS_THAN_OR_EQUAL, maxHeight);
+
+    // Use CompositeFilter to combine multiple filters
+    CompositeFilter heightRangeFilter =
+        CompositeFilterOperator.and(heightMinFilter, heightMaxFilter);
+
+    // Use class Query to assemble a query
+    Query q = new Query("Person").setFilter(heightRangeFilter);
+
+    // Use PreparedQuery interface to retrieve results
+    PreparedQuery pq = datastore.prepare(q);
+
+    for (Entity result : pq.asIterable()) {
+      String firstName = (String) result.getProperty("firstName");
+      String lastName = (String) result.getProperty("lastName");
+      Long height = (Long) result.getProperty("height");
+
+      out.println(firstName + " " + lastName + ", " + height + " inches tall");
+    }
+    // [END gae_java8_datastore_interface_1]
+
+    // Assert
+    assertThat(buf.toString()).contains("Alph Alpha, 60 inches tall");
+    assertThat(buf.toString()).contains("Bee Bravo, 70 inches tall");
+    assertThat(buf.toString()).doesNotContain("Charlie");
+  }
+
+  @Test
+  public void queryInterface_orFilter_printsMatchedEntities() throws Exception {
+    // Arrange
+    Entity a = new Entity("Person", "a");
+    a.setProperty("height", 100);
+    Entity b = new Entity("Person", "b");
+    b.setProperty("height", 150);
+    Entity c = new Entity("Person", "c");
+    c.setProperty("height", 200);
+    datastore.put(ImmutableList.<Entity>of(a, b, c));
+
+    StringWriter buf = new StringWriter();
+    PrintWriter out = new PrintWriter(buf);
+    long minHeight = 125;
+    long maxHeight = 175;
+
+    // Act
+    // [START gae_java8_datastore_interface_3]
+    Filter tooShortFilter = new FilterPredicate("height", FilterOperator.LESS_THAN, minHeight);
+
+    Filter tooTallFilter = new FilterPredicate("height", FilterOperator.GREATER_THAN, maxHeight);
+
+    Filter heightOutOfRangeFilter = CompositeFilterOperator.or(tooShortFilter, tooTallFilter);
+
+    Query q = new Query("Person").setFilter(heightOutOfRangeFilter);
+    // [END gae_java8_datastore_interface_3]
+
+    // Assert
+    List<Entity> results =
+        datastore.prepare(q.setKeysOnly()).asList(FetchOptions.Builder.withDefaults());
+    assertWithMessage("query results").that(results).containsExactly(a, c);
+  }
+
+  @Test
+  public void queryRestrictions_compositeFilter_returnsMatchedEntities() throws Exception {
+    // Arrange
+    Entity a = new Entity("Person", "a");
+    a.setProperty("birthYear", 1930);
+    Entity b = new Entity("Person", "b");
+    b.setProperty("birthYear", 1960);
+    Entity c = new Entity("Person", "c");
+    c.setProperty("birthYear", 1990);
+    datastore.put(ImmutableList.<Entity>of(a, b, c));
+
+    // Act
+    long minBirthYear = 1940;
+    long maxBirthYear = 1980;
+    // [START gae_java8_datastore_inequality_filters_one_property_valid_1]
+    Filter birthYearMinFilter =
+        new FilterPredicate("birthYear", FilterOperator.GREATER_THAN_OR_EQUAL, minBirthYear);
+
+    Filter birthYearMaxFilter =
+        new FilterPredicate("birthYear", FilterOperator.LESS_THAN_OR_EQUAL, maxBirthYear);
+
+    Filter birthYearRangeFilter =
+        CompositeFilterOperator.and(birthYearMinFilter, birthYearMaxFilter);
+
+    Query q = new Query("Person").setFilter(birthYearRangeFilter);
+    // [END gae_java8_datastore_inequality_filters_one_property_valid_1]
+
+    // Assert
+    List<Entity> results =
+        datastore.prepare(q.setKeysOnly()).asList(FetchOptions.Builder.withDefaults());
+    assertWithMessage("query results").that(results).containsExactly(b);
+  }
+
+  @Test
+  public void queryRestrictions_compositeFilter_isInvalid() throws Exception {
+    long minBirthYear = 1940;
+    long maxHeight = 200;
+    // [START gae_java8_datastore_inequality_filters_one_property_invalid]
+    Filter birthYearMinFilter =
+        new FilterPredicate("birthYear", FilterOperator.GREATER_THAN_OR_EQUAL, minBirthYear);
+
+    Filter heightMaxFilter =
+        new FilterPredicate("height", FilterOperator.LESS_THAN_OR_EQUAL, maxHeight);
+
+    Filter invalidFilter = CompositeFilterOperator.and(birthYearMinFilter, heightMaxFilter);
+
+    Query q = new Query("Person").setFilter(invalidFilter);
+    // [END gae_java8_datastore_inequality_filters_one_property_invalid]
+
+    // Note: The local devserver behavior is different than the production
+    // version of Cloud Datastore, so there aren't any assertions we can make
+    // in this test.  The query appears to work with the local test runner,
+    // but will fail in production.
+  }
+
+  @Test
+  public void queryRestrictions_compositeEqualFilter_returnsMatchedEntities() throws Exception {
+    // Arrange
+    Entity a = new Entity("Person", "a");
+    a.setProperty("birthYear", 1930);
+    a.setProperty("city", "Somewhere");
+    a.setProperty("lastName", "Someone");
+    Entity b = new Entity("Person", "b");
+    b.setProperty("birthYear", 1960);
+    b.setProperty("city", "Somewhere");
+    b.setProperty("lastName", "Someone");
+    Entity c = new Entity("Person", "c");
+    c.setProperty("birthYear", 1990);
+    c.setProperty("city", "Somewhere");
+    c.setProperty("lastName", "Someone");
+    Entity d = new Entity("Person", "d");
+    d.setProperty("birthYear", 1960);
+    d.setProperty("city", "Nowhere");
+    d.setProperty("lastName", "Someone");
+    Entity e = new Entity("Person", "e");
+    e.setProperty("birthYear", 1960);
+    e.setProperty("city", "Somewhere");
+    e.setProperty("lastName", "Noone");
+    datastore.put(ImmutableList.<Entity>of(a, b, c, d, e));
+    long minBirthYear = 1940;
+    long maxBirthYear = 1980;
+    String targetCity = "Somewhere";
+    String targetLastName = "Someone";
+
+    // [START gae_java8_datastore_inequality_filters_one_property_valid_2]
+    Filter lastNameFilter = new FilterPredicate("lastName", FilterOperator.EQUAL, targetLastName);
+
+    Filter cityFilter = new FilterPredicate("city", FilterOperator.EQUAL, targetCity);
+
+    Filter birthYearMinFilter =
+        new FilterPredicate("birthYear", FilterOperator.GREATER_THAN_OR_EQUAL, minBirthYear);
+
+    Filter birthYearMaxFilter =
+        new FilterPredicate("birthYear", FilterOperator.LESS_THAN_OR_EQUAL, maxBirthYear);
+
+    Filter validFilter =
+        CompositeFilterOperator.and(
+            lastNameFilter, cityFilter, birthYearMinFilter, birthYearMaxFilter);
+
+    Query q = new Query("Person").setFilter(validFilter);
+    // [END gae_java8_datastore_inequality_filters_one_property_valid_2]
+
+    // Assert
+    List<Entity> results =
+        datastore.prepare(q.setKeysOnly()).asList(FetchOptions.Builder.withDefaults());
+    assertWithMessage("query results").that(results).containsExactly(b);
+  }
+
+  @Test
+  public void queryRestrictions_inequalitySortedFirst_returnsMatchedEntities() throws Exception {
+    // Arrange
+    Entity a = new Entity("Person", "a");
+    a.setProperty("birthYear", 1930);
+    a.setProperty("lastName", "Someone");
+    Entity b = new Entity("Person", "b");
+    b.setProperty("birthYear", 1990);
+    b.setProperty("lastName", "Bravo");
+    Entity c = new Entity("Person", "c");
+    c.setProperty("birthYear", 1960);
+    c.setProperty("lastName", "Charlie");
+    Entity d = new Entity("Person", "d");
+    d.setProperty("birthYear", 1960);
+    d.setProperty("lastName", "Delta");
+    datastore.put(ImmutableList.<Entity>of(a, b, c, d));
+    long minBirthYear = 1940;
+
+    Filter birthYearMinFilter =
+        new FilterPredicate("birthYear", FilterOperator.GREATER_THAN_OR_EQUAL, minBirthYear);
+
+    Query q =
+        new Query("Person")
+            .setFilter(birthYearMinFilter)
+            .addSort("birthYear", SortDirection.ASCENDING)
+            .addSort("lastName", SortDirection.ASCENDING);
+
+    // Assert
+    List<Entity> results =
+        datastore.prepare(q.setKeysOnly()).asList(FetchOptions.Builder.withDefaults());
+    assertWithMessage("query results").that(results).containsExactly(c, d, b).inOrder();
+  }
+
+  @Test
+  public void queryRestrictions_missingSortOnInequality_isInvalid() throws Exception {
+    long minBirthYear = 1940;
+    // [START gae_java8_datastore_inequality_filters_sort_orders_invalid_1]
+    Filter birthYearMinFilter =
+        new FilterPredicate("birthYear", FilterOperator.GREATER_THAN_OR_EQUAL, minBirthYear);
+
+    // Not valid. Missing sort on birthYear.
+    Query q =
+        new Query("Person")
+            .setFilter(birthYearMinFilter)
+            .addSort("lastName", SortDirection.ASCENDING);
+    // [END gae_java8_datastore_inequality_filters_sort_orders_invalid_1]
+
+    // Note: The local devserver behavior is different than the production
+    // version of Cloud Datastore, so there aren't any assertions we can make
+    // in this test.  The query appears to work with the local test runner,
+    // but will fail in production.
+  }
+
+  @Test
+  public void queryRestrictions_sortWrongOrderOnInequality_isInvalid() throws Exception {
+    long minBirthYear = 1940;
+    // [START gae_java8_datastore_inequality_filters_sort_orders_invalid_2]
+    Filter birthYearMinFilter =
+        new FilterPredicate("birthYear", FilterOperator.GREATER_THAN_OR_EQUAL, minBirthYear);
+
+    // Not valid. Sort on birthYear needs to be first.
+    Query q =
+        new Query("Person")
+            .setFilter(birthYearMinFilter)
+            .addSort("lastName", SortDirection.ASCENDING)
+            .addSort("birthYear", SortDirection.ASCENDING);
+    // [END gae_java8_datastore_inequality_filters_sort_orders_invalid_2]
+
+    // Note: The local devserver behavior is different than the production
+    // version of Cloud Datastore, so there aren't any assertions we can make
+    // in this test.  The query appears to work with the local test runner,
+    // but will fail in production.
+  }
+
+  @Test
+  public void queryRestrictions_surprisingMultipleValuesAllMustMatch_returnsNoEntities()
+      throws Exception {
+    Entity a = new Entity("Widget", "a");
+    List<Long> xs = Arrays.asList(1L, 2L);
+    a.setProperty("x", xs);
+    datastore.put(a);
+
+    // [START gae_java8_datastore_surprising_behavior_1]
+    Query q =
+        new Query("Widget")
+            .setFilter(
+                CompositeFilterOperator.and(
+                    new FilterPredicate("x", FilterOperator.GREATER_THAN, 1),
+                    new FilterPredicate("x", FilterOperator.LESS_THAN, 2)));
+    // [END gae_java8_datastore_surprising_behavior_1]
+
+    // Entity "a" will not match because no individual value matches all filters.
+    // See the documentation for more details:
+    // https://cloud.google.com/appengine/docs/java/datastore/query-restrictions
+    // #properties_with_multiple_values_can_behave_in_surprising_ways
+    List<Entity> results =
+        datastore.prepare(q.setKeysOnly()).asList(FetchOptions.Builder.withDefaults());
+    assertWithMessage("query results").that(results).isEmpty();
+  }
+
+  @Test
+  public void queryRestrictions_surprisingMultipleValuesEquals_returnsMatchedEntities()
+      throws Exception {
+    Entity a = new Entity("Widget", "a");
+    a.setProperty("x", ImmutableList.<Long>of(1L, 2L));
+    Entity b = new Entity("Widget", "b");
+    b.setProperty("x", ImmutableList.<Long>of(1L, 3L));
+    Entity c = new Entity("Widget", "c");
+    c.setProperty("x", ImmutableList.<Long>of(-6L, 2L));
+    Entity d = new Entity("Widget", "d");
+    d.setProperty("x", ImmutableList.<Long>of(-6L, 4L));
+    Entity e = new Entity("Widget", "e");
+    e.setProperty("x", ImmutableList.<Long>of(1L, 2L, 3L));
+    datastore.put(ImmutableList.<Entity>of(a, b, c, d, e));
+
+    // [START gae_java8_datastore_surprising_behavior_2]
+    Query q =
+        new Query("Widget")
+            .setFilter(
+                CompositeFilterOperator.and(
+                    new FilterPredicate("x", FilterOperator.EQUAL, 1),
+                    new FilterPredicate("x", FilterOperator.EQUAL, 2)));
+    // [END gae_java8_datastore_surprising_behavior_2]
+
+    // Only "a" and "e" have both 1 and 2 in the "x" array-valued property.
+    // See the documentation for more details:
+    // https://cloud.google.com/appengine/docs/java/datastore/query-restrictions
+    // #properties_with_multiple_values_can_behave_in_surprising_ways
+    List<Entity> results =
+        datastore.prepare(q.setKeysOnly()).asList(FetchOptions.Builder.withDefaults());
+    assertWithMessage("query results").that(results).containsExactly(a, e);
+  }
+
+  @Test
+  public void queryRestrictions_surprisingMultipleValuesNotEquals_returnsMatchedEntities()
+      throws Exception {
+    Entity a = new Entity("Widget", "a");
+    a.setProperty("x", ImmutableList.<Long>of(1L, 2L));
+    Entity b = new Entity("Widget", "b");
+    b.setProperty("x", ImmutableList.<Long>of(1L, 3L));
+    Entity c = new Entity("Widget", "c");
+    c.setProperty("x", ImmutableList.<Long>of(-6L, 2L));
+    Entity d = new Entity("Widget", "d");
+    d.setProperty("x", ImmutableList.<Long>of(-6L, 4L));
+    Entity e = new Entity("Widget", "e");
+    e.setProperty("x", ImmutableList.<Long>of(1L));
+    datastore.put(ImmutableList.<Entity>of(a, b, c, d, e));
+
+    // [START gae_java8_datastore_surprising_behavior_3]
+    Query q = new Query("Widget").setFilter(new FilterPredicate("x", FilterOperator.NOT_EQUAL, 1));
+    // [END gae_java8_datastore_surprising_behavior_3]
+
+    // The query matches any entity that has a some value other than 1. Only
+    // entity "e" is not matched.  See the documentation for more details:
+    // https://cloud.google.com/appengine/docs/java/datastore/query-restrictions
+    // #properties_with_multiple_values_can_behave_in_surprising_ways
+    List<Entity> results =
+        datastore.prepare(q.setKeysOnly()).asList(FetchOptions.Builder.withDefaults());
+    assertWithMessage("query results").that(results).containsExactly(a, b, c, d);
+  }
+
+  @Test
+  public void queryRestrictions_surprisingMultipleValuesTwoNotEquals_returnsMatchedEntities()
+      throws Exception {
+    Entity a = new Entity("Widget", "a");
+    a.setProperty("x", ImmutableList.<Long>of(1L, 2L));
+    Entity b = new Entity("Widget", "b");
+    b.setProperty("x", ImmutableList.<Long>of(1L, 2L, 3L));
+    datastore.put(ImmutableList.<Entity>of(a, b));
+
+    // [START gae_java8_datastore_surprising_behavior_4]
+    Query q =
+        new Query("Widget")
+            .setFilter(
+                CompositeFilterOperator.and(
+                    new FilterPredicate("x", FilterOperator.NOT_EQUAL, 1),
+                    new FilterPredicate("x", FilterOperator.NOT_EQUAL, 2)));
+    // [END gae_java8_datastore_surprising_behavior_4]
+
+    // The two NOT_EQUAL filters in the query become like the combination of queries:
+    // x < 1 OR (x > 1 AND x < 2) OR x > 2
+    //
+    // Only "b" has some value which matches the "x > 2" portion of this query.
+    //
+    // See the documentation for more details:
+    // https://cloud.google.com/appengine/docs/java/datastore/query-restrictions
+    // #properties_with_multiple_values_can_behave_in_surprising_ways
+    List<Entity> results =
+        datastore.prepare(q.setKeysOnly()).asList(FetchOptions.Builder.withDefaults());
+    assertWithMessage("query results").that(results).containsExactly(b);
+  }
+
+  private Entity retrievePersonWithLastName(String targetLastName) {
+    // [START gae_java8_datastore_single_retrieval]
+    Query q =
+        new Query("Person")
+            .setFilter(new FilterPredicate("lastName", FilterOperator.EQUAL, targetLastName));
+
+    PreparedQuery pq = datastore.prepare(q);
+    Entity result = pq.asSingleEntity();
+    // [END gae_java8_datastore_single_retrieval]
+    return result;
+  }
+
+  @Test
+  public void singleRetrievalExample_singleEntity_returnsEntity() throws Exception {
+    Entity a = new Entity("Person", "a");
+    a.setProperty("lastName", "Johnson");
+    Entity b = new Entity("Person", "b");
+    b.setProperty("lastName", "Smith");
+    datastore.put(ImmutableList.<Entity>of(a, b));
+
+    Entity result = retrievePersonWithLastName("Johnson");
+
+    assertWithMessage("result")
+        .that(result)
+        .isEqualTo(a); // Note: Entity.equals() only checks the Key.
+  }
+
+  @Test
+  public void singleRetrievalExample_multitpleEntities_throwsException() throws Exception {
+    Entity a = new Entity("Person", "a");
+    a.setProperty("lastName", "Johnson");
+    Entity b = new Entity("Person", "b");
+    b.setProperty("lastName", "Johnson");
+    datastore.put(ImmutableList.<Entity>of(a, b));
+
+    try {
+      Entity result = retrievePersonWithLastName("Johnson");
+      fail("Expected TooManyResultsException");
+    } catch (TooManyResultsException expected) {
+      // TooManyResultsException does not provide addition details.
+    }
+  }
+
+  // [START gae_java8_datastore_query_limit]
+  private List<Entity> getTallestPeople() {
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+    Query q = new Query("Person").addSort("height", SortDirection.DESCENDING);
+
+    PreparedQuery pq = datastore.prepare(q);
+    return pq.asList(FetchOptions.Builder.withLimit(5));
+  }
+  // [END gae_java8_datastore_query_limit]
+
+  @Test
+  public void queryLimitExample_returnsLimitedEntities() throws Exception {
+    Entity a = new Entity("Person", "a");
+    a.setProperty("height", 200);
+    Entity b = new Entity("Person", "b");
+    b.setProperty("height", 199);
+    Entity c = new Entity("Person", "c");
+    c.setProperty("height", 201);
+    Entity d = new Entity("Person", "d");
+    d.setProperty("height", 198);
+    Entity e = new Entity("Person", "e");
+    e.setProperty("height", 202);
+    Entity f = new Entity("Person", "f");
+    f.setProperty("height", 197);
+    Entity g = new Entity("Person", "g");
+    g.setProperty("height", 203);
+    Entity h = new Entity("Person", "h");
+    h.setProperty("height", 196);
+    datastore.put(ImmutableList.<Entity>of(a, b, c, d, e, f, g, h));
+
+    List<Entity> results = getTallestPeople();
+
+    assertWithMessage("results").that(results).containsExactly(g, e, c, a, b).inOrder();
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/ReadPolicyTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/ReadPolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/ReadPolicyTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/ReadPolicyTest.java
@@ -1,1 +1,115 @@
-../../../../../../../../appengine-java8/datastore/src/test/java/com/example/appengine/ReadPolicyTest.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceConfig;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.ReadPolicy;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link ReadPolicy}.
+ */
+@RunWith(JUnit4.class)
+public class ReadPolicyTest {
+
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+          // Set 100% eventual consistency, so we can test with other job policies.
+          // https://cloud.google
+          // .com/appengine/docs/java/tools/localunittesting
+          // #Java_Writing_High_Replication_Datastore_tests
+          new LocalDatastoreServiceTestConfig()
+              .setDefaultHighRepJobPolicyUnappliedJobPercentage(100));
+
+  @Before
+  public void setUp() {
+    helper.setUp();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void readPolicy_eventual_returnsNoResults() {
+    // [START data_consistency]
+    double deadline = 5.0;
+
+    // Construct a read policy for eventual consistency
+    ReadPolicy policy = new ReadPolicy(ReadPolicy.Consistency.EVENTUAL);
+
+    // Set the read policy
+    DatastoreServiceConfig eventuallyConsistentConfig =
+        DatastoreServiceConfig.Builder.withReadPolicy(policy);
+
+    // Set the call deadline
+    DatastoreServiceConfig deadlineConfig = DatastoreServiceConfig.Builder.withDeadline(deadline);
+
+    // Set both the read policy and the call deadline
+    DatastoreServiceConfig datastoreConfig =
+        DatastoreServiceConfig.Builder.withReadPolicy(policy).deadline(deadline);
+
+    // Get Datastore service with the given configuration
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService(datastoreConfig);
+    // [END data_consistency]
+
+    Entity parent = new Entity("Person", "a");
+    Entity child = new Entity("Person", "b", parent.getKey());
+    datastore.put(ImmutableList.<Entity>of(parent, child));
+
+    // Even though we are using an ancestor query, the policy is set to
+    // eventual, so we should get eventually-consistent results. Since the
+    // local data store test config is set to 100% unapplied jobs, there
+    // should be no results.
+    Query q = new Query("Person").setAncestor(parent.getKey());
+    List<Entity> results = datastore.prepare(q).asList(FetchOptions.Builder.withDefaults());
+    assertWithMessage("query results").that(results).isEmpty();
+  }
+
+  @Test
+  public void readPolicy_strong_returnsAllResults() {
+    double deadline = 5.0;
+    ReadPolicy policy = new ReadPolicy(ReadPolicy.Consistency.STRONG);
+    DatastoreServiceConfig datastoreConfig =
+        DatastoreServiceConfig.Builder.withReadPolicy(policy).deadline(deadline);
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService(datastoreConfig);
+
+    Entity parent = new Entity("Person", "a");
+    Entity child = new Entity("Person", "b", parent.getKey());
+    datastore.put(ImmutableList.<Entity>of(parent, child));
+
+    Query q = new Query("Person").setAncestor(parent.getKey());
+    List<Entity> results = datastore.prepare(q).asList(FetchOptions.Builder.withDefaults());
+    assertWithMessage("query results").that(results).hasSize(2);
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/ReadPolicyTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/ReadPolicyTest.java
@@ -62,7 +62,6 @@ public class ReadPolicyTest {
 
   @Test
   public void readPolicy_eventual_returnsNoResults() {
-    // [START data_consistency]
     double deadline = 5.0;
 
     // Construct a read policy for eventual consistency
@@ -81,7 +80,6 @@ public class ReadPolicyTest {
 
     // Get Datastore service with the given configuration
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService(datastoreConfig);
-    // [END data_consistency]
 
     Entity parent = new Entity("Person", "a");
     Entity child = new Entity("Person", "b", parent.getKey());

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/StartupServletTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/StartupServletTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/StartupServletTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/StartupServletTest.java
@@ -1,1 +1,108 @@
-../../../../../../../../appengine-java8/datastore/src/test/java/com/example/appengine/StartupServletTest.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.mockito.Mockito.when;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.Filter;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Unit tests for {@link StartupServlet}.
+ */
+@RunWith(JUnit4.class)
+public class StartupServletTest {
+
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+          // Set no eventual consistency, that way queries return all results.
+          // https://cloud.google
+          // .com/appengine/docs/java/tools/localunittesting
+          // #Java_Writing_High_Replication_Datastore_tests
+          new LocalDatastoreServiceTestConfig()
+              .setDefaultHighRepJobPolicyUnappliedJobPercentage(0));
+
+  @Mock
+  private HttpServletRequest mockRequest;
+  @Mock
+  private HttpServletResponse mockResponse;
+  private StringWriter responseWriter;
+  private DatastoreService datastore;
+
+  private StartupServlet servletUnderTest;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
+    helper.setUp();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+
+    // Set up a fake HTTP response.
+    responseWriter = new StringWriter();
+    when(mockResponse.getWriter()).thenReturn(new PrintWriter(responseWriter));
+
+    servletUnderTest = new StartupServlet();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void doGet_emptyDatastore_writesOkay() throws Exception {
+    servletUnderTest.doGet(mockRequest, mockResponse);
+    assertWithMessage("StartupServlet response").that(responseWriter.toString()).isEqualTo("ok\n");
+  }
+
+  @Test
+  public void doGet_emptyDatastore_writesPresidents() throws Exception {
+    servletUnderTest.doGet(mockRequest, mockResponse);
+
+    Filter nameFilter = new FilterPredicate("name", FilterOperator.EQUAL, "George Washington");
+    Query q = new Query("Person").setFilter(nameFilter);
+    Entity result = datastore.prepare(q).asSingleEntity();
+    assertWithMessage("name").that(result.getProperty("name")).isEqualTo("George Washington");
+  }
+
+  @Test
+  public void doGet_alreadyPopulated_writesOkay() throws Exception {
+    datastore.put(
+        new Entity(StartupServlet.IS_POPULATED_ENTITY, StartupServlet.IS_POPULATED_KEY_NAME));
+    servletUnderTest.doGet(mockRequest, mockResponse);
+    assertWithMessage("StartupServlet response").that(responseWriter.toString()).isEqualTo("ok\n");
+  }
+}

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/TransactionsTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/TransactionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc.
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/TransactionsTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/TransactionsTest.java
@@ -78,7 +78,6 @@ public class TransactionsTest {
     Entity joe = new Entity("Employee", "Joe");
     datastore.put(joe);
 
-    // [START using_transactions]
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Transaction txn = datastore.beginTransaction();
     try {
@@ -94,13 +93,11 @@ public class TransactionsTest {
         txn.rollback();
       }
     }
-    // [END using_transactions]
   }
 
   @Test
   public void entityGroups() throws Exception {
     try {
-      // [START entity_groups]
       DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
       Entity person = new Entity("Person", "tom");
       datastore.put(person);
@@ -133,7 +130,6 @@ public class TransactionsTest {
       // Throws IllegalArgumentException because the Person entity
       // and the Photo entity belong to different entity groups.
       txn.commit();
-      // [END entity_groups]
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException expected) {
       // We expect to get an exception that complains that we don't have a XG-transaction.
@@ -145,7 +141,6 @@ public class TransactionsTest {
   public void creatingAnEntityInASpecificEntityGroup() throws Exception {
     String boardName = "my-message-board";
 
-    // [START creating_an_entity_in_a_specific_entity_group]
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
     String messageTitle = "Some Title";
@@ -163,12 +158,10 @@ public class TransactionsTest {
     datastore.put(txn, message);
 
     txn.commit();
-    // [END creating_an_entity_in_a_specific_entity_group]
   }
 
   @Test
   public void crossGroupTransactions() throws Exception {
-    // [START cross-group_XG_transactions_using_the_Java_low-level_API]
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     TransactionOptions options = TransactionOptions.Builder.withXG(true);
     Transaction txn = datastore.beginTransaction(options);
@@ -182,7 +175,6 @@ public class TransactionsTest {
     datastore.put(txn, b);
 
     txn.commit();
-    // [END cross-group_XG_transactions_using_the_Java_low-level_API]
   }
 
   @Test
@@ -192,7 +184,6 @@ public class TransactionsTest {
     b.setProperty("count", 41);
     datastore.put(b);
 
-    // [START uses_for_transactions_1]
     int retries = 3;
     while (true) {
       Transaction txn = datastore.beginTransaction();
@@ -219,14 +210,12 @@ public class TransactionsTest {
         }
       }
     }
-    // [END uses_for_transactions_1]
 
     b = datastore.get(KeyFactory.createKey("MessageBoard", boardName));
     assertWithMessage("board.count").that((long) b.getProperty("count")).isEqualTo(42L);
   }
 
   private Entity fetchOrCreate(String boardName) {
-    // [START uses_for_transactions_2]
     Transaction txn = datastore.beginTransaction();
     Entity messageBoard;
     Key boardKey;
@@ -239,7 +228,6 @@ public class TransactionsTest {
       boardKey = datastore.put(txn, messageBoard);
     }
     txn.commit();
-    // [END uses_for_transactions_2]
 
     return messageBoard;
   }
@@ -268,7 +256,6 @@ public class TransactionsTest {
     b.setProperty("count", 13);
     datastore.put(b);
 
-    // [START uses_for_transactions_3]
     DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
 
     // Display information about a message board and its first 10 messages.
@@ -286,14 +273,12 @@ public class TransactionsTest {
     List<Entity> messages = pq.asList(FetchOptions.Builder.withLimit(10));
 
     txn.commit();
-    // [END uses_for_transactions_3]
 
     assertWithMessage("board.count").that(count).isEqualTo(13L);
   }
 
   @Test
   public void transactionalTaskEnqueuing() throws Exception {
-    // [START transactional_task_enqueuing]
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Queue queue = QueueFactory.getDefaultQueue();
     Transaction txn = datastore.beginTransaction();
@@ -304,6 +289,5 @@ public class TransactionsTest {
     // ...
 
     txn.commit();
-    // [END transactional_task_enqueuing]
   }
 }

--- a/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/TransactionsTest.java
+++ b/appengine-java17-bundled-services/datastore/src/test/java/com/example/appengine/TransactionsTest.java
@@ -1,1 +1,309 @@
-../../../../../../../../appengine-java8/datastore/src/test/java/com/example/appengine/TransactionsTest.java
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.appengine;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.Assert.fail;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EntityNotFoundException;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Transaction;
+import com.google.appengine.api.datastore.TransactionOptions;
+import com.google.appengine.api.taskqueue.Queue;
+import com.google.appengine.api.taskqueue.QueueFactory;
+import com.google.appengine.api.taskqueue.TaskOptions;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import java.util.ConcurrentModificationException;
+import java.util.Date;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests to demonstrate App Engine Datastore transactions.
+ */
+@RunWith(JUnit4.class)
+public class TransactionsTest {
+
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+          // Use High Rep job policy to allow cross group transactions in tests.
+          new LocalDatastoreServiceTestConfig().setApplyAllHighRepJobPolicy());
+
+  private DatastoreService datastore;
+
+  @Before
+  public void setUp() {
+    helper.setUp();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+
+  @After
+  public void tearDown() {
+    // Clean up any dangling transactions.
+    Transaction txn = datastore.getCurrentTransaction(null);
+    if (txn != null && txn.isActive()) {
+      txn.rollback();
+    }
+    helper.tearDown();
+  }
+
+  @Test
+  public void usingTransactions() throws Exception {
+    Entity joe = new Entity("Employee", "Joe");
+    datastore.put(joe);
+
+    // [START using_transactions]
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    Transaction txn = datastore.beginTransaction();
+    try {
+      Key employeeKey = KeyFactory.createKey("Employee", "Joe");
+      Entity employee = datastore.get(employeeKey);
+      employee.setProperty("vacationDays", 10);
+
+      datastore.put(txn, employee);
+
+      txn.commit();
+    } finally {
+      if (txn.isActive()) {
+        txn.rollback();
+      }
+    }
+    // [END using_transactions]
+  }
+
+  @Test
+  public void entityGroups() throws Exception {
+    try {
+      // [START entity_groups]
+      DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+      Entity person = new Entity("Person", "tom");
+      datastore.put(person);
+
+      // Transactions on root entities
+      Transaction txn = datastore.beginTransaction();
+
+      Entity tom = datastore.get(person.getKey());
+      tom.setProperty("age", 40);
+      datastore.put(txn, tom);
+      txn.commit();
+
+      // Transactions on child entities
+      txn = datastore.beginTransaction();
+      tom = datastore.get(person.getKey());
+      Entity photo = new Entity("Photo", tom.getKey());
+
+      // Create a Photo that is a child of the Person entity named "tom"
+      photo.setProperty("photoUrl", "http://domain.com/path/to/photo.jpg");
+      datastore.put(txn, photo);
+      txn.commit();
+
+      // Transactions on entities in different entity groups
+      txn = datastore.beginTransaction();
+      tom = datastore.get(person.getKey());
+      Entity photoNotaChild = new Entity("Photo");
+      photoNotaChild.setProperty("photoUrl", "http://domain.com/path/to/photo.jpg");
+      datastore.put(txn, photoNotaChild);
+
+      // Throws IllegalArgumentException because the Person entity
+      // and the Photo entity belong to different entity groups.
+      txn.commit();
+      // [END entity_groups]
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException expected) {
+      // We expect to get an exception that complains that we don't have a XG-transaction.
+    }
+  }
+
+  @Test
+  @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+  public void creatingAnEntityInASpecificEntityGroup() throws Exception {
+    String boardName = "my-message-board";
+
+    // [START creating_an_entity_in_a_specific_entity_group]
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+    String messageTitle = "Some Title";
+    String messageText = "Some message.";
+    Date postDate = new Date();
+
+    Key messageBoardKey = KeyFactory.createKey("MessageBoard", boardName);
+
+    Entity message = new Entity("Message", messageBoardKey);
+    message.setProperty("message_title", messageTitle);
+    message.setProperty("message_text", messageText);
+    message.setProperty("post_date", postDate);
+
+    Transaction txn = datastore.beginTransaction();
+    datastore.put(txn, message);
+
+    txn.commit();
+    // [END creating_an_entity_in_a_specific_entity_group]
+  }
+
+  @Test
+  public void crossGroupTransactions() throws Exception {
+    // [START cross-group_XG_transactions_using_the_Java_low-level_API]
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    TransactionOptions options = TransactionOptions.Builder.withXG(true);
+    Transaction txn = datastore.beginTransaction(options);
+
+    Entity a = new Entity("A");
+    a.setProperty("a", 22);
+    datastore.put(txn, a);
+
+    Entity b = new Entity("B");
+    b.setProperty("b", 11);
+    datastore.put(txn, b);
+
+    txn.commit();
+    // [END cross-group_XG_transactions_using_the_Java_low-level_API]
+  }
+
+  @Test
+  public void usesForTransactions_relativeUpdates() throws Exception {
+    String boardName = "my-message-board";
+    Entity b = new Entity("MessageBoard", boardName);
+    b.setProperty("count", 41);
+    datastore.put(b);
+
+    // [START uses_for_transactions_1]
+    int retries = 3;
+    while (true) {
+      Transaction txn = datastore.beginTransaction();
+      try {
+        Key boardKey = KeyFactory.createKey("MessageBoard", boardName);
+        Entity messageBoard = datastore.get(boardKey);
+
+        long count = (Long) messageBoard.getProperty("count");
+        ++count;
+        messageBoard.setProperty("count", count);
+        datastore.put(txn, messageBoard);
+
+        txn.commit();
+        break;
+      } catch (ConcurrentModificationException e) {
+        if (retries == 0) {
+          throw e;
+        }
+        // Allow retry to occur
+        --retries;
+      } finally {
+        if (txn.isActive()) {
+          txn.rollback();
+        }
+      }
+    }
+    // [END uses_for_transactions_1]
+
+    b = datastore.get(KeyFactory.createKey("MessageBoard", boardName));
+    assertWithMessage("board.count").that((long) b.getProperty("count")).isEqualTo(42L);
+  }
+
+  private Entity fetchOrCreate(String boardName) {
+    // [START uses_for_transactions_2]
+    Transaction txn = datastore.beginTransaction();
+    Entity messageBoard;
+    Key boardKey;
+    try {
+      boardKey = KeyFactory.createKey("MessageBoard", boardName);
+      messageBoard = datastore.get(boardKey);
+    } catch (EntityNotFoundException e) {
+      messageBoard = new Entity("MessageBoard", boardName);
+      messageBoard.setProperty("count", 0L);
+      boardKey = datastore.put(txn, messageBoard);
+    }
+    txn.commit();
+    // [END uses_for_transactions_2]
+
+    return messageBoard;
+  }
+
+  @Test
+  public void usesForTransactions_fetchOrCreate_fetchesExisting() throws Exception {
+    Entity b = new Entity("MessageBoard", "my-message-board");
+    b.setProperty("count", 7);
+    datastore.put(b);
+
+    Entity board = fetchOrCreate("my-message-board");
+
+    assertWithMessage("board.count").that((long) board.getProperty("count")).isEqualTo(7L);
+  }
+
+  @Test
+  public void usesForTransactions_fetchOrCreate_createsNew() throws Exception {
+    Entity board = fetchOrCreate("my-message-board");
+    assertWithMessage("board.count").that((long) board.getProperty("count")).isEqualTo(0L);
+  }
+
+  @Test
+  public void usesForTransactions_readSnapshot() throws Exception {
+    String boardName = "my-message-board";
+    Entity b = new Entity("MessageBoard", boardName);
+    b.setProperty("count", 13);
+    datastore.put(b);
+
+    // [START uses_for_transactions_3]
+    DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
+
+    // Display information about a message board and its first 10 messages.
+    Key boardKey = KeyFactory.createKey("MessageBoard", boardName);
+
+    Transaction txn = datastore.beginTransaction();
+
+    Entity messageBoard = datastore.get(boardKey);
+    long count = (Long) messageBoard.getProperty("count");
+
+    Query q = new Query("Message", boardKey);
+
+    // This is an ancestor query.
+    PreparedQuery pq = datastore.prepare(txn, q);
+    List<Entity> messages = pq.asList(FetchOptions.Builder.withLimit(10));
+
+    txn.commit();
+    // [END uses_for_transactions_3]
+
+    assertWithMessage("board.count").that(count).isEqualTo(13L);
+  }
+
+  @Test
+  public void transactionalTaskEnqueuing() throws Exception {
+    // [START transactional_task_enqueuing]
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    Queue queue = QueueFactory.getDefaultQueue();
+    Transaction txn = datastore.beginTransaction();
+    // ...
+
+    queue.add(txn, TaskOptions.Builder.withUrl("/path/to/handler"));
+
+    // ...
+
+    txn.commit();
+    // [END transactional_task_enqueuing]
+  }
+}


### PR DESCRIPTION
## Description
Fixes #10242
Internal: b/496677589

This PR dereferences the symbolic links in the Java 17 App Engine bundled services module (`appengine-java17-bundled-services`) that previously pointed to the deleted/legacy `appengine-java8` directory. By making these files self-contained (replace actual Java8 code on Java 17 Bundled Servies), this module can run independently without relying on Java 8 code.

Region Tags were removed due point to the same examples as the Java 8 GAE samples.

Additionally, this PR adds the missing JSTL dependency to the Java 17 `pom.xml `to resolve JSP runtime compilation errors (`JasperException / ClassNotFoundException for guestbook_jsp`) when running the development server locally with `mvn appengine:run.`

This PR dereferenced 32 Symbolic links on `appengine-java17-bundled-services/datastore`
  


## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
