### PR TITLE
refactor(gae8): Remove unusued `echo_path` region tag

### DIFF
--- a/appengine-java8/endpoints-v2-backend/src/main/java/com/example/echo/Echo.java
+++ b/appengine-java8/endpoints-v2-backend/src/main/java/com/example/echo/Echo.java
@@ -84,12 +84,10 @@ public class Echo {
    * <p>Note that httpMethod is not specified. This will default to a reasonable HTTP method
    * depending on the API method name. In this case, the HTTP method will default to POST.
    */
-  // [START echo_path]
   @ApiMethod(name = "echo_path_parameter", path = "echo/{n}")
   public Message echoPathParameter(Message message, @Named("n") int n) {
     return doEcho(message, n);
   }
-  // [END echo_path]
 
   /**
    * Echoes the received message back. If n is a non-negative integer, the message is copied that


### PR DESCRIPTION
## Description

Fixes #
b/347351937

Small change to the `Echo.java` file by removing the `[START echo_path]` and `[END echo_path]` region tag

## Checklist

### Testing

- [x]  **I have tested this change on a live environment and verified it works as intended.**
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**

### Compliance & Style

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample

### Post-Approval Actions

- [x] Please **merge** this PR for me once it is approved
