### PR TITLE
refactor(mailjet): remove app region tag from MailjetServlet

### DIFF
--- a/appengine-java8/mailjet/src/main/java/com/example/appengine/mailjet/MailjetServlet.java
+++ b/appengine-java8/mailjet/src/main/java/com/example/appengine/mailjet/MailjetServlet.java
@@ -30,7 +30,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-// [START app]
 @SuppressWarnings("serial")
 public class MailjetServlet extends HttpServlet {
 
@@ -72,4 +71,3 @@ public class MailjetServlet extends HttpServlet {
     }
   }
 }
-// [END app]


### PR DESCRIPTION
## Description

Fixes # 
b/347825621

Removed `app` region tag from MailjetServlet.java due it does not have reference in devsite.

## Checklist

### Testing

- [x] **I have tested this change on a live environment and verified it works as intended.**
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**

### Compliance & Style

- [ ] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample

### Post-Approval Actions

- [x] Please **merge** this PR for me once it is approved
