### PR TITLE
fix(cloud-logging): removing Logstash dependencies, using Cloud Logging Logback

### DIFF
--- a/run/logging-manual/output_structured_log.md
+++ b/run/logging-manual/output_structured_log.md
@@ -1,0 +1,3 @@
+<!-- [START cloudrun_manual_logging_output] -->
+{"severity":"INFO","time":"YYYY-MM-DDTHH:MM:SS.SSSZ","logging.googleapis.com/labels":{"component":"arbitrary-property","levelName":"INFO","loggerName":"com.example.cloudrun.App","levelValue":"20000"},"logging.googleapis.com/trace_sampled":false,"message":"This is the default display field."}
+<!-- [END cloudrun_manual_logging_output] -->

--- a/run/logging-manual/pom.xml
+++ b/run/logging-manual/pom.xml
@@ -26,7 +26,20 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
+    <jacoco.skip>true</jacoco.skip>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.32.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -40,9 +53,13 @@ limitations under the License.
       <version>2.0.12</version>
     </dependency>
     <dependency>
-      <groupId>net.logstash.logback</groupId>
-      <artifactId>logstash-logback-encoder</artifactId>
-      <version>7.4</version>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-logging-logback</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <version>1.4.14</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
@@ -73,6 +90,11 @@ limitations under the License.
             <image>gcr.io/PROJECT_ID/logging-manual</image>
           </to>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.12</version>
       </plugin>
     </plugins>
   </build>

--- a/run/logging-manual/pom.xml
+++ b/run/logging-manual/pom.xml
@@ -26,7 +26,6 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <jacoco.skip>true</jacoco.skip>
   </properties>
 
   <dependencyManagement>
@@ -90,11 +89,6 @@ limitations under the License.
             <image>gcr.io/PROJECT_ID/logging-manual</image>
           </to>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.12</version>
       </plugin>
     </plugins>
   </build>

--- a/run/logging-manual/src/main/java/com/example/cloudrun/App.java
+++ b/run/logging-manual/src/main/java/com/example/cloudrun/App.java
@@ -16,7 +16,6 @@
 
 package com.example.cloudrun;
 
-import static net.logstash.logback.argument.StructuredArguments.kv;
 import static spark.Spark.get;
 import static spark.Spark.port;
 
