### PR TITLE
refactor(gae8): Remove freezed `gae_java8_app_identity_google_apis` region tag

### DIFF
--- a/appengine-java8/appidentity/src/main/java/com/example/appengine/appidentity/UrlShortener.java
+++ b/appengine-java8/appidentity/src/main/java/com/example/appengine/appidentity/UrlShortener.java
@@ -31,7 +31,6 @@ import org.json.JSONTokener;
 
 @SuppressWarnings("serial")
 class UrlShortener {
-  // [START gae_java8_app_identity_google_apis]
 
   /**
    * Returns a shortened URL by calling the Google URL Shortener API.
@@ -74,5 +73,4 @@ class UrlShortener {
       }
     }
   }
-  // [END gae_java8_app_identity_google_apis]
 }


### PR DESCRIPTION
## Description

Fixes #
b/347351868

Remove freezed `gae_java8_app_identity_google_apis` region tag from `UrlShortener.java`. It will be found in devsite with branch commit number.
No functional code has been changed. 

## Checklist

### Testing

- [x] **I have tested this change on a live environment and verified it works as intended.**
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**

### Compliance & Style

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample

### Post-Approval Actions

- [x] Please **merge** this PR for me once it is approved
