### PR TITLE
refactor(vertexai): remove decommisioned `generativeaionvertexai_gemini_token_count_advanced` region tag

### DIFF
--- a/vertexai/snippets/src/main/java/vertexai/gemini/GetMediaTokenCount.java
+++ b/vertexai/snippets/src/main/java/vertexai/gemini/GetMediaTokenCount.java
@@ -16,7 +16,6 @@
 
 package vertexai.gemini;
 
-// [START generativeaionvertexai_gemini_token_count_advanced]
 import com.google.cloud.vertexai.VertexAI;
 import com.google.cloud.vertexai.api.Content;
 import com.google.cloud.vertexai.api.CountTokensResponse;
@@ -58,4 +57,3 @@ public class GetMediaTokenCount {
     }
   }
 }
-// [END generativeaionvertexai_gemini_token_count_advanced]

--- a/vertexai/snippets/src/main/java/vertexai/gemini/QuestionAnswer.java
+++ b/vertexai/snippets/src/main/java/vertexai/gemini/QuestionAnswer.java
@@ -16,7 +16,6 @@
 
 package vertexai.gemini;
 
-// [START generativeaionvertexai_non_stream_text_basic]
 import com.google.cloud.vertexai.VertexAI;
 import com.google.cloud.vertexai.api.GenerateContentResponse;
 import com.google.cloud.vertexai.generativeai.GenerativeModel;
@@ -50,4 +49,3 @@ public class QuestionAnswer {
     }
   }
 }
-// [END generativeaionvertexai_non_stream_text_basic]

--- a/vertexai/snippets/src/main/java/vertexai/gemini/TextInput.java
+++ b/vertexai/snippets/src/main/java/vertexai/gemini/TextInput.java
@@ -16,7 +16,6 @@
 
 package vertexai.gemini;
 
-// [START generativeaionvertexai_gemini_generate_from_text_input]
 import com.google.cloud.vertexai.VertexAI;
 import com.google.cloud.vertexai.api.GenerateContentResponse;
 import com.google.cloud.vertexai.generativeai.GenerativeModel;
@@ -53,4 +52,3 @@ public class TextInput {
     }
   }
 }
-// [END generativeaionvertexai_gemini_generate_from_text_input]


### PR DESCRIPTION
## Description

Fixes #
b/530681617

Region tag `generativeaionvertexai_gemini_token_count_advanced` shows [no reference](https://source.corp.google.com/search?q=%22generativeaionvertexai_gemini_token_count_advanced%22&sq=package:piper%20file:%2F%2Fdepot%2Fgoogle3%20-file:google3%2Fexperimental) in devsite

## Checklist

### Testing

- [x] **I have tested this change on a live environment and verified it works as intended.**
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**

### Compliance & Style

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample

### Post-Approval Actions

- [x] Please **merge** this PR for me once it is approved
