### PR TITLE
refactor(gae8): remove `addlistener` unused region tag

### DIFF
--- a/appengine-java8/firebase-tictactoe/src/main/webapp/static/main.js
+++ b/appengine-java8/firebase-tictactoe/src/main/webapp/static/main.js
@@ -140,14 +140,12 @@ function initGame(gameKey, me, token, channelId, initialMessage) {
     });
     // [END auth_login]
 
-    // [START add_listener]
     // setup a database reference at path /channels/channelId
     channel = firebase.database().ref('channels/' + channelId);
     // add a listener to the path that fires any time the value of the data changes
     channel.on('value', function(data) {
       onMessage(data.val());
     });
-    // [END add_listener]
     onOpened();
     // let the server know that the channel is open
   }


### PR DESCRIPTION
## Description

Removes `add_listener` region tag from GAE8 folder, unused on devsite.

Fixes # 
b/347351826

## Checklist

### Testing

- [x] **I have tested this change on a live environment and verified it works as intended.**
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**

### Compliance & Style

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample

### Post-Approval Actions

- [x] Please **merge** this PR for me once it is approved
