### PR TITLE
refactor(vertexai) remove decommission function_calling region tags 

### DIFF
--- a/vertexai/snippets/src/main/java/vertexai/gemini/FunctionCalling.java
+++ b/vertexai/snippets/src/main/java/vertexai/gemini/FunctionCalling.java
@@ -16,7 +16,6 @@
 
 package vertexai.gemini;
 
-// [START generativeaionvertexai_gemini_function_calling]
 import com.google.cloud.vertexai.VertexAI;
 import com.google.cloud.vertexai.api.Content;
 import com.google.cloud.vertexai.api.FunctionDeclaration;
@@ -111,4 +110,3 @@ public class FunctionCalling {
     }
   }
 }
-// [END generativeaionvertexai_gemini_function_calling]


### PR DESCRIPTION
## Description

Fixes # b/530303154

Reference Migration Map Doc: go/migration-map-vertexai-java

Removed decommissioned VertexAI region tag and references
`generativeaionvertexai_gemini_function_calling`

## Checklist

### Testing

- [ ] **I have tested this change on a live environment and verified it works as intended.**
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**

### Compliance & Style

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample

### Post-Approval Actions

- [x] Please **merge** this PR for me once it is approved
