### PR TITLE
fix(compute): remove duplicate region_tag `dependencies`

### DIFF
--- a/compute/mailjet/pom.xml
+++ b/compute/mailjet/pom.xml
@@ -56,13 +56,11 @@
       <type>jar</type>
       <scope>provided</scope>
     </dependency>
-    <!-- [START dependencies] -->
     <dependency>
       <groupId>com.mailjet</groupId>
       <artifactId>mailjet-client</artifactId>
       <version>${mailjet.version}</version>
     </dependency>
-    <!-- [END dependencies] -->
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
## Description
Fixes # 
b/527028564

* Removed duplicate region tag `dependencies` in [compute/mailjet/pom.xml](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/compute/mailjet/pom.xml), region tag is not used and not references on https://docs.cloud.google.com/compute/docs/tutorials/sending-mail/using-mailjet?hl=en 

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration` (uses standard `1.2.0`)
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only** (Static analysis fails on local JDK 25 due to spotbugs/error-prone incompatibilities, but standard compilation and verify pass successfully)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