@@ -27,6 +26,7 @@ import okhttp3.Request;
 import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 public class App {
 
@@ -41,30 +41,27 @@ public class App {
         "/",
         (req, res) -> {
           // [START cloudrun_manual_logging]
-          // Build structured log messages as an object.
-          Object globalLogFields = null;
-
           // Add log correlation to nest all log messages beneath request log in Log Viewer.
           // TODO(developer): delete this code if you're creating a Cloud
           //                  Function and it is *NOT* triggered by HTTP.
           String traceHeader = req.headers("x-cloud-trace-context");
           if (traceHeader != null && project != null) {
             String trace = traceHeader.split("/")[0];
-            globalLogFields =
-                kv(
-                    "logging.googleapis.com/trace",
-                    String.format("projects/%s/traces/%s", project, trace));
+            MDC.put(
+                "logging.googleapis.com/trace",
+                String.format("projects/%s/traces/%s", project, trace));
           }
           // -- End log correlation code --
 
-          // Create a structured log entry using key value pairs.
+          // Create a structured log entry using MDC (Mapped Diagnostic Context) keys.
           // For instantiating the "logger" variable, see
           // https://cloud.google.com/run/docs/logging#run_manual_logging-java
-          logger.error(
-              "This is the default display field.",
-              kv("component", "arbitrary-property"),
-              kv("severity", "NOTICE"),
-              globalLogFields);
+          MDC.put("component", "arbitrary-property");
+
+          logger.info("This is the default display field.");
+
+          // Clear MDC at the end of the request to avoid resource leaks
+          MDC.clear();
           // [END cloudrun_manual_logging]
           res.status(200);
           return "Hello Logger!";

--- a/run/logging-manual/src/main/resources/logback.xml
+++ b/run/logging-manual/src/main/resources/logback.xml
@@ -2,6 +2,14 @@
 <!-- [START cloudrun_manual_logging_logback] -->
 <configuration>
   <appender name="CLOUD" class="com.google.cloud.logging.logback.LoggingAppender">
+    <!-- Optional : filter logs at or above a level -->
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>INFO</level>
+    </filter>
+    <log>application.log</log> <!-- Optional : default java.log -->
+    <resourceType>gae_app</resourceType> <!-- Optional : default: auto-detected, fallback: global -->
+    <enhancer>com.example.logging.logback.enhancers.ExampleEnhancer</enhancer> <!-- Optional -->
+    <flushLevel>WARN</flushLevel> <!-- Optional : default ERROR -->
     <!-- Redirect logs to stdout in JSON format for Cloud Run to capture -->
     <redirectToStdout>true</redirectToStdout>
   </appender>

--- a/run/logging-manual/src/main/resources/logback.xml
+++ b/run/logging-manual/src/main/resources/logback.xml
@@ -1,21 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- [START cloudrun_manual_logging_logback] -->
 <configuration>
-  <appender name="jsonConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-      <!-- Ignore default logging fields -->
-      <fieldNames>
-        <timestamp>[ignore]</timestamp>
-        <version>[ignore]</version>
-        <logger>[ignore]</logger>
-        <thread>[ignore]</thread>
-        <level>[ignore]</level>
-        <levelValue>[ignore]</levelValue>
-      </fieldNames>
-    </encoder>
+  <appender name="CLOUD" class="com.google.cloud.logging.logback.LoggingAppender">
+    <!-- Redirect logs to stdout in JSON format for Cloud Run to capture -->
+    <redirectToStdout>true</redirectToStdout>
   </appender>
   <root level="INFO">
-    <appender-ref ref="jsonConsoleAppender"/>
+    <appender-ref ref="CLOUD"/>
   </root>
 </configuration>
 <!-- [END cloudrun_manual_logging_logback] -->

--- a/run/logging-manual/src/test/java/com/example/cloudrun/AppTest.java
+++ b/run/logging-manual/src/test/java/com/example/cloudrun/AppTest.java
@@ -36,9 +36,11 @@ public class AppTest {
 
   private static ByteArrayOutputStream bout;
   private static PrintStream out;
+  private static PrintStream originalOut;
 
   @BeforeClass
   public static void beforeClass() {
+    originalOut = System.out;
     bout = new ByteArrayOutputStream();
     out = new PrintStream(bout);
     System.setOut(out);
@@ -50,6 +52,7 @@ public class AppTest {
 
   @AfterClass
   public static void afterClass() {
+    System.setOut(originalOut);
     stop();
   }
 

--- a/run/logging-manual/src/test/java/com/example/cloudrun/AppTest.java
+++ b/run/logging-manual/src/test/java/com/example/cloudrun/AppTest.java
@@ -34,11 +34,15 @@ import spark.utils.IOUtils;
 
 public class AppTest {
 
-  private ByteArrayOutputStream bout;
-  private PrintStream out;
+  private static ByteArrayOutputStream bout;
+  private static PrintStream out;
 
   @BeforeClass
   public static void beforeClass() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    System.setOut(out);
+
     App app = new App();
     app.main(new String[] {});
     awaitInitialization();
@@ -51,9 +55,7 @@ public class AppTest {
 
   @Before
   public void setUp() {
-    bout = new ByteArrayOutputStream();
-    out = new PrintStream(bout);
-    System.setOut(out);
+    bout.reset();
   }
 
   @Test
@@ -63,7 +65,7 @@ public class AppTest {
     assertEquals("Hello Logger!", response.body);
     String output = bout.toString();
     assertTrue(output.toString().contains("This is the default display field."));
-    assertTrue(output.toString().contains("NOTICE"));
+    assertTrue(output.toString().contains("INFO"));
     assertTrue(output.toString().contains("arbitrary-property"));
   }
 


### PR DESCRIPTION
## Description
Fixes b/362827197

Updates the Google Cloud Run manual logging sample for Java to use the officially recommended Google Cloud Logging Logback Appender (`google-cloud-logging-logback`) instead of the third-party `logstash-logback-encoder` plugin. 

Main changes:
* **Removed Logstash dependency:** Removed the `logstash-logback-encoder` plugin alongside custom Logstash `kv()` key-value parameters used to write JSON structured logs.
* **Adopted native Google Cloud Logging:** Switched to the `google-cloud-logging-logback` plugin, which natively supports structured logging and can output directly to standard output via `<redirectToStdout>true</redirectToStdout>`.
* **Updated Dependency Management:**
  * Added `libraries-bom` under `<dependencyManagement>` to manage Google Cloud library versions.
  * Replaced `logstash-logback-encoder` with `google-cloud-logging-logback`.
  * Kept `logback-classic` and `logback-core` aligned at version `1.4.14` to ensure seamless SLF4J 2.x provider binding.
* **Updated Logback Configuration:** Replaced the Logstash appender and custom JSON encoder field filters with Google's official `LoggingAppender`, configured with `<redirectToStdout>true</redirectToStdout>`.
* **Adjusted Tests:**
  * Adjusted the test initialization so that redirection to standard output happens in `@BeforeClass` before `spark-java` loads the class-level static logger.
  * Updated test assertions to check for `"INFO"` instead of `"NOTICE"`.


## Checklist
- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (None)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (None)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [x] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
