### PR TITLE
refactor(gae8): remove unused datastore queries region tag

### DIFF
--- a/appengine-java8/datastore/src/test/java/com/example/appengine/QueriesTest.java
+++ b/appengine-java8/datastore/src/test/java/com/example/appengine/QueriesTest.java
@@ -183,7 +183,6 @@ public class QueriesTest {
 
   @Test
   public void ancestorQueryExample_returnsMatchingEntities() throws Exception {
-    // [START gae_java8_datastore_ancestor_query]
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
     Entity tom = new Entity("Person", "Tom");
@@ -211,7 +210,6 @@ public class QueriesTest {
     // but not campingPhoto, because tom is not an ancestor
     List<Entity> results =
         datastore.prepare(photoQuery).asList(FetchOptions.Builder.withDefaults());
-    // [END gae_java8_datastore_ancestor_query]
 
     assertWithMessage("query results")
         .that(results)


### PR DESCRIPTION
Fixes # 
b/347352390

## Description
Removes unused snippet region tag `gae_java8_datastore_ancestor_query`


## Checklist

### Testing

- [x] **I have tested this change on a live environment and verified it works as intended.**
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**

### Compliance & Style

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample

### Post-Approval Actions

- [x] Please **merge** this PR for me once it is approved
