### PR TITLE
fix(gae): Remove region tag `gae_java8_datastore_property_filter` due it is unused

### DIFF
--- a/appengine-java8/datastore/src/test/java/com/example/appengine/QueriesTest.java
+++ b/appengine-java8/datastore/src/test/java/com/example/appengine/QueriesTest.java
@@ -86,11 +86,9 @@ public class QueriesTest {
 
     // Act
     long minHeight = 160;
-    // [START gae_java8_datastore_property_filter]
     Filter propertyFilter =
         new FilterPredicate("height", FilterOperator.GREATER_THAN_OR_EQUAL, minHeight);
     Query q = new Query("Person").setFilter(propertyFilter);
-    // [END gae_java8_datastore_property_filter]
 
     // Assert
     List<Entity> results =


### PR DESCRIPTION
## Description
Fixes # 
b/348422798

Clean up unused region tag  `gae_java8_datastore_property_filter` on `appengine-java8/datastore/src/test/java/com/example/appengine/QueriesTest.java`


## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [ ] Please **merge** this PR for me once it is approved
