### PR TITLE
ci: Remove kokoro CI from required checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,18 +2,23 @@
 
 Fixes #<ISSUE-NUMBER>
 
-Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.
-
 ## Checklist
+
+### Testing
+
+- [ ] **I have tested this change on a live environment and verified it works as intended.**
+- [ ] **Tests** pass:   `mvn clean verify` **required**
+- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
+- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
+
+### Compliance & Style
 
 - [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
 - [ ] `pom.xml` parent set to latest `shared-configuration`
 - [ ] Appropriate changes to README are included in PR
-- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
-- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
-- [ ] **Tests** pass:   `mvn clean verify` **required**
-- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
-- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
 - [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
-- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
+- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
+
+### Post-Approval Actions
+
 - [ ] Please **merge** this PR for me once it is approved

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -7,8 +7,6 @@ branchProtectionRules:
   requiredStatusCheckContexts:
     - 'cla/google'
     - 'header-check'
-    - 'Kokoro CI - Java 11'
-    - 'Kokoro CI - Java 17'
     - 'Kokoro CI - Lint'
   requiredApprovingReviewCount: 1
   requiresCodeOwnerReviews: true

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -14,9 +14,5 @@ branchProtectionRules:
 permissionRules:
   - team: java-samples-reviewers
     permission: push
-  - team: yoshi-java
-    permission: push
-  - team: yoshi-approver-team
-    permission: push
   - team: devrel-java-admin
     permission: admin


### PR DESCRIPTION
- Removes broken kokoro testing and the defunct yoshi teams
- Updates checklist to reflect changes in testing guidance and improve sample contributor experience
- Retains Kokoro linting pending migration to a non-kokoro linting solution