### PR TITLE
fix(healthcare): remove old healthcare java dependency region tag PR Step 2/2

### DIFF
--- a/healthcare/v1/pom.xml
+++ b/healthcare/v1/pom.xml
@@ -54,9 +54,6 @@
   </properties>
 
   <!-- [START healthcare_java_dependencies] -->
-  <!-- [START dependencies] -->
-  <!--  Using libraries-bom to manage versions.
-  See https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM -->
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -75,7 +72,6 @@
       <artifactId>google-api-services-healthcare</artifactId>
       <version>v1-rev20240130-2.0.0</version>
     </dependency>
-    <!-- [END dependencies] -->
     <!-- [END healthcare_java_dependencies] -->
     <dependency>
       <groupId>com.google.http-client</groupId>
@@ -113,8 +109,6 @@
       <version>4.5.14</version>
     </dependency>
     <!-- [START healthcare_java_dependencies] -->
-    <!-- [START dependencies] -->
   </dependencies>
-  <!-- [END dependencies] -->
   <!-- [END healthcare_java_dependencies] -->
 </project>


### PR DESCRIPTION
## Description
Fixes b/383619440

Remove old region tag `dependencies` to `healthcare_java_dependencies` in `healthcare/v1/pom.xml`.

Please do not merge, we will wait until CL propagation


## Checklist
- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required** (Requires running `gcert` first to authenticate with Airlock to resolve dependencies)
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved