### PR TITLE
refactor(mail): remove unused regon tag `form`

### DIFF
--- a/appengine-java8/mailgun/src/main/webapp/index.html
+++ b/appengine-java8/mailgun/src/main/webapp/index.html
@@ -16,12 +16,10 @@
   <title>Mailgun on Google App Engine Managed VMs</title>
 </head>
 <body>
-<!-- [START form] -->
 <form method="post" action="/send/email">
   <input type="text" name="to" placeholder="Enter recipient email">
   <input type="submit" name="submit" value="Send simple email">
   <input type="submit" name="submit" value="Send complex email">
 </form>
-<!-- [END form] -->
 </body>
 </html>

--- a/appengine-java8/mailjet/src/main/webapp/index.html
+++ b/appengine-java8/mailjet/src/main/webapp/index.html
@@ -16,12 +16,10 @@
   <title>Mailgun on Google App Engine Managed VMs</title>
 </head>
 <body>
-<!-- [START form] -->
 <form method="post" action="/send/email">
   <input type="text" name="to" placeholder="Enter recipient email">
   <input type="text" name="from" placeholder="Enter sender email">
   <input type="submit" name="submit" value="Send email">
 </form>
-<!-- [END form] -->
 </body>
 </html>


### PR DESCRIPTION
Fixes # 
b/347352232

## Description
Removes unused snippet region tags (`<!-- [START form] -->` and `<!-- [END form] -->`) from the `index.html` webapp pages in the `appengine-java8/mailgun` and `appengine-java8/mailjet` sample directories.


## Checklist

### Testing

- [ ] **I have tested this change on a live environment and verified it works as intended.**
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**

### Compliance & Style

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample

### Post-Approval Actions

- [x] Please **merge** this PR for me once it is approved
