### PR TITLE
fix(gae): remove duplicate and redundant region tags "dependencies"

### DIFF
--- a/appengine-java8/endpoints-v2-skeleton/build.gradle
+++ b/appengine-java8/endpoints-v2-skeleton/build.gradle
@@ -36,7 +36,7 @@ apply plugin: 'com.google.cloud.tools.endpoints-framework-server'
 apply plugin: 'com.google.cloud.tools.appengine'
 // [END plugin_applys]
 
-// [START dependencies]
+// [START appengine_endpoints_gradle_dependencies]
 dependencies {
     compile 'com.google.endpoints:endpoints-framework:2.2.2'
     compile 'com.google.appengine:appengine-api-1.0-sdk:2.0.23'
@@ -44,7 +44,7 @@ dependencies {
     compile 'javax.inject:javax.inject:1'
     compileOnly 'javax.servlet:javax.servlet-api:3.1.0'
 }
-// [END dependencies]
+// [END appengine_endpoints_gradle_dependencies]
 
 // [START endpoints_server_configuration]
 // You must replace YOUR_PROJECT_ID with your Google Cloud Project Id

--- a/appengine-java8/mailgun/pom.xml
+++ b/appengine-java8/mailgun/pom.xml
@@ -44,7 +44,6 @@
       <type>jar</type>
       <scope>provided</scope>
     </dependency>
-    <!-- [START dependencies] -->
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-core</artifactId>
@@ -60,7 +59,6 @@
       <artifactId>jersey-multipart</artifactId>
       <version>1.19.4</version>
     </dependency>
-    <!-- [END dependencies] -->
   </dependencies>
   <build>
     <!-- for hot reload of the web application -->

--- a/appengine-java8/mailjet/pom.xml
+++ b/appengine-java8/mailjet/pom.xml
@@ -50,7 +50,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- [START dependencies] -->
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-core</artifactId>
@@ -66,7 +65,6 @@
       <artifactId>jersey-multipart</artifactId>
       <version>1.19.4</version>
     </dependency>
-    <!-- [END dependencies] -->
   </dependencies>
   <build>
     <!-- for hot reload of the web application -->

--- a/appengine-java8/memcache/pom.xml
+++ b/appengine-java8/memcache/pom.xml
@@ -45,7 +45,6 @@ Copyright 2015 Google Inc.
       <scope>provided</scope>
     </dependency>
 
-    <!-- [START dependencies] -->
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
@@ -56,7 +55,6 @@ Copyright 2015 Google Inc.
       <artifactId>xmemcached</artifactId>
       <version>2.4.8</version>
     </dependency>
-    <!-- [END dependencies] -->
   </dependencies>
   <build>
     <!-- for hot reload of the web application -->

--- a/appengine-java8/pubsub/pom.xml
+++ b/appengine-java8/pubsub/pom.xml
@@ -38,7 +38,6 @@
     <failOnMissingWebXml>false</failOnMissingWebXml>    <!-- REQUIRED -->
   </properties>
 
-  <!-- [START dependencies] -->
   <!--  Using libraries-bom to manage versions.
   See https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM -->
   <dependencyManagement>
@@ -62,7 +61,6 @@
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-datastore</artifactId>
     </dependency>
-    <!-- [END dependencies] -->
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
@@ -75,9 +73,7 @@
       <artifactId>jatl</artifactId>
       <version>0.2.3</version>
     </dependency>
-    <!-- [START dependencies] -->
   </dependencies>
-  <!-- [END dependencies] -->
   <build>
     <!-- for hot reload of the web application -->
     <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes</outputDirectory>

--- a/appengine-java8/remote-client/pom.xml
+++ b/appengine-java8/remote-client/pom.xml
@@ -36,7 +36,6 @@
   </properties>
 
   <dependencies>
-  <!-- [START dependencies] -->
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-remote-api</artifactId>
@@ -47,7 +46,6 @@
       <artifactId>appengine-api-1.0-sdk</artifactId>
       <version>2.0.23</version>
     </dependency>
-  <!-- [END dependencies] -->
   </dependencies>
   <build>
     <!-- for hot reload of the web application -->

--- a/appengine-java8/translate-pubsub/pom.xml
+++ b/appengine-java8/translate-pubsub/pom.xml
@@ -37,7 +37,6 @@
     <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
 
-  <!-- [START dependencies] -->
   <!--  Using libraries-bom to manage versions.
   See https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM -->
   <dependencyManagement>
@@ -65,7 +64,6 @@
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-translate</artifactId>
     </dependency>
-    <!-- [END dependencies] -->
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
@@ -73,9 +71,7 @@
       <type>jar</type>
       <scope>provided</scope>
     </dependency>
-    <!-- [START dependencies] -->
   </dependencies>
-  <!-- [END dependencies] -->
   <build>
     <!-- for hot reload of the web application -->
     <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes</outputDirectory>


### PR DESCRIPTION
## Description
Fixes # 
b/526729539

Removes duplicate and generic `dependencies` region tags in `appengine-java8` samples' `pom.xml` files. Renames the unique region tag used in devsite in [`endpoints-v2-skeleton/build.gradle` ](https://source.corp.google.com/piper///depot/google3/third_party/devsite/cloud/en/endpoints/docs/frameworks/java/set-up-environment.md?q=content:(region_tag%5B:%3D%5D%5B%5C%22%27%5Ddependencies%5B%5C%22%27%5D%7Cregion_tag:%5Cs%5B%5C%22%27%5Ddependencies%5B%5C%22%27%5D)%20&sq=package:piper%20file:%2F%2Fdepot%2Fgoogle3%20-file:google3%2Fexperimental) to `appengine_endpoints_gradle_dependencies` to specify the gradle tool/tech used.

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [x] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
