### PR TITLE
fix(media): remove duplicate region_tag `dependencies`

### DIFF
--- a/media/transcoder/pom.xml
+++ b/media/transcoder/pom.xml
@@ -35,7 +35,6 @@
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
   </properties>
-  <!-- [START dependencies] -->
   <!--  Using libraries-bom to manage versions.
   See https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM -->
   <dependencyManagement>
@@ -54,7 +53,6 @@
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-video-transcoder</artifactId>
     </dependency>
-    <!-- [END dependencies] -->
     <!-- Test dependencies -->
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
## Description
Fixes #
b/527028805

Clean up duplicate and generic "dependencies" region tags in `media` samples (`media/transcoder/pom.xml`).

## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required** (failed locally due to storage permissions issues in the current GCP credentials environment)
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only** (failed compiler plug-in execution due to JDK 25 and ErrorProne incompatibility)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
