### PR TITLE
fix(compute/gae): remove redundant `mailjet_imports` region tags

### DIFF
--- a/appengine-java8/mailjet/src/main/java/com/example/appengine/mailjet/MailjetServlet.java
+++ b/appengine-java8/mailjet/src/main/java/com/example/appengine/mailjet/MailjetServlet.java
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-// [START mailjet_imports]
-
 package com.example.appengine.mailjet;
 
 import com.mailjet.client.ClientOptions;
@@ -31,8 +29,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.json.JSONArray;
 import org.json.JSONObject;
-
-// [END mailjet_imports]
 
 // [START app]
 @SuppressWarnings("serial")

--- a/compute/mailjet/src/main/java/com/example/compute/mailjet/MailjetSender.java
+++ b/compute/mailjet/src/main/java/com/example/compute/mailjet/MailjetSender.java
@@ -16,8 +16,6 @@
 
 package com.example.compute.mailjet;
 
-// [START compute_mailjet_imports]
-
 import com.mailjet.client.ClientOptions;
 import com.mailjet.client.MailjetClient;
 import com.mailjet.client.MailjetRequest;
@@ -26,8 +24,6 @@ import com.mailjet.client.errors.MailjetException;
 import com.mailjet.client.resource.Emailv31;
 import org.json.JSONArray;
 import org.json.JSONObject;
-
-// [END compute_mailjet_imports]
 
 // [START compute_mailjet_send_email]
 public class MailjetSender {


### PR DESCRIPTION
## Description

Fixes # 
b/348423770

Removes redundant region tags (`mailjet_imports` and `compute_mailjet_imports`) 


## Checklist

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample 
- [x] Please **merge** this PR for me once it is approved
