### PR TITLE
refactor(gae8): Remove freezed region tag `gae_batch_operations`

### DIFF
--- a/appengine-java8/datastore/src/test/java/com/example/appengine/EntitiesTest.java
+++ b/appengine-java8/datastore/src/test/java/com/example/appengine/EntitiesTest.java
@@ -293,7 +293,6 @@ public class EntitiesTest {
 
   @Test
   public void batchOperations_putsEntities() {
-    // [START gae_batch_operations]
     Entity employee1 = new Entity("Employee");
     Entity employee2 = new Entity("Employee");
     Entity employee3 = new Entity("Employee");
@@ -305,7 +304,6 @@ public class EntitiesTest {
 
     List<Entity> employees = Arrays.asList(employee1, employee2, employee3);
     datastore.put(employees);
-    // [END gae_batch_operations]
 
     Map<Key, Entity> got =
         datastore.get(Arrays.asList(employee1.getKey(), employee2.getKey(), employee3.getKey()));


### PR DESCRIPTION
## Description

Fixes #
b/347352170

Remove freezed `gae_batch_operations` region tag from `EntitiesTest.java`. It will be found in devsite with branch commit number.

## Checklist

### Testing

- [x] **I have tested this change on a live environment and verified it works as intended.**
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**

### Compliance & Style

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample

### Post-Approval Actions

- [x] Please **merge** this PR for me once it is approved
