### PR TITLE
feat(developerknowledge): add Developer Knowledge API samples

### DIFF
--- a/developer-knowledge/README.md
+++ b/developer-knowledge/README.md
@@ -1,0 +1,28 @@
+# Google Developer Knowledge API Java Samples
+
+This directory contains Java code samples demonstrating how to use the [Google Developer Knowledge API](https://developers.google.com/knowledge) client library (`com.google.cloud:google-cloud-developer-knowledge`).
+
+## Setup
+
+1. Enable the Developer Knowledge API on your Google Cloud project:
+   ```bash
+   gcloud services enable developerknowledge.googleapis.com
+   ```
+
+2. Build with Maven:
+   ```bash
+   mvn clean compile
+   ```
+
+## Samples
+
+* **[Search Document Chunks](src/main/java/developerknowledge/SearchDocumentChunks.java)**: Search public developer documentation chunks by query (`developerknowledge_search_document_chunks`).
+* **[Get Document](src/main/java/developerknowledge/GetDocument.java)**: Retrieve a single documentation page with full markdown content (`developerknowledge_get_document`).
+* **[Batch Get Documents](src/main/java/developerknowledge/BatchGetDocuments.java)**: Fetch multiple documentation pages in one call (`developerknowledge_batch_get_documents`).
+* **[Answer Query](src/main/java/developerknowledge/AnswerQuery.java)**: Get a grounded, cited answer to a technical question (`developerknowledge_answer_query`).
+
+## Running Tests
+
+```bash
+mvn test
+```

--- a/developer-knowledge/pom.xml
+++ b/developer-knowledge/pom.xml
@@ -1,0 +1,59 @@
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+        http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example.developerknowledge</groupId>
+  <artifactId>developer-knowledge-samples</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+  <name>Google Developer Knowledge Snippets</name>
+
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.2.0</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-developer-knowledge</artifactId>
+      <version>0.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.4.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/developer-knowledge/pom.xml
+++ b/developer-knowledge/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>com.google.cloud.samples</groupId>
     <artifactId>shared-configuration</artifactId>
-    <version>1.3.0</version>
+    <version>1.2.0</version>
   </parent>
 
   <properties>

--- a/developer-knowledge/pom.xml
+++ b/developer-knowledge/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>com.google.cloud.samples</groupId>
     <artifactId>shared-configuration</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
   </parent>
 
   <properties>

--- a/developer-knowledge/src/main/java/developerknowledge/AnswerQuery.java
+++ b/developer-knowledge/src/main/java/developerknowledge/AnswerQuery.java
@@ -25,17 +25,16 @@ import java.io.IOException;
 public class AnswerQuery {
 
   public static void main(String[] args) throws IOException {
-    String query =
-        args.length > 0 ? args[0] : "How do I create a Google Cloud Storage bucket?";
+    // TODO(developer): Replace these variables before running the sample.
+    String query = "How do I create a Google Cloud Storage bucket?";
     answerQuery(query);
   }
 
-  /**
-   * Answers a developer question grounded in Google developer documentation.
-   *
-   * @param query The technical question to answer.
-   */
+  // Answers a developer question grounded in Google developer documentation.
   public static AnswerQueryResponse answerQuery(String query) throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
     try (DeveloperKnowledgeClient client = DeveloperKnowledgeClient.create()) {
       AnswerQueryRequest request =
           AnswerQueryRequest.newBuilder().setQuery(query).build();

--- a/developer-knowledge/src/main/java/developerknowledge/AnswerQuery.java
+++ b/developer-knowledge/src/main/java/developerknowledge/AnswerQuery.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package developerknowledge;
+
+// [START developerknowledge_answer_query]
+import com.google.developers.knowledge.v1.AnswerQueryRequest;
+import com.google.developers.knowledge.v1.AnswerQueryResponse;
+import com.google.developers.knowledge.v1.DeveloperKnowledgeClient;
+import java.io.IOException;
+
+public class AnswerQuery {
+
+  public static void main(String[] args) throws IOException {
+    String query =
+        args.length > 0 ? args[0] : "How do I create a Google Cloud Storage bucket?";
+    answerQuery(query);
+  }
+
+  /**
+   * Answers a developer question grounded in Google developer documentation.
+   *
+   * @param query The technical question to answer.
+   */
+  public static AnswerQueryResponse answerQuery(String query) throws IOException {
+    try (DeveloperKnowledgeClient client = DeveloperKnowledgeClient.create()) {
+      AnswerQueryRequest request =
+          AnswerQueryRequest.newBuilder().setQuery(query).build();
+
+      AnswerQueryResponse response = client.answerQuery(request);
+
+      System.out.println("Answer:\n" + response.getAnswer().getAnswerText() + "\n");
+      System.out.println("Citations count: " + response.getAnswer().getCitationsCount());
+      System.out.println("References count: " + response.getAnswer().getReferencesCount());
+
+      return response;
+    }
+  }
+}
+// [END developerknowledge_answer_query]

--- a/developer-knowledge/src/main/java/developerknowledge/BatchGetDocuments.java
+++ b/developer-knowledge/src/main/java/developerknowledge/BatchGetDocuments.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package developerknowledge;
+
+// [START developerknowledge_batch_get_documents]
+import com.google.developers.knowledge.v1.BatchGetDocumentsRequest;
+import com.google.developers.knowledge.v1.BatchGetDocumentsResponse;
+import com.google.developers.knowledge.v1.DeveloperKnowledgeClient;
+import com.google.developers.knowledge.v1.Document;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+public class BatchGetDocuments {
+
+  public static void main(String[] args) throws IOException {
+    List<String> names =
+        Arrays.asList(
+            "documents/docs.cloud.google.com/storage/docs/creating-buckets",
+            "documents/docs.cloud.google.com/storage/docs/deleting-buckets");
+    batchGetDocuments(names);
+  }
+
+  /**
+   * Retrieves multiple developer documentation pages in a single request.
+   *
+   * @param names List of resource names in format 'documents/{uri_without_scheme}'.
+   */
+  public static BatchGetDocumentsResponse batchGetDocuments(List<String> names) throws IOException {
+    try (DeveloperKnowledgeClient client = DeveloperKnowledgeClient.create()) {
+      BatchGetDocumentsRequest request =
+          BatchGetDocumentsRequest.newBuilder().addAllNames(names).build();
+
+      BatchGetDocumentsResponse response = client.batchGetDocuments(request);
+
+      for (Document doc : response.getDocumentsList()) {
+        System.out.println("Title: " + doc.getTitle());
+        System.out.println("URI: " + doc.getUri());
+        System.out.println("Content Length: " + doc.getContentLengthBytes() + " bytes\n");
+      }
+
+      return response;
+    }
+  }
+}
+// [END developerknowledge_batch_get_documents]

--- a/developer-knowledge/src/main/java/developerknowledge/BatchGetDocuments.java
+++ b/developer-knowledge/src/main/java/developerknowledge/BatchGetDocuments.java
@@ -28,6 +28,7 @@ import java.util.List;
 public class BatchGetDocuments {
 
   public static void main(String[] args) throws IOException {
+    // TODO(developer): Replace these variables before running the sample.
     List<String> names =
         Arrays.asList(
             "documents/docs.cloud.google.com/storage/docs/creating-buckets",
@@ -35,12 +36,11 @@ public class BatchGetDocuments {
     batchGetDocuments(names);
   }
 
-  /**
-   * Retrieves multiple developer documentation pages in a single request.
-   *
-   * @param names List of resource names in format 'documents/{uri_without_scheme}'.
-   */
+  // Retrieves multiple developer documentation pages in a single request.
   public static BatchGetDocumentsResponse batchGetDocuments(List<String> names) throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
     try (DeveloperKnowledgeClient client = DeveloperKnowledgeClient.create()) {
       BatchGetDocumentsRequest request =
           BatchGetDocumentsRequest.newBuilder().addAllNames(names).build();

--- a/developer-knowledge/src/main/java/developerknowledge/GetDocument.java
+++ b/developer-knowledge/src/main/java/developerknowledge/GetDocument.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package developerknowledge;
+
+// [START developerknowledge_get_document]
+import com.google.developers.knowledge.v1.DeveloperKnowledgeClient;
+import com.google.developers.knowledge.v1.Document;
+import com.google.developers.knowledge.v1.GetDocumentRequest;
+import java.io.IOException;
+
+public class GetDocument {
+
+  public static void main(String[] args) throws IOException {
+    String name =
+        args.length > 0
+            ? args[0]
+            : "documents/docs.cloud.google.com/storage/docs/creating-buckets";
+    getDocument(name);
+  }
+
+  /**
+   * Retrieves a single developer documentation page by its resource name.
+   *
+   * @param name The resource name in format 'documents/{uri_without_scheme}'.
+   */
+  public static Document getDocument(String name) throws IOException {
+    try (DeveloperKnowledgeClient client = DeveloperKnowledgeClient.create()) {
+      GetDocumentRequest request = GetDocumentRequest.newBuilder().setName(name).build();
+
+      Document document = client.getDocument(request);
+
+      System.out.println("Title: " + document.getTitle());
+      System.out.println("URI: " + document.getUri());
+      System.out.println("Data Source: " + document.getDataSource());
+      System.out.println("Content Length: " + document.getContentLengthBytes() + " bytes");
+      String preview = document.getContent();
+      if (preview.length() > 150) {
+        preview = preview.substring(0, 150) + "...";
+      }
+      System.out.println("Content Preview: " + preview + "\n");
+
+      return document;
+    }
+  }
+}
+// [END developerknowledge_get_document]

--- a/developer-knowledge/src/main/java/developerknowledge/GetDocument.java
+++ b/developer-knowledge/src/main/java/developerknowledge/GetDocument.java
@@ -25,19 +25,16 @@ import java.io.IOException;
 public class GetDocument {
 
   public static void main(String[] args) throws IOException {
-    String name =
-        args.length > 0
-            ? args[0]
-            : "documents/docs.cloud.google.com/storage/docs/creating-buckets";
+    // TODO(developer): Replace these variables before running the sample.
+    String name = "documents/docs.cloud.google.com/storage/docs/creating-buckets";
     getDocument(name);
   }
 
-  /**
-   * Retrieves a single developer documentation page by its resource name.
-   *
-   * @param name The resource name in format 'documents/{uri_without_scheme}'.
-   */
+  // Retrieves a single developer documentation page by its resource name.
   public static Document getDocument(String name) throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
     try (DeveloperKnowledgeClient client = DeveloperKnowledgeClient.create()) {
       GetDocumentRequest request = GetDocumentRequest.newBuilder().setName(name).build();
 

--- a/developer-knowledge/src/main/java/developerknowledge/SearchDocumentChunks.java
+++ b/developer-knowledge/src/main/java/developerknowledge/SearchDocumentChunks.java
@@ -26,19 +26,18 @@ import java.io.IOException;
 public class SearchDocumentChunks {
 
   public static void main(String[] args) throws IOException {
-    String query = args.length > 0 ? args[0] : "How to create a Cloud Storage bucket";
-    int pageSize = args.length > 1 ? Integer.parseInt(args[1]) : 5;
+    // TODO(developer): Replace these variables before running the sample.
+    String query = "How to create a Cloud Storage bucket";
+    int pageSize = 5;
     searchDocumentChunks(query, pageSize);
   }
 
-  /**
-   * Searches developer documentation chunks for a given query.
-   *
-   * @param query The search query string.
-   * @param pageSize The maximum number of chunks to return.
-   */
+  // Searches developer documentation chunks for a given query.
   public static SearchDocumentChunksPagedResponse searchDocumentChunks(
       String query, int pageSize) throws IOException {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
     try (DeveloperKnowledgeClient client = DeveloperKnowledgeClient.create()) {
       SearchDocumentChunksRequest request =
           SearchDocumentChunksRequest.newBuilder()

--- a/developer-knowledge/src/main/java/developerknowledge/SearchDocumentChunks.java
+++ b/developer-knowledge/src/main/java/developerknowledge/SearchDocumentChunks.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package developerknowledge;
+
+// [START developerknowledge_search_document_chunks]
+import com.google.developers.knowledge.v1.DeveloperKnowledgeClient;
+import com.google.developers.knowledge.v1.DeveloperKnowledgeClient.SearchDocumentChunksPagedResponse;
+import com.google.developers.knowledge.v1.DocumentChunk;
+import com.google.developers.knowledge.v1.SearchDocumentChunksRequest;
+import java.io.IOException;
+
+public class SearchDocumentChunks {
+
+  public static void main(String[] args) throws IOException {
+    String query = args.length > 0 ? args[0] : "How to create a Cloud Storage bucket";
+    int pageSize = args.length > 1 ? Integer.parseInt(args[1]) : 5;
+    searchDocumentChunks(query, pageSize);
+  }
+
+  /**
+   * Searches developer documentation chunks for a given query.
+   *
+   * @param query The search query string.
+   * @param pageSize The maximum number of chunks to return.
+   */
+  public static SearchDocumentChunksPagedResponse searchDocumentChunks(
+      String query, int pageSize) throws IOException {
+    try (DeveloperKnowledgeClient client = DeveloperKnowledgeClient.create()) {
+      SearchDocumentChunksRequest request =
+          SearchDocumentChunksRequest.newBuilder()
+              .setQuery(query)
+              .setPageSize(pageSize)
+              .build();
+
+      SearchDocumentChunksPagedResponse response = client.searchDocumentChunks(request);
+
+      for (DocumentChunk chunk : response.getPage().getValues()) {
+        System.out.println("Parent Document: " + chunk.getParent());
+        System.out.println("Chunk ID: " + chunk.getId());
+        String preview = chunk.getContent();
+        if (preview.length() > 100) {
+          preview = preview.substring(0, 100) + "...";
+        }
+        System.out.println("Content: " + preview + "\n");
+      }
+
+      return response;
+    }
+  }
+}
+// [END developerknowledge_search_document_chunks]

--- a/developer-knowledge/src/test/java/developerknowledge/SnippetsIT.java
+++ b/developer-knowledge/src/test/java/developerknowledge/SnippetsIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package developerknowledge;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.developers.knowledge.v1.AnswerQueryResponse;
+import com.google.developers.knowledge.v1.BatchGetDocumentsResponse;
+import com.google.developers.knowledge.v1.DeveloperKnowledgeClient.SearchDocumentChunksPagedResponse;
+import com.google.developers.knowledge.v1.Document;
+import com.google.developers.knowledge.v1.DocumentChunk;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SnippetsIT {
+
+  @Test
+  public void testSearchDocumentChunks() throws IOException {
+    SearchDocumentChunksPagedResponse response =
+        SearchDocumentChunks.searchDocumentChunks("Cloud Storage bucket creation", 3);
+    assertThat(response).isNotNull();
+    assertThat(response.getPage().getValues()).isNotEmpty();
+    DocumentChunk firstChunk = response.getPage().getValues().iterator().next();
+    assertThat(firstChunk.getParent()).startsWith("documents/");
+    assertThat(firstChunk.getContent()).isNotEmpty();
+  }
+
+  @Test
+  public void testGetDocument() throws IOException {
+    String name = "documents/docs.cloud.google.com/storage/docs/creating-buckets";
+    Document doc = GetDocument.getDocument(name);
+    assertThat(doc).isNotNull();
+    assertThat(doc.getName()).isEqualTo(name);
+    assertThat(doc.getTitle()).isNotEmpty();
+    assertThat(doc.getContent()).isNotEmpty();
+  }
+
+  @Test
+  public void testBatchGetDocuments() throws IOException {
+    List<String> names =
+        Arrays.asList(
+            "documents/docs.cloud.google.com/storage/docs/creating-buckets",
+            "documents/docs.cloud.google.com/storage/docs/deleting-buckets");
+    BatchGetDocumentsResponse response = BatchGetDocuments.batchGetDocuments(names);
+    assertThat(response).isNotNull();
+    assertThat(response.getDocumentsList()).hasSize(2);
+  }
+
+  @Test
+  public void testAnswerQuery() throws IOException {
+    AnswerQueryResponse response =
+        AnswerQuery.answerQuery("How to create a Cloud Storage bucket");
+    assertThat(response).isNotNull();
+    assertThat(response.getAnswer().getAnswerText()).isNotEmpty();
+  }
+}


### PR DESCRIPTION
## Description
Adds Java code samples demonstrating how to use the Google Developer Knowledge API client library (`com.google.cloud:google-cloud-developer-knowledge`):
- `SearchDocumentChunks.java` (`developerknowledge_search_document_chunks`): Searches public documentation chunks with manual pagination handling.
- `GetDocument.java` (`developerknowledge_get_document`): Retrieves a single documentation page with full markdown content.
- `BatchGetDocuments.java` (`developerknowledge_batch_get_documents`): Fetches multiple documentation pages in one call.
- `AnswerQuery.java` (`developerknowledge_answer_query`): Queries documentation for grounded answers and citations.
- `SnippetsIT.java`: JUnit4 integration test suite verifying all 4 sample methods against the live API.