### PR TITLE
refactor(jobs): Remove `quickstart` duplicated region tag

### DIFF
--- a/jobs/v3/src/main/java/com/google/samples/JobServiceQuickstart.java
+++ b/jobs/v3/src/main/java/com/google/samples/JobServiceQuickstart.java
@@ -33,7 +33,6 @@ import java.util.Collections;
 public class JobServiceQuickstart {
 
   // [START job_search_quick_start]
-  // [START quickstart]
 
   private static final JsonFactory JSON_FACTORY = new GsonFactory();
   private static final NetHttpTransport NET_HTTP_TRANSPORT = new NetHttpTransport();
@@ -92,6 +91,5 @@ public class JobServiceQuickstart {
     }
   }
 
-  // [END quickstart]
   // [END job_search_quick_start]
 }


### PR DESCRIPTION
## Description

Fixes #
b/347826002

Removed `quickstart` middle step process on the rename in `jobs/v3/src/main/java/com/google/samples/JobServiceQuickstart.java`

## Checklist

### Testing

- [x] **I have tested this change on a live environment and verified it works as intended.**
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**

### Compliance & Style

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample

### Post-Approval Actions

- [x] Please **merge** this PR for me once it is approved
