### PR TITLE
refactor(gae8): Remove `delete_import` unsued region tag

### DIFF
--- a/appengine-java8/search/src/main/java/com/example/appengine/search/DeleteServlet.java
+++ b/appengine-java8/search/src/main/java/com/example/appengine/search/DeleteServlet.java
@@ -17,7 +17,6 @@
 package com.example.appengine.search;
 
 // @formatter:off
-// [START delete_import]
 import com.google.appengine.api.search.Document;
 import com.google.appengine.api.search.Field;
 import com.google.appengine.api.search.GetRequest;
@@ -36,7 +35,6 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-// [END delete_import]
 // CHECKSTYLE:OFF
 // @formatter:on
 // CHECKSTYLE:ON


### PR DESCRIPTION
## Description

Fixes #
b/347351981

* Removed the `// [START delete_import]` and `// [END delete_import]` region tag from `DeleteServlet.java` 

## Checklist

### Testing

- [x] **I have tested this change on a live environment and verified it works as intended.**
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**

### Compliance & Style

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample

### Post-Approval Actions

- [x] Please **merge** this PR for me once it is approved
