### PR TITLE
chore(gae): Remove unused `gae_java8_datastore_inequality_filters_sort_orders_invalid_2` and `...invalid_1` region tag

### DIFF
--- a/appengine-java8/datastore/src/test/java/com/example/appengine/QueriesTest.java
+++ b/appengine-java8/datastore/src/test/java/com/example/appengine/QueriesTest.java
@@ -605,7 +605,6 @@ public class QueriesTest {
   @Test
   public void queryRestrictions_missingSortOnInequality_isInvalid() throws Exception {
     long minBirthYear = 1940;
-    // [START gae_java8_datastore_inequality_filters_sort_orders_invalid_1]
     Filter birthYearMinFilter =
         new FilterPredicate("birthYear", FilterOperator.GREATER_THAN_OR_EQUAL, minBirthYear);
 
@@ -614,7 +613,6 @@ public class QueriesTest {
         new Query("Person")
             .setFilter(birthYearMinFilter)
             .addSort("lastName", SortDirection.ASCENDING);
-    // [END gae_java8_datastore_inequality_filters_sort_orders_invalid_1]
 
     // Note: The local devserver behavior is different than the production
     // version of Cloud Datastore, so there aren't any assertions we can make
@@ -625,7 +623,6 @@ public class QueriesTest {
   @Test
   public void queryRestrictions_sortWrongOrderOnInequality_isInvalid() throws Exception {
     long minBirthYear = 1940;
-    // [START gae_java8_datastore_inequality_filters_sort_orders_invalid_2]
     Filter birthYearMinFilter =
         new FilterPredicate("birthYear", FilterOperator.GREATER_THAN_OR_EQUAL, minBirthYear);
 
@@ -635,7 +632,6 @@ public class QueriesTest {
             .setFilter(birthYearMinFilter)
             .addSort("lastName", SortDirection.ASCENDING)
             .addSort("birthYear", SortDirection.ASCENDING);
-    // [END gae_java8_datastore_inequality_filters_sort_orders_invalid_2]
 
     // Note: The local devserver behavior is different than the production
     // version of Cloud Datastore, so there aren't any assertions we can make


### PR DESCRIPTION
## Description

Fixes #
b/347352192

Removed unused region tags `gae_java8_datastore_inequality_filters_sort_orders_invalid_2` and `gae_java8_datastore_inequality_filters_sort_orders_invalid_1`

## Checklist

### Testing

- [x] **I have tested this change on a live environment and verified it works as intended.**
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**

### Compliance & Style

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample

### Post-Approval Actions

- [x] Please **merge** this PR for me once it is approved
