### PR TITLE
fix(cloud-run): CloudRun/HelloWorld upgrade to Java25 along Docker

### DIFF
--- a/run/helloworld/Dockerfile
+++ b/run/helloworld/Dockerfile
@@ -15,7 +15,7 @@
 # [START cloudrun_helloworld_dockerfile]
 # Use the official maven image to create a build artifact.
 # https://hub.docker.com/_/maven
-FROM maven:3-eclipse-temurin-17-alpine as builder
+FROM maven:3-eclipse-temurin-25-alpine as builder
 
 # Copy local code to the container image.
 WORKDIR /app
@@ -27,7 +27,7 @@ RUN mvn package -DskipTests
 
 # Use Eclipse Temurin for base image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM eclipse-temurin:17.0.18_8-jre-alpine
+FROM eclipse-temurin:25-jre-alpine
 
 # Copy the jar to the production image from the builder stage.
 COPY --from=builder /app/target/helloworld-*.jar /helloworld.jar

--- a/run/helloworld/pom.xml
+++ b/run/helloworld/pom.xml
@@ -24,7 +24,7 @@ limitations under the License.
   <parent>
     <groupId>com.google.cloud.samples</groupId>
     <artifactId>shared-configuration</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.2</version>
   </parent>
   <dependencyManagement>
     <dependencies>
@@ -41,9 +41,9 @@ limitations under the License.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.target>17</maven.compiler.target>
-    <maven.compiler.source>17</maven.compiler.source>
-    <spring-boot.version>3.2.2</spring-boot.version>
+    <maven.compiler.target>25</maven.compiler.target>
+    <maven.compiler.source>25</maven.compiler.source>
+    <spring-boot.version>3.5.0</spring-boot.version>
   </properties>
   <dependencies>
     <dependency>
@@ -69,6 +69,11 @@ limitations under the License.
   <build>
     <plugins>
       <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.14</version>
+      </plugin>
+      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <version>${spring-boot.version}</version>
@@ -84,8 +89,11 @@ limitations under the License.
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.6</version>
         <configuration>
+          <from>
+            <image>eclipse-temurin:25-jre-alpine</image>
+          </from>
           <to>
             <image>gcr.io/PROJECT_ID/helloworld</image>
           </to>

--- a/run/helloworld/pom.xml
+++ b/run/helloworld/pom.xml
@@ -41,8 +41,9 @@ limitations under the License.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.target>25</maven.compiler.target>
-    <maven.compiler.source>25</maven.compiler.source>
+    <!--Change this to 25 in your workspace-->
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
     <spring-boot.version>3.5.0</spring-boot.version>
   </properties>
   <dependencies>

--- a/run/helloworld/src/test/java/com/example/helloworld/HelloworldApplicationTests.java
+++ b/run/helloworld/src/test/java/com/example/helloworld/HelloworldApplicationTests.java
@@ -29,7 +29,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
+@SpringBootTest(classes = HelloworldApplication.class)
 @AutoConfigureMockMvc
 public class HelloworldApplicationTests {
 

--- a/run/helloworld/src/test/java/com/example/helloworld/HelloworldApplicationTests.java
+++ b/run/helloworld/src/test/java/com/example/helloworld/HelloworldApplicationTests.java
@@ -20,16 +20,13 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(classes = HelloworldApplication.class)
+@SpringBootTest
 @AutoConfigureMockMvc
 public class HelloworldApplicationTests {
 


### PR DESCRIPTION
## Description

Fixes: b/470273769

Upgrade the Hello World Cloud Run sample to Java 25. This includes:
- Updating parent `shared-configuration` version to `1.2.2`.
- Updating compiler source and target versions to `25`.
- Updating Spring Boot version to `3.5.0` to match compatibility requirements for Java 25.
- Updating Jib plugin configuration to build from `eclipse-temurin:25-jre-alpine`.
- Updating the multi-stage `Dockerfile` to use `maven:3-eclipse-temurin-25-alpine` for the builder stage and `eclipse-temurin:25-jre-alpine` for the runner stage.
- Fixing unit tests bootstrap issue under Spring Boot 3.5.0 by specifying the test context class `HelloworldApplication.class`.

**Notes**
Here we have an issue with Kokoro when upgrading samples to Java25
Kokoro fails on both Java 11 and Java 17 presubmit builds, caused by the same issue: the repository's test runner ([btlr](https://github.com/googleapis/btlr) ) does not yet support Java version 25 as a compiler target in pom.xml, and fails immediately when encountering it.

This PR follows the workaround applied in [appengine-java25/helloworld/pom.xml](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/2c245f768270259d9e6d62d876461bf858085ed4/appengine-java25/helloworld/pom.xml#L33 
) and [flexible/java-25/websocket-jetty/pom.xml](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/2c245f768270259d9e6d62d876461bf858085ed4/flexible/java-25/websocket-jetty/pom.xml#L37
) ) which is **using Java 21 Target in POM**

We would set `maven.compiler.target` and `maven.compiler.source `to 21 in pom.xml, but keep the build/runtime environment in the Dockerfile configured to use Java 25.





## Checklist
- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [x] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only** (Note: fails under JDK 25 compiler with `IllegalAccessError` on unnamed module/ErrorProne access to `com.sun.tools.javac.api.BasicJavacTask`)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved