### PR TITLE
refactor(gae): remove region tags from datastore inequality filters

### DIFF
--- a/appengine-java8/datastore/src/test/java/com/example/appengine/QueriesTest.java
+++ b/appengine-java8/datastore/src/test/java/com/example/appengine/QueriesTest.java
@@ -475,7 +475,6 @@ public class QueriesTest {
     // Act
     long minBirthYear = 1940;
     long maxBirthYear = 1980;
-    // [START gae_java8_datastore_inequality_filters_one_property_valid_1]
     Filter birthYearMinFilter =
         new FilterPredicate("birthYear", FilterOperator.GREATER_THAN_OR_EQUAL, minBirthYear);
 
@@ -486,7 +485,6 @@ public class QueriesTest {
         CompositeFilterOperator.and(birthYearMinFilter, birthYearMaxFilter);
 
     Query q = new Query("Person").setFilter(birthYearRangeFilter);
-    // [END gae_java8_datastore_inequality_filters_one_property_valid_1]
 
     // Assert
     List<Entity> results =
@@ -498,7 +496,6 @@ public class QueriesTest {
   public void queryRestrictions_compositeFilter_isInvalid() throws Exception {
     long minBirthYear = 1940;
     long maxHeight = 200;
-    // [START gae_java8_datastore_inequality_filters_one_property_invalid]
     Filter birthYearMinFilter =
         new FilterPredicate("birthYear", FilterOperator.GREATER_THAN_OR_EQUAL, minBirthYear);
 
@@ -508,7 +505,6 @@ public class QueriesTest {
     Filter invalidFilter = CompositeFilterOperator.and(birthYearMinFilter, heightMaxFilter);
 
     Query q = new Query("Person").setFilter(invalidFilter);
-    // [END gae_java8_datastore_inequality_filters_one_property_invalid]
 
     // Note: The local devserver behavior is different than the production
     // version of Cloud Datastore, so there aren't any assertions we can make
@@ -545,7 +541,6 @@ public class QueriesTest {
     String targetCity = "Somewhere";
     String targetLastName = "Someone";
 
-    // [START gae_java8_datastore_inequality_filters_one_property_valid_2]
     Filter lastNameFilter = new FilterPredicate("lastName", FilterOperator.EQUAL, targetLastName);
 
     Filter cityFilter = new FilterPredicate("city", FilterOperator.EQUAL, targetCity);
@@ -561,7 +556,6 @@ public class QueriesTest {
             lastNameFilter, cityFilter, birthYearMinFilter, birthYearMaxFilter);
 
     Query q = new Query("Person").setFilter(validFilter);
-    // [END gae_java8_datastore_inequality_filters_one_property_valid_2]
 
     // Assert
     List<Entity> results =


### PR DESCRIPTION
## Fixes
b/347351984

## Description
Refactor Datastore queries test by removing redundant and unused snippet region tags (`gae_java8_datastore_inequality_filters_one_property_valid_1`, `gae_java8_datastore_inequality_filters_one_property_invalid`, `gae_java8_datastore_inequality_filters_one_property_valid_2`) in `appengine-java8/datastore/src/test/java/com/example/appengine/QueriesTest.java`.


## Checklist

### Testing

- [x] **I have tested this change on a live environment and verified it works as intended.**
- [x] **Tests** pass:   `mvn clean verify` **required**
- [x] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [x] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**

### Compliance & Style

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [x] `pom.xml` parent set to latest `shared-configuration`
- [x] Appropriate changes to README are included in PR
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample

### Post-Approval Actions

- [x] Please **merge** this PR for me once it is approved
