### PR TITLE
refactor(tts): Remove `tts_synthesize_text_audio_profile` duplicated region tag

### DIFF
--- a/texttospeech/snippets/src/main/java/com/example/texttospeech/SynthesizeText.java
+++ b/texttospeech/snippets/src/main/java/com/example/texttospeech/SynthesizeText.java
@@ -75,7 +75,9 @@ public class SynthesizeText {
       }
     }
   }
+
   // [END tts_synthesize_text]
+
   /**
    * Demonstrates using the Text to Speech client with audio profiles to synthesize text or ssml
    *

--- a/texttospeech/snippets/src/main/java/com/example/texttospeech/SynthesizeText.java
+++ b/texttospeech/snippets/src/main/java/com/example/texttospeech/SynthesizeText.java
@@ -76,8 +76,6 @@ public class SynthesizeText {
     }
   }
   // [END tts_synthesize_text]
-
-  // [START tts_synthesize_text_audio_profile]
   /**
    * Demonstrates using the Text to Speech client with audio profiles to synthesize text or ssml
    *
@@ -122,7 +120,6 @@ public class SynthesizeText {
       }
     }
   }
-  // [END tts_synthesize_text_audio_profile]
 
   // [START tts_synthesize_ssml]
   /**


### PR DESCRIPTION
## Description

Fixes #
b/536065373

Removes duplicated region tag `tts_synthesize_text_audio_profile` from `texttospeech/snippets/src/main/java/com/example/texttospeech/SynthesizeText.java` to prevent region tag collisions and ensure accurate snippet mapping in documentation. 
NOTE: Don't remove file because it is used and linked to other region tags, which if neccessary will be treated in their own bug.

## Checklist

### Testing

- [x] **I have tested this change on a live environment and verified it works as intended.**
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**

### Compliance & Style

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample

### Post-Approval Actions

- [x] Please **merge** this PR for me once it is approved
