### PR TITLE
chore: remove redundant region tags from GcsEvent POJOs from java-samples/functions

### DIFF
--- a/functions/imagemagick/src/main/java/functions/eventpojos/GcsEvent.java
+++ b/functions/imagemagick/src/main/java/functions/eventpojos/GcsEvent.java
@@ -18,7 +18,6 @@ package functions.eventpojos;
 
 import java.util.Date;
 
-// [START functions_helloworld_gcs_event]
 public class GcsEvent {
   // Cloud Functions uses GSON to populate this object.
   // Field types/names are specified by Cloud Functions
@@ -69,4 +68,3 @@ public class GcsEvent {
     this.updated = updated;
   }
 }
-// [END functions_helloworld_gcs_event]

--- a/functions/ocr/ocr-process-image/src/main/java/functions/eventpojos/GcsEvent.java
+++ b/functions/ocr/ocr-process-image/src/main/java/functions/eventpojos/GcsEvent.java
@@ -18,7 +18,6 @@ package functions.eventpojos;
 
 import java.util.Date;
 
-// [START functions_helloworld_gcs_event]
 public class GcsEvent {
   // Cloud Functions uses GSON to populate this object.
   // Field types/names are specified by Cloud Functions
@@ -69,4 +68,3 @@ public class GcsEvent {
     this.updated = updated;
   }
 }
-// [END functions_helloworld_gcs_event]


### PR DESCRIPTION
## Description

Fixes b/385748009

Removes the duplicate `functions_helloworld_gcs_event` region tags from the GcsEvent POJO files in both `functions/imagemagick` and `functions/ocr/ocr-process-image` 

The file `GcsEvent.java` is used in the implementation of `ImageMagick.java`. However, its region tag is currently duplicated across multiple locations on repository.

**Affected File Paths**

The duplicate region tags are found in the following `GcsEvent.java` files:
1. `functions/helloworld/hello-gcs/src/main/java/functions/eventpojos/GcsEvent.java`
2. `functions/ocr/ocr-process-image/src/main/java/functions/eventpojos/GcsEvent.java`
3. `functions/imagemagick/src/main/java/functions/eventpojos/GcsEvent.java`

in the case of `functions/hello-gsc`, it keeps a metadata reference on `functions.txtpb` which trigger an error if is removed.


**Context and References**

* **Status of `ImageMagick.java`:** This file is not orphaned. Its region tags (`functions_imagemagick_setup`, `functions_imagemagick_analyze`, and `functions_imagemagick_blur`) are actively referenced by the 1st Generation ImageMagick Tutorial (`imagemagick-1st-gen.md`).
* **Reference Links:**
    * [GcsEvent.java Source](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/functions/imagemagick/src/main/java/functions/eventpojos/GcsEvent.java)
    * [ImageMagick.java Source](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/functions/ImageMagick.java)



## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [x] Appropriate changes to README are included in PR (No changes required since this only refactors comments/region tags in existing files)
- [] These samples need a new **API enabled** in testing projects to pass (None)
- [] These samples need a new/updated **env vars** in testing projects set to pass (None)
- [x] **Tests** pass:   `mvn clean verify` **required** (Integration tests require configured GCS buckets and Vision API credentials in local testing. The codebase structure remains intact and CI will execute them with target credentials)
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required** (Both modified projects ran and passed with 0 checkstyle violations)
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only** (No code logic was added or changed)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample (N/A - modified existing files only)
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample (N/A)
- [x] Please **merge** this PR for me once it is approved
