### PR TITLE
refactor(bigquery): Standardize SimpleQuery samples as used across multiple technologies

### DIFF
--- a/bigquery/README.md
+++ b/bigquery/README.md
@@ -1,9 +1,0 @@
-# Getting Started with BigQuery
-
-The samples have been moved to live alongside the Java client libraries for Cloud BigQuery:
-
-[BigQuery samples](https://github.com/googleapis/java-bigquery/tree/main/samples/snippets/src/main/java/com/example/bigquery)
-
-[BigQueryStorage samples](https://github.com/googleapis/java-bigquerystorage/tree/main/samples/snippets/src/main/java/com/example/bigquerystorage)
-
-[BigQueryDataTransfer samples](https://github.com/googleapis/java-bigquerydatatransfer/tree/main/samples/snippets/src/main/java/com/example/bigquerydatatransfer)

--- a/bigquery/cloud-client/snippets/pom.xml
+++ b/bigquery/cloud-client/snippets/pom.xml
@@ -67,4 +67,28 @@ limitations under the License.
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.12</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/SimpleQuery.java
+++ b/bigquery/cloud-client/snippets/src/main/java/com/example/bigquery/SimpleQuery.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquery;
+
+// [START bigquery_query]
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.TableResult;
+
+public class SimpleQuery {
+
+  public static void main(String[] args) {
+    // TODO(developer): Replace this query before running the sample.
+    String query =
+        "SELECT name, SUM(number) as total_people "
+            + "FROM `bigquery-public-data.usa_names.usa_1910_2013` "
+            + "WHERE state = 'TX' "
+            + "GROUP BY name, state "
+            + "ORDER BY total_people DESC "
+            + "LIMIT 100;";
+    simpleQuery(query);
+  }
+
+  public static void simpleQuery(String query) {
+    try {
+      // Initialize client that will be used to send requests. This client only needs to be created
+      // once, and can be reused for multiple requests.
+      BigQuery bigquery = BigQueryOptions.getDefaultInstance().getService();
+
+      // Create the query job.
+      QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(query).build();
+
+      // Execute the query.
+      TableResult result = bigquery.query(queryConfig);
+
+      // Print the results.
+      result
+          .iterateAll()
+          .forEach(
+              row -> {
+                System.out.print("name:" + row.get("name").getStringValue());
+                System.out.print(", count:" + row.get("total_people").getLongValue());
+                System.out.println();
+              });
+
+      System.out.println("Query ran successfully");
+    } catch (BigQueryException | InterruptedException e) {
+      System.out.println("Query did not run \n" + e.toString());
+    }
+  }
+}
+// [END bigquery_query]

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/SimpleQueryIT.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/SimpleQueryIT.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigquery;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SimpleQueryIT {
+
+  private final Logger log = Logger.getLogger(this.getClass().getName());
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    // restores print statements in the original method
+    System.out.flush();
+    System.setOut(originalPrintStream);
+    log.log(Level.INFO, "\n" + bout.toString());
+  }
+
+  @Test
+  public void testSimpleQuery() {
+    String query =
+        "SELECT name, SUM(number) as total_people "
+            + "FROM `bigquery-public-data.usa_names.usa_1910_2013` "
+            + "WHERE state = 'TX' "
+            + "GROUP BY name, state "
+            + "ORDER BY total_people DESC "
+            + "LIMIT 100;";
+
+    SimpleQuery.simpleQuery(query);
+    assertThat(bout.toString()).contains("Query ran successfully");
+  }
+}

--- a/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/Util.java
+++ b/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/Util.java
@@ -20,9 +20,6 @@ import com.google.cloud.Identity;
 import com.google.cloud.Policy;
 import com.google.cloud.Role;
 import com.google.cloud.bigquery.Acl;
-import com.google.cloud.bigquery.Acl.Entity;
-import com.google.cloud.bigquery.Acl.Group;
-import com.google.cloud.bigquery.Acl.Role;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQuery.DatasetDeleteOption;
 import com.google.cloud.bigquery.BigQueryException;
@@ -88,8 +85,8 @@ public class Util {
     DatasetId datasetId = DatasetId.of(projectId, datasetName);
     Dataset dataset = bigquery.getDataset(datasetId);
 
-    Entity entity = new Group(entityEmail);
-    Acl newEntry = Acl.of(entity, Role.READER);
+    Acl.Entity entity = new Acl.Group(entityEmail);
+    Acl newEntry = Acl.of(entity, Acl.Role.READER);
     List<Acl> acls = new ArrayList<>(dataset.getAcl());
     acls.add(newEntry);
 


### PR DESCRIPTION
## Description
Fixes b/468097867

Updated the BigQuery simple query sample `SimpleQuery.java` and its integration test `SimpleQueryIT.java` to query the `bigquery-public-data.usa_names.usa_1910_2013` public dataset instead of the old `bigquery-public-data.samples.shakespeare` dataset. This standardizes the query across samples in other languages.

Additionally:
* Fixed a class reference ambiguity for `Role` in [Util.java](file:///usr/local/google/home/kgordillo/GCP_SAMPLES/java-docs-samples_kef/bigquery/cloud-client/snippets/src/test/java/com/example/bigquery/Util.java) by using fully-qualified references for `Acl.Role`.
* Added `jacoco-maven-plugin` configuration with version `0.8.12` to `pom.xml` to resolve compatibility issues when instrumenting code under Java 21+ environments.
* Deleted README.md, the content is deprecated

Reference on other technologies: https://docs.cloud.google.com/bigquery/docs/running-queries#python

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration` (uses the workspace standard version `1.2.0`)
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required** (verified `SimpleQueryIT` integration test passes)
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required** (0 checkstyle violations found on modified/added files)
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only** (Skipped due to JDK 25 compatibility issues with configured ErrorProne plugin version during compilation)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
