### PR TITLE
refactor: remove region_tags redudancy on Endpoints Kubernetes tutorial

### DIFF
--- a/endpoints/getting-started/k8s/esp_echo_http.yaml
+++ b/endpoints/getting-started/k8s/esp_echo_http.yaml
@@ -38,13 +38,10 @@ spec:
       labels:
         app: esp-echo
     spec:
-      # [START endpoints_secret1_yaml_java]
       volumes:
         - name: service-account-creds
           secret:
             secretName: service-account-creds
-      # [END endpoints_secret1_yaml_java]
-      # [START endpoints_service_yaml_java]
       containers:
         - name: esp
           image: gcr.io/endpoints-release/endpoints-runtime:1
@@ -55,15 +52,12 @@ spec:
             "--rollout_strategy", "managed",
             "--service_account_key", "/etc/nginx/creds/service-account-creds.json",
           ]
-      # [END endpoints_service_yaml_java]
           ports:
             - containerPort: 8080
-          # [START endpoints_secret2_yaml_java]
           volumeMounts:
             - mountPath: /etc/nginx/creds
               name: service-account-creds
               readOnly: true
-          # [END endpoints_secret2_yaml_java]
         - name: echo
           image: gcr.io/endpoints-release/echo:latest
           ports:


### PR DESCRIPTION
## Description

Fixes # b/384511454
Removed these region tags, due they are not used on cloud java Endpoints samples.
* `endpoints_secret1_yaml_java`
* `endpoints_service_yaml_java`
* `endpoints_secret2_yaml_java`

Please go to b/384511454 for context and support of this PR.

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
