### PR TITLE
refactor(gae8): Remove unused `api_ref` region tag

### DIFF
--- a/appengine-java8/endpoints-v2-migration/src/main/java/com/example/helloendpoints/Greetings.java
+++ b/appengine-java8/endpoints-v2-migration/src/main/java/com/example/helloendpoints/Greetings.java
@@ -27,8 +27,6 @@ import javax.inject.Named;
 
 // [END begin]
 
-// [START api_def]
-
 /** Defines v1 of a helloworld API, which provides simple "greeting" methods. */
 @Api(
     name = "helloworld",
@@ -45,8 +43,7 @@ public class Greetings {
     greetings.add(new HelloGreeting("hello world!"));
     greetings.add(new HelloGreeting("goodbye world!"));
   }
-  // [END api_def]
-
+  
   // [START getgreetings]
 
   public HelloGreeting getGreeting(@Named("id") Integer id) throws NotFoundException {


### PR DESCRIPTION
## Description

Fixes # 
b/347351460

Remove `api_ref` region tag from `Greetings.java` file 

## Checklist

### Testing

- [x] **I have tested this change on a live environment and verified it works as intended.**
- [ ] **Tests** pass:   `mvn clean verify` **required**
- [ ] **Lint**  passes: `mvn -P lint checkstyle:check` **required**
- [ ] **Static Analysis**:  `mvn -P lint clean compile pmd:cpd-check spotbugs:check` **advisory only**

### Compliance & Style

- [x] I have followed [Sample Format Guide](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md)
- [ ] `pom.xml` parent set to latest `shared-configuration`
- [ ] Appropriate changes to README are included in PR
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample

### Post-Approval Actions

- [x] Please **merge** this PR for me once it is approved
